### PR TITLE
fix(skills): 装在盘上却在第二列看不见的 skill + 跨团队同名包

### DIFF
--- a/apps/daemon/src/backend/mod.rs
+++ b/apps/daemon/src/backend/mod.rs
@@ -107,7 +107,7 @@ pub struct TeamEnvSecretRow {
 /// needs the metadata too: the frontmatter rewrite that makes a skill legible
 /// to an agent (`when_to_use`, `when_not_to_use`, owner) is fed from these
 /// fields, and the install list carries only versions.
-#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
+#[derive(Debug, Clone, Default, serde::Deserialize, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TeamSkillRow {
     pub slug: String,

--- a/apps/daemon/src/daemon/server/rpc.rs
+++ b/apps/daemon/src/daemon/server/rpc.rs
@@ -3,6 +3,32 @@
 
 use super::*;
 
+/// The slugs the inventory's team branch speaks for: rows the registry reports
+/// as installed for this Agent.
+///
+/// This set — not the presence of an `origin.json` — is what makes a directory
+/// under `~/.agents/skills` somebody else's to report. An origin only says the
+/// directory arrived as a package; it says nothing about whether any row will
+/// actually claim it, and two ordinary flows leave packs that none does:
+///
+/// - a ClawHub install (`clawhub_install` stamps its own v1 payload, registry
+///   URL, no team) — the team registry has never heard of it;
+/// - a skill shared from this machine, whose install got recorded against the
+///   member actor rather than the Agent, so the Agent's own row is missing.
+///
+/// Judging by the origin dropped both out of the inventory entirely: skipped by
+/// the personal branch, never emitted by the team branch, invisible in the
+/// skills column while the runtime went on loading them off disk. Judging by
+/// what was actually emitted cannot do that — an unclaimed pack is reported as
+/// the Agent's own, which is the honest reading and, more to the point, is
+/// visible.
+fn claimed_slugs(rows: &[crate::backend::TeamSkillRow]) -> std::collections::BTreeSet<String> {
+    rows.iter()
+        .filter(|row| row.installed)
+        .map(|row| row.slug.clone())
+        .collect()
+}
+
 async fn skill_inventory(
     backend: &dyn crate::backend::Backend,
     team_id: &str,
@@ -14,6 +40,7 @@ async fn skill_inventory(
         .map_err(|e| e.to_string())?;
     let root = crate::runtime::team_skills::team_cloud_skills_dir(team_id);
     let mut items = Vec::new();
+    let claimed = claimed_slugs(&desired);
     for row in desired.into_iter().filter(|row| row.installed) {
         let origin = teamclu_skillpack::read_origin(&root.join(&row.slug));
         let actual_version = origin
@@ -49,9 +76,9 @@ async fn skill_inventory(
                 let Some(slug) = entry.file_name().to_str().map(str::to_owned) else {
                     continue;
                 };
-                // A registry origin means this is desktop/member managed, not an
-                // Agent personal skill. Never merge it into the daemon inventory.
-                if teamclu_skillpack::read_origin(&entry.path()).is_some() {
+                // Already spoken for by the team branch above; reporting it twice
+                // would put the same slug in the list under two ids.
+                if claimed.contains(&slug) {
                     continue;
                 }
                 let read_only = crate::config::is_inherent_skill(&slug);
@@ -97,7 +124,14 @@ fn personal_skill_dir_name(item_id: &str) -> Option<&str> {
     }
 }
 
-fn remove_personal_skill(item_id: &str) -> Result<(), (&'static str, String)> {
+/// `claimed` is the same set the inventory used to decide what this Agent's own
+/// skills are. Passing it here rather than re-deriving one is what keeps the two
+/// in step: anything this refuses must be absent from that list, or the column
+/// grows a row whose delete button can only ever fail.
+fn remove_personal_skill(
+    item_id: &str,
+    claimed: &std::collections::BTreeSet<String>,
+) -> Result<(), (&'static str, String)> {
     let slug = personal_skill_dir_name(item_id)
         .ok_or(("invalid_item", "personal skill id is invalid".into()))?;
     if crate::config::is_inherent_skill(slug) {
@@ -119,11 +153,8 @@ fn remove_personal_skill(item_id: &str) -> Result<(), (&'static str, String)> {
             "personal skill id escapes the global skill root".into(),
         ));
     }
-    if teamclu_skillpack::read_origin(&path).is_some() {
-        return Err((
-            "not_personal_skill",
-            "team or registry skills require uninstall".into(),
-        ));
+    if claimed.contains(slug) {
+        return Err(("not_personal_skill", "team skills require uninstall".into()));
     }
     match std::fs::remove_dir_all(&path) {
         Ok(()) => Ok(()),
@@ -624,7 +655,15 @@ impl DaemonServer {
                     .await;
                 }
                 (AgentCapabilityAction::RemovePersonalSkill, AgentCapabilityKind::AgentSkill) => {
-                    remove_personal_skill(&management.item_id)?;
+                    // Fetched rather than assumed: "is this the Agent's own?" is
+                    // the registry's answer, and it has to be the same answer the
+                    // list this delete came from was built on.
+                    let rows = ctx
+                        .backend
+                        .team_skills(&team_id)
+                        .await
+                        .map_err(|e| ("inventory_failed", e.to_string()))?;
+                    remove_personal_skill(&management.item_id, &claimed_slugs(&rows))?;
                 }
                 (AgentCapabilityAction::InstallTeamItem, AgentCapabilityKind::AgentMcp) => {
                     ctx.backend
@@ -1660,7 +1699,52 @@ impl DaemonServer {
 
 #[cfg(test)]
 mod agent_management_tests {
-    use super::{mcp_inventory, personal_skill_dir_name};
+    use super::{claimed_slugs, mcp_inventory, personal_skill_dir_name, remove_personal_skill};
+    use crate::backend::TeamSkillRow;
+    use std::collections::BTreeSet;
+
+    fn row(slug: &str, installed: bool) -> TeamSkillRow {
+        TeamSkillRow {
+            slug: slug.to_owned(),
+            installed,
+            ..Default::default()
+        }
+    }
+
+    /// Only an *installed* row speaks for a slug. A skill the team publishes but
+    /// this Agent never installed leaves any same-named directory on disk the
+    /// Agent's own — the team branch skips that row, so the personal branch has
+    /// to report it or nothing will.
+    #[test]
+    fn only_installed_rows_claim_a_slug() {
+        let claimed = claimed_slugs(&[row("installed-one", true), row("offered-only", false)]);
+        assert!(claimed.contains("installed-one"));
+        assert!(!claimed.contains("offered-only"));
+    }
+
+    /// The pack the customer lost: shared from this machine, so it carries a
+    /// `registry: "team"` origin, but the install was recorded against the member
+    /// actor and no row of the Agent's claims it. Judging by the origin made it
+    /// vanish; judging by the claim keeps it visible as the Agent's own.
+    #[test]
+    fn an_unclaimed_pack_stays_the_agents_own_whatever_its_origin_says() {
+        let claimed = claimed_slugs(&[row("something-else", true)]);
+        assert!(!claimed.contains("spr-investigate-auto"));
+    }
+
+    /// Delete has to refuse exactly what the list withheld, and nothing more.
+    #[test]
+    fn remove_refuses_only_the_slugs_the_team_branch_reported() {
+        let claimed: BTreeSet<String> = ["team-owned".to_owned()].into_iter().collect();
+
+        let refused = remove_personal_skill("personal:team-owned", &claimed);
+        assert_eq!(refused.unwrap_err().0, "not_personal_skill");
+
+        // Unclaimed: allowed past the guard. It fails later on a missing
+        // directory, which is a different, honest error.
+        let allowed = remove_personal_skill("personal:unclaimed-pack", &claimed);
+        assert!(!matches!(allowed, Err(("not_personal_skill", _))));
+    }
 
     #[test]
     fn personal_skill_ids_address_exactly_one_directory() {

--- a/apps/desktop/src/commands/team_skills.rs
+++ b/apps/desktop/src/commands/team_skills.rs
@@ -1128,10 +1128,14 @@ fn move_to_trash(target: &std::path::Path, slug: &str) -> Result<String, String>
 /// Retire the personal original a skill was shared from.
 ///
 /// Sharing copies the directory into the pack root and leaves the original
-/// where it was, so the slug now exists twice — and the pack root ranks below
-/// nearly every other skills root, meaning the copy the user goes on editing is
-/// the original while publish, dirty detection, and diff all read the pack. One
-/// name, one file is the only version of this that stays comprehensible.
+/// where it was, so the slug now exists twice and the two copies compete. The
+/// pack root (`~/.agents/skills`) is rank 2 — ahead of every root but the
+/// workspace's `.claude/skills` (daemon `skill_dir_specs`, desktop loader
+/// `priorityOrder`) — so unless the original sat in that one root, the pack is
+/// what agents load and what publish, dirty detection and diff all read.
+/// Whichever copy loses, its author goes on editing a file nothing reads, and
+/// nothing tells them so. One name, one file is the only version of this that
+/// stays comprehensible.
 ///
 /// Refuses rather than guesses in three cases: a source that resolves to the
 /// pack itself (nothing to retire, and removing it would delete what was just

--- a/apps/desktop/src/commands/team_skills.rs
+++ b/apps/desktop/src/commands/team_skills.rs
@@ -916,13 +916,27 @@ pub struct TeamSkillInspectResult {
 /// happened to name, so a personal skill sitting at the pack's path was
 /// registered as that team version and auto-follow saw nothing left to do —
 /// content that was never the team's, pinned as the team's, permanently.
+/// Whether an installed pack was laid down for a different team than the one
+/// being reconciled.
+///
+/// An absent id on either side answers `false`: packs written before the field
+/// existed carry none, and "I cannot tell whose this is" is not evidence that it
+/// is somebody else's any more than it is evidence that it is ours.
+fn belongs_to_another_team(origin: &SkillOrigin, team_id: Option<&str>) -> bool {
+    team_id
+        .map(str::trim)
+        .filter(|id| !id.is_empty())
+        .zip(origin.team_id.as_deref())
+        .is_some_and(|(want, have)| want != have)
+}
+
 #[tauri::command]
 pub fn team_skill_inspect(
     slug: String,
     expected_version: Option<i64>,
     team_id: Option<String>,
 ) -> Result<TeamSkillInspectResult, String> {
-    let _ = (expected_version, team_id);
+    let _ = expected_version;
     let slug = slug.trim().to_string();
     validate_slug(&slug)?;
     let target = global_skills_dir()?.join(&slug);
@@ -942,7 +956,25 @@ pub fn team_skill_inspect(
 
     let origin = read_origin(&target);
 
-    if let Some(origin) = origin.as_ref().filter(|o| o.registry != SOURCE_TEAM) {
+    // Another registry's pack, or another *team's*. Both mean the same thing to
+    // every caller — "not ours to touch" — so both answer `foreign`.
+    //
+    // The team half matters because one flat root serves every team the user
+    // belongs to and a slug can only name one directory. Two teams publishing
+    // `deploy-check` therefore contend for `~/.agents/skills/deploy-check`, and
+    // with the team ignored the reconcile could not see the contention: on
+    // differing version numbers it overwrote the other team's bytes in place,
+    // and on matching ones — the common case, since every team's versions start
+    // at 1 — it did nothing at all and left the runtime serving one team's file
+    // as the other team's skill. Reporting it stops auto-follow and puts the
+    // collision on screen, which is not co-existence but is at least the truth.
+    //
+    // An absent `teamId` (packs from before the field existed) is not evidence
+    // of anything and never makes a pack foreign.
+    if let Some(origin) = origin
+        .as_ref()
+        .filter(|o| o.registry != SOURCE_TEAM || belongs_to_another_team(o, team_id.as_deref()))
+    {
         return Ok(TeamSkillInspectResult {
             slug,
             state: "foreign".to_string(),
@@ -1475,6 +1507,50 @@ mod tests {
         std::fs::create_dir_all(&dir).unwrap();
         std::fs::write(dir.join("SKILL.md"), "body\n").unwrap();
         dir
+    }
+
+    fn origin_for(team: Option<&str>) -> SkillOrigin {
+        SkillOrigin {
+            version: ORIGIN_VERSION,
+            registry: SOURCE_TEAM.to_string(),
+            slug: "deploy-check".into(),
+            installed_version: "3".into(),
+            installed_at: 1,
+            team_id: team.map(str::to_owned),
+            files: None,
+        }
+    }
+
+    /// One flat root serves every team the user belongs to, and a slug names
+    /// exactly one directory — so two teams that both publish `deploy-check`
+    /// contend for the same one. With the team ignored the reconcile could not
+    /// see the contention: on differing version numbers it overwrote the other
+    /// team's bytes, and on matching ones — the common case, every team's
+    /// versions starting at 1 — it did nothing and left the runtime serving one
+    /// team's file as the other team's skill.
+    #[test]
+    fn a_pack_installed_for_another_team_is_not_ours() {
+        assert!(belongs_to_another_team(
+            &origin_for(Some("team-a")),
+            Some("team-b")
+        ));
+        assert!(!belongs_to_another_team(
+            &origin_for(Some("team-a")),
+            Some("team-a")
+        ));
+    }
+
+    /// Neither side knowing is not evidence either way, and guessing "somebody
+    /// else's" would strand every pack written before the field existed in a
+    /// conflict nobody can resolve.
+    #[test]
+    fn an_unrecorded_team_never_makes_a_pack_foreign() {
+        assert!(!belongs_to_another_team(&origin_for(None), Some("team-b")));
+        assert!(!belongs_to_another_team(&origin_for(Some("team-a")), None));
+        assert!(!belongs_to_another_team(
+            &origin_for(Some("team-a")),
+            Some("  ")
+        ));
     }
 
     #[test]

--- a/packages/app/src/lib/skills/__tests__/auto-follow.test.ts
+++ b/packages/app/src/lib/skills/__tests__/auto-follow.test.ts
@@ -66,6 +66,40 @@ describe('planReconcile', () => {
     expect(plan.install).toEqual([])
   })
 
+  test('holds removal back for a pack the other ledger still wants', () => {
+    // Auto-follow reads the Agent's desired set, but installs recorded before
+    // that was true sit on the member's. A pack missing from the Agent's set is
+    // therefore not evidence anybody stopped wanting it — planning removal off
+    // the Agent's set alone emptied a machine's team packs on the first tick
+    // after the switch.
+    const plan = planReconcile(
+      [],
+      [pack('deploy-check', '4')],
+      new Set(),
+      TEAM,
+      new Set(['deploy-check']),
+    )
+    expect(plan.remove).toEqual([])
+  })
+
+  test('still removes a pack neither ledger asks for', () => {
+    const plan = planReconcile(
+      [],
+      [pack('deploy-check', '4')],
+      new Set(),
+      TEAM,
+      new Set(['something-else']),
+    )
+    expect(plan.remove).toEqual(['deploy-check'])
+  })
+
+  test('the other ledger holds removal back without ever forcing an install', () => {
+    // `alsoWanted` is a removal veto, not a desired set: a slug only the member
+    // still wants must not start being downloaded onto the Agent's disk.
+    const plan = planReconcile([], [], new Set(), TEAM, new Set(['deploy-check']))
+    expect(plan.install).toEqual([])
+  })
+
   test('never removes another team’s pack', () => {
     // One flat directory serves every team the user belongs to. Reconciling for
     // team B must not read team A's packs as leftovers — that turned every team

--- a/packages/app/src/lib/skills/auto-follow.ts
+++ b/packages/app/src/lib/skills/auto-follow.ts
@@ -82,16 +82,24 @@ export const RECONCILE_INTERVAL_MS = 10 * 60 * 1000
  * switching teams makes the other team's packs look like leftovers and deletes
  * them — and packs installed before the id was recorded are never removable at
  * all, because "I cannot tell whose this is" is not evidence that it is mine.
+ *
+ * `alsoWanted` names slugs some *other* ledger still asks for, and only ever
+ * holds removal back. Auto-follow reads the Agent's desired set, while installs
+ * recorded before that was true sit on the member's — so for as long as both
+ * ledgers exist, a pack missing from the Agent's set is not evidence that
+ * anybody stopped wanting it. Planning removal off the Agent's set alone would
+ * empty a machine's team packs on the first tick after the switch.
  */
 export function planReconcile(
   desired: DesiredSkill[],
   onDisk: OnDiskSkill[],
   blocked: ReadonlySet<string>,
   teamId: string,
+  alsoWanted: ReadonlySet<string> = new Set(),
 ): ReconcilePlan {
   const bySlug = new Map(onDisk.map((p) => [p.slug, p]))
   const plan: ReconcilePlan = { install: [], remove: [], blocked: [] }
-  const wanted = new Set<string>()
+  const wanted = new Set<string>(alsoWanted)
 
   for (const skill of desired) {
     if (!skill.installed) continue

--- a/packages/app/src/stores/team-share-browser.ts
+++ b/packages/app/src/stores/team-share-browser.ts
@@ -1267,6 +1267,10 @@ export const useTeamShareBrowserStore = create<TeamShareBrowserState>((set, get)
   sharePersonalSkill: async (slug, input) => {
     const teamId = currentTeamId()
     if (!teamId) throw new Error('no current team')
+    // The Agent whose disk this pack ends up on. Sharing is only reachable when
+    // that Agent is this machine — `localSkillFiles` hands back the files to
+    // share from nowhere else — so this is the local daemon's actor.
+    const subjectActorId = get().subjectActorId
     const wsPath = await workspacePath()
     const skill = get().skills.items.find((s) => s.slug === slug)
     if (!skill || skill.kind !== 'personal') {
@@ -1342,7 +1346,16 @@ export const useTeamShareBrowserStore = create<TeamShareBrowserState>((set, get)
     })
     await ensureAgentsSkillsPaths(wsPath)
 
-    await backend.teamSkills.installTeamSkill(teamId, input.slug, { version: 1 })
+    // Against the Agent, not the member. `team_skill_install_from_dir` above put
+    // the pack in this machine's skills root, and the machine is an Agent — the
+    // daemon's inventory answers "what do I have installed" about its own actor,
+    // so a record on the member is one nothing that renders this list ever reads.
+    // That is how a freshly shared skill used to disappear from the column the
+    // moment it was shared.
+    await backend.teamSkills.installTeamSkill(teamId, input.slug, {
+      version: 1,
+      ...(subjectActorId ? { actorId: subjectActorId } : {}),
+    })
 
     // Retire the original now that the pack exists and the server knows about
     // it. Leaving it produces two files answering to one name, and the pack
@@ -1369,6 +1382,7 @@ export const useTeamShareBrowserStore = create<TeamShareBrowserState>((set, get)
   publishSkillVersion: async (slug, input) => {
     const teamId = currentTeamId()
     if (!teamId) throw new Error('no current team')
+    const subjectActorId = get().subjectActorId
     const wsPath = await workspacePath()
     const skill = get().skills.items.find((s) => s.slug === slug)
     if (!skill) throw new Error(`${slug} is not in the registry`)
@@ -1421,7 +1435,12 @@ export const useTeamShareBrowserStore = create<TeamShareBrowserState>((set, get)
         isGlobal: true,
       },
     })
-    await backend.teamSkills.installTeamSkill(teamId, slug, { version: version.version })
+    // Same reason as Share: the pack landed on this Agent's disk, so this Agent
+    // is who the install belongs to.
+    await backend.teamSkills.installTeamSkill(teamId, slug, {
+      version: version.version,
+      ...(subjectActorId ? { actorId: subjectActorId } : {}),
+    })
 
     // Publishing a version off local edits forks this skill from the
     // marketplace copy it was adopted from. Staying subscribed would let the

--- a/packages/app/src/stores/team-share-browser.ts
+++ b/packages/app/src/stores/team-share-browser.ts
@@ -1495,19 +1495,30 @@ export const useTeamShareBrowserStore = create<TeamShareBrowserState>((set, get)
   reconcileSkills: async () => {
     const teamId = currentTeamId()
     if (!teamId) return
-    // Deliberately independent of `subjectActorId`. Auto-follow is always about
-    // the signed-in member's own disk — it fetches the member's desired set
-    // (`listTeamSkills(teamId)`, no actorId) no matter which Agent the browser
-    // pane happens to be pointed at. Bailing out when a subject was selected
-    // meant the Agent picker, which auto-selects the sole manageable Agent the
-    // moment the Skills or MCP section opens, silently switched local
-    // auto-follow off for the rest of the session.
+    // Scoped to this *machine's* Agent, not to `subjectActorId`. The disk being
+    // reconciled is this device's, so the ledger that describes it is the local
+    // daemon's — and reading it from the Agent picker instead would make
+    // auto-follow follow whichever Agent the browser pane happens to point at,
+    // including somebody else's machine. `getKnownLocalDaemonActorId` is fixed
+    // for the device, so the picker cannot switch auto-follow off either, which
+    // is what an earlier `subjectActorId` dependency did.
+    //
+    // Both ledgers are read. Installs made before this was Agent-scoped sit on
+    // the member's, so the Agent's set is the authority on what to install and
+    // what version to write back, while removal is held to what *neither*
+    // ledger asks for. Planning removal off the Agent's set alone would empty a
+    // machine's team packs on the first tick after the switch.
     const backend = getBackend()
+    const localAgentId = getKnownLocalDaemonActorId()
     let desired
+    let memberDesired
     let listed: OnDiskSkill[]
     try {
-      ;[desired, listed] = await Promise.all([
+      ;[memberDesired, desired, listed] = await Promise.all([
         backend.teamSkills.listTeamSkills(teamId),
+        localAgentId
+          ? backend.teamSkills.listTeamSkills(teamId, { actorId: localAgentId })
+          : backend.teamSkills.listTeamSkills(teamId),
         listInstalledPacks(),
       ])
     } catch {
@@ -1515,6 +1526,10 @@ export const useTeamShareBrowserStore = create<TeamShareBrowserState>((set, get)
       // a failed fetch must never be read as "the team removed everything".
       return
     }
+    // Only ever holds removal back — see `planReconcile`.
+    const stillWantedByMember = new Set(
+      memberDesired.filter((s) => s.installed).map((s) => s.slug),
+    )
 
     const states: Record<string, SkillLocalState> = {}
     const errors: Record<string, string> = {}
@@ -1542,7 +1557,7 @@ export const useTeamShareBrowserStore = create<TeamShareBrowserState>((set, get)
     // queues them for a fresh install, and the tick overwrites edits it was
     // never able to see.
     const onDisk = await listInstalledPacks().catch(() => listed)
-    const plan = planReconcile(desired, onDisk, blocked, teamId)
+    const plan = planReconcile(desired, onDisk, blocked, teamId, stillWantedByMember)
 
     for (const { slug, version } of plan.install) {
       try {
@@ -1591,7 +1606,13 @@ export const useTeamShareBrowserStore = create<TeamShareBrowserState>((set, get)
     }))
     for (const { slug, version } of planVersionWriteback(desired, settled)) {
       try {
-        await backend.teamSkills.installTeamSkill(teamId, slug, { version })
+        // Against the same Agent whose desired set drove this tick; writing the
+        // member's row here would leave the Agent's forever behind and every
+        // pack permanently "updating…".
+        await backend.teamSkills.installTeamSkill(teamId, slug, {
+          version,
+          ...(localAgentId ? { actorId: localAgentId } : {}),
+        })
       } catch {
         // The disk is already right; only the record is behind, and the next
         // tick recomputes this from fresh server state and tries again.

--- a/services/fc/src/lib/pg-repo/team-skills.ts
+++ b/services/fc/src/lib/pg-repo/team-skills.ts
@@ -38,7 +38,7 @@ import {
   amuxcBlobs,
 } from "../../db/schema/index.js";
 import { ApiError } from "../http-utils.js";
-import { requireActorForTeam, resolveTeamRole } from "./authz.js";
+import { checkAgentOwnership, requireActorForTeam, resolveTeamRole } from "./authz.js";
 import { alignTeamSkillToMarketplace } from "./marketplace.js";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -190,13 +190,22 @@ export function makeTeamSkillsRepo(db: DbLike, ctx: TeamSkillsCtx) {
   }
 
   /**
-   * The three install gates from the design doc:
-   *   - target is the caller's own member actor  → allow
+   * The install gates:
+   *   - target is the caller's own member actor   → allow
+   *   - target is an agent the caller owns        → allow
    *   - target is a visibility='team' agent actor → require team admin
    *   - target is somebody else's member actor    → deny, always
    *
    * The last one is deliberate: an admin owns the team's shared agents, not a
    * teammate's personal setup. "Push a skill onto a person" is not a thing.
+   *
+   * The owner gate exists because a member's own machine is an agent, not a
+   * member actor: sharing or publishing a skill from the desktop installs it
+   * into that machine's skills root, and the install has to be recorded against
+   * the agent that will be asked "what do you have installed". Without this
+   * branch that record could only land on the member, where the agent's own
+   * inventory never looks — the skill then sat on disk, loaded by the runtime,
+   * and missing from the skills column.
    */
   async function assertCanInstallFor(userId: string, teamId: string, targetActorId: string) {
     const callerActorId = await requireActorForTeam(db, userId, teamId);
@@ -225,6 +234,7 @@ export function makeTeamSkillsRepo(db: DbLike, ctx: TeamSkillsCtx) {
         "cannot install on behalf of another member — only on yourself or a team agent",
       );
     }
+    if (await checkAgentOwnership(db, userId, targetActorId)) return callerActorId;
     if (agentRow.visibility !== "team") {
       throw new ApiError(
         403,
@@ -869,6 +879,25 @@ export function makeTeamSkillsRepo(db: DbLike, ctx: TeamSkillsCtx) {
         throw new ApiError(400, "validation_failed", `unknown version: ${body.version}`);
       }
 
+      // Delete-then-insert rather than ON CONFLICT, for the same reason the
+      // Supabase implementation does it: the unique index coalesces
+      // `workspace_id`, and an expression index cannot be named as a conflict
+      // target here. Drizzle 0.36 does not render an `sql` fragment in
+      // `target` — it emitted the literal identifier `"undefined"`, so the
+      // statement was `on conflict ("actor_id","skill_id","scope","undefined")`
+      // and every install died on `42703 column "undefined" does not exist`.
+      // Nothing caught it because no test had ever executed this method; the
+      // route tests stub the repo, and the daemon logs the failure at warn and
+      // retries forever.
+      await db
+        .delete(teamSkillInstalls)
+        .where(
+          and(
+            eq(teamSkillInstalls.actorId, targetActorId),
+            eq(teamSkillInstalls.skillId, skill.id),
+            eq(teamSkillInstalls.scope, scope),
+          ),
+        );
       const [row] = await (db.insert(teamSkillInstalls) as any)
         .values({
           teamId,
@@ -877,15 +906,6 @@ export function makeTeamSkillsRepo(db: DbLike, ctx: TeamSkillsCtx) {
           installedVersion: version,
           scope,
           workspaceId,
-        })
-        .onConflictDoUpdate({
-          target: [
-            teamSkillInstalls.actorId,
-            teamSkillInstalls.skillId,
-            teamSkillInstalls.scope,
-            sql`coalesce(${teamSkillInstalls.workspaceId}, '00000000-0000-0000-0000-000000000000'::uuid)`,
-          ],
-          set: { installedVersion: version, updatedAt: new Date() },
         })
         .returning();
       return mapInstall(row);

--- a/services/fc/src/lib/supabase-repo.ts
+++ b/services/fc/src/lib/supabase-repo.ts
@@ -3655,7 +3655,7 @@ export function createSupabaseBusinessRepository(options) {
 
       const { data: agentRow, error: agErr } = await supabase
         .from("agents")
-        .select("visibility")
+        .select("visibility, owner_member_id")
         .eq("id", targetActorId)
         .maybeSingle();
       if (agErr) throw agErr;
@@ -3665,6 +3665,16 @@ export function createSupabaseBusinessRepository(options) {
           "forbidden",
           "cannot install on behalf of another member — only on yourself or a team agent",
         );
+      }
+      // An agent you own is yours to install on, personal or not. A member's own
+      // machine is an agent, not a member actor, and it is that actor the daemon
+      // answers "what do I have installed" about — so sharing or publishing a
+      // skill from the desktop has to be recordable against it. Without this the
+      // record could only land on the member, where the machine's own inventory
+      // never looks, and the skill went missing from the skills column while the
+      // runtime went on loading it off disk.
+      if (agentRow.owner_member_id && agentRow.owner_member_id === callerActorId) {
+        return callerActorId;
       }
       if (agentRow.visibility !== "team") {
         throw new ApiError(

--- a/services/fc/test/pg-repo-team-skills-authz.test.ts
+++ b/services/fc/test/pg-repo-team-skills-authz.test.ts
@@ -17,7 +17,7 @@ import assert from "node:assert/strict";
 import { eq } from "drizzle-orm";
 import { makeTestDb } from "./db/pglite.js";
 import { createPgBusinessRepository } from "../src/lib/pg-repo/index.js";
-import { actors, members, teamMembers } from "../src/db/schema/index.js";
+import { actors, agents, members, teamMembers } from "../src/db/schema/index.js";
 
 const BOOTSTRAP = `
 create table if not exists team_skills (
@@ -82,6 +82,17 @@ create table if not exists team_skill_installs (
   installed_at timestamptz not null default now(),
   updated_at timestamptz not null default now()
 );
+-- The upsert in installTeamSkill names exactly this index as its conflict
+-- target, so without it every install here dies inside pglite rather than in
+-- the gate under test. coalesce is in the key because NULLs never collide in
+-- a unique index — mirrors 20260806000000_team_skills_registry.sql.
+create unique index if not exists uniq_team_skill_install
+  on team_skill_installs (
+    actor_id,
+    skill_id,
+    scope,
+    coalesce(workspace_id, '00000000-0000-0000-0000-000000000000'::uuid)
+  );
 `;
 
 async function seedMember(db: any, teamId: string, userId: string, role = "member") {
@@ -92,6 +103,21 @@ async function seedMember(db: any, teamId: string, userId: string, role = "membe
   await db.insert(members).values({ id: actor.id, status: "active" });
   await db.insert(teamMembers).values({ teamId, memberId: actor.id, role });
   return actor;
+}
+
+async function seedAgentActor(db: any, teamId: string, ownerMemberId: string, visibility: string) {
+  const [agentActor] = await db
+    .insert(actors)
+    .values({ teamId, actorType: "agent", displayName: "TestBot" })
+    .returning();
+  await db.insert(agents).values({
+    id: agentActor.id,
+    agentKind: "claude",
+    status: "active",
+    visibility,
+    ownerMemberId,
+  });
+  return agentActor;
 }
 
 /** A team whose owner published `deploy-check`, plus an unrelated plain member. */
@@ -121,6 +147,54 @@ async function scenario() {
 
   return { db, team, ownerActor, memberActor, memberRepo };
 }
+
+/**
+ * A member's own machine is an agent, and it is the actor the daemon's inventory
+ * answers about. Sharing or publishing a skill from the desktop installs into
+ * that machine's skills root, so the install has to be recordable against it —
+ * the alternative is a record on the member that the machine's own inventory
+ * never reads, which is how a freshly shared skill vanished from the column.
+ *
+ * Its visibility is `personal`; the pre-existing team-agent gate needs admin and
+ * would have refused this outright.
+ */
+test("a member may install on a personal agent they own", async () => {
+  const { db, team, memberActor, memberRepo } = await scenario();
+  const agentActor = await seedAgentActor(db, team.id, memberActor.id, "personal");
+
+  const install = await memberRepo.installTeamSkill(team.id, "deploy-check", {
+    actorId: agentActor.id,
+    version: 1,
+  });
+
+  assert.equal(install.actorId, agentActor.id);
+});
+
+/** Ownership, not agent-ness: somebody else's machine stays off limits. */
+test("a member may not install on an agent they do not own", async () => {
+  const { db, team, ownerActor, memberRepo } = await scenario();
+  const agentActor = await seedAgentActor(db, team.id, ownerActor.id, "personal");
+
+  await assert.rejects(
+    () => memberRepo.installTeamSkill(team.id, "deploy-check", { actorId: agentActor.id, version: 1 }),
+    /personal/,
+  );
+});
+
+/** And the install the owner just recorded is theirs to take back. */
+test("an owner may uninstall from their own personal agent", async () => {
+  const { db, team, memberActor, memberRepo } = await scenario();
+  const agentActor = await seedAgentActor(db, team.id, memberActor.id, "personal");
+  await memberRepo.installTeamSkill(team.id, "deploy-check", {
+    actorId: agentActor.id,
+    version: 1,
+  });
+
+  await memberRepo.uninstallTeamSkill(team.id, "deploy-check", { actorId: agentActor.id });
+
+  const rows = await memberRepo.listTeamSkillInstalls(team.id, { actorId: agentActor.id });
+  assert.equal(rows.length, 0);
+});
 
 test("a plain member can publish a new version of somebody else's skill", async () => {
   const { team, ownerActor, memberActor, memberRepo } = await scenario();


### PR DESCRIPTION
## 起因

客户报：`~/.agents/skills/spr-investigate-auto` 好好躺在盘上、`SKILL.md` 也在，但 Skills 第二列里没有它，其他 skill 都在。

排查出来是**两套"扫描"的分工没对齐**，而且踩中的不止一条路径；顺着"一个扁平 root 服务所有团队"这个前提往下查，又带出跨团队同名包的问题。

> 前置背景：第二列的行**不来自** 5 个 runtime root 的扫描，而来自 daemon 的 `skill_inventory`——它只看「团队注册表里 `installed` 的行」+「`~/.agents/skills` 下的非团队目录」。设置页 → Roles & Skills 才走 `skill_dir_specs` 那五个 root。排查"某个 skill 看不见"必须先问在哪个界面。

## 1. inventory 安全网

`skill_inventory` 的 personal 分支用「有没有 `.clawhub/origin.json`」判定一个目录该不该让给团队分支。但 origin 只说明这个目录是以"包"的形式装进来的，**完全不代表真有哪一行会认领它**。两条日常路径都会留下没人认领的包：

- **ClawHub 市场安装** —— `clawhub_install` 写的是自己那套 v1 payload（`registry` 是市场地址、没有 `teamId`、没有 `files`），团队注册表根本没听说过它；
- **从本机分享出去的 skill** —— install 记账没落到这个 Agent 头上（见 §2），它自己的行是缺的。

两种情况下 personal 分支跳过、team 分支不产出，skill 在第二列彻底消失，而 runtime 照常从盘上加载它。

判据改成「**团队分支这一趟实际产出了哪些 slug**」。没被认领的包报成 Agent 自己的——身份也许标得不够准，但它可见。`remove_personal_skill` 接同一个集合：它拒绝的必须正好是列表扣下的那些。

## 2. 记账记到 Agent 头上

`skill_inventory` 问服务端的是「**我**装了哪些团队 skill」，caller 是 daemon 那个 agent actor。而 `sharePersonalSkill` / `publishSkillVersion` 从桌面调 `installTeamSkill` 时不带 `actorId`，服务端 `targetActorId = body.actorId ?? callerActorId` 把这笔账记在了**人**头上。两个账本对不上，于是自己分享出去的 skill 转头就从列表里消失。

- 客户端两处带上 `subjectActorId`。
- 服务端 `assertCanInstallFor` / `assertCanInstallTeamSkillFor` 增加「**target 是调用者自己拥有的 agent**」放行分支。成员自己的机器是个 `visibility='personal'` 的 agent，原有门禁只认「自己的 member actor」和「`visibility='team'` + 团队管理员」，会把这条正当路径 403 掉。**两套 repo 都改了**：`pg-repo` 和 `supabase-repo`（部署默认走后者）。

## 3. 自动跟随整体改成 Agent 作用域

`reconcileSkills` 之前读的是成员的 desired set，现在按本机 daemon 的 actor 读、按它回写。用 `getKnownLocalDaemonActorId()` 而不是 `subjectActorId`——被 reconcile 的是这台设备的盘，跟着 Agent 选择器走会让自动跟随去跟随别人的机器，而且选择器一自动选中就会把本地自动跟随关掉（那正是被替换的那段注释在防的事）。

**删除不跟着切。** 历史上的 install 行记在人头上，切过去以后 Agent 侧的 desired set 是空的，照它删会在切换后第一个 tick 把这台机器上该团队的团队包**全部删光**。`planReconcile` 因此多收一个 `alsoWanted`，只用来否决删除：装/升级/回写看 Agent 的账本，删只删两个账本都不要的。

## 4. 另一个团队的同名包不再被静默顶掉

`team_skill_inspect` 的签名里一直有 `team_id`，函数体第一行是 `let _ = (expected_version, team_id);` —— **参数被显式丢掉**。于是两个团队都有 `deploy-check` 时，谁都看不见冲突：

- **版本号不同** → `planReconcile` 的 `bySlug` 只按 slug 索引，直接就地覆写另一个团队的字节，切回去再反向覆写一遍；
- **版本号相同**（常态——每个团队的版本都从 1 开始）→ 什么都不做，runtime 就一直把一个团队的文件当另一个团队的 skill 加载，回写还会往服务端写一条「已收敛」。

现在 `origin.team_id` 存在且不等于当前 team 时返回 `foreign`。`foreign` 已经是「不是我们的，别碰」的既有语义，会被 `blocked` 接住。这**不解决共存**——一个 slug 只有一个目录——但从"静默给错内容"变成"看得见的冲突"。任一侧没有 team id 都不算 foreign。

> 删除路径本来就有 `pack.teamId !== teamId` 的防护，那一条一直是对的。

## 5. 顺带：一个从没被执行过的 upsert

`pg-repo` 的 `installTeamSkill` 用 `onConflictDoUpdate`，冲突目标里放了个 `` sql`coalesce(...)` `` 表达式，而 drizzle 0.36 把它渲染成字面标识符 `"undefined"`：

```sql
on conflict ("actor_id","skill_id","scope","undefined")
```

每次调用必死在 `42703 column "undefined" does not exist`。用一个"装到自己头上"的探针证实过——那条路径不碰本 PR 新加的门禁，照样炸。之所以一直没人发现：**这个方法从来没被任何测试执行过**（`team-skills.test.ts` 把 repo 打了桩），而 daemon 那侧把失败降级成 `tracing::warn!` 无限重试。改成 delete-then-insert，和 `supabase-repo` 里同样理由的同样写法对齐。**只影响 `BACKEND_KIND=postgres`**；部署默认的 supabase 路径本来就是对的，所以这不是客户的病因，是个潜伏的雷。

## 6. 一处过期注释

`team_skill_retire_personal` 的注释说 pack root「排在几乎所有其他 skills root 之下」，方向反了：`~/.agents/skills` 是 rank 2，只低于工作区的 `.claude/skills`。行为没问题，改的是那段解释。

## 部署影响

本 PR 触碰 `services/fc/**`，合并到 main 会触发 `self-host-deploy.yml`。

## 验证

- `cargo test -p amuxd --locked` → lib 1358 全绿（新增 3 个 inventory / remove 守卫用例）
- 桌面 `--lib team_skill` 17 全绿（新增 2 个跨团队用例）；`cargo fmt --check` 干净
- `pnpm test:unit` → 2958 全绿（新增 3 个 `planReconcile` 用例）；`pnpm lint` 0 error
- FC `tsc -p tsconfig.json`（部署构建用的那个）干净；`test/pg-repo-team-skills-authz.test.ts` 9/9 全绿（新增 3 个门禁用例，并给测试 bootstrap 补上 `uniq_team_skill_install`）
- FC 全量有 7 个红（deploy-env-parity / pg-repo-teams / pg-repo-contract）。把本 PR 的 FC 改动还原后是**一模一样的 7 个**，既有问题；FC 测试目前不进 CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)