### PR TITLE
fix(fc): mount OSS-sync data plane under /v1/sync to bypass gateway basicauth

### DIFF
--- a/apps/daemon/src/sync/oss/fc_client.rs
+++ b/apps/daemon/src/sync/oss/fc_client.rs
@@ -208,7 +208,7 @@ impl FcClient {
             next_cursor: Option<String>,
         }
 
-        let page: RawPage = self.post("/sync/manifest", &body).await?;
+        let page: RawPage = self.post("/v1/sync/manifest", &body).await?;
         Ok(ManifestPage {
             snapshot_seq: page.snapshot_seq,
             items: page.items,
@@ -236,7 +236,7 @@ impl FcClient {
         if let Some(nid) = node_id {
             body["nodeId"] = Value::String(nid.to_string());
         }
-        self.post("/sync/upload/prepare", &body).await
+        self.post("/v1/sync/upload/prepare", &body).await
     }
 
     /// PUT blob to presigned URL.
@@ -267,7 +267,7 @@ impl FcClient {
             "teamId": team_id,
             "uploadSessionId": upload_session_id,
         });
-        self.post("/sync/upload/complete", &body).await
+        self.post("/v1/sync/upload/complete", &body).await
     }
 
     /// POST /sync/download
@@ -280,7 +280,7 @@ impl FcClient {
             "teamId": team_id,
             "contentHash": content_hash,
         });
-        self.post("/sync/download", &body).await
+        self.post("/v1/sync/download", &body).await
     }
 
     /// GET blob from presigned URL, verifying cipher_hash after download.
@@ -340,7 +340,7 @@ impl FcClient {
         }
         // Returns the tombstone's new version so callers can record it for a later
         // re-add CAS (see engine mark_tombstoned).
-        let resp: DeleteResp = self.post("/sync/delete", &body).await?;
+        let resp: DeleteResp = self.post("/v1/sync/delete", &body).await?;
         Ok(resp.version)
     }
 
@@ -360,7 +360,7 @@ impl FcClient {
     ) -> Result<Vec<BatchItemOutcome<PrepareResult>>, SyncError> {
         let body = serde_json::json!({ "teamId": team_id, "items": items });
         let results = self
-            .post_batch_raw("/sync/upload/prepare-batch", &body, items.len())
+            .post_batch_raw("/v1/sync/upload/prepare-batch", &body, items.len())
             .await?;
         Ok(results.iter().map(parse_batch_item).collect())
     }
@@ -377,7 +377,7 @@ impl FcClient {
             .collect();
         let body = serde_json::json!({ "teamId": team_id, "items": items });
         let results = self
-            .post_batch_raw("/sync/upload/complete-batch", &body, session_ids.len())
+            .post_batch_raw("/v1/sync/upload/complete-batch", &body, session_ids.len())
             .await?;
         Ok(results.iter().map(parse_batch_item).collect())
     }
@@ -394,7 +394,7 @@ impl FcClient {
             .collect();
         let body = serde_json::json!({ "teamId": team_id, "items": items });
         let results = self
-            .post_batch_raw("/sync/download-batch", &body, content_hashes.len())
+            .post_batch_raw("/v1/sync/download-batch", &body, content_hashes.len())
             .await?;
         Ok(results.iter().map(parse_batch_item).collect())
     }
@@ -407,7 +407,7 @@ impl FcClient {
     ) -> Result<Vec<BatchItemOutcome<DeleteResult>>, SyncError> {
         let body = serde_json::json!({ "teamId": team_id, "items": items });
         let results = self
-            .post_batch_raw("/sync/delete-batch", &body, items.len())
+            .post_batch_raw("/v1/sync/delete-batch", &body, items.len())
             .await?;
         Ok(results.iter().map(parse_batch_item).collect())
     }
@@ -511,7 +511,7 @@ impl FcClient {
         struct ModeResp {
             mode: String,
         }
-        let resp: ModeResp = self.post("/sync/set-mode", &body).await?;
+        let resp: ModeResp = self.post("/v1/sync/set-mode", &body).await?;
         Ok(resp.mode)
     }
 
@@ -522,7 +522,7 @@ impl FcClient {
         struct ModeResp {
             mode: Option<String>,
         }
-        let resp: ModeResp = self.post("/sync/team-mode", &body).await?;
+        let resp: ModeResp = self.post("/v1/sync/team-mode", &body).await?;
         Ok(resp.mode)
     }
 

--- a/services/fc/src/app.ts
+++ b/services/fc/src/app.ts
@@ -176,7 +176,11 @@ export function createApp(deps: AppDeps): Hono {
   });
 
   // Legacy /sync/* (set-mode, team-mode, manifest, upload/*, download, delete, versions)
-  app.all("/sync/*", async (c) => {
+  // Mounted under /v1/sync/* so a gateway that basicauth-gates the bare
+  // /sync* prefix (Shopee test) can't block JWT-authed sync ticks. The /v1
+  // mount is stripped before dispatch so the spec names (/sync/manifest, …)
+  // stay the switch keys — handler and log tests need no path changes.
+  app.all("/v1/sync/*", async (c) => {
     const url = new URL(c.req.url);
     const headers = Object.fromEntries(c.req.raw.headers);
     let body: any = {};
@@ -188,7 +192,7 @@ export function createApp(deps: AppDeps): Hono {
       const t = await c.req.text();
       body = t ? JSON.parse(t) : {};
     }
-    const r = await handleSyncRequest({ path: url.pathname, httpMethod: c.req.method, headers, body });
+    const r = await handleSyncRequest({ path: url.pathname.replace(/^\/v1\/sync/, "/sync"), httpMethod: c.req.method, headers, body });
     return sendLegacy(c, r);
   });
 

--- a/services/fc/test/live-sync-query.test.ts
+++ b/services/fc/test/live-sync-query.test.ts
@@ -68,15 +68,15 @@ test(
 );
 
 test(
-  "GET /sync/versions: teamId+path query params reach legacy handler (live)",
+  "GET /v1/sync/versions: teamId+path query params reach legacy handler (live)",
   { skip: !LIVE },
   async () => {
-    const missing = await get("/sync/versions");
+    const missing = await get("/v1/sync/versions");
     assert.equal(missing.status, 400);
     assert.match(errorMessage(missing.body), /teamId is required/i);
 
     const withParams = await get(
-      `/sync/versions?teamId=${encodeURIComponent(TEAM_ID)}&path=${encodeURIComponent("smoke.md")}`,
+      `/v1/sync/versions?teamId=${encodeURIComponent(TEAM_ID)}&path=${encodeURIComponent("smoke.md")}`,
     );
     assert.ok(
       !/teamId is required/i.test(errorMessage(withParams.body)),

--- a/services/fc/test/rate-limit-exempt.test.ts
+++ b/services/fc/test/rate-limit-exempt.test.ts
@@ -9,15 +9,15 @@ function makeDeps() {
   };
 }
 
-// The per-IP limiter allows 10 req/min. /sync/* is the JWT-authenticated
+// The per-IP limiter allows 10 req/min. /v1/sync/* is the JWT-authenticated
 // OSS-sync data plane where one tick issues several requests and team members
 // often share a NAT IP — it must NOT be rate limited (a 429 here failed whole
 // sync ticks in the field). Unauthenticated admin paths stay covered.
 
-test("/sync/* is exempt from the per-IP rate limit", async () => {
+test("/v1/sync/* is exempt from the per-IP rate limit", async () => {
   const app = createApp(makeDeps());
   for (let i = 0; i < 25; i++) {
-    const res = await app.request("/sync/manifest", {
+    const res = await app.request("/v1/sync/manifest", {
       method: "POST",
       headers: {
         "content-type": "application/json",


### PR DESCRIPTION
The Shopee test gateway (Caddy/SGW) basicauth-gates the bare /sync prefix, returning 401 (www-authenticate: Basic) for every /sync request before it reaches the FC app, so the daemon OSS-sync timer 401s on every tick and knowledge never syncs. The /v1 namespace is proxied normally, so move the legacy sync protocol under /v1/sync.

FC app.ts: route the legacy sync block under /v1/sync with the /v1 mount stripped before dispatch, so the spec endpoint names (/sync/manifest, ...) stay the switch keys (handler and log tests unchanged).
Daemon fc_client.rs: 11 sync paths move from /sync/X to /v1/sync/X.
FC tests: live-sync-query and rate-limit-exempt hit the new path.

Verified: rate-limit-exempt (/v1/sync/manifest reaches handler) and missing-endpoints (the /v1/sync readers are not shadowed by the catch-all) pass; cargo check -p amuxd clean.
