### PR TITLE
refactor(skills): 删除入口挪到技能列表行上，并改成输入名字确认

### DIFF
--- a/packages/app/src/components/sidebar/TeamShareListColumn.tsx
+++ b/packages/app/src/components/sidebar/TeamShareListColumn.tsx
@@ -20,8 +20,19 @@ import {
   Store,
   Bot,
   ChevronDown,
+  Trash2,
 } from 'lucide-react'
+import { toast } from 'sonner'
 import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -99,6 +110,99 @@ interface RowProps {
   expanded?: boolean
   onToggleExpand?: () => void
   onClick: () => void
+}
+
+/**
+ * Removing a skill from the team registry, confirmed by typing its name.
+ *
+ * Type-to-confirm rather than a plain Yes/No because of who is exposed: the
+ * click is one person's, the consequence is every member's machine, and there
+ * is no undo — the version history goes with the row. A dialog that a reflex
+ * can dismiss is the wrong weight for that, and the name has to be read off the
+ * row to be typed, which is exactly the "am I on the row I think I am" check
+ * that a misfire fails.
+ */
+export function DeleteTeamSkillDialog({
+  slug,
+  open,
+  busy,
+  onCancel,
+  onConfirm,
+}: {
+  slug: string
+  open: boolean
+  busy: boolean
+  onCancel: () => void
+  onConfirm: () => void
+}) {
+  const { t } = useTranslation()
+  const [typed, setTyped] = React.useState('')
+
+  // Cleared per skill, not per open: reopening on a different row must not
+  // arrive pre-confirmed with the previous row's name still in the box.
+  React.useEffect(() => {
+    setTyped('')
+  }, [slug, open])
+
+  const matches = typed.trim() === slug
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!next && !busy) onCancel()
+      }}
+    >
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{t('teamShare.skillDeleteTeamTitle', '从团队移除')}</DialogTitle>
+          <DialogDescription>
+            {t(
+              'teamShare.skillDeleteTeamConfirm',
+              '将「{{name}}」从团队 registry 移除？所有成员都会看不到它，下次同步时会从各自机器上卸载，版本历史一并删除，且无法撤销。',
+              { name: slug },
+            )}
+          </DialogDescription>
+        </DialogHeader>
+        <div className="flex flex-col gap-2">
+          <label htmlFor="delete-team-skill-confirm" className="text-[12px] text-muted-foreground">
+            {t('teamShare.skillDeleteTeamTypePrompt', '输入 {{name}} 确认', { name: slug })}
+          </label>
+          <Input
+            id="delete-team-skill-confirm"
+            value={typed}
+            autoFocus
+            autoComplete="off"
+            spellCheck={false}
+            disabled={busy}
+            onChange={(e) => setTyped(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' && matches && !busy) onConfirm()
+            }}
+            placeholder={slug}
+          />
+        </div>
+        <DialogFooter>
+          <Button type="button" variant="outline" disabled={busy} onClick={onCancel}>
+            {t('common.cancel', 'Cancel')}
+          </Button>
+          <Button
+            type="button"
+            variant="destructive"
+            disabled={busy || !matches}
+            onClick={onConfirm}
+          >
+            {busy ? (
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+            ) : (
+              <Trash2 className="mr-2 h-4 w-4" />
+            )}
+            {t('teamShare.skillDeleteTeamAction', '移除')}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
 }
 
 function ItemRow({
@@ -213,6 +317,12 @@ type SkillRow = {
    * for something that only exists in the cloud until it is installed.
    */
   packDir?: string
+  /**
+   * Present on team-registry rows only, and the reason the row can offer a
+   * delete at all. `id` is not a substitute: a personal skill whose name the
+   * registry also uses carries `personal:<slug>`.
+   */
+  deletableSlug?: string
 }
 
 export function TeamShareListColumn({ section }: { section: TeamShareSection }) {
@@ -231,8 +341,31 @@ export function TeamShareListColumn({ section }: { section: TeamShareSection }) 
   const reconcileSkills = useTeamShareBrowserStore((s) => s.reconcileSkills)
   const loadSection = useTeamShareBrowserStore((s) => s.loadSection)
   const setCreating = useTeamShareBrowserStore((s) => s.setCreating)
+  const deleteTeamSkill = useTeamShareBrowserStore((s) => s.deleteTeamSkill)
   const openDetail = useTeamShareBrowserStore((s) => s.openDetail)
   const currentTeamId = useCurrentTeamStore((s) => s.team?.id ?? null)
+
+  // The skill a delete has been started on, and whether that delete is running.
+  const [deleteTarget, setDeleteTarget] = React.useState<string | null>(null)
+  const [deleting, setDeleting] = React.useState(false)
+
+  const runDeleteTeamSkill = React.useCallback(async () => {
+    if (!deleteTarget || deleting) return
+    setDeleting(true)
+    try {
+      await deleteTeamSkill(deleteTarget)
+      setDeleteTarget(null)
+      toast.success(t('teamShare.skillDeleteTeamDone', '已从团队移除'))
+    } catch (e) {
+      toast.error(
+        t('teamShare.skillDeleteTeamFailed', '移除失败：{{msg}}', {
+          msg: e instanceof Error ? e.message : String(e),
+        }),
+      )
+    } finally {
+      setDeleting(false)
+    }
+  }, [deleteTarget, deleting, deleteTeamSkill, t])
 
   // Which skill packages are showing their files, and which one is being added
   // to. View state, not persisted: it says nothing about the skill itself.
@@ -458,6 +591,7 @@ export function TeamShareListColumn({ section }: { section: TeamShareSection }) 
             </span>
           ),
           dimmed: s.status === 'deprecated',
+          deletableSlug: s.kind === 'personal' ? undefined : s.slug,
           // Three states, and only one of them is asking for anything.
           //
           // Behind on version is a transitional state that resolves itself
@@ -932,7 +1066,36 @@ export function TeamShareListColumn({ section }: { section: TeamShareSection }) 
                         title={row.title}
                         meta={row.meta}
                         badge={row.badge}
-                        trailing={row.trailing}
+                        trailing={
+                          row.deletableSlug ? (
+                            <span className="flex items-center gap-1">
+                              {row.trailing}
+                              {/*
+                                A span, for the reason the chevron above is one:
+                                the row is itself a button and nesting another
+                                is invalid. Hidden until the row is hovered so a
+                                destructive action is not sitting under the
+                                cursor of everyone scrolling the list, and
+                                stopPropagation so reaching for it does not also
+                                select the row underneath.
+                              */}
+                              <span
+                                role="button"
+                                aria-label={t('teamShare.skillDeleteTeam', '从团队移除')}
+                                title={t('teamShare.skillDeleteTeam', '从团队移除')}
+                                onClick={(e) => {
+                                  e.stopPropagation()
+                                  setDeleteTarget(row.deletableSlug!)
+                                }}
+                                className="flex h-5 w-5 shrink-0 items-center justify-center rounded text-faint opacity-0 transition-opacity hover:bg-muted hover:text-destructive focus-visible:opacity-100 group-hover:opacity-100"
+                              >
+                                <Trash2 className="h-3.5 w-3.5" />
+                              </span>
+                            </span>
+                          ) : (
+                            row.trailing
+                          )
+                        }
                         dimmed={row.dimmed}
                         expandable={Boolean(row.packDir)}
                         expanded={isExpanded}
@@ -1133,6 +1296,16 @@ export function TeamShareListColumn({ section }: { section: TeamShareSection }) 
         any other section. Same slot as the skills column's scan paths.
       */}
       {section === 'knowledge' && <KnowledgeSyncFooter />}
+
+      {deleteTarget && (
+        <DeleteTeamSkillDialog
+          slug={deleteTarget}
+          open
+          busy={deleting}
+          onCancel={() => setDeleteTarget(null)}
+          onConfirm={() => void runDeleteTeamSkill()}
+        />
+      )}
     </div>
   )
 }

--- a/packages/app/src/components/sidebar/__tests__/DeleteTeamSkillDialog.test.tsx
+++ b/packages/app/src/components/sidebar/__tests__/DeleteTeamSkillDialog.test.tsx
@@ -1,0 +1,117 @@
+import { describe, expect, test, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, cleanup } from '@testing-library/react'
+import React from 'react'
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (_key: string, fallback: string, vars?: Record<string, string>) =>
+      vars ? fallback.replace(/\{\{(\w+)\}\}/g, (_m, k) => vars[k] ?? '') : fallback,
+  }),
+}))
+
+import { DeleteTeamSkillDialog } from '../TeamShareListColumn'
+
+/**
+ * The gate on deleting a team skill.
+ *
+ * Worth its own test because it is the only thing standing between one click
+ * and every member losing a skill: the click is one person's, the consequence
+ * is the whole team's, and there is no undo.
+ */
+describe('DeleteTeamSkillDialog', () => {
+  const onConfirm = vi.fn()
+  const onCancel = vi.fn()
+
+  const setup = (slug = 'deploy-check') =>
+    render(
+      <DeleteTeamSkillDialog
+        slug={slug}
+        open
+        busy={false}
+        onCancel={onCancel}
+        onConfirm={onConfirm}
+      />,
+    )
+
+  const confirmButton = () => screen.getByRole('button', { name: '移除' })
+  const box = () => screen.getByRole('textbox')
+
+  beforeEach(() => {
+    cleanup()
+    onConfirm.mockClear()
+    onCancel.mockClear()
+  })
+
+  test('refuses to confirm until the name is typed', () => {
+    setup()
+    expect(confirmButton()).toBeDisabled()
+
+    fireEvent.change(box(), { target: { value: 'deploy' } })
+    expect(confirmButton()).toBeDisabled()
+
+    fireEvent.change(box(), { target: { value: 'deploy-check' } })
+    expect(confirmButton()).toBeEnabled()
+
+    fireEvent.click(confirmButton())
+    expect(onConfirm).toHaveBeenCalledTimes(1)
+  })
+
+  test('a different skill\'s name does not open the gate', () => {
+    // The check people actually need: not "did you mean it" but "are you on the
+    // row you think you are". A near-miss must not pass.
+    setup()
+    fireEvent.change(box(), { target: { value: 'deploy-checks' } })
+    expect(confirmButton()).toBeDisabled()
+  })
+
+  test('surrounding whitespace is forgiven', () => {
+    setup()
+    fireEvent.change(box(), { target: { value: '  deploy-check ' } })
+    expect(confirmButton()).toBeEnabled()
+  })
+
+  test('Enter confirms only once the name matches', () => {
+    setup()
+    fireEvent.change(box(), { target: { value: 'nope' } })
+    fireEvent.keyDown(box(), { key: 'Enter' })
+    expect(onConfirm).not.toHaveBeenCalled()
+
+    fireEvent.change(box(), { target: { value: 'deploy-check' } })
+    fireEvent.keyDown(box(), { key: 'Enter' })
+    expect(onConfirm).toHaveBeenCalledTimes(1)
+  })
+
+  test('a delete in flight cannot be fired twice', () => {
+    render(
+      <DeleteTeamSkillDialog
+        slug="deploy-check"
+        open
+        busy
+        onCancel={onCancel}
+        onConfirm={onConfirm}
+      />,
+    )
+    fireEvent.change(box(), { target: { value: 'deploy-check' } })
+    expect(confirmButton()).toBeDisabled()
+  })
+
+  test('switching to another skill clears what was already typed', () => {
+    // Otherwise closing on one row and opening on the next arrives
+    // pre-confirmed, which is the failure this dialog exists to prevent.
+    const { rerender } = setup()
+    fireEvent.change(box(), { target: { value: 'deploy-check' } })
+    expect(confirmButton()).toBeEnabled()
+
+    rerender(
+      <DeleteTeamSkillDialog
+        slug="release-notes"
+        open
+        busy={false}
+        onCancel={onCancel}
+        onConfirm={onConfirm}
+      />,
+    )
+    expect(confirmButton()).toBeDisabled()
+    expect(box()).toHaveValue('')
+  })
+})

--- a/packages/app/src/components/teamshare/SkillDetail.tsx
+++ b/packages/app/src/components/teamshare/SkillDetail.tsx
@@ -52,12 +52,7 @@ import { resolveAgentDevicePresenceSync } from '@/lib/agent-device-reachability'
 import { useActorPresenceStore } from '@/stores/actor-presence-store'
 import { useEffectiveWorkspacePath } from '@/lib/effective-workspace'
 
-/**
- * `delete` removes a personal skill from this disk; `delete-team` removes a
- * skill from the team registry, for everybody. Two different blast radii, so
- * they get two different confirmations.
- */
-type SkillConfirmAction = 'delete' | 'delete-team' | 'uninstall'
+type SkillConfirmAction = 'delete' | 'uninstall'
 
 const CodeEditor = lazy(() => import('@/components/editors/CodeEditor'))
 const DiffRenderer = lazy(() =>
@@ -863,7 +858,6 @@ export function SkillDetail({ slug }: { slug: string }) {
   const installSkill = useTeamShareBrowserStore((s) => s.installSkill)
   const uninstallSkill = useTeamShareBrowserStore((s) => s.uninstallSkill)
   const deletePersonalSkill = useTeamShareBrowserStore((s) => s.deletePersonalSkill)
-  const deleteTeamSkill = useTeamShareBrowserStore((s) => s.deleteTeamSkill)
   const publishSkillVersion = useTeamShareBrowserStore((s) => s.publishSkillVersion)
   const discardLocalSkill = useTeamShareBrowserStore((s) => s.discardLocalSkill)
   const restoreDiscardedSkill = useTeamShareBrowserStore((s) => s.restoreDiscardedSkill)
@@ -1041,24 +1035,6 @@ export function SkillDetail({ slug }: { slug: string }) {
       setBusy(false)
     }
   }, [item, busy, deletePersonalSkill, t])
-
-  const runDeleteTeam = React.useCallback(async () => {
-    if (!item || busy) return
-    setBusy(true)
-    setConfirmAction(null)
-    try {
-      await deleteTeamSkill(item.slug)
-      toast.success(t('teamShare.skillDeleteTeamDone', 'Removed from the team'))
-    } catch (e) {
-      toast.error(
-        t('teamShare.skillDeleteTeamFailed', 'Remove failed: {{msg}}', {
-          msg: e instanceof Error ? e.message : String(e),
-        }),
-      )
-    } finally {
-      setBusy(false)
-    }
-  }, [item, busy, deleteTeamSkill, t])
 
   const runShare = React.useCallback(
     async (input: {
@@ -1433,26 +1409,6 @@ export function SkillDetail({ slug }: { slug: string }) {
           </>
         )}
 
-        {/*
-          Deleting from the registry, next to install/uninstall because that is
-          where the user is looking — but visually quieter than either, and
-          behind its own confirmation: this one lands on every member's machine,
-          not just this one. Ungated on purpose for now; any member may delete,
-          as they may publish and revert.
-        */}
-        {isRegistry && (
-          <Button
-            type="button"
-            variant="ghost"
-            onClick={() => setConfirmAction('delete-team')}
-            disabled={busy}
-            className="h-8 gap-1.5 text-[13px] text-muted-foreground hover:text-destructive"
-          >
-            <Trash2 className="h-3.5 w-3.5" />
-            {t('teamShare.skillDeleteTeam', 'Remove from team')}
-          </Button>
-        )}
-
         {isPersonal && (
           <>
             {!isBuiltin ? (
@@ -1751,9 +1707,7 @@ export function SkillDetail({ slug }: { slug: string }) {
             <DialogTitle>
               {confirmAction === 'delete'
                 ? t('teamShare.skillDeleteTitle', 'Delete Skill')
-                : confirmAction === 'delete-team'
-                  ? t('teamShare.skillDeleteTeamTitle', 'Remove from team')
-                  : t('teamShare.skillUninstallTitle', 'Uninstall Skill')}
+                : t('teamShare.skillUninstallTitle', 'Uninstall Skill')}
             </DialogTitle>
             <DialogDescription>
               {confirmAction === 'delete'
@@ -1762,17 +1716,11 @@ export function SkillDetail({ slug }: { slug: string }) {
                     'Are you sure you want to delete "{{name}}"? This permanently removes the skill from disk and cannot be undone.',
                     { name: item.name },
                   )
-                : confirmAction === 'delete-team'
-                  ? t(
-                      'teamShare.skillDeleteTeamConfirm',
-                      'Remove "{{name}}" from the team registry? It disappears for every member, and uninstalls itself from their machines on the next sync. Its version history goes with it — this cannot be undone.',
-                      { name: item.name },
-                    )
-                  : t(
-                      'teamShare.skillUninstallConfirm',
-                      'Uninstall "{{name}}"? You can install it again from Team Available later.',
-                      { name: item.name },
-                    )}
+                : t(
+                    'teamShare.skillUninstallConfirm',
+                    'Uninstall "{{name}}"? You can install it again from Team Available later.',
+                    { name: item.name },
+                  )}
             </DialogDescription>
           </DialogHeader>
           <DialogFooter>
@@ -1789,11 +1737,7 @@ export function SkillDetail({ slug }: { slug: string }) {
               variant="destructive"
               disabled={busy}
               onClick={() =>
-                void (confirmAction === 'delete'
-                  ? runDelete()
-                  : confirmAction === 'delete-team'
-                    ? runDeleteTeam()
-                    : runUninstall())
+                void (confirmAction === 'delete' ? runDelete() : runUninstall())
               }
             >
               {busy ? (
@@ -1803,9 +1747,7 @@ export function SkillDetail({ slug }: { slug: string }) {
               )}
               {confirmAction === 'delete'
                 ? t('teamShare.skillDelete', 'Delete')
-                : confirmAction === 'delete-team'
-                  ? t('teamShare.skillDeleteTeamAction', 'Remove')
-                  : t('teamShare.skillUninstall', 'Uninstall')}
+                : t('teamShare.skillUninstall', 'Uninstall')}
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/packages/app/src/locales/en.json
+++ b/packages/app/src/locales/en.json
@@ -82,6 +82,7 @@
     "skillDeleteTeamTitle": "Remove from team",
     "skillDeleteTeamConfirm": "Remove \"{{name}}\" from the team registry? It disappears for every member, and uninstalls itself from their machines on the next sync. Its version history goes with it — this cannot be undone.",
     "skillDeleteTeamAction": "Remove",
+    "skillDeleteTeamTypePrompt": "Type {{name}} to confirm",
     "skillDeleteTeamDone": "Removed from the team",
     "skillDeleteTeamFailed": "Remove failed: {{msg}}",
     "skillRetiredToast": "\"{{slug}}\" was removed by the team and uninstalled from this machine.",

--- a/packages/app/src/locales/zh-CN.json
+++ b/packages/app/src/locales/zh-CN.json
@@ -82,6 +82,7 @@
     "skillDeleteTeamTitle": "从团队移除",
     "skillDeleteTeamConfirm": "将「{{name}}」从团队 registry 移除？所有成员都会看不到它，下次同步时会从各自机器上卸载，版本历史一并删除，且无法撤销。",
     "skillDeleteTeamAction": "移除",
+    "skillDeleteTeamTypePrompt": "输入 {{name}} 确认",
     "skillDeleteTeamDone": "已从团队移除",
     "skillDeleteTeamFailed": "移除失败：{{msg}}",
     "skillRetiredToast": "「{{slug}}」已被团队移除，已从本机卸载。",


### PR DESCRIPTION
#1091 的跟进。删除功能本身不变，只换入口位置和确认方式。

## 为什么挪

原来那个「从团队移除」按钮在**详情页头部**，挨着安装 / 卸载。位置不直观 —— 那一排是对**这台机器**的操作（装、卸、保存），中间夹一个影响全队且不可撤销的动作，既不是人找它的地方，也和邻居不是一个量级。

## 改成什么

**入口挪到技能列表的行上。** 鼠标停在团队技能那一行才出现一个 `Trash2`，就在状态图标旁边。团队技能才有（装没装都有），个人技能没有 —— 它们走的是自己那套只动本机的删除。

用 `span` 而不是 `button`，和上面那个 chevron 同一个原因：行本身就是 `button`，再嵌一个是非法的；`stopPropagation` 让点它不会顺带选中这一行。默认 `opacity-0`，避免一个破坏性动作长期停在每个人滚动列表时的光标底下。

**确认改成输入技能名**，不再是一个 Yes/No。点击是一个人的，后果是每个成员机器上的，而且没有撤销 —— 版本历史跟着行一起没。一个手滑就能关掉的对话框对不上这个分量；而名字必须从行上读出来才能敲进去，这恰好就是「我是不是点错行了」那道检查。

## 测试

`DeleteTeamSkillDialog` 单独导出并单测 6 条，覆盖的都是这道门真正要挡住的东西：

- 近似的名字（`deploy-checks`）**不放行**
- 首尾空格放行
- Enter 只在匹配之后才触发
- 执行中不能再点第二次
- **换一个技能会清空已输入的内容** —— 否则在这一行关掉、在下一行打开就是预先确认好的状态，正是这个对话框存在的意义所在

前端全量 **3019 passed / 0 failed**；`pnpm typecheck` 干净；lint 无新增（只剩一条本次未触及的既有 warning）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)