### PR TITLE
docs(fc): 把建团队那句注释指向真正开通 LiteLLM 的路由

### DIFF
--- a/services/fc/src/lib/routes/teams.ts
+++ b/services/fc/src/lib/routes/teams.ts
@@ -33,12 +33,19 @@ export function registerTeams(router) {
 
   // POST /v1/teams — slim team creation (Task 3 of share-onboarding refactor).
   //
-  // LiteLLM provisioning is now an explicit second step that the client
-  // triggers via POST /v1/teams/:teamId/litellm/setup. This route only writes
-  // the teams row + the bare team_workspace_config row (sync_mode=NULL,
-  // litellm_team_id=NULL). The response still includes aiGatewayEndpoint and
-  // litellmKey as null fields for back-compat with the Rust client
-  // (`Option<String>` — see apps/desktop/src/commands/oss_sync/fc_client.rs).
+  // This route only writes the teams row + the bare team_workspace_config row
+  // (sync_mode=NULL, litellm_team_id=NULL); LiteLLM is provisioned separately.
+  //
+  // Not via POST /v1/teams/:teamId/litellm/setup, which this comment used to
+  // name: no client calls that route. Provisioning happens lazily on the first
+  // POST /v1/teams/:teamId/litellm/member-key, which the daemon fires itself
+  // (`runtime/managed_llm.rs`) and which auto-provisions when
+  // `litellm_team_id` is still NULL (`supabase-repo.ts` `ensureMemberKey`).
+  // The explicit /setup route remains for ops and for tests.
+  //
+  // The response still includes aiGatewayEndpoint and litellmKey as null
+  // fields for back-compat with the Rust client (`Option<String>` — see
+  // apps/desktop/src/commands/oss_sync/fc_client.rs).
   router.post("/v1/teams", async (ctx) => {
     const body = ctx.json;
     // name is optional: when omitted, the repository seeds it from the caller's


### PR DESCRIPTION
`POST /v1/teams` 上那句注释说 LiteLLM 的开通「is now an explicit second step that the client triggers via POST /v1/teams/:teamId/litellm/setup」。

**机制说对了，地址说错了。**

没有任何客户端调 `/litellm/setup`。曾经调它的那个桌面端命令在 #1086 里作为不可达代码删掉了，也没有东西替代它。但开通照常发生，只是在别处：daemon 会打一次 `POST /v1/teams/:id/litellm/member-key`（`runtime/managed_llm.rs`：「Kick a one-time, fire-and-forget LiteLLM member-key provisioning POST」），而 `ensureMemberKey` 在 `litellm_team_id` 仍为 NULL 时会直接 `provisionLiteLlmForTeam(teamId)`。

这句注释是有代价的 —— **我自己就被它带偏过**。在 #1086 里我照着它推断「要么开通改由人工做，要么客户端入口缺失」，还差点据此开一个「功能可能不可达」的 issue。真去查 `routes/team-litellm.ts` 才看到旁边那条自助路由。下一个读到它的人会重走一遍这段弯路，或者更糟——直接得出「这个功能坏了」的结论。

改后的注释指向真实路径，并说明 `/setup` 留着是给 ops 和测试用的，免得它看起来像被遗弃的死路由。

## 范围

纯注释，无行为变化 —— diff 里除注释行外零改动（已用 `git diff | grep -v '^[+-]\s*//'` 验证为空）。

## ⚠️ 它会触发一次真实部署

`services/fc/**` 是 `self-host-deploy.yml` 的触发路径，合进 main 会 SSH 到 ECS、重建 fc 容器、compose up、等健康检查、跑 e2e。为一行注释走一次线上部署可能不划算 —— 如果你想把它攒着和别的 FC 改动一起走，这个 PR 放着不合也没问题。

## 本机验证的边界

`services/fc` 不在 pnpm workspace 里（`pnpm-workspace.yaml` 只含 `apps/*` 和 `packages/*`），依赖在 Docker 构建里装，所以本地没有 node_modules，`pnpm build` / `pnpm typecheck` 都报 `Cannot find type definition file for 'node'`，**跑不了**。改动纯注释所以类型上无风险，但这个限制值得记一笔：碰 `services/fc/src/**` 的真实代码改动，本地是验证不到的（而 FC 的类型错误会让整个 self-host 部署挂掉）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
