### PR TITLE
refactor(fc): 服务端删掉 share-mode（客户端侧见 #1077）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,13 +152,19 @@ Team sync is owned by the amuxd daemon (OSS engine). The legacy iroh-based P2P
 mode has been removed, and so has git share — `git` is not invoked anywhere in
 the product.
 
-**Share mode is a switch, not a choice.** `oss` (Alibaba OSS with WebDAV) is the
-only backend; enabling it is one-shot and permanent (`ShareMode` in
-`packages/app/src/stores/team-share.ts` is `'oss' | null`, mirroring
-`GET /v1/teams/:id/share-mode`). The retired `managed_git` / `custom_git` values
-still exist in the Postgres enum because in-use enum values cannot be dropped —
-legacy rows carrying them read as "enabled" and nothing more. Branch on
-null-ness, never on the value.
+**There is no share-mode switch any more.** It was a one-shot cloud flag with no
+producer left in the product — nothing shipped a call that set it — so every team
+created since read as "off", and everything branching on it silently did nothing
+(the sync button, the status poll, the daemon's sync, and a link sweep that
+*removed* the team links it exists to create). Whether a team can sync is decided
+by its **team secret**, checked where the sync runs
+(`sync::dispatch::run_once`): no secret → nothing to encrypt or decrypt with →
+`skipped`; secret → sync.
+
+The `teams.share_mode` column and its Postgres enum are still there (in-use enum
+values cannot be dropped, and dropping the column is a one-way door on
+production data), but no code reads or writes them. Do not reintroduce a branch
+on them.
 
 Shared: `skills/`, `.mcp/`, `knowledge/`
 
@@ -257,9 +263,7 @@ Cloud API endpoints: see `docs/openapi/teamclu-api.v1.yaml` (the contract) —
 
 Team share onboarding endpoints (see `docs/openapi/teamclu-api.v1.yaml`):
 
-- `POST /v1/teams/:id/share-mode` — one-shot lock to `oss` (409 once locked, 400 for any other mode).
-- `GET  /v1/teams/:id/share-mode` — `{ mode, enabledAt }`; `mode: null` means team-share 未开通.
-- `GET  /v1/teams/:id/workspace-config` — merged shape `{ shareMode, syncMode, litellmTeamId }`. The legacy `{ defaultWorkspaceId, pinnedWorkspaceIds }` shape now lives at `GET /v1/teams/:id/workspace-defaults` (PUT path is unchanged).
+- `GET  /v1/teams/:id/workspace-config` — merged shape `{ syncMode, litellmTeamId, llm }`. The legacy `{ defaultWorkspaceId, pinnedWorkspaceIds }` shape now lives at `GET /v1/teams/:id/workspace-defaults` (PUT path is unchanged).
 - `POST /v1/teams/:id/litellm/setup` — provisions LiteLLM and returns `{ aiGatewayEndpoint, litellmKey }`; 503 `litellm_unavailable` if FC is not configured.
 
 <!-- seahelm:suggest:start -->

--- a/apps/daemon/e2e/oss-sync/harness/fc-client.mjs
+++ b/apps/daemon/e2e/oss-sync/harness/fc-client.mjs
@@ -23,11 +23,6 @@ export async function createTeam(base, token, name) {
   return out.id;
 }
 
-/** 一次性锁定 share-mode=oss。 */
-export async function lockOss(base, token, teamId) {
-  return postJson(`${base}/v1/teams/${encodeURIComponent(teamId)}/share-mode`, { mode: "oss" }, token);
-}
-
 /** 建 agent invite（amuxd），返回 invite token。 */
 export async function createAgentInvite(base, token, teamId, displayName) {
   const out = await postJson(

--- a/apps/daemon/e2e/oss-sync/harness/setup.mjs
+++ b/apps/daemon/e2e/oss-sync/harness/setup.mjs
@@ -25,7 +25,6 @@ export async function provisionTwoNodeTeam({ threeNode = false } = {}) {
 
   const teamName = `e2e-oss-${stamp}`;
   const teamId = await fc.createTeam(base, ownerToken, teamName);
-  await fc.lockOss(base, ownerToken, teamId);
 
   const services = threeNode ? ["node-a", "node-b", "node-c"] : ["node-a", "node-b"];
 

--- a/apps/daemon/e2e/oss-sync/tests/unit-http.test.mjs
+++ b/apps/daemon/e2e/oss-sync/tests/unit-http.test.mjs
@@ -28,12 +28,12 @@ test("postJson sends bearer + body and parses json", async () => {
 test("postJson throws HttpCallError with status+body on non-2xx", async () => {
   const srv = await serve((req, res) => {
     res.writeHead(409, { "content-type": "application/json" });
-    res.end(JSON.stringify({ error: "share_mode_locked" }));
+    res.end(JSON.stringify({ error: "conflict" }));
   });
   const port = srv.address().port;
   await assert.rejects(
     () => postJson(`http://127.0.0.1:${port}/x`, {}, null),
-    (e) => e instanceof HttpCallError && e.status === 409 && /share_mode_locked/.test(e.body),
+    (e) => e instanceof HttpCallError && e.status === 409 && /conflict/.test(e.body),
   );
   srv.close();
 });

--- a/apps/daemon/src/backend/cloud_api/mod.rs
+++ b/apps/daemon/src/backend/cloud_api/mod.rs
@@ -2960,7 +2960,6 @@ mod tests {
         Mock::given(method("GET"))
             .and(path("/v1/teams/team-1/workspace-config"))
             .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
-                "shareMode": "oss",
                 "llm": {
                     "enabled": true,
                     "baseUrl": "https://ai.ucar.cc",

--- a/docs/openapi/teamclu-api.v1.yaml
+++ b/docs/openapi/teamclu-api.v1.yaml
@@ -1561,7 +1561,7 @@ paths:
         Returns the legacy team workspace defaults shape:
         `{ defaultWorkspaceId, pinnedWorkspaceIds, updatedAt }`.
         Distinct from `GET /v1/teams/{teamId}/workspace-config`, which returns
-        the merged share-mode + litellm shape introduced in the team-share
+        the merged sync + litellm shape introduced in the team-share
         onboarding refactor.
       tags: [Teams]
       parameters:
@@ -1609,9 +1609,8 @@ paths:
       summary: Put team workspace config (legacy defaults shape)
       description: |
         Upserts the legacy team workspace defaults shape
-        (`defaultWorkspaceId`, `pinnedWorkspaceIds`). Does not modify
-        share-mode or litellm fields — those are managed via the
-        `/share-mode` and `/litellm/setup` endpoints.
+        (`defaultWorkspaceId`, `pinnedWorkspaceIds`). Does not modify the
+        litellm fields — those are managed via `/litellm/setup`.
       tags: [Teams]
       parameters:
         - $ref: "#/components/parameters/TeamId"
@@ -2595,68 +2594,6 @@ paths:
         "204": { description: Deleted. }
         "403": { $ref: "#/components/responses/Error" }
         "404": { $ref: "#/components/responses/Error" }
-  /v1/teams/{teamId}/share-mode:
-    post:
-      operationId: enableTeamShareMode
-      summary: Enable team knowledge sync (one-shot, permanent)
-      description: |
-        Turns on team knowledge sync. This is a switch, not a choice: git
-        share modes are gone and the only backend is Supabase Storage. `mode`
-        is vestigial — omit it, or send `oss`; `managed_git` and `custom_git`
-        are rejected with 400. Once enabled the team cannot be un-enabled
-        (`DELETE` returns 410) and a second call returns 409
-        `share_mode_locked`.
-      tags: [Teams]
-      parameters:
-        - $ref: "#/components/parameters/TeamId"
-      requestBody:
-        required: false
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/EnableShareModeRequest"
-      responses:
-        "200":
-          description: Team after share mode is enabled.
-          headers:
-            X-Request-Id:
-              $ref: "#/components/headers/RequestId"
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Team"
-        "400":
-          $ref: "#/components/responses/Error"
-        "401":
-          $ref: "#/components/responses/Error"
-        "404":
-          $ref: "#/components/responses/Error"
-        "409":
-          $ref: "#/components/responses/Error"
-    get:
-      operationId: getTeamShareMode
-      summary: Get team share mode status
-      tags: [Teams]
-      parameters:
-        - $ref: "#/components/parameters/TeamId"
-      responses:
-        "200":
-          description: |
-            Current team share status. `mode` is null when sync has never been
-            enabled; any non-null value means enabled. Branch on null-ness, not
-            on the value — `managed_git` / `custom_git` survive on legacy rows
-            and mean nothing beyond "enabled".
-          headers:
-            X-Request-Id:
-              $ref: "#/components/headers/RequestId"
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ShareStatus"
-        "401":
-          $ref: "#/components/responses/Error"
-        "404":
-          $ref: "#/components/responses/Error"
   /v1/teams/{teamId}/litellm/setup:
     post:
       operationId: setupTeamLiteLlm
@@ -6133,43 +6070,10 @@ components:
           type:
             - string
             - "null"
-    TeamShareMode:
-      type: string
-      enum: [oss]
-      description: |
-        Team share mode. `oss` (Alibaba OSS / WebDAV) is the only backend. The
-        retired `managed_git` / `custom_git` values survive on legacy rows in
-        the database; the API neither accepts nor returns them.
-    EnableShareModeRequest:
-      type: object
-      description: |
-        Body is optional and carries no decision. `mode` is kept only so
-        existing clients keep working; the sole accepted value is `oss`.
-      properties:
-        mode:
-          type: string
-          enum: [oss]
-    ShareStatus:
-      type: object
-      required: [mode, enabledAt]
-      properties:
-        mode:
-          oneOf:
-            - $ref: "#/components/schemas/TeamShareMode"
-            - type: "null"
-        enabledAt:
-          type:
-            - string
-            - "null"
-          format: date-time
     MergedWorkspaceConfig:
       type: object
-      required: [shareMode, syncMode, litellmTeamId]
+      required: [syncMode, litellmTeamId]
       properties:
-        shareMode:
-          oneOf:
-            - $ref: "#/components/schemas/TeamShareMode"
-            - type: "null"
         syncMode:
           type:
             - string

--- a/packages/app/src/lib/backend/cloud-api/auth.ts
+++ b/packages/app/src/lib/backend/cloud-api/auth.ts
@@ -99,9 +99,9 @@ export function createAuthModule(
           message: "Invite claim returned no team.",
         });
       }
-      // The team share mode is owned by the cloud (`GET /v1/teams/:id/share-mode`)
-      // and surfaced via the team-share store; we no longer persist a local
-      // `team_mode` into teamclu.json after a join.
+      // No local `team_mode` is persisted into teamclu.json after a join. The
+      // cloud share-mode flag that used to decide it is gone entirely: whether
+      // a team can sync is decided by its team secret, in the daemon.
       return claim;
     },
     async listPendingInvites(): Promise<PendingInvite[]> {

--- a/services/fc/src/lib/pg-repo/authz.ts
+++ b/services/fc/src/lib/pg-repo/authz.ts
@@ -54,7 +54,8 @@ export async function requireActorForTeam(
 }
 
 /**
- * Ensures the authenticated user is the team owner before share-mode mutations.
+ * Ensures the authenticated user is the team owner before owner-only team
+ * mutations.
  */
 export async function requireTeamOwner(
   db: DbLike,

--- a/services/fc/src/lib/pg-repo/index.ts
+++ b/services/fc/src/lib/pg-repo/index.ts
@@ -101,7 +101,6 @@ export function createPgBusinessRepository({ db, accessToken, userId, callerActo
     listLiteLlmKeys: (teamId: string) => teamsRepo.listLiteLlmKeys(teamId, teamsCtx),
     setLiteLlmBudget: (teamId: string, input: { maxBudget?: unknown }) => teamsRepo.setLiteLlmBudget(teamId, input, teamsCtx),
     getLiteLlmUsage: (teamId: string, opts?: { range?: string; date?: string }) => teamsRepo.getLiteLlmUsage(teamId, opts ?? {}, teamsCtx),
-    disableShareMode: (teamId: string) => teamsRepo.disableShareMode(teamId, teamsCtx),
     removeTeamActor: (teamId: string, actorId: string) => teamsRepo.removeTeamActor(teamId, actorId, teamsCtx),
     // Account upgrade (default-org → own org) is org-model-specific and only
     // implemented on the supabase backend (postgres has no org model).

--- a/services/fc/src/lib/pg-repo/teams.ts
+++ b/services/fc/src/lib/pg-repo/teams.ts
@@ -70,7 +70,6 @@ async function resolveOwnersForTeam(db: any, teamId: string, actorIds: string[])
 function mapTeam(r: any) {
   return {
     id: r.id, name: r.name, slug: r.slug, createdAt: iso(r.createdAt),
-    shareMode: r.shareMode ?? null, shareEnabledAt: iso(r.shareEnabledAt),
     visibility: r.visibility ?? "private",
   };
 }
@@ -143,27 +142,6 @@ export function makeTeamsRepo(db: PgDatabase<any, any>, deps: TeamsRepoDeps = {}
       if (!r) throw new ApiError(404, "not_found", "team not found");
       return mapTeam(r);
     },
-    async getShareMode(teamId: string) {
-      const [r] = await db.select().from(teams).where(eq(teams.id, teamId)).limit(1);
-      if (!r) return { mode: null, enabledAt: null };
-      return { mode: r.shareMode ?? null, enabledAt: iso(r.shareEnabledAt) };
-    },
-    async enableShareMode(teamId: string, mode: "oss") {
-      const [r] = await (db.update(teams) as any)
-        .set({
-          shareMode: mode,
-          shareEnabledAt: new Date(),
-          updatedAt: new Date(),
-        })
-        .where(and(eq(teams.id, teamId), isNull(teams.shareMode)))
-        .returning();
-      if (!r) {
-        const [exists] = await db.select({ id: teams.id, sm: teams.shareMode }).from(teams).where(eq(teams.id, teamId)).limit(1);
-        if (!exists) throw new ApiError(404, "not_found", "team not found");
-        throw new ApiError(409, "conflict", "share_mode already locked");
-      }
-      return { id: r.id, shareMode: r.shareMode, shareEnabledAt: iso(r.shareEnabledAt) };
-    },
     async getTeamWorkspaceConfig(teamId: string) {
       const [r] = await db.select().from(teamWorkspaceConfig).where(eq(teamWorkspaceConfig.teamId, teamId)).limit(1);
       return r ?? null;
@@ -201,7 +179,6 @@ export function makeTeamsRepo(db: PgDatabase<any, any>, deps: TeamsRepoDeps = {}
       }
       const storedModels = Array.isArray(wc?.llmModels) ? wc.llmModels : [];
       return {
-        shareMode: t?.shareMode ?? null,
         syncMode: wc?.syncMode ?? null,
         litellmTeamId: wc?.litellmTeamId ?? null,
         // `models` is the STORED, authoritative per-team list; `availableModels`
@@ -377,25 +354,6 @@ export function makeTeamsRepo(db: PgDatabase<any, any>, deps: TeamsRepoDeps = {}
       const [r] = await (db.update(teams) as any).set({ visibility, updatedAt: new Date() }).where(eq(teams.id, teamId)).returning();
       if (!r) throw new ApiError(404, "not_found", "team not found");
       return mapTeam(r);
-    },
-
-    /**
-     * Owner-only: clears the team's share mode + git config back to the
-     * unconfigured state. Mirrors supabase-repo.disableShareMode.
-     */
-    async disableShareMode(teamId: string, ctx?: { userId?: string }) {
-      const userId = ctx?.userId;
-      if (!userId) throw new ApiError(401, "missing_auth", "authenticated user required");
-      await requireTeamOwner(db, userId, teamId);
-      await (db.update(teams) as any)
-        .set({
-          shareMode: null,
-          shareEnabledAt: null,
-          gitCredentialRef: null,
-          updatedAt: new Date(),
-        })
-        .where(eq(teams.id, teamId));
-      return { mode: null, enabledAt: null };
     },
 
     /**

--- a/services/fc/src/lib/repository-contract.ts
+++ b/services/fc/src/lib/repository-contract.ts
@@ -940,40 +940,6 @@ test("repository contract: getTeamDirectory returns actors and members", async (
     }
   });
 
-  test("repository contract: enableShareMode locks team to an oss share mode", async () => {
-    const repo = createRepository();
-    const out = await repo.enableShareMode("team-share-1", "oss");
-    assert.ok(out, "result must be returned");
-    assert.equal(out.id, "team-share-1");
-    assert.equal(out.shareMode, "oss");
-    assert.ok(out.shareEnabledAt, "shareEnabledAt must be set");
-  });
-
-  test("repository contract: enableShareMode is idempotent on the same team", async () => {
-    const repo = createRepository();
-    await repo.enableShareMode("team-share-3", "oss");
-    const out = await repo.enableShareMode("team-share-3", "oss");
-    assert.equal(out.shareMode, "oss");
-    const current = await repo.getShareMode("team-share-3");
-    assert.equal(current.mode, "oss");
-  });
-
-  test("repository contract: getShareMode returns null mode for fresh team", async () => {
-    const repo = createRepository();
-    const out = await repo.getShareMode("team-share-fresh");
-    assert.ok(out, "result must be returned");
-    assert.equal(out.mode, null);
-    assert.equal(out.enabledAt, null);
-  });
-
-  test("repository contract: getShareMode reflects a previously enabled share mode", async () => {
-    const repo = createRepository();
-    await repo.enableShareMode("team-share-4", "oss");
-    const out = await repo.getShareMode("team-share-4");
-    assert.equal(out.mode, "oss");
-    assert.ok(out.enabledAt, "enabledAt must be set once mode is enabled");
-  });
-
   test("repository contract: ensureMemberKey returns the caller's own key + gateway endpoint", async () => {
     const repo = createRepository();
     assert.equal(typeof repo.ensureMemberKey, "function", "repository must implement ensureMemberKey");
@@ -1012,36 +978,10 @@ test("repository contract: getTeamDirectory returns actors and members", async (
     assert.ok(out.litellmKey.length > 0, "litellmKey must be non-empty");
   });
 
-  test("repository contract: getWorkspaceConfig merges share + workspace fields", async () => {
-    const repo = createRepository();
-    await repo.enableShareMode("team-share-5", "oss");
-    const out = await repo.getWorkspaceConfig("team-share-5");
-    assert.ok(out, "result must be returned");
-    assert.deepEqual(Object.keys(out).sort(), [
-      "litellmTeamId",
-      "llm",
-      "shareMode",
-      "syncMode",
-    ].sort());
-    assert.equal(out.shareMode, "oss");
-    // llm block: shape is always present. `models` is the stored per-team
-    // list (empty here), `availableModels` is the gateway proxy (no endpoint
-    // → []). The gateway dep is never required for the request to succeed.
-    assert.ok(out.llm && typeof out.llm === "object", "llm block must be present");
-    assert.equal(out.llm.aiGatewayEndpoint, null);
-    assert.equal(out.llm.enabled, false);
-    assert.equal(out.llm.baseUrl, null);
-    assert.ok(Array.isArray(out.llm.models), "llm.models must be an array");
-    assert.equal(out.llm.models.length, 0);
-    assert.ok(Array.isArray(out.llm.availableModels), "llm.availableModels must be an array");
-    assert.equal(out.llm.availableModels.length, 0);
-  });
-
-  test("repository contract: getWorkspaceConfig returns null share for fresh team", async () => {
+  test("repository contract: getWorkspaceConfig returns an empty llm block for a fresh team", async () => {
     const repo = createRepository();
     const out = await repo.getWorkspaceConfig("team-share-fresh-2");
     assert.ok(out, "result must be returned");
-    assert.equal(out.shareMode, null);
     assert.ok(out.llm && typeof out.llm === "object", "llm block must be present");
     assert.equal(out.llm.aiGatewayEndpoint, null);
     assert.deepEqual(out.llm.models, []);

--- a/services/fc/src/lib/routes/team-share.ts
+++ b/services/fc/src/lib/routes/team-share.ts
@@ -1,28 +1,5 @@
 import { ApiError } from "../http-utils.js";
 
-// `share_mode` is now a switch, not a choice. The column, the enum and this
-// field keep their historical names — the value that means "on" is `oss`
-// because that is the only one every existing client already understands:
-// `normalizeShareStatus` in packages/app/src/stores/team-share.ts collapses an
-// unrecognised value to `mode: null`, which renders an enabled team as
-// "not set up" and reopens the onboarding wizard.
-const SHARE_MODE_ON = "oss";
-
-function validateShareModeInput(body) {
-  const mode = body?.mode;
-  // Accepting only the enabled value keeps the endpoint honest about what it
-  // can actually do; a client still asking for a git mode gets told, rather
-  // than getting a team configured for a backend that no longer exists.
-  if (mode !== undefined && mode !== SHARE_MODE_ON) {
-    throw new ApiError(
-      400,
-      "validation_failed",
-      `mode must be "${SHARE_MODE_ON}" — git share modes are no longer supported`,
-    );
-  }
-  return { mode: SHARE_MODE_ON };
-}
-
 function validateLlmConfigInput(body) {
   const enabled = body?.enabled;
   if (typeof enabled !== "boolean") {
@@ -48,49 +25,7 @@ function validateLlmConfigInput(body) {
   return { enabled, baseUrl, models };
 }
 
-function isLockViolation(err) {
-  if (!err) return false;
-  if (err.code === "check_violation") return true;
-  const msg = err.message || "";
-  return /locked|already.*share_mode/i.test(msg);
-}
-
 export function registerTeamShare(router) {
-  router.post("/v1/teams/:teamId/share-mode", async (ctx) => {
-    const { mode } = validateShareModeInput(ctx.json ?? {});
-    try {
-      const team = await ctx.repository.enableShareMode(ctx.params.teamId, mode);
-      return { body: team };
-    } catch (err) {
-      if (err instanceof ApiError) throw err;
-      if (isLockViolation(err)) {
-        throw new ApiError(
-          409,
-          "share_mode_locked",
-          err.message || "Team share mode is already locked",
-          { cause: err },
-        );
-      }
-      throw err;
-    }
-  });
-
-  router.get("/v1/teams/:teamId/share-mode", async (ctx) => {
-    const result = await ctx.repository.getShareMode(ctx.params.teamId);
-    return { body: result };
-  });
-
-  router.delete("/v1/teams/:teamId/share-mode", async () => {
-    // Turning sync off would leave every member holding a half-synced tree with
-    // no way to reconcile it, and the DB trigger refuses to clear the column
-    // anyway. Say so instead of failing deeper down.
-    throw new ApiError(
-      410,
-      "share_mode_permanent",
-      "Team knowledge sync cannot be disabled once enabled",
-    );
-  });
-
   router.get("/v1/teams/:teamId/workspace-config", async (ctx) => {
     const result = await ctx.repository.getWorkspaceConfig(ctx.params.teamId);
     return { body: result };

--- a/services/fc/src/lib/routes/workspaces.ts
+++ b/services/fc/src/lib/routes/workspaces.ts
@@ -67,12 +67,11 @@ export function registerWorkspaces(router) {
     return { body: w };
   });
 
-  // NOTE: GET /v1/teams/:teamId/workspace-config now lives in
-  // routes/team-share.mjs and returns the merged share+litellm shape
-  // (shareMode, syncMode, litellmTeamId).
-  // The legacy { defaultWorkspaceId, pinnedWorkspaceIds } shape is now
-  // exposed via GET /v1/teams/:teamId/workspace-defaults so the merged
-  // share-mode endpoint can own the canonical path.
+  // NOTE: GET /v1/teams/:teamId/workspace-config lives in routes/team-share.ts
+  // and returns the merged sync + litellm shape (syncMode, litellmTeamId).
+  // The legacy { defaultWorkspaceId, pinnedWorkspaceIds } shape is exposed via
+  // GET /v1/teams/:teamId/workspace-defaults so that merged endpoint can own
+  // the canonical path.
   router.get("/v1/teams/:teamId/workspace-defaults", async (ctx) => {
     const teamId = decodeURIComponent(ctx.params.teamId);
     const cfg = await ctx.repository.getTeamWorkspaceConfig(teamId);

--- a/services/fc/src/lib/supabase-repo.ts
+++ b/services/fc/src/lib/supabase-repo.ts
@@ -434,20 +434,6 @@ export function createSupabaseBusinessRepository(options) {
     return createServiceRoleClient();
   }
 
-  async function shareModeServiceRpc(rpcName, args) {
-    const admin = await serviceRoleClient("change team share mode");
-    const { data, error } = await admin.rpc(rpcName, args);
-    if (error) {
-      const code = error?.code || "";
-      if (code === "PGRST202") {
-        throw new Error(
-          `${rpcName} RPC is missing on the database (apply migration 20260604120000_disable_team_share)`,
-        );
-      }
-      throw error;
-    }
-    return data;
-  }
 
 
   return {
@@ -872,46 +858,6 @@ export function createSupabaseBusinessRepository(options) {
       if (error) throw error;
     },
 
-    // --- Team share mode (Task 3 of share-onboarding refactor) ---
-
-    async enableShareMode(teamId, mode) {
-      await requireCallerTeamOwner(teamId);
-      const args = {
-        p_team_id: teamId,
-        p_mode: mode,
-        p_git_remote_url: null,
-        p_git_auth_kind: null,
-        p_git_credential_ref: null,
-      };
-      const data = await shareModeServiceRpc("enable_team_share", args);
-      const row = requiredRow(data, "teams.enableShareMode");
-      return mapTeam(row);
-    },
-
-    async getShareMode(teamId) {
-      const { data, error } = await supabase
-        .from("teams")
-        .select("share_mode, share_enabled_at")
-        .eq("id", teamId)
-        .maybeSingle();
-      if (error) throw error;
-      if (!data) {
-        return { mode: null, enabledAt: null };
-      }
-      return {
-        mode: data.share_mode ?? null,
-        enabledAt: data.share_enabled_at ?? null,
-      };
-    },
-
-    async disableShareMode(teamId) {
-      await requireCallerTeamOwner(teamId);
-      const data = await shareModeServiceRpc("disable_team_share", {
-        p_team_id: teamId,
-      });
-      if (data) requiredRow(data, "teams.disableShareMode");
-      return { mode: null, enabledAt: null };
-    },
 
     async setupLiteLlm(teamId) {
       // Lazy import keeps the LiteLLM client out of cold-path repo constructors
@@ -1084,20 +1030,13 @@ export function createSupabaseBusinessRepository(options) {
     },
 
     async getWorkspaceConfig(teamId) {
-      const [teamRes, configRes] = await Promise.all([
-        supabase
-          .from("teams")
-          .select("share_mode")
-          .eq("id", teamId)
-          .maybeSingle(),
-        supabase
-          .from("team_workspace_config")
-          .select("sync_mode, litellm_team_id, ai_gateway_endpoint, llm_enabled, llm_base_url, llm_models")
-          .eq("team_id", teamId)
-          .maybeSingle(),
-      ]);
-      if (teamRes.error) throw teamRes.error;
-      if (configRes.error) throw configRes.error;
+      const { data: configData, error: configError } = await supabase
+        .from("team_workspace_config")
+        .select("sync_mode, litellm_team_id, ai_gateway_endpoint, llm_enabled, llm_base_url, llm_models")
+        .eq("team_id", teamId)
+        .maybeSingle();
+      if (configError) throw configError;
+      const configRes = { data: configData };
       const aiGatewayEndpoint = configRes.data?.ai_gateway_endpoint ?? null;
       // availableModels proxies the LiteLLM gateway GET /v1/models (the gateway
       // authoritatively lists its models) and degrades to [] whenever the
@@ -1122,7 +1061,6 @@ export function createSupabaseBusinessRepository(options) {
       }
       const storedModels = Array.isArray(configRes.data?.llm_models) ? configRes.data.llm_models : [];
       return {
-        shareMode: teamRes.data?.share_mode ?? null,
         syncMode: configRes.data?.sync_mode ?? null,
         litellmTeamId: configRes.data?.litellm_team_id ?? null,
         // `models` is the STORED, authoritative per-team list; `availableModels`

--- a/services/fc/src/lib/supabase-repo/shared.ts
+++ b/services/fc/src/lib/supabase-repo/shared.ts
@@ -245,8 +245,6 @@ export function mapTeam(row) {
     createdAt: row?.created_at ?? null,
     orgId: row?.oid ?? null,
     orgName: (row?.orgs as any)?.name ?? null,
-    shareMode: row?.share_mode ?? null,
-    shareEnabledAt: row?.share_enabled_at ?? null,
     visibility: row?.visibility ?? "private",
   };
 }

--- a/services/fc/test/pg-repo-contract.test.ts
+++ b/services/fc/test/pg-repo-contract.test.ts
@@ -6,7 +6,7 @@
  *     in-memory stores on each call, initialized from fixture JSON files and hardcoded data.
  *   - Tests assume pre-seeded fixture IDs: "team-1", "actor-1", "session-1",
  *     "message-1", "workspace-1", "shortcut-1", "agent-1", "idea-1", etc.
- *   - enableShareMode tests use "team-share-1" … "team-share-5", "team-share-fresh",
+ *   - team-scoped tests use "team-share-1" … "team-share-5", "team-share-fresh",
  *     "team-share-fresh-2" as team IDs that are mutated within each isolated test.
  *
  * IDENTITY CONVENTION (pg-repo, documented here as the canonical rule):
@@ -37,8 +37,7 @@
  *   that domain and seed the UUID fixtures in makeContractDb().
  *
  * WHAT IS GREEN NOW:
- *   renameTeam · getShareMode · enableShareMode (oss / lock)
- *   getTeamWorkspaceConfig · putTeamWorkspaceConfig · getWorkspaceConfig
+ *   renameTeam · getTeamWorkspaceConfig · putTeamWorkspaceConfig · getWorkspaceConfig
  */
 
 import { test } from "node:test";
@@ -138,81 +137,6 @@ test("pg-repo [teams]: putTeamWorkspaceConfig upserts row, getTeamWorkspaceConfi
   const cfg = await repo.getTeamWorkspaceConfig(T1);
   assert.ok(cfg, "config should exist after put");
   assert.equal(cfg.teamId, T1);
-});
-
-// --- getShareMode null for fresh team ---
-test("pg-repo [teams]: getShareMode returns null mode for fresh team", async () => {
-  const { pg, repo } = await makeRepo();
-  await seedTeam(pg, TSF, "team-share-fresh-slug");
-
-  const out = await repo.getShareMode(TSF);
-  assert.ok(out, "result must be returned");
-  assert.equal(out.mode, null);
-  assert.equal(out.enabledAt, null);
-});
-
-// --- enableShareMode oss ---
-test("pg-repo [teams]: enableShareMode locks team to oss share mode", async () => {
-  const { pg, repo } = await makeRepo();
-  await seedTeam(pg, TS1, "team-share-1-slug");
-
-  const out = await repo.enableShareMode(TS1, "oss");
-  assert.ok(out, "result must be returned");
-  assert.equal(out.id, TS1);
-  assert.equal(out.shareMode, "oss");
-  assert.ok(out.shareEnabledAt, "shareEnabledAt must be set");
-});
-
-test("pg-repo [teams]: enableShareMode switches mode on the same team", async () => {
-  const { pg, repo } = await makeRepo();
-  await seedTeam(pg, TS3, "team-share-3-slug");
-
-  await repo.enableShareMode(TS3, "oss");
-  await repo.enableShareMode(TS3, "oss");
-  const out = await repo.getShareMode(TS3);
-  assert.equal(out.mode, "oss");
-});
-
-// --- getShareMode reflects enabled mode ---
-test("pg-repo [teams]: getShareMode reflects a previously enabled share mode", async () => {
-  const { pg, repo } = await makeRepo();
-  await seedTeam(pg, TS4, "team-share-4-slug");
-
-  await repo.enableShareMode(TS4, "oss");
-  const out = await repo.getShareMode(TS4);
-  assert.equal(out.mode, "oss");
-  assert.ok(out.enabledAt, "enabledAt must be set once mode is enabled");
-});
-
-// --- getWorkspaceConfig returns null share for fresh team ---
-test("pg-repo [teams]: getWorkspaceConfig returns null share fields for fresh team", async () => {
-  const { pg, repo } = await makeRepo();
-  await seedTeam(pg, TSF2, "team-share-fresh-2-slug");
-
-  const out = await repo.getWorkspaceConfig(TSF2);
-  assert.ok(out, "result must be returned");
-  assert.equal(out.shareMode, null);
-});
-
-// --- getWorkspaceConfig merges share + workspace fields ---
-test("pg-repo [teams]: getWorkspaceConfig merges share + workspace fields", async () => {
-  const { pg, repo } = await makeRepo();
-  await seedTeam(pg, TS5, "team-share-5-slug");
-
-  await repo.enableShareMode(TS5, "oss");
-  const out = await repo.getWorkspaceConfig(TS5);
-  assert.ok(out, "result must be returned");
-  assert.deepEqual(Object.keys(out).sort(), [
-    "litellmTeamId",
-    "llm",
-    "shareMode",
-    "syncMode",
-  ].sort());
-  assert.equal(out.shareMode, "oss");
-  // Additive llm block: no aiGatewayEndpoint persisted → endpoint null, models [].
-  assert.ok(out.llm && typeof out.llm === "object");
-  assert.equal(out.llm.aiGatewayEndpoint, null);
-  assert.deepEqual(out.llm.models, []);
 });
 
 // --- getWorkspaceConfig surfaces gateway endpoint + proxied models ---

--- a/services/fc/test/pg-repo-teams.test.ts
+++ b/services/fc/test/pg-repo-teams.test.ts
@@ -26,7 +26,7 @@ test("listTeams returns mapped rows ordered by created_at", async () => {
   const repo = createPgBusinessRepository({ db, accessToken: "x" });
   const rows = await repo.listTeams({ limit: 50 });
   assert.equal(rows.length, 2);
-  assert.deepEqual(Object.keys(rows[0]).sort(), ["createdAt","id","name","shareEnabledAt","shareMode","slug"]);
+  assert.deepEqual(Object.keys(rows[0]).sort(), ["createdAt","id","name","slug","visibility"]);
 });
 
 test("listAllMyTeams returns only teams the caller belongs to", async () => {
@@ -70,27 +70,6 @@ test("renameTeam updates name", async () => {
   assert.equal(out.name, "Renamed");
 });
 
-test("getShareMode null for fresh team, reflects enabled mode", async () => {
-  const { db } = await makeTestDb();
-  const t = await seedTeam(db);
-  const repo = createPgBusinessRepository({ db, accessToken: "x" });
-  assert.deepEqual(await repo.getShareMode(t.id), { mode: null, enabledAt: null });
-  await repo.enableShareMode(t.id, "oss");
-  const sm = await repo.getShareMode(t.id);
-  assert.equal(sm.mode, "oss");
-  assert.equal(typeof sm.enabledAt, "string");
-});
-
-test("enableShareMode can switch modes on the same team", async () => {
-  const { db } = await makeTestDb();
-  const t = await seedTeam(db);
-  const repo = createPgBusinessRepository({ db, accessToken: "x" });
-  await repo.enableShareMode(t.id, "oss");
-  await repo.enableShareMode(t.id, "oss");
-  const sm = await repo.getShareMode(t.id);
-  assert.equal(sm.mode, "oss");
-});
-
 test("get/putTeamWorkspaceConfig roundtrip; getWorkspaceConfig merges", async () => {
   const { db } = await makeTestDb();
   const t = await seedTeam(db);
@@ -100,7 +79,6 @@ test("get/putTeamWorkspaceConfig roundtrip; getWorkspaceConfig merges", async ()
   const wc = await repo.getWorkspaceConfig(t.id);
   assert.equal(wc.syncMode, "oss");
   assert.equal(wc.litellmTeamId, "lt1");
-  assert.equal(wc.shareMode, null);
   // Defaults for the new per-team LLM config block.
   assert.equal(wc.llm.enabled, false);
   assert.equal(wc.llm.baseUrl, null);
@@ -336,32 +314,7 @@ test("listAllMyTeams requires userId context", async () => {
   await assert.rejects(() => repo.listAllMyTeams(), /missing_auth|authenticated/i);
 });
 
-// ── drift-parity: disableShareMode ──────────────────────────────────────────
-
-test("disableShareMode clears share mode (owner-only)", async () => {
-  const { db } = await makeTestDb();
-  const { teamId, userId } = await seedOwner(db);
-  const repo = createPgBusinessRepository({ db, userId });
-  await repo.enableShareMode(teamId, "oss");
-  assert.equal((await repo.getShareMode(teamId)).mode, "oss");
-
-  const out = await repo.disableShareMode(teamId);
-  assert.deepEqual(out, { mode: null, enabledAt: null });
-  assert.deepEqual(await repo.getShareMode(teamId), { mode: null, enabledAt: null });
-});
-
-test("disableShareMode rejects non-owner", async () => {
-  const { db } = await makeTestDb();
-  const { teamId } = await seedOwner(db);
-  const otherUser = crypto.randomUUID();
-  const [otherActor] = await db.insert(actors).values({ teamId, actorType: "member", displayName: "Other", userId: otherUser }).returning();
-  await db.insert(members).values({ id: otherActor.id, status: "active" });
-  await db.insert(teamMembers).values({ teamId, memberId: otherActor.id, role: "member" });
-  const repo = createPgBusinessRepository({ db, userId: otherUser });
-  await assert.rejects(() => repo.disableShareMode(teamId), /forbidden|owner/i);
-});
-
-// ── drift-parity: getLiteLlmUsage empty shape when unprovisioned ─────────────
+// ── drift-parity: team workspace config ─────────────────────────────────────
 
 test("getLiteLlmUsage returns empty shape without querying when LiteLLM unprovisioned", async () => {
   const { db } = await makeTestDb();

--- a/services/fc/test/supabase-repo.test.ts
+++ b/services/fc/test/supabase-repo.test.ts
@@ -330,7 +330,7 @@ const OWNER_AUTH = {
   },
 };
 
-function fakeSupabaseForShareMode(rpcData, rpcCalls = []) {
+function fakeSupabaseForOwnerRpc(rpcData, rpcCalls = []) {
   return fakeSupabase({
     rpcCalls,
     rpcData,
@@ -668,65 +668,6 @@ test("bootstrapTeam rejects a token the trust secret does not verify", async () 
     "a signature the trust secret rejects must not bootstrap a team",
   );
   assert.deepEqual(rpcCalls, [], "no RPC may run for an unverified caller");
-});
-
-test("enableShareMode calls the enable_team_share rpc", async () => {
-  const rpcCalls = [];
-  const repo = createRepo(fakeSupabaseForShareMode({
-      enable_team_share: [{
-        id: "team-1",
-        name: "Acme",
-        slug: "acme",
-        created_at: "2026-05-28T00:00:00Z",
-        share_mode: "oss",
-        share_enabled_at: "2026-05-28T01:00:00Z",
-        git_remote_url: null,
-        git_auth_kind: null,
-      }],
-  }, rpcCalls));
-
-  const result = await repo.enableShareMode("team-1", "oss");
-
-  assert.deepEqual(rpcCalls[0], {
-    name: "enable_team_share",
-    args: {
-      p_team_id: "team-1",
-      p_mode: "oss",
-      p_git_remote_url: null,
-      p_git_auth_kind: null,
-      p_git_credential_ref: null,
-    },
-  });
-  assert.equal(result.id, "team-1");
-  assert.equal(result.shareMode, "oss");
-  assert.equal(result.shareEnabledAt, "2026-05-28T01:00:00Z");
-});
-
-test("getShareMode returns nulls when team row absent", async () => {
-  const repo = createRepo(fakeSupabase({ tableData: { teams: [] } }));
-  const result = await repo.getShareMode("team-missing");
-  assert.deepEqual(result, {
-    mode: null,
-    enabledAt: null,
-  });
-});
-
-test("getShareMode maps team columns to camelCase", async () => {
-  const repo = createRepo(fakeSupabase({
-    tableData: {
-      teams: [{
-        share_mode: "oss",
-        share_enabled_at: "2026-05-28T03:00:00Z",
-        git_remote_url: "https://git.example.com/repo.git",
-        git_auth_kind: "https_token",
-      }],
-    },
-  }));
-  const result = await repo.getShareMode("team-3");
-  assert.deepEqual(result, {
-    mode: "oss",
-    enabledAt: "2026-05-28T03:00:00Z",
-  });
 });
 
 test("setupLiteLlm persists via update_team_litellm RPC", async () => {
@@ -1077,9 +1018,9 @@ test("setLiteLlmBudget rejects non-owner with 403", async () => {
 
 test("setLiteLlmBudget throws 409 litellm_not_provisioned when litellm_team_id is unset", async () => {
   const repo = createRepo(
-    fakeSupabaseForShareMode({}),
+    fakeSupabaseForOwnerRpc({}),
   );
-  // fakeSupabaseForShareMode has no team_workspace_config rows
+  // fakeSupabaseForOwnerRpc has no team_workspace_config rows
   await assert.rejects(
     () => repo.setLiteLlmBudget("team-budget-3", { maxBudget: 25 }),
     (err: any) => err.statusCode === 409 && err.code === "litellm_not_provisioned",
@@ -1128,7 +1069,6 @@ test("getWorkspaceConfig merges teams + team_workspace_config rows", async () =>
   // the stored, authoritative per-team list; `availableModels` is the optional
   // gateway picker source and stays empty when no gateway answers.
   assert.deepEqual(result, {
-    shareMode: "oss",
     syncMode: "git",
     litellmTeamId: "litellm-team-zzz",
     llm: {
@@ -1147,7 +1087,6 @@ test("getWorkspaceConfig returns nulls when both rows absent", async () => {
   }));
   const result = await repo.getWorkspaceConfig("team-7");
   assert.deepEqual(result, {
-    shareMode: null,
     syncMode: null,
     litellmTeamId: null,
     // Absent config means LLM disabled, not "unknown": the client renders the

--- a/services/fc/test/team-share.test.ts
+++ b/services/fc/test/team-share.test.ts
@@ -7,39 +7,10 @@ function makeRepo(overrides: any = {}) {
   const calls = [];
   const repo = {
     calls,
-    async enableShareMode(teamId, mode) {
-      calls.push({ method: "enableShareMode", teamId, mode });
-      if (overrides.enableShareModeError) throw overrides.enableShareModeError;
-      return overrides.enableShareModeResult ?? {
-        id: teamId,
-        name: "Team",
-        slug: null,
-        createdAt: null,
-        shareMode: mode,
-        shareEnabledAt: "2026-05-28T00:00:00Z",
-      };
-    },
-    async getShareMode(teamId) {
-      calls.push({ method: "getShareMode", teamId });
-      if (overrides.getShareModeError) throw overrides.getShareModeError;
-      return overrides.getShareModeResult ?? {
-        mode: "oss",
-        enabledAt: "2026-05-28T00:00:00Z",
-      };
-    },
-    async disableShareMode(teamId) {
-      calls.push({ method: "disableShareMode", teamId });
-      if (overrides.disableShareModeError) throw overrides.disableShareModeError;
-      return overrides.disableShareModeResult ?? {
-        mode: null,
-        enabledAt: null,
-      };
-    },
     async getWorkspaceConfig(teamId) {
       calls.push({ method: "getWorkspaceConfig", teamId });
       if (overrides.getWorkspaceConfigError) throw overrides.getWorkspaceConfigError;
       return overrides.getWorkspaceConfigResult ?? {
-        shareMode: "oss",
         syncMode: "oss",
         litellmTeamId: "lt-1",
         llm: {
@@ -76,107 +47,6 @@ function bearerHeaders() {
   return { Authorization: "Bearer test-token", "X-Request-Id": "req_share_test1" };
 }
 
-test("POST /v1/teams/:id/share-mode oss → 200 with team payload", async () => {
-  const repo = makeRepo();
-  const res = await handleBusinessApiRequest({
-    httpMethod: "POST",
-    path: "/v1/teams/team-1/share-mode",
-    headers: bearerHeaders(),
-    body: JSON.stringify({ mode: "oss" }),
-  }, { createRepository: () => repo });
-
-  assert.equal(res.statusCode, 200);
-  const body = JSON.parse(res.body);
-  assert.equal(body.shareMode, "oss");
-  assert.deepEqual(repo.calls[0], {
-    method: "enableShareMode",
-    teamId: "team-1",
-    mode: "oss",
-  });
-});
-
-test("POST /v1/teams/:id/share-mode rejects the retired git modes → 400", async () => {
-  // A client on an older build still offering the three-way wizard must be
-  // told, not quietly given a team pointed at a backend that is gone.
-  for (const mode of ["managed_git", "custom_git", "bogus"]) {
-    const repo = makeRepo();
-    const res = await handleBusinessApiRequest({
-      httpMethod: "POST",
-      path: "/v1/teams/team-1/share-mode",
-      headers: bearerHeaders(),
-      body: JSON.stringify({ mode }),
-    }, { createRepository: () => repo });
-
-    assert.equal(res.statusCode, 400, `${mode} must be refused`);
-    assert.equal(JSON.parse(res.body).error.code, "validation_failed");
-    assert.equal(repo.calls.length, 0, `${mode} must not reach the repository`);
-  }
-});
-
-test("POST /v1/teams/:id/share-mode with no body enables sync", async () => {
-  // `mode` is vestigial now — there is only one thing this endpoint can do.
-  const repo = makeRepo();
-  const res = await handleBusinessApiRequest({
-    httpMethod: "POST",
-    path: "/v1/teams/team-1/share-mode",
-    headers: bearerHeaders(),
-    body: JSON.stringify({}),
-  }, { createRepository: () => repo });
-
-  assert.equal(res.statusCode, 200);
-  assert.deepEqual(repo.calls[0], {
-    method: "enableShareMode",
-    teamId: "team-1",
-    mode: "oss",
-  });
-});
-
-test("POST /v1/teams/:id/share-mode lock violation (pg check_violation) → 409", async () => {
-  const lockErr = Object.assign(new Error("locked"), { code: "check_violation" });
-  const repo = makeRepo({ enableShareModeError: lockErr });
-  const res = await handleBusinessApiRequest({
-    httpMethod: "POST",
-    path: "/v1/teams/team-1/share-mode",
-    headers: bearerHeaders(),
-    body: JSON.stringify({ mode: "oss" }),
-  }, { createRepository: () => repo });
-
-  assert.equal(res.statusCode, 409);
-  const body = JSON.parse(res.body);
-  assert.equal(body.error.code, "share_mode_locked");
-});
-
-test("DELETE /v1/teams/:id/share-mode → 410, sync cannot be turned off", async () => {
-  // Disabling would strand every member with a half-synced tree and no way to
-  // reconcile; the DB trigger refuses to clear the column anyway.
-  const repo = makeRepo();
-  const res = await handleBusinessApiRequest({
-    httpMethod: "DELETE",
-    path: "/v1/teams/team-1/share-mode",
-    headers: bearerHeaders(),
-  }, { createRepository: () => repo });
-
-  assert.equal(res.statusCode, 410);
-  assert.equal(JSON.parse(res.body).error.code, "share_mode_permanent");
-  assert.equal(repo.calls.length, 0, "must not reach the repository");
-});
-
-test("GET /v1/teams/:id/share-mode → 200", async () => {
-  const repo = makeRepo();
-  const res = await handleBusinessApiRequest({
-    httpMethod: "GET",
-    path: "/v1/teams/team-1/share-mode",
-    headers: bearerHeaders(),
-  }, { createRepository: () => repo });
-
-  assert.equal(res.statusCode, 200);
-  const body = JSON.parse(res.body);
-  assert.deepEqual(body, {
-    mode: "oss",
-    enabledAt: "2026-05-28T00:00:00Z",
-  });
-});
-
 test("GET /v1/teams/:id/workspace-config → 200 with merged shape", async () => {
   const repo = makeRepo();
   const res = await handleBusinessApiRequest({
@@ -188,7 +58,6 @@ test("GET /v1/teams/:id/workspace-config → 200 with merged shape", async () =>
   assert.equal(res.statusCode, 200);
   const body = JSON.parse(res.body);
   assert.deepEqual(body, {
-    shareMode: "oss",
     syncMode: "oss",
     litellmTeamId: "lt-1",
     llm: {

--- a/tests/e2e/smoke-team-share-onboarding.test.ts
+++ b/tests/e2e/smoke-team-share-onboarding.test.ts
@@ -12,7 +12,7 @@
  *   - amuxd daemon running (pnpm daemon:run) with valid SUPABASE_URL +
  *     SUPABASE_ANON_KEY in apps/daemon/.env.
  *   - A reachable Cloud API (TEAMCLU_CLOUD_API_URL) capable of returning
- *     200 on POST /v1/teams and POST /v1/teams/:id/share-mode.
+ *     200 on POST /v1/teams.
  *   - A LiteLLM provisioning env (for the optional litellm setup path).
  *
  * Because the share UI currently has no stable `data-testid` hooks


### PR DESCRIPTION
拆自 #1077。那个 PR 删的是客户端与 daemon 侧对 `share_mode` 的判断，这个 PR 删服务端。**单独提是因为 `services/fc/**` 一合到 main 就会自动部署**（`self-host-deploy.yml`），blast radius 应该看得见。

## 为什么删

`share_mode` 是一次性开关，但产品里已经没有任何地方能打开它。全仓只有两个测试 harness 会调 `POST /v1/teams/:id/share-mode`（`tests/e2e/` 和 `apps/daemon/e2e/`），桌面端连 enable 命令都早已删除，iOS / Expo 从不碰。于是自那以后创建的每个团队这个值永远是 `null`，所有分支在它上面的代码就永远静默地什么都不做——包括一条会**删掉团队软链**的巡检。

判据换成了**团队密钥**（见 #1077 的 `sync::dispatch::run_once`）：没有密钥就没有可加解密的东西，有密钥就一定能同步。

## 删了什么

- **路由**：`POST` / `GET` / `DELETE /v1/teams/:id/share-mode` 三条
- **仓储**：pg 与 supabase 两套的 `enableShareMode` / `getShareMode` / `disableShareMode`。`disableShareMode` 其实早就是死代码——DELETE 路由直接返回 410，从来没调用过它
- **载荷**：team 对象不再带 `shareMode` / `shareEnabledAt`；`GET /v1/teams/:id/workspace-config` 不再带 `shareMode`。核对过全仓没有任何客户端读这两个字段
- **OpenAPI**：路径、`TeamShareMode` / `EnableShareModeRequest` / `ShareStatus` 三个 schema、`MergedWorkspaceConfig.shareMode`
- **测试**：针对该开关的用例删除；**只测别的东西却顺带断言了 `shareMode` 的用例改断言而不是删掉**（`listTeams` / `listAllMyTeams` / workspace-config roundtrip 等）
- **e2e harness**：`lockOss` 及其调用
- **CLAUDE.md**：那段「Share mode is a switch, not a choice」改写成现在的判据

## DB 不动

`teams.share_mode` 列和 `team_share_mode` 枚举保留：

- 枚举里在用的值删不掉
- 删列是对线上数据的单向操作，值得单独走一次迁移和一次明确决定
- drizzle schema 里也保留列定义，否则下次 `db:generate` 会生成一个删列的迁移

留着不读不写即可。

## 合并顺序

建议**在 #1077 之后合**。#1077 之前的客户端会 `GET /v1/teams/:id/share-mode`；这个端点没了之后它们拿到 404，`team_share_get_status` 失败 → status 保持 null——也就是那些团队今天本来就是的样子，不会更糟，但先合 #1077 更干净。

## 测试

- `npm run build`（部署走的那个 tsconfig，src 类型错误会把整个 self-host 部署带 migration 一起弄挂）：通过
- `npm test`：只剩 4 个**改动前就存在**的失败（3 个 deploy env 校验 + `getWorkspaceConfig.llm proxies gateway models`，后者断言 `llm.models` 等于网关列表而实现里那是 `availableModels`）
- `redocly lint`：3 errors / 7 warnings，与改动前逐条一致（拿 `git show HEAD:` 的原文件跑过对照）
- daemon 侧只动了一处测试 fixture 里的 `"shareMode": "oss"` 一行

🤖 Generated with [Claude Code](https://claude.com/claude-code)
