### PR TITLE
fix: mid-turn follow-up without breaking live panel

### DIFF
--- a/apps/daemon/src/daemon/server/remote_tools.rs
+++ b/apps/daemon/src/daemon/server/remote_tools.rs
@@ -31,6 +31,21 @@ impl DaemonServer {
         teamclu_session_id: &str,
         requester_actor_id: &str,
     ) {
+        // ── Remote-tool per-turn prompt injection (PAUSED) ─────────────────
+        // Host-level `amuxd-remote-tools` MCP auto-inject is already off
+        // (`runtime/supervisor.rs`). This hook still ran on every @mention /
+        // RPC prompt and prefixed user text with `remote_context_instructions`
+        // (rtctx_* + amuxd-remote-tools routing hints via
+        // `RuntimeHandle::next_prompt_context` → `send_prompt_with_requester`).
+        //
+        // To restore end-to-end remote tools:
+        // 1. Re-enable MCP baseline in `supervisor.rs` (strip/remove pause).
+        // 2. Uncomment the block below.
+        // 3. See `docs/remote-tools.md`.
+        let _ = (runtime_id, teamclu_session_id, requester_actor_id);
+        return;
+
+        /*
         let (acp_session_id, worktree) = {
             let agents = self.agents.lock().await;
             agents
@@ -57,6 +72,7 @@ impl DaemonServer {
             }
             None => {}
         }
+        */
     }
 
     pub(crate) async fn spawn_remote_tool_sock_handler(

--- a/apps/daemon/src/remote_tools/turn_context.rs
+++ b/apps/daemon/src/remote_tools/turn_context.rs
@@ -90,6 +90,8 @@ pub fn inject_remote_context(prompt: &str, remote_context_id: &str) -> String {
 }
 
 pub fn remote_context_instructions(remote_context_id: &str) -> String {
+    // Used by `prepare_remote_tool_context_for_turn` when per-turn injection is
+    // re-enabled (see daemon/server/remote_tools.rs).
     if remote_context_id.is_empty() {
         return String::new();
     }

--- a/apps/daemon/src/runtime/opencode_http/client.rs
+++ b/apps/daemon/src/runtime/opencode_http/client.rs
@@ -11,6 +11,14 @@ use crate::proto::amux;
 
 const BASIC_AUTH_USER: &str = "opencode";
 
+/// opencode `SessionStatus.type` collapsed for turn-boundary decisions.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OpencodeSessionPhase {
+    Idle,
+    Running,
+    Unknown,
+}
+
 #[derive(Clone)]
 pub struct ServeClient {
     http: reqwest::Client,
@@ -232,6 +240,22 @@ impl ServeClient {
             .map_err(|e| crate::error::AmuxError::Agent(format!("session status body: {e}")))
     }
 
+    /// Classify one session's `SessionStatus` object from `/session/status`.
+    pub fn session_phase_from_status(status: &serde_json::Value) -> OpencodeSessionPhase {
+        match status.get("type").and_then(|v| v.as_str()) {
+            Some("idle") => OpencodeSessionPhase::Idle,
+            Some("busy") | Some("retry") => OpencodeSessionPhase::Running,
+            _ => OpencodeSessionPhase::Unknown,
+        }
+    }
+
+    /// Look up `session_id` in a `/session/status` response map.
+    pub fn session_phase_from_map(map: &serde_json::Value, session_id: &str) -> OpencodeSessionPhase {
+        map.get(session_id)
+            .map(Self::session_phase_from_status)
+            .unwrap_or(OpencodeSessionPhase::Unknown)
+    }
+
     /// GET /question → all pending question requests (across sessions).
     pub async fn question_list(
         &self,
@@ -443,6 +467,44 @@ pub fn session_model_id(session: &serde_json::Value) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn session_phase_from_status_classifies_idle_busy_retry() {
+        assert_eq!(
+            ServeClient::session_phase_from_status(&serde_json::json!({"type":"idle"})),
+            OpencodeSessionPhase::Idle
+        );
+        assert_eq!(
+            ServeClient::session_phase_from_status(&serde_json::json!({"type":"busy"})),
+            OpencodeSessionPhase::Running
+        );
+        assert_eq!(
+            ServeClient::session_phase_from_status(&serde_json::json!({
+                "type":"retry","attempt":1,"message":"quota","next":0
+            })),
+            OpencodeSessionPhase::Running
+        );
+        assert_eq!(
+            ServeClient::session_phase_from_status(&serde_json::json!({})),
+            OpencodeSessionPhase::Unknown
+        );
+    }
+
+    #[test]
+    fn session_phase_from_map_looks_up_session_id() {
+        let map = serde_json::json!({
+            "ses_a": {"type":"busy"},
+            "ses_b": {"type":"idle"},
+        });
+        assert_eq!(
+            ServeClient::session_phase_from_map(&map, "ses_a"),
+            OpencodeSessionPhase::Running
+        );
+        assert_eq!(
+            ServeClient::session_phase_from_map(&map, "ses_missing"),
+            OpencodeSessionPhase::Unknown
+        );
+    }
 
     #[test]
     fn session_model_id_rejoins_provider_and_id() {

--- a/apps/daemon/src/runtime/opencode_http/mod.rs
+++ b/apps/daemon/src/runtime/opencode_http/mod.rs
@@ -11,7 +11,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use tokio::sync::{mpsc, oneshot};
-use tracing::{info, warn};
+use tracing::{debug, info, warn};
 
 use crate::proto::amux;
 use crate::runtime::acp_event_frame::AcpEventFrame;
@@ -926,6 +926,56 @@ async fn emit_frame(
         .await;
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct ActiveTurnStatusCheck {
+    emit_turn_open: bool,
+    reconcile_stale_idle: bool,
+}
+
+/// When daemon already claims an active turn, cross-check opencode before
+/// deciding whether to re-emit Idle→Active on the next prompt.
+fn active_turn_status_check(phase: client::OpencodeSessionPhase) -> ActiveTurnStatusCheck {
+    match phase {
+        client::OpencodeSessionPhase::Running => ActiveTurnStatusCheck {
+            emit_turn_open: false,
+            reconcile_stale_idle: false,
+        },
+        client::OpencodeSessionPhase::Idle => ActiveTurnStatusCheck {
+            emit_turn_open: true,
+            reconcile_stale_idle: true,
+        },
+        client::OpencodeSessionPhase::Unknown => ActiveTurnStatusCheck {
+            emit_turn_open: false,
+            reconcile_stale_idle: false,
+        },
+    }
+}
+
+async fn opencode_session_phase(
+    shared: &Arc<HostGeneration>,
+    directory: &str,
+    session_id: &str,
+) -> client::OpencodeSessionPhase {
+    let client = match shared.serve.ensure().await {
+        Ok(c) => c,
+        Err(e) => {
+            warn!(
+                session_id,
+                error = %e,
+                "session/status poll skipped: serve unavailable"
+            );
+            return client::OpencodeSessionPhase::Unknown;
+        }
+    };
+    match client.session_status(directory).await {
+        Ok(map) => client::ServeClient::session_phase_from_map(&map, session_id),
+        Err(e) => {
+            warn!(session_id, error = %e, "session/status poll failed");
+            client::OpencodeSessionPhase::Unknown
+        }
+    }
+}
+
 async fn do_prompt(
     shared: &Arc<HostGeneration>,
     session_id: &str,
@@ -939,6 +989,41 @@ async fn do_prompt(
     // consume the stuck-turn watchdog budget.
     let resolved =
         crate::runtime::prompt_attachments::resolve_all(&attachment_urls, session_id).await;
+
+    let (directory, was_turn_active) = {
+        let routes = shared.routes.lock();
+        let Some(route) = routes.get(session_id) else {
+            warn!(session_id, "prompt for unknown opencode session");
+            return;
+        };
+        (route.directory.clone(), route.turn_active)
+    };
+
+    let mut emit_turn_open = !was_turn_active;
+    if was_turn_active {
+        let phase = opencode_session_phase(&shared, &directory, session_id).await;
+        let check = active_turn_status_check(phase);
+        if check.reconcile_stale_idle {
+            warn!(
+                session_id,
+                "turn_active but opencode session/status is idle; reconciling stale turn"
+            );
+            let taken = {
+                let mut routes = shared.routes.lock();
+                routes
+                    .get_mut(session_id)
+                    .and_then(take_active_turn)
+            };
+            close_orphaned_turn(session_id, taken).await;
+        } else if phase == client::OpencodeSessionPhase::Running {
+            debug!(
+                session_id,
+                "turn_active confirmed by opencode session/status busy/retry"
+            );
+        }
+        emit_turn_open = check.emit_turn_open;
+    }
+
     let (event_tx, directory, model, turn_seq) = {
         let mut routes = shared.routes.lock();
         let Some(route) = routes.get_mut(session_id) else {
@@ -962,13 +1047,15 @@ async fn do_prompt(
     };
 
     crate::runtime::agent_trace::log_prompt_begin(session_id, &text, attachment_urls.len());
-    emit_frame(
-        &event_tx,
-        session_id,
-        translate::status_change(amux::AgentStatus::Idle, amux::AgentStatus::Active),
-        reply_to.clone(),
-    )
-    .await;
+    if emit_turn_open {
+        emit_frame(
+            &event_tx,
+            session_id,
+            translate::status_change(amux::AgentStatus::Idle, amux::AgentStatus::Active),
+            reply_to.clone(),
+        )
+        .await;
+    }
 
     let mut text = text;
     crate::runtime::prompt_attachments::substitute_in_message(&mut text, &resolved);
@@ -2308,6 +2395,21 @@ mod turn_activity_tests {
         )
     }
 
+    #[test]
+    fn active_turn_status_check_confirms_running_and_reconciles_idle() {
+        let running = active_turn_status_check(client::OpencodeSessionPhase::Running);
+        assert!(!running.emit_turn_open);
+        assert!(!running.reconcile_stale_idle);
+
+        let idle = active_turn_status_check(client::OpencodeSessionPhase::Idle);
+        assert!(idle.emit_turn_open);
+        assert!(idle.reconcile_stale_idle);
+
+        let unknown = active_turn_status_check(client::OpencodeSessionPhase::Unknown);
+        assert!(!unknown.emit_turn_open);
+        assert!(!unknown.reconcile_stale_idle);
+    }
+
     /// A route whose runtime goes away mid-turn must still close the turn, or
     /// the client sits on "replying" forever. Reproduces the app-workspace
     /// re-point: a prompt is in flight when the session is detached and
@@ -2330,11 +2432,10 @@ mod turn_activity_tests {
         assert_eq!(frame.turn_reply_to_message_id.as_deref(), Some("reply-1"));
     }
 
-    /// Reproduces mid-turn follow-up: `do_prompt` has no busy gate, so a second
-    /// prompt while `turn_active` re-emits Idle→Active and clears
-    /// `tools_in_flight` (turn 1 tools still running upstream).
+    /// Mid-turn follow-up must not re-emit Idle→Active — the agent is already
+    /// active and the frontend treats that transition as a turn boundary.
     #[tokio::test]
-    async fn second_prompt_while_turn_active_reopens_turn_and_clears_tools() {
+    async fn second_prompt_while_turn_active_skips_idle_to_active() {
         let shared = test_generation();
         let (tx, mut rx) = mpsc::channel(8);
         {
@@ -2347,41 +2448,46 @@ mod turn_activity_tests {
             routes.insert("ses_repro".to_string(), route);
         }
 
-        // Mirror the synchronous head of `do_prompt` (lines 1046–1074).
-        let (event_tx, turn_seq) = {
+        // Mirror the synchronous head of `do_prompt`.
+        let was_turn_active = {
+            let routes = shared.routes.lock();
+            routes.get("ses_repro").expect("route").turn_active
+        };
+        let (event_tx, turn_seq, emit_turn_open) = {
             let mut routes = shared.routes.lock();
             let route = routes.get_mut("ses_repro").expect("route");
+            let was_turn_active = route.turn_active;
             route.turn_active = true;
             route.turn_seq += 1;
             route.tools_in_flight.clear();
-            (route.event_tx.clone(), route.turn_seq)
+            (
+                route.event_tx.clone(),
+                route.turn_seq,
+                !was_turn_active,
+            )
         };
-        emit_frame(
-            &event_tx,
-            "ses_repro",
-            translate::status_change(amux::AgentStatus::Idle, amux::AgentStatus::Active),
-            None,
-        )
-        .await;
-
-        let frame = rx.try_recv().expect("second prompt emits Idle→Active");
-        assert_eq!(frame.acp_session_id, "ses_repro");
-        match frame.event.event {
-            Some(amux::acp_event::Event::StatusChange(sc)) => {
-                assert_eq!(sc.old_status, amux::AgentStatus::Idle as i32);
-                assert_eq!(sc.new_status, amux::AgentStatus::Active as i32);
-            }
-            other => panic!("expected StatusChange, got {other:?}"),
+        assert!(was_turn_active);
+        assert!(!emit_turn_open);
+        if emit_turn_open {
+            emit_frame(
+                &event_tx,
+                "ses_repro",
+                translate::status_change(amux::AgentStatus::Idle, amux::AgentStatus::Active),
+                None,
+            )
+            .await;
         }
+
+        assert!(
+            rx.try_recv().is_err(),
+            "mid-turn prompt must not emit Idle→Active"
+        );
 
         let routes = shared.routes.lock();
         let route = routes.get("ses_repro").expect("route");
         assert!(route.turn_active);
-        assert_eq!(turn_seq, 2);
-        assert!(
-            route.tools_in_flight.is_empty(),
-            "second prompt clears in-flight tool tracking for turn 1"
-        );
+        assert_eq!(route.turn_seq, turn_seq);
+        assert!(route.tools_in_flight.is_empty());
     }
 
     #[tokio::test]

--- a/apps/daemon/src/runtime/pi_rpc/mod.rs
+++ b/apps/daemon/src/runtime/pi_rpc/mod.rs
@@ -948,6 +948,20 @@ async fn emit_frame(
         .await;
 }
 
+/// Mid-turn follow-up plan — aligned with opencode_http `do_prompt`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct PiMidTurnPromptPlan {
+    emit_turn_open: bool,
+    use_steer: bool,
+}
+
+fn pi_mid_turn_prompt_plan(was_turn_active: bool) -> PiMidTurnPromptPlan {
+    PiMidTurnPromptPlan {
+        emit_turn_open: !was_turn_active,
+        use_steer: was_turn_active,
+    }
+}
+
 async fn do_prompt(
     shared: &Arc<Shared>,
     session_id: &str,
@@ -959,6 +973,17 @@ async fn do_prompt(
     let reply_to = reply_to_message_id.filter(|id| !id.is_empty());
     let resolved =
         crate::runtime::prompt_attachments::resolve_all(&attachment_urls, session_id).await;
+
+    let was_turn_active = {
+        let routes = shared.routes.lock();
+        let Some(route) = routes.get(session_id) else {
+            warn!(session_id, "prompt for unknown pi session");
+            return;
+        };
+        route.turn_active
+    };
+    let plan = pi_mid_turn_prompt_plan(was_turn_active);
+
     let event_tx = {
         let mut routes = shared.routes.lock();
         let Some(route) = routes.get_mut(session_id) else {
@@ -972,44 +997,39 @@ async fn do_prompt(
     };
 
     crate::runtime::agent_trace::log_prompt_begin(session_id, &text, attachment_urls.len());
-    emit_frame(
-        &event_tx,
-        session_id,
-        status_change(amux::AgentStatus::Idle, amux::AgentStatus::Active),
-        reply_to.clone(),
-    )
-    .await;
+    if plan.emit_turn_open {
+        emit_frame(
+            &event_tx,
+            session_id,
+            status_change(amux::AgentStatus::Idle, amux::AgentStatus::Active),
+            reply_to.clone(),
+        )
+        .await;
+    } else {
+        debug!(
+            session_id,
+            "mid-turn pi prompt: steer without Idle→Active re-emit"
+        );
+    }
 
     let mut message = text;
     crate::runtime::prompt_attachments::substitute_in_message(&mut message, &resolved);
     crate::runtime::prompt_attachments::append_unreferenced(&mut message, &resolved, true);
 
+    let mut prompt_body = serde_json::json!({
+        "type": "prompt",
+        "message": message,
+    });
+    // pi reads `streamingBehavior` only while a turn is streaming. Mid-turn
+    // follow-ups use `steer` (fold into the live run); idle prompts omit it.
+    if plan.use_steer {
+        prompt_body["streamingBehavior"] = serde_json::json!("steer");
+    }
+
     let result = match ensure_session_ready(shared, session_id).await {
         Ok(proc) => {
             proc.client
-                .request(with_session(
-                    serde_json::json!({
-                        "type": "prompt",
-                        "message": message,
-                        // pi refuses a bare prompt while a turn is running:
-                        // "Agent is already processing. Specify streamingBehavior
-                        // ('steer' or 'followUp') to queue the message." Sending
-                        // one anyway is how a message typed mid-reply was lost.
-                        //
-                        // `followUp` runs it after the current turn; `steer` folds
-                        // it into the running one. followUp matches what TeamClu
-                        // already promises elsewhere — a message is its own turn
-                        // with its own reply, and the client's own queue holds
-                        // messages until the stream ends rather than redirecting it.
-                        //
-                        // Always sent, not only when busy: pi reads the field only
-                        // on the streaming branch, so an idle prompt is unaffected
-                        // and no extra `get_state` round trip is needed to decide.
-                        "streamingBehavior": "followUp"
-                    }),
-                    proc.mode,
-                    session_id,
-                ))
+                .request(with_session(prompt_body, proc.mode, session_id))
                 .await
         }
         Err(e) => Err(e),
@@ -1577,6 +1597,17 @@ impl AgentBackend for PiRpcBackend {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn mid_turn_prompt_plan_steers_without_turn_open() {
+        let idle = pi_mid_turn_prompt_plan(false);
+        assert!(idle.emit_turn_open);
+        assert!(!idle.use_steer);
+
+        let busy = pi_mid_turn_prompt_plan(true);
+        assert!(!busy.emit_turn_open);
+        assert!(busy.use_steer);
+    }
 
     #[test]
     fn split_model_id_at_first_slash() {

--- a/packages/app/src/components/MqttLiveWiring.tsx
+++ b/packages/app/src/components/MqttLiveWiring.tsx
@@ -58,7 +58,7 @@ import { acquireRuntimeStateStore, useRuntimeStateStore } from "@/stores/runtime
 import { findStaleLiveStreams, STALE_STREAM_SWEEP_MS } from "@/lib/stale-stream-recovery";
 import { acquireActorPresenceStore } from "@/stores/actor-presence-store";
 import { MessageKind, type Message as TeamcluMessage } from "@/lib/proto/teamclu_pb";
-import { agentStreamKey, isAgentActiveStatus, isTerminalAgentStatus, isToolOnlyTurnAnchor, mergePendingAgentReplies, normalizeToolResultEvent, normalizeToolUseEvent, registerDiscardPendingStreamReply, rememberLiveEventId, shouldPatchFlushedToolEvent, streamEntryHasVisibleContent } from "@/lib/live-agent-stream";
+import { agentStreamKey, isTerminalAgentStatus, isToolOnlyTurnAnchor, isTurnOpeningStatusChange, mergePendingAgentReplies, normalizeToolResultEvent, normalizeToolUseEvent, registerDiscardPendingStreamReply, rememberLiveEventId, shouldPatchFlushedToolEvent, streamEntryHasVisibleContent } from "@/lib/live-agent-stream";
 import { mapAcpPlanEntries, syncPlanFromTodoTool, syncPlanFromTodoToolResult } from "@/lib/sync-plan-from-todowrite";
 import { reportSkillUsage } from "@/lib/telemetry/skill-usage";
 import { upsertMessagesBatch, softDeleteMessage, type MessageRow } from "@/lib/local-cache";
@@ -1254,7 +1254,7 @@ export function MqttLiveWiring({ userId, teamId, onMyActorId }: MqttLiveWiringPr
                 oldStatus: sc.oldStatus,
                 newStatus: sc.newStatus,
               });
-              if (isAgentActiveStatus(sc.newStatus)) {
+              if (isTurnOpeningStatusChange(sc.oldStatus, sc.newStatus)) {
                 const streamKey = agentStreamKey(sid, actorId);
                 followUpActiveRef.current[streamKey] = true;
                 const flushed = flushTurnAgentReply(

--- a/packages/app/src/lib/__tests__/live-agent-stream.test.ts
+++ b/packages/app/src/lib/__tests__/live-agent-stream.test.ts
@@ -9,6 +9,7 @@ import {
 import {
   buildInterruptedStreamAnchor,
   isAgentActiveStatus,
+  isTurnOpeningStatusChange,
   isTerminalAgentStatus,
   joinDistinctPendingReplyChunks,
   isToolOnlyTurnAnchor,
@@ -124,6 +125,18 @@ describe("live agent stream event helpers", () => {
     expect(isAgentActiveStatus(AgentStatus.ACTIVE)).toBe(true);
     expect(isAgentActiveStatus(AgentStatus.IDLE)).toBe(false);
     expect(isAgentActiveStatus(2)).toBe(true);
+  });
+
+  it("recognizes turn-opening statusChange only for Idle to Active", () => {
+    expect(
+      isTurnOpeningStatusChange(AgentStatus.IDLE, AgentStatus.ACTIVE),
+    ).toBe(true);
+    expect(
+      isTurnOpeningStatusChange(AgentStatus.ACTIVE, AgentStatus.ACTIVE),
+    ).toBe(false);
+    expect(
+      isTurnOpeningStatusChange(AgentStatus.ACTIVE, AgentStatus.IDLE),
+    ).toBe(false);
   });
 
   it("dedupes repeated live event ids per session", () => {

--- a/packages/app/src/lib/live-agent-stream.ts
+++ b/packages/app/src/lib/live-agent-stream.ts
@@ -313,6 +313,14 @@ export function isAgentActiveStatus(status: AgentStatus | number | undefined): b
   return status === AgentStatus.ACTIVE;
 }
 
+/** True only for the canonical turn-open signal — not mid-turn follow-ups. */
+export function isTurnOpeningStatusChange(
+  oldStatus: AgentStatus | number | undefined,
+  newStatus: AgentStatus | number | undefined,
+): boolean {
+  return oldStatus === AgentStatus.IDLE && newStatus === AgentStatus.ACTIVE;
+}
+
 /** True when the flushed AGENT_REPLY already carries this tool id in parts_json. */
 function flushedMessageHasTool(
   sessionId: string,


### PR DESCRIPTION
## Summary

- **OpenCode + frontend**: When a turn is already active, daemon no longer re-emits `Idle→Active` on follow-up prompts; cross-checks opencode `/session/status` for stale `turn_active`. Frontend only flushes/archives the live dock on canonical `Idle→Active` (`isTurnOpeningStatusChange`), not every `ACTIVE`.
- **Pi**: Align mid-turn behavior — busy prompts use `streamingBehavior: steer` and skip fake `Idle→Active`, matching opencode semantics.
- **Remote tools**: Pause per-turn `remote_context_instructions` prompt prefix (MCP auto-inject was already off); commented restore path in `remote_tools.rs`.

## Test plan

- [ ] OpenCode: send a message while agent is replying — live panel stays continuous, follow-up is handled without reset
- [ ] Pi: same mid-turn @mention test — no second `Idle→Active` in logs; steer injects into running turn
- [ ] Pi: send "停吧" during permission wait — model should see steer message (not queued followUp after full run)
- [ ] Any @mention prompt — no `TeamClu remote tool context` / `rtctx_*` prefix in agent behavior
- [ ] `cargo test -p amuxd mid_turn_prompt_plan --manifest-path apps/daemon/Cargo.toml`
- [ ] `pnpm test:unit -- live-agent-stream mid-turn-followup-repro`


Made with [Cursor](https://cursor.com)