### PR TITLE
fix(daemon): 隔离两个读了不属于自己的 home 的测试

### DIFF
--- a/apps/daemon/src/config/workspace_control.rs
+++ b/apps/daemon/src/config/workspace_control.rs
@@ -1688,6 +1688,13 @@ mod tests {
 
     #[test]
     fn get_mcp_empty_workspace_returns_empty_map() {
+        // `get_mcp` merges the device-scoped `~/.amuxd/mcp.json` into whatever
+        // the workspace has, so "empty" is only true of an isolated home. This
+        // was the one test in this module that skipped the isolation its
+        // neighbours all take, which made it fail on any machine with device
+        // MCP servers configured — CI has none, so it passed there and only
+        // ever failed for whoever ran the suite locally.
+        let _isolation = isolate_global_config();
         let dir = tempfile::tempdir().unwrap();
         let store = make_store();
         let servers = store.get_mcp(&ws_id(dir.path())).unwrap();

--- a/apps/daemon/src/daemon/runtime_env.rs
+++ b/apps/daemon/src/daemon/runtime_env.rs
@@ -133,6 +133,18 @@ mod execution_context_tests {
 
     #[tokio::test]
     async fn configured_team_fallback_keeps_workspace_context_revisions_equal() {
+        // The two `assemble` calls below are compared field by field, and one of
+        // those fields — `OPENCODE_CONFIG` — is derived from the amuxd home.
+        // Every test that *moves* `HOME` / `AMUXD_HOME` already serializes on
+        // `TEST_HOME_LOCK`, but a reader that does not join them can still have
+        // one moved out from under it between its two reads, and then the two
+        // maps differ by a path rooted in two different tempdirs. That is what
+        // made this fail in CI while passing alone. The guard both joins that
+        // lock and pins a home of its own, so the comparison no longer depends
+        // on whatever the ambient environment happens to be.
+        let amuxd_home = tempfile::tempdir().unwrap();
+        let _env = crate::test_brand_env::BrandEnvGuard::set_amuxd_home(amuxd_home.path());
+
         let workspace = tempfile::tempdir().unwrap();
         let backend = Arc::new(MockBackend::default());
         backend.state().workspaces_by_id.insert(


### PR DESCRIPTION
`cargo test -p amuxd` 有两个红灯，都不是任何人的改动引起的：**一个只在 CI 红，一个只在本机红**。根因是同一个错误——读进程级路径状态，却没参与守护它的那把锁。

## 一、只在 CI 红：读侧没进锁

`configured_team_fallback_keeps_workspace_context_revisions_equal` 调两次 `assemble()` 然后逐字段比对，而其中一个字段 `OPENCODE_CONFIG` 是从 amuxd home 推导的。

值得说清楚的是：**mutator 侧其实很自律**。`team_link` / `workspace_link` / `global_team_store` / `workspace_resolver` / `claude_skills` / `cli::process` / `daemon::server` 里每一处 `set_var("HOME", …)` 都守着 `TEST_HOME_LOCK`。问题在于这个测试自己不改 HOME，也就没参与那把锁——于是一个**完全合法地持着锁的** mutator 在它两次 `assemble` 之间改掉了 HOME。锁序列化了改的人，没序列化读的人。

失败形态自己写明了答案——两个 map 只差 `OPENCODE_CONFIG`，指向两个不同 tempdir，一个带 `.amuxd/` 一个不带：

```
left:  /tmp/.tmp37LI8p/teams/_unclaimed/state/opencode.json
right: /tmp/.tmpERE1gP/.amuxd/teams/_unclaimed/state/opencode.json
```

那正是「AMUXD_HOME 直接指向 tempdir」和「HOME 指向 tempdir 再派生 `$HOME/.amuxd`」两种写法的指纹。单独跑必绿，负载高时假红（在 #1086 上红过一次）。

## 二、只在本机红：漏了本模块自己的隔离

`get_mcp_empty_workspace_returns_empty_map` 是它那个模块里**唯一没调 `isolate_global_config()`** 的测试——紧挨着它下面那个还专门注释了「the isolation is what keeps this test off the real one」。

`get_mcp` 会合并设备级的 `~/.amuxd/mcp.json`，所以「empty」只在隔离的 home 里成立。CI runner 上没有这个文件，所以那边一直绿；**只有在真机上跑全量的人会红**（我这台有 4 个设备级 MCP server），方向正好和第一个相反。

## 修法

两个都用仓库自己的 `BrandEnvGuard::set_amuxd_home`——它进同一把 `TEST_HOME_LOCK`、钉一个临时 home、drop 时还原。没有发明新机制，也没加新的 clippy 例外（`#[tokio::test]` 里持 `std::sync::Mutex` 跨 `.await` 的写法 `workspace_resolver.rs:849` 已有先例，照着走的）。

## 验证

`cargo test -p amuxd --locked --bin amuxd` → **1354 passed, 0 failed**，这是本机第一次完全干净的一趟。两个测试单独跑也都绿。fmt 干净。

顺带：这个仓库里同族的「只在干净机器上通过 / 负载高假红」的测试，这是第三和第四个了（另外两个是 pi catalog probe 和 mqtt reconnect）。`apps/desktop/tests/*.rs` 那两个集成测试在 CI 里根本不跑（`rust-check` 只跑 `--lib`），是同一个盲区的另一面，值得单独看一眼。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
