### PR TITLE
fix(app): restore workspace file-tree header entry and right-panel 'files' tab

### DIFF
--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -18,6 +18,7 @@ import { appDisplayName } from "@/lib/build-config";
 import { buildSessionDeeplink } from "@/lib/session-deeplink";
 import { markStartup } from "@/lib/startup-perf";
 import {
+  BookOpen,
   FolderGit,
   ChevronLeft,
   X,
@@ -1132,6 +1133,18 @@ function AppContent() {
                   label={t("chat.actorSheet.title", "Actors")}
                   isActive={isPanelOpen && activeTab === "actors"}
                   onClick={() => isPanelOpen && activeTab === "actors" ? closePanel() : openPanel("actors")}
+                />
+              )}
+              {/* Workspace file tree. Restored as a header entry that opens the
+                  right-panel `files` tab (rendered by the existing FileBrowser,
+                  not the deleted RAG KnowledgeBrowser). Gate mirrors the
+                  pre-#1054 condition: desktop + a workspace path. */}
+              {capabilities.workspace && (
+                <HeaderPanelTab
+                  icon={BookOpen}
+                  label={t("navigation.files", "files")}
+                  isActive={isPanelOpen && activeTab === "files"}
+                  onClick={() => isPanelOpen && activeTab === "files" ? closePanel() : openPanel("files")}
                 />
               )}
               {/* The team shared files tab moved to the Knowledge entry in the

--- a/packages/app/src/components/panel/RightPanel.tsx
+++ b/packages/app/src/components/panel/RightPanel.tsx
@@ -2,6 +2,7 @@ import { SessionDiffPanel } from '@/components/chat/SessionDiffPanel'
 import { SessionList } from '@/components/chat/SessionList'
 import { SessionActorPanel } from '@/components/chat/SessionActorSheet'
 import { ShortcutsPanel } from './ShortcutsPanel'
+import { FileBrowser } from '@/components/workspace/FileBrowser'
 import { ActorsView } from '@/components/panel/ActorsView'
 import { useWorkspaceStore } from '@/stores/workspace'
 import { useSessionStore } from '@/stores/session'
@@ -12,7 +13,7 @@ import type { FileDiff } from '@/stores/session-types'
 interface RightPanelProps {
   diff?: FileDiff[]
   // Override the active tab from store
-  defaultTab?: 'diff' | 'session' | 'shortcuts' | 'actors'
+  defaultTab?: 'diff' | 'session' | 'shortcuts' | 'files' | 'actors'
   // Compact mode for file mode layout
   compact?: boolean
 }
@@ -29,11 +30,17 @@ export function RightPanel({ diff, defaultTab, compact }: RightPanelProps) {
   const activeTab = defaultTab || storeActiveTab
   const diffData = diff ?? sessionDiff
 
+  // `files` renders a self-contained FileBrowser that owns its own scroll
+  // area and keeps a fixed toolbar. That pane must NOT sit inside an outer
+  // `overflow-auto` scroller — otherwise the toolbar header scrolls away with
+  // the tree. Give it a bounded flex column so the inner scroll area (and thus
+  // the pinned toolbar) works.
+  const selfScrolling = activeTab === 'files'
   const noPadding = activeTab === 'session' || activeTab === 'actors'
 
   return (
     <div
-      className={`h-full min-h-0 overflow-auto ${noPadding ? '' : (compact ? 'p-1' : 'p-2')}`}
+      className={`h-full min-h-0 ${selfScrolling ? 'overflow-hidden flex flex-col' : 'overflow-auto'} ${noPadding ? '' : (compact ? 'p-1' : 'p-2')}`}
     >
       {activeTab === 'shortcuts' && (
         <ShortcutsPanel />
@@ -43,6 +50,9 @@ export function RightPanel({ diff, defaultTab, compact }: RightPanelProps) {
       )}
       {activeTab === 'session' && (
         <SessionList compact={compact} />
+      )}
+      {activeTab === 'files' && (
+        <FileBrowser variant="panel" />
       )}
       {activeTab === 'actors' && (
         activeSessionId

--- a/packages/app/src/locales/en.json
+++ b/packages/app/src/locales/en.json
@@ -431,6 +431,7 @@
   "navigation": {
     "changes": "Changes",
     "shortcuts": "Shortcuts",
+    "files": "Files",
     "hideTabs": "Hide files",
     "restoreTabs": "Show files",
     "collapsePanel": "Collapse panel",

--- a/packages/app/src/locales/zh-CN.json
+++ b/packages/app/src/locales/zh-CN.json
@@ -431,6 +431,7 @@
   "navigation": {
     "changes": "变更",
     "shortcuts": "快捷方式",
+    "files": "文件",
     "hideTabs": "隐藏文件",
     "restoreTabs": "显示文件",
     "collapsePanel": "收起面板",

--- a/packages/app/src/stores/workspace.ts
+++ b/packages/app/src/stores/workspace.ts
@@ -72,11 +72,17 @@ export interface FileNode {
 
 // Right panel tab type.
 //
-// `files` (the RAG knowledge browser) and `teamShared` are gone. The knowledge
-// browser went with the RAG module; `teamShared` rendered the team repo dir,
-// which holds nothing now that knowledge syncs to `shared/knowledge`, and it
-// had already lost its header entry to the left-nav Knowledge column.
-export type RightPanelTab = "diff" | "shortcuts" | "actors";
+// `files` is the workspace file tree (rendered by the `FileBrowser` component,
+// which still lives in components/workspace/). It was dropped from the right
+// panel by #1054 (which removed the separate RAG `KnowledgeBrowser` that also
+// lived under this tab id), but the `FileBrowser` itself was retained — it is
+// also rendered in the left team-share column. Restoring the `files` tab here
+// re-opens the right-panel entry to the same `FileBrowser`, with no RAG
+// dependency. `teamShared` is intentionally NOT restored: that tab pointed at
+// the team repo dir, which is empty now that knowledge syncs to
+// `shared/knowledge`, and its header entry already moved to the left-nav
+// Knowledge column.
+export type RightPanelTab = "diff" | "shortcuts" | "files" | "actors";
 
 // Undo operation types for file operations
 interface UndoOperation {


### PR DESCRIPTION
## What

Restores the conversation-header **files** entry and the right-panel **`files`** tab so users can open the workspace file tree from the header again. Renders the **existing** `FileBrowser` component (workspace file tree), not the deleted RAG `KnowledgeBrowser` — no RAG dependency.

## Why

PR #1054 (Remove RAG module) deleted the right-panel `files` tab and its header entry because that tab happened to render the RAG `KnowledgeBrowser`, which was removed with the whole RAG module. But the workspace `FileBrowser` component itself was retained (it still renders in the left team-share column) — only its right-panel/header wiring was lost, so users could no longer open the workspace file tree from the conversation header.

This re-opens that path using the retained `FileBrowser`, with no RAG reintroduction. `teamShared` is intentionally left gone: it pointed at the (now empty) team repo dir and its header entry already moved to the left-nav Knowledge column.

## Changes

- `packages/app/src/stores/workspace.ts` — re-add `"files"` to `RightPanelTab`; updated the comment to explain the retained-`FileBrowser` rationale vs. the deleted RAG browser.
- `packages/app/src/components/panel/RightPanel.tsx` — import `FileBrowser`; render `{activeTab === 'files' && <FileBrowser variant="panel" />}` and restore the `selfScrolling` layout branch so the toolbar stays pinned (mirrors the pre-#1054 layout).
- `packages/app/src/App.tsx` — re-add the `BookOpen` import and the header `files` `HeaderPanelTab`, gated on `capabilities.workspace` (the pre-#1054 condition); placed between Actors and Changes.
- `packages/app/src/locales/{en,zh-CN}.json` — re-add the `navigation.files` key (dropped as a dead key by #1054; now has a consumer again).

## Verification

- ✅ `tsc --noEmit` — clean
- ✅ `vitest run src/components/workspace/__tests__/FileBrowser.test.tsx` — 3/3 pass
- ✅ `vitest run src/__tests__/App.test.tsx` — 12/12 pass (no conflict with the #1054-era `files`-tab/`BookOpen` assertion removal)
- ✅ `vitest run src/__tests__/i18n-parity.test.ts` — 5/5 pass (key restored on both locales)
- ✅ `pnpm lint` — 0 errors (only pre-existing `useEffect` deps warning in App.tsx, unrelated)

## Out of scope

- The **Actors** ("人群") header tab is intentionally **not** touched — its code is intact; it is hidden only because login is currently broken (no active session → `hasCurrentSession` gate). It returns once the backend is reachable; no code change needed there.
- Does not reintroduce the RAG module / `KnowledgeBrowser`.
- Does not restore the `teamShared` tab.
