### PR TITLE
fix(desktop): 菜单栏跟随 UI 语言，冷启动改问操作系统而不是 LANG

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9843,6 +9843,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "sys-locale",
  "tar",
  "tauri",
  "tauri-build",

--- a/apps/desktop/Cargo.toml
+++ b/apps/desktop/Cargo.toml
@@ -46,6 +46,9 @@ tauri-plugin-window-state = "2"
 # clipboard-manager plugin is text/image only, so it cannot carry file paths.
 tauri-plugin-clipboard = "2.1"
 tauri-plugin-aptabase = "1.0"
+# OS UI language for the cold-start menu bar / tray labels. Windows does not
+# set LANG or LC_ALL, so an env probe can never see a Chinese Windows.
+sys-locale = "0.3"
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order"] }
 prost = "0.13"

--- a/apps/desktop/src/commands/app_menu.rs
+++ b/apps/desktop/src/commands/app_menu.rs
@@ -3,53 +3,172 @@
 //! Replaces Tauri's default menu so we can:
 //! - use the product brand name (not Cargo package `teamclu`) in About/Hide/Quit
 //! - add Settings… with ⌘, that opens the in-app Settings dialog
+//! - render the bar in the language the user picked in Settings
+//!
+//! That last one is not free. `muda::PredefinedMenuItemType::text` is a
+//! hardcoded English table on *every* platform (`&Copy`, `Cu&t`, `Select &All`,
+//! `&Exit`, …), so passing `None` for an item's text pins it to English no
+//! matter what the OS or the app is set to. Every label therefore has to be
+//! supplied explicitly, which is what `MenuLabels` carries.
+//!
+//! The frontend owns the translations (`menu.*` in the locale files) and pushes
+//! a full set through `update_app_menu_labels` on boot and on every language
+//! change. The EN/ZH tables below only cover cold start, before any JS has run.
 
-use std::sync::Mutex;
-
+use serde::Deserialize;
 use tauri::{
     menu::{
-        AboutMetadata, Menu, MenuItem, MenuItemBuilder, PredefinedMenuItem, Submenu,
-        HELP_SUBMENU_ID, WINDOW_SUBMENU_ID,
+        AboutMetadata, Menu, MenuItemBuilder, PredefinedMenuItem, Submenu, HELP_SUBMENU_ID,
+        WINDOW_SUBMENU_ID,
     },
-    AppHandle, Emitter, Manager, State, Wry,
+    AppHandle, Emitter, Manager,
 };
 
 use crate::branding;
+use crate::commands::prefers_zh_locale;
 
 pub const APP_SETTINGS_ID: &str = "app_settings";
 pub const OPEN_SETTINGS_EVENT: &str = "open-app-settings";
 
-pub struct AppMenuState {
-    pub settings: Mutex<MenuItem<Wry>>,
+/// Every string the menu bar shows, minus the brand name this module splices
+/// into About / Hide / Quit.
+///
+/// Field names mirror the `menu.*` keys in `packages/app/src/locales/*.json`;
+/// the frontend sends this whole struct as one camelCase object.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MenuLabels {
+    // Submenu titles.
+    pub file: String,
+    pub edit: String,
+    pub view: String,
+    pub window: String,
+    pub help: String,
+    // Items.
+    pub settings: String,
+    pub undo: String,
+    pub redo: String,
+    pub cut: String,
+    pub copy: String,
+    pub paste: String,
+    pub select_all: String,
+    pub minimize: String,
+    /// Windows / Linux wording for the Window submenu.
+    pub maximize: String,
+    /// macOS wording for the same item — AppKit calls it Zoom, not Maximize.
+    pub zoom: String,
+    pub fullscreen: String,
+    /// Windows / Linux File submenu.
+    pub close: String,
+    /// macOS, where the item closes the window rather than the document.
+    pub close_window: String,
+    pub about: String,
+    pub hide: String,
+    pub hide_others: String,
+    pub services: String,
+    pub quit: String,
 }
 
-impl AppMenuState {
-    pub fn new(settings: MenuItem<Wry>) -> Self {
+impl MenuLabels {
+    /// Mnemonics (`&`) match what muda ships, so the Alt-key shortcuts Windows
+    /// users have today survive the switch to explicit labels.
+    pub fn en() -> Self {
         Self {
-            settings: Mutex::new(settings),
+            file: "&File".into(),
+            edit: "&Edit".into(),
+            view: "&View".into(),
+            window: "&Window".into(),
+            help: "&Help".into(),
+            settings: "Settings…".into(),
+            undo: "Undo".into(),
+            redo: "Redo".into(),
+            cut: "Cu&t".into(),
+            copy: "&Copy".into(),
+            paste: "&Paste".into(),
+            select_all: "Select &All".into(),
+            minimize: "&Minimize".into(),
+            maximize: "Ma&ximize".into(),
+            zoom: "Zoom".into(),
+            fullscreen: "Toggle Full Screen".into(),
+            close: "&Close".into(),
+            close_window: "C&lose Window".into(),
+            about: "About".into(),
+            hide: "Hide".into(),
+            hide_others: "Hide Others".into(),
+            services: "Services".into(),
+            quit: "Quit".into(),
+        }
+    }
+
+    /// Only the top-level titles carry a mnemonic, in the `文件(&F)` form
+    /// Windows uses for CJK menus — that is where Alt navigation starts, and
+    /// tacking `(&X)` onto every item makes the open menu hard to read.
+    pub fn zh() -> Self {
+        Self {
+            file: "文件(&F)".into(),
+            edit: "编辑(&E)".into(),
+            view: "视图(&V)".into(),
+            window: "窗口(&W)".into(),
+            help: "帮助(&H)".into(),
+            settings: "设置…".into(),
+            undo: "撤销".into(),
+            redo: "重做".into(),
+            cut: "剪切".into(),
+            copy: "复制".into(),
+            paste: "粘贴".into(),
+            select_all: "全选".into(),
+            minimize: "最小化".into(),
+            maximize: "最大化".into(),
+            zoom: "缩放".into(),
+            fullscreen: "切换全屏".into(),
+            close: "关闭".into(),
+            close_window: "关闭窗口".into(),
+            about: "关于".into(),
+            hide: "隐藏".into(),
+            hide_others: "隐藏其他".into(),
+            services: "服务".into(),
+            quit: "退出".into(),
+        }
+    }
+
+    /// Cold-start labels, picked from the OS locale because the persisted UI
+    /// language lives in the webview's localStorage and no JS has run yet.
+    pub fn for_os_locale() -> Self {
+        if prefers_zh_locale() {
+            Self::zh()
+        } else {
+            Self::en()
         }
     }
 }
 
-fn prefers_zh_locale() -> bool {
-    let hint = std::env::var("LC_ALL")
-        .or_else(|_| std::env::var("LANG"))
-        .unwrap_or_default()
-        .to_lowercase();
-    hint.starts_with("zh") || hint.contains(".zh") || hint.contains("_zh")
-}
-
-fn settings_label_cold_start() -> &'static str {
-    if prefers_zh_locale() {
-        "设置…"
-    } else {
-        "Settings…"
+/// Windows spells a CJK mnemonic as `文件(&F)`; muda's macOS backend strips the
+/// `&` and nothing else, which would leave a stray `文件(F)` in the menu bar.
+/// Drop the whole group there. English labels (`&File`) have no group and pass
+/// through untouched.
+#[cfg(target_os = "macos")]
+fn label(text: &str) -> String {
+    let Some(head) = text.strip_suffix(')') else {
+        return text.to_string();
+    };
+    match head.rfind("(&") {
+        Some(i) if head[i + 2..].chars().count() == 1 => head[..i].to_string(),
+        _ => text.to_string(),
     }
 }
 
-/// Build the app-wide menu and install it. Returns the Settings item so callers
-/// can keep a handle for locale updates.
-pub fn install_app_menu(app: &AppHandle) -> tauri::Result<MenuItem<Wry>> {
+#[cfg(not(target_os = "macos"))]
+fn label(text: &str) -> String {
+    text.to_string()
+}
+
+/// Build the app-wide menu and install it.
+///
+/// Called again with a fresh `labels` whenever the UI language changes. Tauri's
+/// `set_menu` removes the previous menu first, so re-installing is the
+/// supported way to relabel — and it beats holding a `set_text` handle for each
+/// of the ~20 items, half of which only exist behind a `#[cfg]`.
+pub fn install_app_menu(app: &AppHandle, labels: &MenuLabels) -> tauri::Result<()> {
     let brand = branding::brand_name(app.config().product_name.as_deref());
     let version = app.package_info().version.to_string();
     let about_metadata = AboutMetadata {
@@ -59,33 +178,56 @@ pub fn install_app_menu(app: &AppHandle) -> tauri::Result<MenuItem<Wry>> {
         authors: app.config().bundle.publisher.clone().map(|p| vec![p]),
         ..Default::default()
     };
+    let about_brand = label(&format!("{} {brand}", labels.about));
 
-    let settings = MenuItemBuilder::with_id(APP_SETTINGS_ID, settings_label_cold_start())
+    let settings = MenuItemBuilder::with_id(APP_SETTINGS_ID, label(&labels.settings))
         .accelerator("CmdOrCtrl+,")
         .build(app)?;
+
+    // Linux/BSD get neither the File submenu nor the macOS app submenu, so
+    // nothing there hosts Settings…. Keep one builder rather than fanning it
+    // out per platform, and mark the binding used on those targets.
+    #[cfg(any(
+        target_os = "linux",
+        target_os = "dragonfly",
+        target_os = "freebsd",
+        target_os = "netbsd",
+        target_os = "openbsd"
+    ))]
+    let _ = &settings;
+
+    #[cfg(target_os = "macos")]
+    let maximize_label = label(&labels.zoom);
+    #[cfg(not(target_os = "macos"))]
+    let maximize_label = label(&labels.maximize);
+
+    #[cfg(target_os = "macos")]
+    let close_label = label(&labels.close_window);
+    #[cfg(not(target_os = "macos"))]
+    let close_label = label(&labels.close);
 
     let window_menu = Submenu::with_id_and_items(
         app,
         WINDOW_SUBMENU_ID,
-        "Window",
+        label(&labels.window),
         true,
         &[
-            &PredefinedMenuItem::minimize(app, None)?,
-            &PredefinedMenuItem::maximize(app, None)?,
+            &PredefinedMenuItem::minimize(app, Some(&label(&labels.minimize)))?,
+            &PredefinedMenuItem::maximize(app, Some(&maximize_label))?,
             #[cfg(target_os = "macos")]
             &PredefinedMenuItem::separator(app)?,
-            &PredefinedMenuItem::close_window(app, None)?,
+            &PredefinedMenuItem::close_window(app, Some(&close_label))?,
         ],
     )?;
 
     let help_menu = Submenu::with_id_and_items(
         app,
         HELP_SUBMENU_ID,
-        "Help",
+        label(&labels.help),
         true,
         &[
             #[cfg(not(target_os = "macos"))]
-            &PredefinedMenuItem::about(app, None, Some(about_metadata.clone()))?,
+            &PredefinedMenuItem::about(app, Some(&about_brand), Some(about_metadata.clone()))?,
         ],
     )?;
 
@@ -95,16 +237,16 @@ pub fn install_app_menu(app: &AppHandle) -> tauri::Result<MenuItem<Wry>> {
         &brand,
         true,
         &[
-            &PredefinedMenuItem::about(app, Some(&format!("About {brand}")), Some(about_metadata))?,
+            &PredefinedMenuItem::about(app, Some(&about_brand), Some(about_metadata))?,
             &PredefinedMenuItem::separator(app)?,
             &settings,
             &PredefinedMenuItem::separator(app)?,
-            &PredefinedMenuItem::services(app, None)?,
+            &PredefinedMenuItem::services(app, Some(&label(&labels.services)))?,
             &PredefinedMenuItem::separator(app)?,
-            &PredefinedMenuItem::hide(app, Some(&format!("Hide {brand}")))?,
-            &PredefinedMenuItem::hide_others(app, None)?,
+            &PredefinedMenuItem::hide(app, Some(&label(&format!("{} {brand}", labels.hide))))?,
+            &PredefinedMenuItem::hide_others(app, Some(&label(&labels.hide_others)))?,
             &PredefinedMenuItem::separator(app)?,
-            &PredefinedMenuItem::quit(app, Some(&format!("Quit {brand}")))?,
+            &PredefinedMenuItem::quit(app, Some(&label(&format!("{} {brand}", labels.quit))))?,
         ],
     )?;
 
@@ -122,38 +264,44 @@ pub fn install_app_menu(app: &AppHandle) -> tauri::Result<MenuItem<Wry>> {
             )))]
             &Submenu::with_items(
                 app,
-                "File",
+                label(&labels.file),
                 true,
                 &[
                     #[cfg(not(target_os = "macos"))]
                     &settings,
                     #[cfg(not(target_os = "macos"))]
                     &PredefinedMenuItem::separator(app)?,
-                    &PredefinedMenuItem::close_window(app, None)?,
+                    &PredefinedMenuItem::close_window(app, Some(&close_label))?,
                     #[cfg(not(target_os = "macos"))]
-                    &PredefinedMenuItem::quit(app, Some(&format!("Quit {brand}")))?,
+                    &PredefinedMenuItem::quit(
+                        app,
+                        Some(&label(&format!("{} {brand}", labels.quit))),
+                    )?,
                 ],
             )?,
             &Submenu::with_items(
                 app,
-                "Edit",
+                label(&labels.edit),
                 true,
                 &[
-                    &PredefinedMenuItem::undo(app, None)?,
-                    &PredefinedMenuItem::redo(app, None)?,
+                    &PredefinedMenuItem::undo(app, Some(&label(&labels.undo)))?,
+                    &PredefinedMenuItem::redo(app, Some(&label(&labels.redo)))?,
                     &PredefinedMenuItem::separator(app)?,
-                    &PredefinedMenuItem::cut(app, None)?,
-                    &PredefinedMenuItem::copy(app, None)?,
-                    &PredefinedMenuItem::paste(app, None)?,
-                    &PredefinedMenuItem::select_all(app, None)?,
+                    &PredefinedMenuItem::cut(app, Some(&label(&labels.cut)))?,
+                    &PredefinedMenuItem::copy(app, Some(&label(&labels.copy)))?,
+                    &PredefinedMenuItem::paste(app, Some(&label(&labels.paste)))?,
+                    &PredefinedMenuItem::select_all(app, Some(&label(&labels.select_all)))?,
                 ],
             )?,
             #[cfg(target_os = "macos")]
             &Submenu::with_items(
                 app,
-                "View",
+                label(&labels.view),
                 true,
-                &[&PredefinedMenuItem::fullscreen(app, None)?],
+                &[&PredefinedMenuItem::fullscreen(
+                    app,
+                    Some(&label(&labels.fullscreen)),
+                )?],
             )?,
             &window_menu,
             &help_menu,
@@ -161,7 +309,7 @@ pub fn install_app_menu(app: &AppHandle) -> tauri::Result<MenuItem<Wry>> {
     )?;
 
     let _ = app.set_menu(menu)?;
-    Ok(settings)
+    Ok(())
 }
 
 /// Show the main window and ask the frontend to open Settings.
@@ -173,15 +321,41 @@ pub fn open_app_settings(app: &AppHandle) {
     }
 }
 
+/// Rebuild the menu bar in the UI's current language.
 #[tauri::command]
-pub fn update_app_menu_labels(
-    state: State<'_, AppMenuState>,
-    settings: String,
-) -> Result<(), String> {
-    state
-        .settings
-        .lock()
-        .map_err(|e| e.to_string())?
-        .set_text(settings)
-        .map_err(|e| e.to_string())
+pub fn update_app_menu_labels(app: AppHandle, labels: MenuLabels) -> Result<(), String> {
+    install_app_menu(&app, &labels).map_err(|e| e.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The frontend sends whatever `menu.*` holds; a missing key would silently
+    /// drop the whole payload, so the two tables must stay field-complete.
+    #[test]
+    fn label_tables_are_distinct_and_filled() {
+        let en = MenuLabels::en();
+        let zh = MenuLabels::zh();
+        assert_ne!(en.file, zh.file);
+        assert_ne!(en.quit, zh.quit);
+        assert!(!zh.select_all.is_empty());
+        assert!(!en.select_all.is_empty());
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn macos_drops_cjk_mnemonic_groups() {
+        assert_eq!(label("文件(&F)"), "文件");
+        assert_eq!(label("&File"), "&File");
+        // Not a mnemonic — a parenthesised word must survive.
+        assert_eq!(label("设置(高级)"), "设置(高级)");
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    #[test]
+    fn other_platforms_keep_mnemonics_verbatim() {
+        assert_eq!(label("文件(&F)"), "文件(&F)");
+        assert_eq!(label("&File"), "&File");
+    }
 }

--- a/apps/desktop/src/commands/mod.rs
+++ b/apps/desktop/src/commands/mod.rs
@@ -46,6 +46,23 @@ pub mod workspace_files;
 #[cfg(target_os = "windows")]
 use crate::process_util::CommandNoWindow;
 
+/// True when the OS is set to a Chinese locale.
+///
+/// Cold-start only: the language the user picked in Settings lives in the
+/// webview's localStorage, which Rust cannot read before the frontend boots,
+/// so the native menu bar and tray start from the OS and get corrected the
+/// moment `syncTrayMenuLabels` runs.
+///
+/// `sys_locale` asks the OS itself. The previous `LC_ALL` / `LANG` probe was a
+/// Unix convention that Windows does not follow — neither variable is normally
+/// set there, so a Chinese Windows always cold-started in English.
+pub fn prefers_zh_locale() -> bool {
+    sys_locale::get_locale()
+        .unwrap_or_default()
+        .to_lowercase()
+        .starts_with("zh")
+}
+
 /// The short application name, injected at compile time via `build.rs`.
 pub const APP_SHORT_NAME: &str = env!("APP_SHORT_NAME");
 /// Deep-link scheme for this build (`app.scheme`, default `teamclu`).

--- a/apps/desktop/src/commands/tray_menu.rs
+++ b/apps/desktop/src/commands/tray_menu.rs
@@ -27,14 +27,10 @@ impl TrayMenuState {
 /// Labels for the three tray items: show main / agent settings / quit.
 pub type TrayLabels = (&'static str, &'static str, &'static str);
 
-/// Pick cold-start tray labels from OS locale (frontend will re-sync once UI
-/// i18n is ready). Prefer zh when LANG / LC_ALL looks Chinese; otherwise EN.
+/// Pick cold-start tray labels from the OS locale (the frontend re-syncs once
+/// UI i18n is ready).
 pub fn initial_tray_labels() -> TrayLabels {
-    let hint = std::env::var("LC_ALL")
-        .or_else(|_| std::env::var("LANG"))
-        .unwrap_or_default()
-        .to_lowercase();
-    if hint.starts_with("zh") || hint.contains(".zh") || hint.contains("_zh") {
+    if super::prefers_zh_locale() {
         tray_labels_zh()
     } else {
         tray_labels_en()

--- a/apps/desktop/src/lib.rs
+++ b/apps/desktop/src/lib.rs
@@ -612,9 +612,13 @@ pub fn run() {
             }
 
             // --- App menu bar (Settings… ⌘,, brand-correct About/Hide/Quit) ---
-            match commands::app_menu::install_app_menu(app.handle()) {
-                Ok(settings_item) => {
-                    app.manage(commands::app_menu::AppMenuState::new(settings_item));
+            // Cold-start from the OS locale; the frontend pushes the UI's own
+            // language through `update_app_menu_labels` as soon as it boots.
+            match commands::app_menu::install_app_menu(
+                app.handle(),
+                &commands::app_menu::MenuLabels::for_os_locale(),
+            ) {
+                Ok(()) => {
                     app.on_menu_event(|app, event| {
                         if event.id().as_ref() == commands::app_menu::APP_SETTINGS_ID {
                             commands::app_menu::open_app_settings(app);

--- a/packages/app/src/lib/sync-tray-menu.ts
+++ b/packages/app/src/lib/sync-tray-menu.ts
@@ -1,6 +1,42 @@
 import i18n from '@/lib/i18n'
 import { isTauri } from '@/lib/utils'
 
+/**
+ * The native menu bar has no OS-supplied translations to fall back on — muda
+ * pins every predefined item to English — so Rust needs the full label set, not
+ * just the ones we added ourselves. Fallbacks mirror `menu.*` in `zh-CN.json`.
+ *
+ * `&` marks the Windows Alt-key mnemonic; macOS strips it. CJK spells it as a
+ * trailing `(&X)` group, which Rust drops on macOS.
+ */
+function appMenuLabels() {
+  return {
+    file: i18n.t('menu.file', '文件(&F)'),
+    edit: i18n.t('menu.edit', '编辑(&E)'),
+    view: i18n.t('menu.view', '视图(&V)'),
+    window: i18n.t('menu.window', '窗口(&W)'),
+    help: i18n.t('menu.help', '帮助(&H)'),
+    settings: i18n.t('menu.settings', '设置…'),
+    undo: i18n.t('menu.undo', '撤销'),
+    redo: i18n.t('menu.redo', '重做'),
+    cut: i18n.t('menu.cut', '剪切'),
+    copy: i18n.t('menu.copy', '复制'),
+    paste: i18n.t('menu.paste', '粘贴'),
+    selectAll: i18n.t('menu.selectAll', '全选'),
+    minimize: i18n.t('menu.minimize', '最小化'),
+    maximize: i18n.t('menu.maximize', '最大化'),
+    zoom: i18n.t('menu.zoom', '缩放'),
+    fullscreen: i18n.t('menu.fullscreen', '切换全屏'),
+    close: i18n.t('menu.close', '关闭'),
+    closeWindow: i18n.t('menu.closeWindow', '关闭窗口'),
+    about: i18n.t('menu.about', '关于'),
+    hide: i18n.t('menu.hide', '隐藏'),
+    hideOthers: i18n.t('menu.hideOthers', '隐藏其他'),
+    services: i18n.t('menu.services', '服务'),
+    quit: i18n.t('menu.quit', '退出'),
+  }
+}
+
 /** Push current i18n strings into native tray + app menu bar. */
 export async function syncTrayMenuLabels(): Promise<void> {
   if (!isTauri()) return
@@ -11,9 +47,7 @@ export async function syncTrayMenuLabels(): Promise<void> {
       agentSettings: i18n.t('tray.agentSettings', '本地 Agent 设置…'),
       quit: i18n.t('tray.quitAndStopAgent', '退出并停止 Agent'),
     })
-    await invoke('update_app_menu_labels', {
-      settings: i18n.t('menu.settings', '设置…'),
-    })
+    await invoke('update_app_menu_labels', { labels: appMenuLabels() })
   } catch {
     // Tray / app menu may be unavailable in web / early boot — ignore.
   }

--- a/packages/app/src/locales/en.json
+++ b/packages/app/src/locales/en.json
@@ -323,7 +323,29 @@
     "panelTitle": "Local Agent"
   },
   "menu": {
-    "settings": "Settings…"
+    "settings": "Settings…",
+    "file": "&File",
+    "edit": "&Edit",
+    "view": "&View",
+    "window": "&Window",
+    "help": "&Help",
+    "undo": "Undo",
+    "redo": "Redo",
+    "cut": "Cu&t",
+    "copy": "&Copy",
+    "paste": "&Paste",
+    "selectAll": "Select &All",
+    "minimize": "&Minimize",
+    "maximize": "Ma&ximize",
+    "zoom": "Zoom",
+    "fullscreen": "Toggle Full Screen",
+    "close": "&Close",
+    "closeWindow": "C&lose Window",
+    "about": "About",
+    "hide": "Hide",
+    "hideOthers": "Hide Others",
+    "services": "Services",
+    "quit": "Quit"
   },
   "tray": {
     "showMain": "Open main window",

--- a/packages/app/src/locales/zh-CN.json
+++ b/packages/app/src/locales/zh-CN.json
@@ -323,7 +323,29 @@
     "panelTitle": "本地 Agent"
   },
   "menu": {
-    "settings": "设置…"
+    "settings": "设置…",
+    "file": "文件(&F)",
+    "edit": "编辑(&E)",
+    "view": "视图(&V)",
+    "window": "窗口(&W)",
+    "help": "帮助(&H)",
+    "undo": "撤销",
+    "redo": "重做",
+    "cut": "剪切",
+    "copy": "复制",
+    "paste": "粘贴",
+    "selectAll": "全选",
+    "minimize": "最小化",
+    "maximize": "最大化",
+    "zoom": "缩放",
+    "fullscreen": "切换全屏",
+    "close": "关闭",
+    "closeWindow": "关闭窗口",
+    "about": "关于",
+    "hide": "隐藏",
+    "hideOthers": "隐藏其他",
+    "services": "服务",
+    "quit": "退出"
   },
   "tray": {
     "showMain": "打开主窗口",


### PR DESCRIPTION
## 问题

Windows 上把语言设成中文，窗口顶部菜单栏依然是整排英文。

## 根因

两层，叠在一起：

1. **muda 的预定义项全平台写死英文。** `PredefinedMenuItemType::text`（`muda-0.19.3/src/items/predefined.rs:267-301`）是一张硬编码表 —— `&Copy` / `Cu&t` / `&Paste` / `Select &All` / `Undo` / `Redo` / `&Minimize` / `Ma&ximize` / `Close` / `&Exit` / `&About`。给 item 传 `None` 就等于把它钉死在英文，既不看系统语言也不看 app 语言。而 `app_menu.rs` 里每一个 `PredefinedMenuItem` 传的都是 `None`。
2. **顶层标题是硬编码字面量。** `"File"` / `"Edit"` / `"Window"` / `"Help"` 直接写在 `app_menu.rs` 里，没走 i18n。

结果就是整条菜单栏只有 `Settings…` 会跟随语言（前端 `sync-tray-menu.ts` 推 `update_app_menu_labels`），locale 文件里也确实只有 `menu.settings` 一个键。

**Windows 特有的加重项**：冷启动语言探测读的是 `LC_ALL` / `LANG`。那是 Unix 惯例，Windows 默认不设这两个变量，所以中文 Windows 一律冷启动成英文。托盘菜单还能等前端起来后被 `syncTrayMenuLabels` 纠正，菜单栏则只有 `Settings…` 会被纠正。

## 改动

**Rust (`apps/desktop/`)**

- `commands/app_menu.rs` — 新增 `MenuLabels`（23 个字段，覆盖整条菜单栏），所有 `PredefinedMenuItem` 从 `None` 改成显式传译文；内置 `en()` / `zh()` 两张表只用于冷启动。`install_app_menu` 改成接收 labels，语言切换时重新安装。`AppMenuState` 随之删掉。
- `commands/mod.rs` — 新增 `prefers_zh_locale()`，改用 `sys-locale` 问操作系统。
- `commands/tray_menu.rs` — 冷启动探测收敛到同一个函数。
- `Cargo.toml` — `sys-locale = "0.3"`，本来就在依赖树里（`tauri-plugin-aptabase` 带进来的），版本不变。

**前端**

- `locales/en.json` / `zh-CN.json` — `menu.*` 从 1 个键补到 23 个。
- `lib/sync-tray-menu.ts` — 推全量标签。

## 两个取舍

**为什么是重装菜单而不是 `set_text`。** Tauri 的 `set_menu` 内部会先 `remove_menu()`（`tauri-2.11.5/src/app.rs:962`），重装是官方支持的换标签路径。替代方案是给 ~20 个 item 各存一个句柄，其中一半还在 `#[cfg]` 后面 —— 那份 per-platform `Option` 字段的账不值得记。

**助记符。** 英文标签保留 muda 原有的 `&`，所以 Windows 上英文的 Alt 快捷键跟今天完全一样。中文只在五个顶层标题上带 `文件(&F)` 这种 Windows CJK 写法，子项不带 —— 每项都挂 `(&X)` 打开菜单很难读。muda 的 macOS 后端只剥 `&` 不剥括号组，会留下「文件(F)」，所以加了个 macOS-only 的 `label()` 把整组去掉；只匹配单字符助记符，「设置(高级)」这类不会被误伤（有单测）。

英文下的实际渲染基本与改动前一致。唯一变化是 Windows 的 Help → About，从 muda 默认的 `&About` 变成「About TeamClu」/「关于 TeamClu」，符合 Windows 惯例。

## 验证

| 检查 | 结果 |
|---|---|
| `pnpm rust:check` | 通过 |
| `pnpm rust:clippy` | 通过（exit 0，无新告警） |
| `cargo test -p teamclu --lib commands::app_menu` | 2 passed |
| `pnpm typecheck` | 通过 |
| `pnpm lint` | 0 errors（53 个均为既有 warning） |
| `vitest src/lib/__tests__` | 134 files / 873 tests |
| `i18n-parity.test.ts` | 5 passed |

以上均在 macOS 本地跑。**Windows 侧靠 CI 的 `desktop-windows` job 把关** —— 这个 PR 里 `#[cfg(target_os = "windows")]` 分支不少（`labels.maximize` / `labels.close` / File 菜单里的 settings 与 quit / Help 里的 About），本地 macOS 编译过不构成证明。

**真机渲染没验证**：中文 Windows 上助记符下划线的实际显示、以及 About 对话框，需要人工在 Windows 上确认一次。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
