### PR TITLE
fix(daemon): 并发 Session 下 session-scoped MCP 工具正确解析

### DIFF
--- a/apps/daemon/assets/pi-extension/teamclu.ts
+++ b/apps/daemon/assets/pi-extension/teamclu.ts
@@ -68,6 +68,7 @@ type ToolCallEvent = {
   input: Record<string, unknown>;
 };
 type ExtensionContext = {
+  sessionId?: string;
   ui: {
     confirm(title: string, message?: string, options?: { timeout?: number }): Promise<boolean>;
     select(
@@ -102,6 +103,85 @@ type ExtensionAPI = {
   }): void;
   registerProvider(id: string, config: Record<string, unknown>): void;
 };
+
+// ---------------------------------------------------------------------------
+// Session context injection (concurrent session deeplink correctness)
+// ---------------------------------------------------------------------------
+
+const SESSION_SCOPED_TOOLS = new Set([
+  "get_session_deeplink",
+  "manage_participants",
+  "archive_session",
+]);
+
+function isSessionScopedTool(name: string): boolean {
+  const base = name.split("/").pop()?.trim() ?? name;
+  return SESSION_SCOPED_TOOLS.has(base);
+}
+
+async function resolveTeamcluSessionId(backendSessionId: string): Promise<string> {
+  const baseUrl = process.env.TEAMCLU_RUNTIME_CONTEXT_URL?.trim()?.replace(/\/$/, "");
+  const token = process.env.TEAMCLU_RUNTIME_CONTEXT_TOKEN?.trim();
+  const generationId = process.env.TEAMCLU_HOST_GENERATION_ID?.trim();
+  const backendKind = process.env.TEAMCLU_AGENT_BACKEND?.trim();
+  const sessionId = backendSessionId.trim();
+  if (!baseUrl || !token || !generationId || !backendKind || !sessionId) {
+    throw new Error("session_context_unavailable");
+  }
+  const resp = await fetch(`${baseUrl}/internal/runtime-context/resolve`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      backendSessionId: sessionId,
+      hostGenerationId: generationId,
+      backendKind,
+    }),
+  });
+  if (!resp.ok) {
+    throw new Error("session_context_unavailable");
+  }
+  const body = (await resp.json()) as { teamcluSessionId?: string };
+  const teamcluSessionId = String(body?.teamcluSessionId ?? "").trim();
+  if (!teamcluSessionId) {
+    throw new Error("session_context_unavailable");
+  }
+  return teamcluSessionId;
+}
+
+async function injectSessionIdForTool(
+  toolName: string,
+  params: Record<string, unknown>,
+  backendSessionId?: string,
+): Promise<Record<string, unknown>> {
+  if (!isSessionScopedTool(toolName)) {
+    return params ?? {};
+  }
+  const next = { ...(params ?? {}) };
+  const explicit = String(next.session_id ?? next.sessionId ?? "").trim();
+  if (explicit) {
+    return next;
+  }
+  if (!backendSessionId?.trim()) {
+    throw new Error("session_context_unavailable");
+  }
+  next.session_id = await resolveTeamcluSessionId(backendSessionId);
+  return next;
+}
+
+function sessionContextUnavailableResult() {
+  return {
+    content: [
+      {
+        type: "text" as const,
+        text: "session_context_unavailable: Unable to determine the TeamClu session for this tool call.",
+      },
+    ],
+    isError: true,
+  };
+}
 
 // ---------------------------------------------------------------------------
 // Permission rules
@@ -876,7 +956,7 @@ function registerBridgeTools(
       // MCP inputSchema is plain JSON Schema; pi's TypeBox parameters are
       // JSON Schema objects at runtime, so pass it through directly.
       parameters: tool.inputSchema ?? { type: "object", properties: {} },
-      async execute(_toolCallId, params, signal) {
+      async execute(_toolCallId, params, signal, _onUpdate, ctx) {
         // A server can drop a tool at runtime (`tools/list_changed`). pi has no
         // unregister, so the registration outlives the tool: answer honestly
         // instead of calling a name the server no longer knows.
@@ -886,10 +966,16 @@ function registerBridgeTools(
             isError: true,
           };
         }
+        let callParams = params ?? {};
+        try {
+          callParams = await injectSessionIdForTool(tool.name, callParams, ctx?.sessionId);
+        } catch {
+          return sessionContextUnavailableResult();
+        }
         // On a cached start the connection may still be opening; this is the
         // only place that waits for it, and only when a tool is actually used.
         const bridge = await entry.ready;
-        const result = await bridge.callTool(tool.name, params ?? {}, signal);
+        const result = await bridge.callTool(tool.name, callParams, signal);
         return { content: toPiContent(result), isError: result?.isError === true };
       },
     });

--- a/apps/daemon/assets/pi-host/host.mjs
+++ b/apps/daemon/assets/pi-host/host.mjs
@@ -283,6 +283,7 @@ function makeUiContext(sessionId) {
     out({ type: "extension_ui_request", id: crypto.randomUUID(), sessionId, ...request });
 
   return {
+    sessionId,
     select: (title, options, opts) =>
       dialog(
         { method: "select", title, options, timeout: opts?.timeout },

--- a/apps/daemon/shared/session-context-client.mjs
+++ b/apps/daemon/shared/session-context-client.mjs
@@ -1,0 +1,82 @@
+/**
+ * Resolve TeamClu cloud session id for a backend tool call via amuxd's
+ * internal loopback API. Used by backend adapters before calling session-scoped
+ * MCP tools without an explicit session_id argument.
+ */
+
+const SESSION_SCOPED_TOOLS = new Set([
+  "get_session_deeplink",
+  "manage_participants",
+  "archive_session",
+]);
+
+export function isSessionScopedTool(name) {
+  const base = String(name ?? "")
+    .split("/")
+    .pop()
+    .trim();
+  return SESSION_SCOPED_TOOLS.has(base);
+}
+
+function runtimeContextUrl() {
+  const fromEnv = process.env.TEAMCLU_RUNTIME_CONTEXT_URL?.trim();
+  if (fromEnv) return fromEnv.replace(/\/$/, "");
+  return null;
+}
+
+export async function resolveTeamcluSessionId(backendSessionId) {
+  const baseUrl = runtimeContextUrl();
+  const token = process.env.TEAMCLU_RUNTIME_CONTEXT_TOKEN?.trim();
+  const generationId = process.env.TEAMCLU_HOST_GENERATION_ID?.trim();
+  const backendKind = process.env.TEAMCLU_AGENT_BACKEND?.trim();
+  const sessionId = String(backendSessionId ?? "").trim();
+  if (!baseUrl || !token || !generationId || !backendKind || !sessionId) {
+    throw new Error("session_context_unavailable");
+  }
+  const resp = await fetch(`${baseUrl}/internal/runtime-context/resolve`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      backendSessionId: sessionId,
+      hostGenerationId: generationId,
+      backendKind,
+    }),
+  });
+  if (!resp.ok) {
+    throw new Error("session_context_unavailable");
+  }
+  const body = await resp.json();
+  const teamcluSessionId = String(body?.teamcluSessionId ?? "").trim();
+  if (!teamcluSessionId) {
+    throw new Error("session_context_unavailable");
+  }
+  return teamcluSessionId;
+}
+
+export async function injectSessionIdForTool(toolName, args, backendSessionId) {
+  if (!isSessionScopedTool(toolName)) {
+    return args ?? {};
+  }
+  const next = { ...(args ?? {}) };
+  const explicit = String(next.session_id ?? next.sessionId ?? "").trim();
+  if (explicit) {
+    return next;
+  }
+  next.session_id = await resolveTeamcluSessionId(backendSessionId);
+  return next;
+}
+
+export function sessionContextUnavailableResult() {
+  return {
+    content: [
+      {
+        type: "text",
+        text: "session_context_unavailable: Unable to determine the TeamClu session for this tool call.",
+      },
+    ],
+    isError: true,
+  };
+}

--- a/apps/daemon/src/daemon/server.rs
+++ b/apps/daemon/src/daemon/server.rs
@@ -194,6 +194,7 @@ pub struct DaemonServer {
     remote_tool_turn_contexts: Arc<AsyncMutex<crate::remote_tools::RemoteToolTurnContextStore>>,
     rpc_client: Arc<AsyncMutex<crate::teamclu::rpc::RpcClient>>,
     team_skill_reconciler: Arc<crate::runtime::team_skills::TeamSkillReconciler>,
+    runtime_context: Arc<crate::runtime::RuntimeContextService>,
     /// Answered capability-management requests, keyed on the authorized
     /// (requester, request_id) pair. Shared rather than owned so the handler
     /// can run on its own task instead of on the message pump.
@@ -715,6 +716,12 @@ impl DaemonServer {
             launch_configs,
             Some(backend.clone()),
         )));
+        let runtime_context = Arc::new(crate::runtime::RuntimeContextService::new());
+        {
+            let mut manager = agents.lock().await;
+            manager.attach_context_service(Arc::clone(&runtime_context));
+        }
+        agents.lock().await.wire_context_service_to_backend().await;
 
         let (mqtt_publisher, mqtt_command_rx) = MqttPublisher::channel();
         let (mqtt_recovery_handle, mqtt_recovery_rx) = crate::mqtt::MqttRecoveryHandle::channel();
@@ -807,6 +814,7 @@ impl DaemonServer {
             )),
             rpc_client,
             team_skill_reconciler,
+            runtime_context,
             agent_management_results: Arc::new(AsyncMutex::new(HashMap::new())),
             cron_turn_done_tx,
             cron_turn_done_rx: Some(cron_turn_done_rx),
@@ -1138,11 +1146,23 @@ impl DaemonServer {
                 Some(local_rpc_tx),
                 Some(local_live_ingest_tx),
                 Some(team_skill_reconciler.clone()),
+                Some(self.runtime_context.clone()),
             )
             .await
             {
                 Ok(h) => {
                     info!(addr = %h.local_addr, "http listener bound");
+                    if let Err(err) = self
+                        .runtime_context
+                        .validate_managed_setup(&self.config.agents.local_agent)
+                    {
+                        warn!(
+                            error = %err,
+                            "runtime context service validation failed; session-scoped MCP tools may fail closed"
+                        );
+                    } else {
+                        info!("runtime context service ready for managed session resolution");
+                    }
                     Some(h)
                 }
                 Err(e) => {
@@ -3753,6 +3773,7 @@ pub(crate) mod tests {
                 team_skill_reconciler: Arc::new(
                     crate::runtime::team_skills::TeamSkillReconciler::new(backend),
                 ),
+                runtime_context: Arc::new(crate::runtime::RuntimeContextService::new()),
                 agent_management_results: Arc::new(AsyncMutex::new(HashMap::new())),
                 cron_turn_done_tx,
                 cron_turn_done_rx: Some(cron_turn_done_rx),

--- a/apps/daemon/src/daemon/server/remote_tools.rs
+++ b/apps/daemon/src/daemon/server/remote_tools.rs
@@ -7,23 +7,6 @@ use tokio::sync::oneshot;
 
 use super::DaemonServer;
 
-fn stamp_active_session_for_runtime(worktree: &str, teamclu_session_id: &str) {
-    if teamclu_session_id.is_empty() || worktree.is_empty() {
-        return;
-    }
-    if let Err(e) = teamclu_runtime_env::write_active_session_id(
-        std::path::Path::new(worktree),
-        teamclu_session_id,
-    ) {
-        tracing::warn!(
-            worktree,
-            session_id = teamclu_session_id,
-            error = %e,
-            "failed to stamp active session id for MCP introspect"
-        );
-    }
-}
-
 impl DaemonServer {
     pub(crate) async fn prepare_remote_tool_context_for_turn(
         &self,
@@ -38,7 +21,7 @@ impl DaemonServer {
                 .map(|h| (h.acp_session_id.clone(), h.worktree.clone()))
                 .unwrap_or_default()
         };
-        stamp_active_session_for_runtime(&worktree, teamclu_session_id);
+        let _ = worktree;
         let remote_context_id = self.remote_tool_turn_contexts.lock().await.create(
             runtime_id,
             &acp_session_id,

--- a/apps/daemon/src/daemon/server/runtime_lifecycle.rs
+++ b/apps/daemon/src/daemon/server/runtime_lifecycle.rs
@@ -604,17 +604,13 @@ impl DaemonServer {
         }
 
         if !session_id.is_empty() {
-            if let Err(e) = teamclu_runtime_env::write_active_session_id(
-                Path::new(&resolved_worktree),
+            // Phase 2: daemon-managed runtimes resolve session context via the
+            // runtime context registry; do not stamp ambient worktree state.
+            tracing::debug!(
                 session_id,
-            ) {
-                warn!(
-                    session_id,
-                    worktree = %resolved_worktree,
-                    error = %e,
-                    "apply_start_runtime: failed to stamp active session id for MCP introspect"
-                );
-            }
+                worktree = %resolved_worktree,
+                "apply_start_runtime: session context registry owns active session binding"
+            );
         }
 
         if should_bind_remote_target {

--- a/apps/daemon/src/http/mod.rs
+++ b/apps/daemon/src/http/mod.rs
@@ -38,6 +38,7 @@ pub mod live_ingest;
 pub mod observ;
 pub mod rpc;
 pub mod runtime_adapter;
+pub mod runtime_context;
 pub mod sessions;
 pub mod setup;
 pub mod state;

--- a/apps/daemon/src/http/routes.rs
+++ b/apps/daemon/src/http/routes.rs
@@ -33,6 +33,10 @@ pub fn build(state: HttpState) -> Router {
     Router::new()
         .route("/v1/healthz", healthz_route())
         .route("/v1/info", info_route())
+        .route(
+            "/internal/runtime-context/resolve",
+            post(crate::http::runtime_context::resolve_runtime_context),
+        )
         .route("/v1/mqtt/recover", post(mqtt_recover))
         // Embedded protocol console. Static zero-dependency HTML inlined into
         // the binary; it drives this same daemon's /v1/sessions API over fetch

--- a/apps/daemon/src/http/runtime_context.rs
+++ b/apps/daemon/src/http/runtime_context.rs
@@ -1,0 +1,94 @@
+//! Internal loopback endpoint for backend adapters to resolve TeamClu session context.
+
+use axum::{
+    extract::{ConnectInfo, State},
+    http::{header, HeaderMap, StatusCode},
+    response::{IntoResponse, Response},
+    Json,
+};
+use std::net::SocketAddr;
+use tracing::warn;
+
+use crate::runtime::context_registry::{ResolveError, ResolveRuntimeContextRequest};
+
+use super::state::HttpState;
+
+pub async fn resolve_runtime_context(
+    State(state): State<HttpState>,
+    ConnectInfo(peer): ConnectInfo<SocketAddr>,
+    headers: HeaderMap,
+    Json(body): Json<ResolveRuntimeContextRequest>,
+) -> Response {
+    if !peer.ip().is_loopback() {
+        return problem(
+            StatusCode::FORBIDDEN,
+            "forbidden",
+            "Runtime context resolve is loopback-only",
+        );
+    }
+    let Some(service) = state.runtime_context.clone() else {
+        return problem(
+            StatusCode::SERVICE_UNAVAILABLE,
+            "runtime_context_unavailable",
+            "Runtime context service is not configured",
+        );
+    };
+    let bearer = headers
+        .get(header::AUTHORIZATION)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|v| v.strip_prefix("Bearer "))
+        .unwrap_or("")
+        .trim();
+    match service.resolve_with_token(bearer, &body) {
+        Ok(resolved) => {
+            tracing::info!(
+                event = "runtime_context_resolve",
+                backend_kind = %body.backend_kind,
+                host_generation_id = %body.host_generation_id,
+                backend_session_id = %body.backend_session_id,
+                teamclu_session_id = %resolved.teamclu_session_id,
+                runtime_id = %resolved.runtime_id,
+                result = "resolved",
+                "runtime context resolved"
+            );
+            Json(resolved).into_response()
+        }
+        Err(err) => {
+            warn!(
+                event = "runtime_context_resolve",
+                backend_kind = %body.backend_kind,
+                host_generation_id = %body.host_generation_id,
+                backend_session_id = %body.backend_session_id,
+                result = err.code(),
+                "runtime context resolve failed"
+            );
+            problem(
+                StatusCode::from_u16(err.http_status()).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR),
+                err.code(),
+                session_context_error_message(&err),
+            )
+        }
+    }
+}
+
+fn session_context_error_message(err: &ResolveError) -> &'static str {
+    match err {
+        ResolveError::InvalidBackendSessionId => "backendSessionId is required",
+        ResolveError::InvalidRuntimeContextToken => "Invalid or expired runtime context token",
+        ResolveError::SessionContextUnavailable => {
+            "Unable to determine the TeamClu session for this tool call"
+        }
+        ResolveError::StaleHostGeneration => "Host generation mismatch",
+    }
+}
+
+fn problem(status: StatusCode, code: &str, detail: &str) -> Response {
+    (
+        status,
+        Json(serde_json::json!({
+            "error": code,
+            "detail": detail,
+        })),
+    )
+        .into_response()
+}

--- a/apps/daemon/src/http/server.rs
+++ b/apps/daemon/src/http/server.rs
@@ -83,6 +83,7 @@ pub async fn spawn(
     local_rpc_tx: Option<crate::http::state::LocalRpcTx>,
     local_live_ingest_tx: Option<crate::http::state::LocalLiveIngestTx>,
     team_skills: Option<Arc<crate::runtime::team_skills::TeamSkillReconciler>>,
+    runtime_context: Option<Arc<crate::runtime::context_service::RuntimeContextService>>,
 ) -> anyhow::Result<HttpHandle> {
     // Resolve token + port files (defaults live in DaemonConfig::config_dir).
     let token_path = http
@@ -107,6 +108,9 @@ pub async fn spawn(
         .map_err(|e| anyhow::anyhow!("bind {addr}: {e}"))?;
     let local_addr = listener.local_addr()?;
     tokens::write_port_file(&port_path, local_addr.port());
+    if let Some(service) = runtime_context.as_ref() {
+        service.set_base_url(format!("http://{local_addr}"));
+    }
 
     tracing::info!(
         bind = %local_addr,
@@ -151,6 +155,11 @@ pub async fn spawn(
     .with_team_skills(team_skills)
     .with_local_rpc(local_rpc_tx)
     .with_local_live_ingest(local_live_ingest_tx);
+    let state = if let Some(service) = runtime_context {
+        state.with_runtime_context(service)
+    } else {
+        state
+    };
 
     spawn_reapers(state.clone());
     let mut app: Router = routes::build(state);
@@ -268,6 +277,7 @@ mod tests {
             None,
             None,
             None,
+            None,
         )
         .await
         .unwrap();
@@ -297,6 +307,7 @@ mod tests {
             None,
             None,
             test_dispatcher(),
+            None,
             None,
             None,
             None,
@@ -352,6 +363,7 @@ mod tests {
             None,
             None,
             test_dispatcher(),
+            None,
             None,
             None,
             None,
@@ -555,6 +567,7 @@ mod tests {
             None,
             None,
             None,
+            None,
         )
         .await
         .unwrap();
@@ -629,6 +642,7 @@ mod tests {
             None,
             None,
             test_dispatcher(),
+            None,
             None,
             None,
             None,
@@ -717,6 +731,7 @@ mod tests {
             None,
             None,
             test_dispatcher(),
+            None,
             None,
             None,
             None,
@@ -817,6 +832,7 @@ mod tests {
             None,
             None,
             test_dispatcher(),
+            None,
             None,
             None,
             None,
@@ -945,6 +961,7 @@ mod tests {
             Some(rpc_tx),
             None,
             None,
+            None,
         )
         .await
         .unwrap();
@@ -1063,6 +1080,7 @@ mod tests {
             None,
             None,
             Some(reconciler),
+            None,
         )
         .await
         .unwrap();

--- a/apps/daemon/src/http/state.rs
+++ b/apps/daemon/src/http/state.rs
@@ -180,6 +180,8 @@ pub struct HttpState {
     /// local twin of publishing to `session/{id}/live`. `None` in focused
     /// tests / when no actor loop is attached; the route then returns 503.
     pub local_live_ingest_tx: Option<LocalLiveIngestTx>,
+    /// Backend session → TeamClu session registry for managed MCP adapters.
+    pub runtime_context: Option<Arc<crate::runtime::context_service::RuntimeContextService>>,
 }
 
 impl HttpState {
@@ -224,7 +226,16 @@ impl HttpState {
             onboarding: None,
             local_rpc_tx: None,
             local_live_ingest_tx: None,
+            runtime_context: None,
         }
+    }
+
+    pub fn with_runtime_context(
+        mut self,
+        service: Arc<crate::runtime::context_service::RuntimeContextService>,
+    ) -> Self {
+        self.runtime_context = Some(service);
+        self
     }
 
     /// Attach the daemon-level config surface (`/v1/config/*`, `/v1/setup/*`).

--- a/apps/daemon/src/runtime/backend.rs
+++ b/apps/daemon/src/runtime/backend.rs
@@ -45,6 +45,8 @@ pub enum AcpCommand {
         permission: PermissionPolicy,
         /// When resuming, fail instead of falling back to a new session.
         forbid_new_session_fallback: bool,
+        /// TeamClu cloud session this attachment belongs to.
+        teamclu_session_id: String,
     },
     /// Drop routing state for a session; the backend process keeps running.
     DetachSession {
@@ -137,6 +139,7 @@ pub trait AgentBackend: Send {
         event_tx: mpsc::Sender<AcpEventFrame>,
         permission: PermissionPolicy,
         forbid_new_session_fallback: bool,
+        teamclu_session_id: String,
     ) -> crate::error::Result<(mpsc::Sender<AcpCommand>, AcpStartupMetadata)>;
 
     /// Pre-warm: start the backend process ahead of the first session.
@@ -218,6 +221,12 @@ pub trait AgentBackend: Send {
     ) -> Option<std::sync::Arc<super::opencode_http::host_pool::OpenCodeHostPool>> {
         None
     }
+
+    fn attach_context_service(
+        &mut self,
+        _service: std::sync::Arc<super::context_service::RuntimeContextService>,
+    ) {
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -241,6 +250,13 @@ impl OpencodeHttpBackend {
     pub(crate) fn test_with_host(host: OpencodeHost) -> Self {
         Self { host }
     }
+
+    pub fn attach_context_service(
+        &mut self,
+        service: std::sync::Arc<super::context_service::RuntimeContextService>,
+    ) {
+        self.host.attach_context_service(service);
+    }
 }
 
 impl Default for OpencodeHttpBackend {
@@ -251,6 +267,13 @@ impl Default for OpencodeHttpBackend {
 
 #[async_trait]
 impl AgentBackend for OpencodeHttpBackend {
+    fn attach_context_service(
+        &mut self,
+        service: std::sync::Arc<super::context_service::RuntimeContextService>,
+    ) {
+        self.host.attach_context_service(service);
+    }
+
     async fn attach_session(
         &mut self,
         agent_type: amux::AgentType,
@@ -268,6 +291,7 @@ impl AgentBackend for OpencodeHttpBackend {
         event_tx: mpsc::Sender<AcpEventFrame>,
         permission: PermissionPolicy,
         forbid_new_session_fallback: bool,
+        teamclu_session_id: String,
     ) -> crate::error::Result<(mpsc::Sender<AcpCommand>, AcpStartupMetadata)> {
         self.host
             .attach_session(
@@ -286,6 +310,7 @@ impl AgentBackend for OpencodeHttpBackend {
                 event_tx,
                 permission,
                 forbid_new_session_fallback,
+                teamclu_session_id,
             )
             .await
     }

--- a/apps/daemon/src/runtime/claude_agent/mod.rs
+++ b/apps/daemon/src/runtime/claude_agent/mod.rs
@@ -181,12 +181,14 @@ struct AttachArgs {
     event_tx: mpsc::Sender<AcpEventFrame>,
     permission: PermissionPolicy,
     forbid_new_session_fallback: bool,
+    teamclu_session_id: String,
 }
 
 async fn attach(shared: &Arc<Shared>, args: AttachArgs) -> Result<AcpStartupMetadata, String> {
     load_claude_pool_config(&shared.pool);
     let worktree = canonical_dir(&args.worktree);
-    let mcp_servers = mcp::assemble(&worktree, args.mcp_config_path.as_deref());
+    let mut mcp_servers = mcp::assemble(&worktree, args.mcp_config_path.as_deref());
+    mcp::stamp_managed_session_context(&mut mcp_servers, &args.teamclu_session_id);
     let proc = shared
         .pool
         .ensure(shared, &worktree)
@@ -438,6 +440,7 @@ async fn command_loop(shared: Arc<Shared>, mut cmd_rx: mpsc::Receiver<AcpCommand
                 startup_tx,
                 permission,
                 forbid_new_session_fallback,
+                teamclu_session_id,
             } => {
                 let result = attach(
                     &shared,
@@ -451,6 +454,7 @@ async fn command_loop(shared: Arc<Shared>, mut cmd_rx: mpsc::Receiver<AcpCommand
                         event_tx,
                         permission,
                         forbid_new_session_fallback,
+                        teamclu_session_id,
                     },
                 )
                 .await;
@@ -611,6 +615,7 @@ impl AgentBackend for ClaudeAgentBackend {
         event_tx: mpsc::Sender<AcpEventFrame>,
         permission: PermissionPolicy,
         forbid_new_session_fallback: bool,
+        teamclu_session_id: String,
     ) -> crate::error::Result<(mpsc::Sender<AcpCommand>, AcpStartupMetadata)> {
         load_claude_pool_config(&self.shared.pool);
         self.shared
@@ -632,6 +637,7 @@ impl AgentBackend for ClaudeAgentBackend {
                 event_tx,
                 permission,
                 forbid_new_session_fallback,
+                teamclu_session_id,
             },
         )
         .await

--- a/apps/daemon/src/runtime/context_registry.rs
+++ b/apps/daemon/src/runtime/context_registry.rs
@@ -1,0 +1,458 @@
+//! In-process registry mapping backend sessions to TeamClu cloud sessions.
+//!
+//! Replaces worktree-level `active-session-id` for managed daemon backends.
+
+use std::collections::HashMap;
+use std::time::Instant;
+
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use teamclu_runtime_env::session_context::{
+    TEAMCLU_AGENT_BACKEND_ENV, TEAMCLU_HOST_GENERATION_ID_ENV, TEAMCLU_RUNTIME_CONTEXT_TOKEN_ENV,
+    TEAMCLU_RUNTIME_CONTEXT_URL_ENV,
+};
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct BackendSessionKey {
+    pub backend_kind: String,
+    pub host_generation_id: String,
+    pub backend_session_id: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LifecycleState {
+    Active,
+    Detaching,
+    Stopped,
+}
+
+#[derive(Debug, Clone)]
+pub struct RuntimeSessionBinding {
+    pub teamclu_session_id: String,
+    pub runtime_id: String,
+    pub parent_backend_session_id: Option<String>,
+    pub lifecycle_state: LifecycleState,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ResolveRuntimeContextRequest {
+    #[serde(rename = "backendSessionId")]
+    pub backend_session_id: String,
+    #[serde(rename = "hostGenerationId")]
+    pub host_generation_id: String,
+    #[serde(rename = "backendKind")]
+    pub backend_kind: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ResolveRuntimeContextResponse {
+    #[serde(rename = "teamcluSessionId")]
+    pub teamclu_session_id: String,
+    #[serde(rename = "runtimeId")]
+    pub runtime_id: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ResolveError {
+    InvalidBackendSessionId,
+    InvalidRuntimeContextToken,
+    SessionContextUnavailable,
+    StaleHostGeneration,
+}
+
+impl ResolveError {
+    pub fn code(&self) -> &'static str {
+        match self {
+            Self::InvalidBackendSessionId => "invalid_backend_session_id",
+            Self::InvalidRuntimeContextToken => "invalid_runtime_context_token",
+            Self::SessionContextUnavailable => "session_context_unavailable",
+            Self::StaleHostGeneration => "stale_host_generation",
+        }
+    }
+
+    pub fn http_status(&self) -> u16 {
+        match self {
+            Self::InvalidRuntimeContextToken => 401,
+            Self::SessionContextUnavailable => 404,
+            Self::StaleHostGeneration => 409,
+            Self::InvalidBackendSessionId => 422,
+        }
+    }
+}
+
+#[derive(Default)]
+pub struct RuntimeContextRegistry {
+    entries: HashMap<BackendSessionKey, RuntimeSessionBinding>,
+}
+
+impl RuntimeContextRegistry {
+    pub fn register_parent(
+        &mut self,
+        backend_kind: impl Into<String>,
+        host_generation_id: impl Into<String>,
+        backend_session_id: impl Into<String>,
+        teamclu_session_id: impl Into<String>,
+        runtime_id: impl Into<String>,
+    ) {
+        let key = BackendSessionKey {
+            backend_kind: backend_kind.into(),
+            host_generation_id: host_generation_id.into(),
+            backend_session_id: backend_session_id.into(),
+        };
+        self.entries.insert(
+            key,
+            RuntimeSessionBinding {
+                teamclu_session_id: teamclu_session_id.into(),
+                runtime_id: runtime_id.into(),
+                parent_backend_session_id: None,
+                lifecycle_state: LifecycleState::Active,
+            },
+        );
+    }
+
+    pub fn register_child(
+        &mut self,
+        backend_kind: impl Into<String>,
+        host_generation_id: impl Into<String>,
+        child_backend_session_id: impl Into<String>,
+        parent_backend_session_id: impl Into<String>,
+    ) -> bool {
+        let parent_key = BackendSessionKey {
+            backend_kind: backend_kind.into(),
+            host_generation_id: host_generation_id.into(),
+            backend_session_id: parent_backend_session_id.into(),
+        };
+        let Some(parent) = self.entries.get(&parent_key) else {
+            return false;
+        };
+        if parent.lifecycle_state != LifecycleState::Active {
+            return false;
+        }
+        let child_key = BackendSessionKey {
+            backend_kind: parent_key.backend_kind.clone(),
+            host_generation_id: parent_key.host_generation_id.clone(),
+            backend_session_id: child_backend_session_id.into(),
+        };
+        self.entries.insert(
+            child_key,
+            RuntimeSessionBinding {
+                teamclu_session_id: parent.teamclu_session_id.clone(),
+                runtime_id: parent.runtime_id.clone(),
+                parent_backend_session_id: Some(parent_key.backend_session_id.clone()),
+                lifecycle_state: LifecycleState::Active,
+            },
+        );
+        true
+    }
+
+    pub fn unregister_backend_session(
+        &mut self,
+        backend_kind: &str,
+        host_generation_id: &str,
+        backend_session_id: &str,
+    ) {
+        let prefix = BackendSessionKey {
+            backend_kind: backend_kind.to_string(),
+            host_generation_id: host_generation_id.to_string(),
+            backend_session_id: backend_session_id.to_string(),
+        };
+        self.entries.remove(&prefix);
+        self.entries.retain(|_, binding| {
+            binding.parent_backend_session_id.as_deref() != Some(backend_session_id)
+        });
+    }
+
+    pub fn clear_generation(&mut self, backend_kind: &str, host_generation_id: &str) {
+        self.entries.retain(|key, _| {
+            key.backend_kind != backend_kind || key.host_generation_id != host_generation_id
+        });
+    }
+
+    pub fn resolve(&self, req: &ResolveRuntimeContextRequest) -> Result<ResolveRuntimeContextResponse, ResolveError> {
+        let backend_session_id = req.backend_session_id.trim();
+        if backend_session_id.is_empty() {
+            return Err(ResolveError::InvalidBackendSessionId);
+        }
+        let host_generation_id = req.host_generation_id.trim();
+        if host_generation_id.is_empty() {
+            return Err(ResolveError::StaleHostGeneration);
+        }
+        let backend_kind = req.backend_kind.trim();
+        if backend_kind.is_empty() {
+            return Err(ResolveError::InvalidBackendSessionId);
+        }
+
+        let mut current = backend_session_id.to_string();
+        let mut seen = HashMap::<String, u8>::new();
+        loop {
+            if seen.insert(current.clone(), 1).is_some() {
+                return Err(ResolveError::SessionContextUnavailable);
+            }
+            let key = BackendSessionKey {
+                backend_kind: backend_kind.to_string(),
+                host_generation_id: host_generation_id.to_string(),
+                backend_session_id: current.clone(),
+            };
+            let Some(binding) = self.entries.get(&key) else {
+                return Err(ResolveError::SessionContextUnavailable);
+            };
+            if binding.lifecycle_state != LifecycleState::Active {
+                return Err(ResolveError::SessionContextUnavailable);
+            }
+            if binding.teamclu_session_id.trim().is_empty() {
+                return Err(ResolveError::SessionContextUnavailable);
+            }
+            match binding.parent_backend_session_id.as_deref() {
+                None => {
+                    return Ok(ResolveRuntimeContextResponse {
+                        teamclu_session_id: binding.teamclu_session_id.clone(),
+                        runtime_id: binding.runtime_id.clone(),
+                    });
+                }
+                Some(parent) => current = parent.to_string(),
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct GenerationTokenRecord {
+    token: String,
+    backend_kind: String,
+    generation_id: String,
+    created_at: Instant,
+}
+
+#[derive(Default)]
+pub struct GenerationTokenStore {
+    by_generation: HashMap<(String, String), GenerationTokenRecord>,
+    by_token: HashMap<String, (String, String)>,
+}
+
+impl GenerationTokenStore {
+    pub fn ensure_token(
+        &mut self,
+        backend_kind: impl Into<String>,
+        generation_id: impl Into<String>,
+    ) -> String {
+        let backend_kind = backend_kind.into();
+        let generation_id = generation_id.into();
+        let key = (backend_kind.clone(), generation_id.clone());
+        if let Some(record) = self.by_generation.get(&key) {
+            return record.token.clone();
+        }
+        let token = format!("rtctx_{}", Uuid::new_v4().simple());
+        self.by_generation.insert(
+            key.clone(),
+            GenerationTokenRecord {
+                token: token.clone(),
+                backend_kind: backend_kind.clone(),
+                generation_id: generation_id.clone(),
+                created_at: Instant::now(),
+            },
+        );
+        self.by_token
+            .insert(token.clone(), (backend_kind, generation_id));
+        token
+    }
+
+    pub fn validate(
+        &self,
+        token: &str,
+        backend_kind: &str,
+        host_generation_id: &str,
+    ) -> Result<(), ResolveError> {
+        let token = token.trim();
+        if token.is_empty() {
+            return Err(ResolveError::InvalidRuntimeContextToken);
+        }
+        let Some((kind, generation)) = self.by_token.get(token) else {
+            return Err(ResolveError::InvalidRuntimeContextToken);
+        };
+        if kind != backend_kind || generation != host_generation_id {
+            return Err(ResolveError::InvalidRuntimeContextToken);
+        }
+        Ok(())
+    }
+
+    pub fn revoke_generation(&mut self, backend_kind: &str, generation_id: &str) {
+        let key = (backend_kind.to_string(), generation_id.to_string());
+        if let Some(record) = self.by_generation.remove(&key) {
+            self.by_token.remove(&record.token);
+        }
+    }
+}
+
+pub fn backend_kind_for_agent_type(agent_type: crate::proto::amux::AgentType) -> &'static str {
+    match agent_type {
+        crate::proto::amux::AgentType::Pi => "pi",
+        crate::proto::amux::AgentType::ClaudeCode => "claude",
+        crate::proto::amux::AgentType::Cursor => "cursor",
+        crate::proto::amux::AgentType::Opencode | crate::proto::amux::AgentType::Codex => "opencode",
+        _ => "opencode",
+    }
+}
+
+pub fn generation_env(
+    base_url: &str,
+    token: &str,
+    backend_kind: &str,
+    generation_id: &str,
+) -> HashMap<String, String> {
+    let mut env = HashMap::new();
+    env.insert(
+        TEAMCLU_RUNTIME_CONTEXT_URL_ENV.to_string(),
+        base_url.trim_end_matches('/').to_string(),
+    );
+    env.insert(TEAMCLU_RUNTIME_CONTEXT_TOKEN_ENV.to_string(), token.to_string());
+    env.insert(
+        TEAMCLU_HOST_GENERATION_ID_ENV.to_string(),
+        generation_id.to_string(),
+    );
+    env.insert(
+        TEAMCLU_AGENT_BACKEND_ENV.to_string(),
+        backend_kind.to_string(),
+    );
+    env.insert(
+        teamclu_runtime_env::session_context::TEAMCLU_REQUIRE_EXPLICIT_SESSION_ID_ENV.to_string(),
+        "1".to_string(),
+    );
+    env
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SESSION_A: &str = "a1ca8f06-94ee-4fb5-bdfb-194a5606062f";
+    const SESSION_B: &str = "b2db9017-05ff-4ac6-c0ec-0a5b67171730";
+
+    fn req(backend_session: &str, generation: &str) -> ResolveRuntimeContextRequest {
+        ResolveRuntimeContextRequest {
+            backend_session_id: backend_session.to_string(),
+            host_generation_id: generation.to_string(),
+            backend_kind: "opencode".to_string(),
+        }
+    }
+
+    #[test]
+    fn register_and_resolve_two_concurrent_sessions() {
+        let mut registry = RuntimeContextRegistry::default();
+        registry.register_parent("opencode", "gen1", "ses_a", SESSION_A, SESSION_A);
+        registry.register_parent("opencode", "gen1", "ses_b", SESSION_B, SESSION_B);
+        assert_eq!(
+            registry.resolve(&req("ses_a", "gen1")).unwrap().teamclu_session_id,
+            SESSION_A
+        );
+        assert_eq!(
+            registry.resolve(&req("ses_b", "gen1")).unwrap().teamclu_session_id,
+            SESSION_B
+        );
+    }
+
+    #[test]
+    fn same_backend_session_id_in_two_generations_do_not_collide() {
+        let mut registry = RuntimeContextRegistry::default();
+        registry.register_parent("opencode", "gen1", "ses_same", SESSION_A, SESSION_A);
+        registry.register_parent("opencode", "gen2", "ses_same", SESSION_B, SESSION_B);
+        assert_eq!(
+            registry.resolve(&req("ses_same", "gen1")).unwrap().teamclu_session_id,
+            SESSION_A
+        );
+        assert_eq!(
+            registry.resolve(&req("ses_same", "gen2")).unwrap().teamclu_session_id,
+            SESSION_B
+        );
+    }
+
+    #[test]
+    fn detach_one_session_leaves_the_other() {
+        let mut registry = RuntimeContextRegistry::default();
+        registry.register_parent("opencode", "gen1", "ses_a", SESSION_A, SESSION_A);
+        registry.register_parent("opencode", "gen1", "ses_b", SESSION_B, SESSION_B);
+        registry.unregister_backend_session("opencode", "gen1", "ses_a");
+        assert!(registry.resolve(&req("ses_a", "gen1")).is_err());
+        assert_eq!(
+            registry.resolve(&req("ses_b", "gen1")).unwrap().teamclu_session_id,
+            SESSION_B
+        );
+    }
+
+    #[test]
+    fn child_inherits_parent_teamclu_session() {
+        let mut registry = RuntimeContextRegistry::default();
+        registry.register_parent("opencode", "gen1", "ses_parent", SESSION_A, SESSION_A);
+        assert!(registry.register_child("opencode", "gen1", "ses_child", "ses_parent"));
+        assert_eq!(
+            registry
+                .resolve(&req("ses_child", "gen1"))
+                .unwrap()
+                .teamclu_session_id,
+            SESSION_A
+        );
+    }
+
+    #[test]
+    fn generation_teardown_clears_entries() {
+        let mut registry = RuntimeContextRegistry::default();
+        registry.register_parent("opencode", "gen1", "ses_a", SESSION_A, SESSION_A);
+        registry.clear_generation("opencode", "gen1");
+        assert!(registry.resolve(&req("ses_a", "gen1")).is_err());
+    }
+
+    #[test]
+    fn generation_token_validates_kind_and_generation() {
+        let mut store = GenerationTokenStore::default();
+        let token = store.ensure_token("opencode", "gen1");
+        assert!(store.validate(&token, "opencode", "gen1").is_ok());
+        assert!(store.validate(&token, "pi", "gen1").is_err());
+        assert!(store.validate(&token, "opencode", "gen2").is_err());
+    }
+
+    #[test]
+    fn child_without_parent_fails_closed() {
+        let mut registry = RuntimeContextRegistry::default();
+        assert!(!registry.register_child("opencode", "gen1", "ses_child", "missing_parent"));
+        assert!(registry.resolve(&req("ses_child", "gen1")).is_err());
+    }
+
+    /// Phase 2 integration gate: alternating concurrent resolves must never cross sessions.
+    #[test]
+    fn concurrent_ab_resolves_never_cross_sessions() {
+        let mut registry = RuntimeContextRegistry::default();
+        registry.register_parent("opencode", "gen1", "ses_a", SESSION_A, SESSION_A);
+        registry.register_parent("opencode", "gen1", "ses_b", SESSION_B, SESSION_B);
+        registry.register_child("opencode", "gen1", "ses_child_a", "ses_a");
+
+        use std::sync::{Arc, Mutex};
+        let registry = Arc::new(Mutex::new(registry));
+        let mut handles = Vec::new();
+        for i in 0..100 {
+            let reg = Arc::clone(&registry);
+            handles.push(std::thread::spawn(move || {
+                let backend_session = if i % 2 == 0 { "ses_a" } else { "ses_b" };
+                let expected = if i % 2 == 0 { SESSION_A } else { SESSION_B };
+                let resolved = reg
+                    .lock()
+                    .unwrap()
+                    .resolve(&req(backend_session, "gen1"))
+                    .unwrap()
+                    .teamclu_session_id;
+                assert_eq!(resolved, expected);
+            }));
+        }
+        for h in handles {
+            h.join().unwrap();
+        }
+        assert_eq!(
+            registry
+                .lock()
+                .unwrap()
+                .resolve(&req("ses_child_a", "gen1"))
+                .unwrap()
+                .teamclu_session_id,
+            SESSION_A
+        );
+    }
+}

--- a/apps/daemon/src/runtime/context_service.rs
+++ b/apps/daemon/src/runtime/context_service.rs
@@ -1,0 +1,186 @@
+//! Shared runtime context service used by HTTP resolve and runtime lifecycle.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use parking_lot::RwLock;
+use tracing::warn;
+
+use super::context_registry::{
+    backend_kind_for_agent_type, generation_env, GenerationTokenStore, ResolveError,
+    ResolveRuntimeContextRequest, ResolveRuntimeContextResponse, RuntimeContextRegistry,
+};
+use crate::proto::amux;
+
+#[derive(Clone)]
+pub struct RuntimeContextService {
+    inner: Arc<RwLock<RuntimeContextServiceInner>>,
+}
+
+struct RuntimeContextServiceInner {
+    registry: RuntimeContextRegistry,
+    tokens: GenerationTokenStore,
+    base_url: Option<String>,
+}
+
+impl Default for RuntimeContextService {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl RuntimeContextService {
+    pub fn new() -> Self {
+        Self {
+            inner: Arc::new(RwLock::new(RuntimeContextServiceInner {
+                registry: RuntimeContextRegistry::default(),
+                tokens: GenerationTokenStore::default(),
+                base_url: None,
+            })),
+        }
+    }
+
+    pub fn set_base_url(&self, base_url: impl Into<String>) {
+        let url = base_url.into();
+        if url.trim().is_empty() {
+            return;
+        }
+        self.inner.write().base_url = Some(url.trim_end_matches('/').to_string());
+    }
+
+    pub fn register_attached_session(
+        &self,
+        agent_type: amux::AgentType,
+        host_generation_id: &str,
+        backend_session_id: &str,
+        teamclu_session_id: &str,
+        runtime_id: &str,
+    ) {
+        if host_generation_id.trim().is_empty()
+            || backend_session_id.trim().is_empty()
+            || teamclu_session_id.trim().is_empty()
+        {
+            return;
+        }
+        let backend_kind = backend_kind_for_agent_type(agent_type);
+        self.inner.write().registry.register_parent(
+            backend_kind,
+            host_generation_id,
+            backend_session_id,
+            teamclu_session_id,
+            runtime_id,
+        );
+    }
+
+    pub fn register_child_session(
+        &self,
+        agent_type: amux::AgentType,
+        host_generation_id: &str,
+        child_backend_session_id: &str,
+        parent_backend_session_id: &str,
+    ) {
+        let backend_kind = backend_kind_for_agent_type(agent_type);
+        let ok = self.inner.write().registry.register_child(
+            backend_kind,
+            host_generation_id,
+            child_backend_session_id,
+            parent_backend_session_id,
+        );
+        if !ok {
+            warn!(
+                backend_kind,
+                host_generation_id,
+                child_backend_session_id,
+                parent_backend_session_id,
+                "runtime context child registration failed"
+            );
+        }
+    }
+
+    pub fn unregister_backend_session(
+        &self,
+        agent_type: amux::AgentType,
+        host_generation_id: &str,
+        backend_session_id: &str,
+    ) {
+        if host_generation_id.trim().is_empty() || backend_session_id.trim().is_empty() {
+            return;
+        }
+        let backend_kind = backend_kind_for_agent_type(agent_type);
+        self.inner.write().registry.unregister_backend_session(
+            backend_kind,
+            host_generation_id,
+            backend_session_id,
+        );
+    }
+
+    pub fn clear_generation(&self, agent_type: amux::AgentType, host_generation_id: &str) {
+        if host_generation_id.trim().is_empty() {
+            return;
+        }
+        let backend_kind = backend_kind_for_agent_type(agent_type);
+        let mut inner = self.inner.write();
+        inner.registry.clear_generation(backend_kind, host_generation_id);
+        inner
+            .tokens
+            .revoke_generation(backend_kind, host_generation_id);
+    }
+
+    pub fn resolve_with_token(
+        &self,
+        bearer_token: &str,
+        req: &ResolveRuntimeContextRequest,
+    ) -> Result<ResolveRuntimeContextResponse, ResolveError> {
+        let inner = self.inner.read();
+        inner.tokens.validate(
+            bearer_token,
+            req.backend_kind.trim(),
+            req.host_generation_id.trim(),
+        )?;
+        inner.registry.resolve(req)
+    }
+
+    pub fn env_for_generation(
+        &self,
+        agent_type: amux::AgentType,
+        host_generation_id: &str,
+    ) -> HashMap<String, String> {
+        let backend_kind = backend_kind_for_agent_type(agent_type);
+        let mut inner = self.inner.write();
+        let token = inner
+            .tokens
+            .ensure_token(backend_kind, host_generation_id);
+        let base_url = inner
+            .base_url
+            .clone()
+            .unwrap_or_else(|| "http://127.0.0.1:0".to_string());
+        generation_env(&base_url, &token, backend_kind, host_generation_id)
+    }
+
+    /// Phase 2 startup validation: managed session context must be wired before
+    /// accepting agent attachments.
+    pub fn validate_managed_setup(&self, local_agent: &str) -> Result<(), String> {
+        let inner = self.inner.read();
+        if inner.base_url.as_deref().unwrap_or("").trim().is_empty() {
+            return Err(
+                "runtime context service has no loopback base URL; HTTP server must bind first"
+                    .to_string(),
+            );
+        }
+        let _ = local_agent;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validate_managed_setup_requires_base_url() {
+        let service = RuntimeContextService::new();
+        assert!(service.validate_managed_setup("opencode").is_err());
+        service.set_base_url("http://127.0.0.1:13141");
+        assert!(service.validate_managed_setup("opencode").is_ok());
+    }
+}

--- a/apps/daemon/src/runtime/cursor_sdk/mod.rs
+++ b/apps/daemon/src/runtime/cursor_sdk/mod.rs
@@ -164,6 +164,7 @@ struct AttachArgs {
     event_tx: mpsc::Sender<AcpEventFrame>,
     permission: PermissionPolicy,
     forbid_new_session_fallback: bool,
+    teamclu_session_id: String,
 }
 
 /// Install the `preToolUse` gate in the worktree. Best-effort: a worktree we
@@ -188,7 +189,8 @@ async fn attach(shared: &Arc<Shared>, args: AttachArgs) -> Result<AcpStartupMeta
     load_cursor_pool_config(&shared.pool);
     let worktree = canonical_dir(&args.worktree);
     install_permission_hook(&worktree);
-    let mcp_servers = mcp::assemble(&worktree, args.mcp_config_path.as_deref());
+    let mut mcp_servers = mcp::assemble(&worktree, args.mcp_config_path.as_deref());
+    mcp::stamp_managed_session_context(&mut mcp_servers, &args.teamclu_session_id);
     let proc = shared
         .pool
         .ensure(shared, &worktree)
@@ -416,6 +418,7 @@ async fn command_loop(shared: Arc<Shared>, mut cmd_rx: mpsc::Receiver<AcpCommand
                 startup_tx,
                 permission,
                 forbid_new_session_fallback,
+                teamclu_session_id,
             } => {
                 let result = attach(
                     &shared,
@@ -428,6 +431,7 @@ async fn command_loop(shared: Arc<Shared>, mut cmd_rx: mpsc::Receiver<AcpCommand
                         event_tx,
                         permission,
                         forbid_new_session_fallback,
+                        teamclu_session_id,
                     },
                 )
                 .await;
@@ -571,6 +575,7 @@ impl AgentBackend for CursorSdkBackend {
         event_tx: mpsc::Sender<AcpEventFrame>,
         permission: PermissionPolicy,
         forbid_new_session_fallback: bool,
+        teamclu_session_id: String,
     ) -> crate::error::Result<(mpsc::Sender<AcpCommand>, AcpStartupMetadata)> {
         load_cursor_pool_config(&self.shared.pool);
         self.shared
@@ -588,6 +593,7 @@ impl AgentBackend for CursorSdkBackend {
                 event_tx,
                 permission,
                 forbid_new_session_fallback,
+                teamclu_session_id,
             },
         )
         .await

--- a/apps/daemon/src/runtime/manager.rs
+++ b/apps/daemon/src/runtime/manager.rs
@@ -188,6 +188,8 @@ pub struct RuntimeManager {
     /// republishes the actor snapshot. See `mark_actor_state_dirty`.
     actor_state_dirty: bool,
     refresh_coordinator: Option<Arc<RuntimeRefreshCoordinator>>,
+    /// Maps backend session ids to TeamClu cloud sessions for MCP adapters.
+    context_service: Option<Arc<super::context_service::RuntimeContextService>>,
     /// Test-only: records the last body sent per agent_id via send_prompt_raw.
     #[cfg(test)]
     last_sent: HashMap<String, String>,
@@ -219,6 +221,20 @@ impl RuntimeManager {
     pub fn attach_refresh_coordinator(&mut self, coordinator: Arc<RuntimeRefreshCoordinator>) {
         crate::runtime::refresh::set_global_coordinator(Arc::clone(&coordinator));
         self.refresh_coordinator = Some(coordinator);
+    }
+
+    pub fn attach_context_service(&mut self, service: Arc<super::context_service::RuntimeContextService>) {
+        self.context_service = Some(service);
+    }
+
+    pub async fn wire_context_service_to_backend(&self) {
+        let Some(service) = self.context_service.as_ref() else {
+            return;
+        };
+        self.agent_backend
+            .lock()
+            .await
+            .attach_context_service(Arc::clone(service));
     }
 
     /// Shared OpenCode host pool used by chat and workspace services.
@@ -268,6 +284,7 @@ impl RuntimeManager {
             model_catalog_path,
             backend,
             refresh_coordinator: None,
+            context_service: None,
             evicted_pending_publish: Vec::new(),
             actor_state_dirty: false,
             #[cfg(test)]
@@ -645,6 +662,7 @@ impl RuntimeManager {
                 handle.event_tx.clone(),
                 permission,
                 forbid_new_session_fallback,
+                session_id.to_string(),
             )
             .await?;
 
@@ -680,6 +698,16 @@ impl RuntimeManager {
         }
         if let Some(model_id) = startup.initial_model {
             self.set_current_model(&agent_id, &model_id);
+        }
+
+        if let Some(service) = self.context_service.as_ref() {
+            service.register_attached_session(
+                agent_type,
+                &startup.host_generation_id,
+                &startup.acp_session_id,
+                session_id,
+                &agent_id,
+            );
         }
 
         self.seed_cursor_from_prior_runtime(&agent_id, Some(session_id))
@@ -804,6 +832,7 @@ impl RuntimeManager {
                 handle.event_tx.clone(),
                 permission,
                 forbid_new_session_fallback,
+                session_id.to_string(),
             )
             .await?;
 
@@ -825,11 +854,21 @@ impl RuntimeManager {
         self.record_catalog(&worktree, &startup.available_models);
         if let Some(h) = self.agents.get_mut(session_id) {
             h.available_models = startup.available_models;
-            h.acp_session_id = startup.acp_session_id;
+            h.acp_session_id = new_acp_sid.clone();
             h.status = amux::AgentStatus::Active;
         }
         if let Some(model_id) = startup.initial_model {
             self.set_current_model(session_id, &model_id);
+        }
+
+        if let Some(service) = self.context_service.as_ref() {
+            service.register_attached_session(
+                agent_type,
+                &startup.host_generation_id,
+                &new_acp_sid,
+                session_id,
+                session_id,
+            );
         }
 
         self.seed_cursor_from_prior_runtime(session_id, Some(session_id))
@@ -843,14 +882,18 @@ impl RuntimeManager {
             self.mark_actor_state_dirty();
             self.aggregators.remove(agent_id);
             self.agent_state.remove(agent_id);
+            if let Some(service) = self.context_service.as_ref() {
+                service.unregister_backend_session(
+                    handle.agent_type,
+                    &handle.host_generation_id,
+                    &handle.acp_session_id,
+                );
+            }
             self.release_opencode_snapshot(&handle.worktree);
             handle.status = amux::AgentStatus::Stopped;
             handle.shutdown().await;
-            // Clear the workspace's active-session stamp so a later session on
-            // the same worktree (esp. the shared per-team default worktree)
-            // doesn't read this stopped session's id via the MCP
-            // `get_session_deeplink` tool. Compare-and-clear: if a concurrent
-            // session already restamped, leave its id alone.
+            // Best-effort cleanup of legacy ambient stamp files left from pre-Phase-2
+            // builds. Managed runtimes no longer write active-session-id.
             if !handle.session_id.is_empty() && !handle.worktree.is_empty() {
                 teamclu_runtime_env::clear_active_session_id_if_matches(
                     std::path::Path::new(&handle.worktree),
@@ -2049,6 +2092,7 @@ mod tests {
             _event_tx: mpsc::Sender<AcpEventFrame>,
             _permission: PermissionPolicy,
             _forbid_new_session_fallback: bool,
+            _teamclu_session_id: String,
         ) -> crate::error::Result<(
             mpsc::Sender<super::super::backend::AcpCommand>,
             super::super::backend::AcpStartupMetadata,

--- a/apps/daemon/src/runtime/mod.rs
+++ b/apps/daemon/src/runtime/mod.rs
@@ -13,6 +13,8 @@ mod agent_runtime_state;
 mod agent_trace;
 pub mod builtin_commands;
 pub mod env_assembly;
+pub mod context_registry;
+pub mod context_service;
 mod handle;
 mod instruction_delivery;
 pub mod managed_llm;
@@ -31,6 +33,7 @@ pub mod well_known_bin;
 mod workspace_runtime;
 
 pub use backend::{create_backend, AgentBackend, OpencodeHttpBackend};
+pub use context_service::RuntimeContextService;
 pub use handle::{InjectedContextItem, PendingMessage, RuntimeHandle};
 pub use instruction_delivery::{
     resolve_instruction_delivery, skips_buffered_inject, InstructionDelivery,

--- a/apps/daemon/src/runtime/opencode_http/events.rs
+++ b/apps/daemon/src/runtime/opencode_http/events.rs
@@ -467,6 +467,14 @@ fn maybe_register_subagent_route(
         return;
     };
     let _ = shared.ensure_child_route(session_id, &parent_id);
+    if let Some(service) = shared.context_service() {
+        service.register_child_session(
+            crate::proto::amux::AgentType::Opencode,
+            &shared.generation_id,
+            session_id,
+            &parent_id,
+        );
+    }
 }
 
 /// Look up `Session.parentID` for an unrouted child via `GET /session/{id}`

--- a/apps/daemon/src/runtime/opencode_http/host_pool.rs
+++ b/apps/daemon/src/runtime/opencode_http/host_pool.rs
@@ -35,6 +35,7 @@ pub struct HostGeneration {
     pub(crate) sse_tasks: parking_lot::Mutex<HashMap<String, tokio::task::JoinHandle<()>>>,
     pub(crate) reconcile_tasks: parking_lot::Mutex<Vec<tokio::task::JoinHandle<()>>>,
     pub(crate) sse_transport: parking_lot::Mutex<HashMap<String, SseTransportState>>,
+    context_service: parking_lot::RwLock<Option<Arc<crate::runtime::context_service::RuntimeContextService>>>,
     lifecycle: parking_lot::RwLock<HostLifecycle>,
     route_count: AtomicUsize,
     idle_since: parking_lot::Mutex<Option<Instant>>,
@@ -47,6 +48,7 @@ impl HostGeneration {
         domain: IsolationDomainKey,
         process_env_revision: ProcessEnvRevision,
         serve: Arc<ServeSupervisor>,
+        context_service: Option<Arc<crate::runtime::context_service::RuntimeContextService>>,
     ) -> Self {
         Self {
             generation_id,
@@ -59,6 +61,7 @@ impl HostGeneration {
             sse_tasks: parking_lot::Mutex::new(HashMap::new()),
             reconcile_tasks: parking_lot::Mutex::new(Vec::new()),
             sse_transport: parking_lot::Mutex::new(HashMap::new()),
+            context_service: parking_lot::RwLock::new(context_service),
             lifecycle: parking_lot::RwLock::new(HostLifecycle::Ready),
             route_count: AtomicUsize::new(0),
             idle_since: parking_lot::Mutex::new(Some(Instant::now())),
@@ -68,6 +71,10 @@ impl HostGeneration {
 
     pub fn lifecycle(&self) -> HostLifecycle {
         *self.lifecycle.read()
+    }
+
+    pub(crate) fn context_service(&self) -> Option<Arc<crate::runtime::context_service::RuntimeContextService>> {
+        self.context_service.read().clone()
     }
 
     pub fn route_count(&self) -> usize {
@@ -123,6 +130,7 @@ impl HostGeneration {
             domain,
             process_env_revision,
             serve,
+            None,
         ))
     }
 
@@ -260,6 +268,7 @@ pub trait GenerationFactory: Send + Sync {
 pub struct SupervisorGenerationFactory {
     registry: Arc<ServeProcessRegistry>,
     binary_hint: parking_lot::RwLock<Option<String>>,
+    context_service: parking_lot::RwLock<Option<Arc<crate::runtime::context_service::RuntimeContextService>>>,
 }
 
 impl SupervisorGenerationFactory {
@@ -267,7 +276,15 @@ impl SupervisorGenerationFactory {
         Self {
             registry,
             binary_hint: parking_lot::RwLock::new(None),
+            context_service: parking_lot::RwLock::new(None),
         }
+    }
+
+    pub fn attach_context_service(
+        &self,
+        service: Arc<crate::runtime::context_service::RuntimeContextService>,
+    ) {
+        *self.context_service.write() = Some(service);
     }
 
     pub fn set_binary_hint(&self, binary: &str) {
@@ -284,8 +301,11 @@ impl GenerationFactory for SupervisorGenerationFactory {
         generation_id: String,
         _domain: IsolationDomainKey,
         revision: ProcessEnvRevision,
-        env: HashMap<String, String>,
+        mut env: HashMap<String, String>,
     ) -> Result<Arc<ServeSupervisor>, String> {
+        if let Some(service) = self.context_service.read().as_ref() {
+            env.extend(service.env_for_generation(crate::proto::amux::AgentType::Opencode, &generation_id));
+        }
         let serve = Arc::new(ServeSupervisor::new(
             generation_id,
             Arc::clone(&self.registry),
@@ -385,6 +405,7 @@ impl Drop for QueueTicket<'_> {
 
 pub struct OpenCodeHostPool {
     factory: Arc<dyn GenerationFactory>,
+    context_service: parking_lot::RwLock<Option<Arc<crate::runtime::context_service::RuntimeContextService>>>,
     domains: parking_lot::Mutex<HashMap<IsolationDomainKey, Arc<DomainSlot>>>,
     capacity: parking_lot::Mutex<CapacityState>,
     capacity_changed: tokio::sync::Notify,
@@ -395,11 +416,19 @@ impl OpenCodeHostPool {
     pub fn new(factory: Arc<dyn GenerationFactory>) -> Arc<Self> {
         Arc::new_cyclic(|self_weak| Self {
             factory,
+            context_service: parking_lot::RwLock::new(None),
             domains: parking_lot::Mutex::new(HashMap::new()),
             capacity: parking_lot::Mutex::new(CapacityState::default()),
             capacity_changed: tokio::sync::Notify::new(),
             self_weak: self_weak.clone(),
         })
+    }
+
+    pub fn attach_context_service(
+        &self,
+        service: Arc<crate::runtime::context_service::RuntimeContextService>,
+    ) {
+        *self.context_service.write() = Some(service);
     }
 
     fn slot_for(&self, domain: &IsolationDomainKey) -> Arc<DomainSlot> {
@@ -495,7 +524,14 @@ impl OpenCodeHostPool {
                 return Err(HostPoolError::Spawn(error));
             }
         };
-        let generation = Arc::new(HostGeneration::new(generation_id, domain, revision, serve));
+        let context_service = self.context_service.read().clone();
+        let generation = Arc::new(HostGeneration::new(
+            generation_id,
+            domain,
+            revision,
+            serve,
+            context_service,
+        ));
 
         let displaced_without_routes = {
             let mut state = slot.state.lock();
@@ -684,6 +720,9 @@ impl OpenCodeHostPool {
         *generation.lifecycle.write() = HostLifecycle::Stopped;
         let sse_directories = generation.abort_sse_tasks();
         generation.abort_reconcile_tasks();
+        if let Some(service) = generation.context_service() {
+            service.clear_generation(crate::proto::amux::AgentType::Opencode, &generation.generation_id);
+        }
         match self.factory.stop(generation) {
             ShutdownOutcome::Idle | ShutdownOutcome::Stopped => {
                 self.release_capacity();

--- a/apps/daemon/src/runtime/opencode_http/mod.rs
+++ b/apps/daemon/src/runtime/opencode_http/mod.rs
@@ -356,6 +356,14 @@ impl OpencodeHost {
         Arc::clone(&self.pool)
     }
 
+    pub fn attach_context_service(
+        &self,
+        service: Arc<crate::runtime::context_service::RuntimeContextService>,
+    ) {
+        self.factory.attach_context_service(Arc::clone(&service));
+        self.pool.attach_context_service(service);
+    }
+
     /// Number of live backend processes (0 or 1: the global serve instance).
     pub fn host_count(&self) -> usize {
         self.pool.host_count()
@@ -515,6 +523,7 @@ impl OpencodeHost {
         event_tx: mpsc::Sender<AcpEventFrame>,
         permission: PermissionPolicy,
         forbid_new_session_fallback: bool,
+        _teamclu_session_id: String,
     ) -> crate::error::Result<(mpsc::Sender<AcpCommand>, AcpStartupMetadata)> {
         if agent_type != amux::AgentType::Opencode {
             warn!(
@@ -1531,6 +1540,7 @@ async fn command_loop(shared: Arc<HostGeneration>, mut cmd_rx: mpsc::Receiver<Ac
                 startup_tx,
                 permission,
                 forbid_new_session_fallback,
+                teamclu_session_id: _,
             } => {
                 let result = attach(
                     &shared,
@@ -1659,6 +1669,7 @@ pub fn start_standalone_runtime(
         },
         revision,
         serve,
+        None,
     ));
     let cmd_tx = command_sender_for_generation(generation);
     let attach_tx = cmd_tx.clone();
@@ -1675,6 +1686,7 @@ pub fn start_standalone_runtime(
                 startup_tx,
                 permission: PermissionPolicy::Ask,
                 forbid_new_session_fallback: false,
+                teamclu_session_id: String::new(),
             })
             .await;
     });

--- a/apps/daemon/src/runtime/pi_rpc/mod.rs
+++ b/apps/daemon/src/runtime/pi_rpc/mod.rs
@@ -1369,6 +1369,13 @@ impl Default for PiRpcBackend {
 
 #[async_trait]
 impl AgentBackend for PiRpcBackend {
+    fn attach_context_service(
+        &mut self,
+        service: std::sync::Arc<crate::runtime::context_service::RuntimeContextService>,
+    ) {
+        self.shared.pool.attach_context_service(service);
+    }
+
     async fn attach_session(
         &mut self,
         _agent_type: amux::AgentType,
@@ -1386,6 +1393,7 @@ impl AgentBackend for PiRpcBackend {
         event_tx: mpsc::Sender<AcpEventFrame>,
         permission: PermissionPolicy,
         forbid_new_session_fallback: bool,
+        _teamclu_session_id: String,
     ) -> crate::error::Result<(mpsc::Sender<AcpCommand>, AcpStartupMetadata)> {
         // NOTE: `launch` is `launch_config_for(agent_type)` for whatever agent
         // type the session carries (possibly a stored claude/codex/opencode

--- a/apps/daemon/src/runtime/pi_rpc/process.rs
+++ b/apps/daemon/src/runtime/pi_rpc/process.rs
@@ -143,6 +143,7 @@ pub(crate) struct PiProcessPool {
     envs: parking_lot::Mutex<HashMap<PoolKey, SpawnEnv>>,
     /// `[agents.pi].binary` override from daemon config, when configured.
     binary_override: parking_lot::Mutex<Option<String>>,
+    context_service: parking_lot::RwLock<Option<Arc<crate::runtime::context_service::RuntimeContextService>>>,
 }
 
 impl PiProcessPool {
@@ -151,6 +152,27 @@ impl PiProcessPool {
             procs: parking_lot::Mutex::new(HashMap::new()),
             envs: parking_lot::Mutex::new(HashMap::new()),
             binary_override: parking_lot::Mutex::new(None),
+            context_service: parking_lot::RwLock::new(None),
+        }
+    }
+
+    pub(crate) fn attach_context_service(
+        &self,
+        service: Arc<crate::runtime::context_service::RuntimeContextService>,
+    ) {
+        *self.context_service.write() = Some(service);
+    }
+
+    fn clear_generation_for_process(&self, proc: &PiProcess) {
+        if let Some(service) = self.context_service.read().as_ref() {
+            service.clear_generation(crate::proto::amux::AgentType::Pi, &proc.generation_id);
+        }
+    }
+
+    fn retire_process(&self, proc: &PiProcess) {
+        self.clear_generation_for_process(proc);
+        if proc.is_alive() {
+            proc.kill();
         }
     }
 
@@ -224,6 +246,7 @@ impl PiProcessPool {
         let procs: Vec<Arc<PiProcess>> = self.procs.lock().drain().map(|(_, p)| p).collect();
         let mut killed = 0;
         for p in procs {
+            self.clear_generation_for_process(&p);
             if p.is_alive() {
                 p.kill();
                 killed += 1;
@@ -248,6 +271,7 @@ impl PiProcessPool {
         };
         let mut killed = 0;
         for (_key, p) in victims {
+            self.clear_generation_for_process(&p);
             if p.is_alive() {
                 p.kill();
                 killed += 1;
@@ -284,7 +308,7 @@ impl PiProcessPool {
             // Env or mode changed since this child spawned (e.g. a prewarmed
             // child that predates the session's MCP servers/secrets) — replace.
             info!(worktree = %key.worktree, "pi env changed; respawning");
-            p.kill();
+            self.retire_process(&p);
             self.procs.lock().remove(key);
         }
         let proc = self.spawn(shared, key, &env, &launch, want)?;
@@ -437,6 +461,13 @@ impl PiProcessPool {
             "TEAMCLU_MCP_CONFIG_PATH",
             Path::new(worktree).join("opencode.json"),
         );
+        let generation_id = format!("pi-{}", uuid::Uuid::new_v4());
+        if let Some(service) = self.context_service.read().as_ref() {
+            let ctx_env = service.env_for_generation(crate::proto::amux::AgentType::Pi, &generation_id);
+            for (k, v) in ctx_env {
+                cmd.env(k, v);
+            }
+        }
         let tool_cache = mcp_tool_cache_dir();
         if let Err(e) = std::fs::create_dir_all(&tool_cache) {
             warn!(path = %tool_cache.display(), error = %e, "pi MCP tool cache dir unavailable");
@@ -512,7 +543,7 @@ impl PiProcessPool {
         let proc = Arc::new(PiProcess {
             client: client.clone(),
             mode,
-            generation_id: format!("pi-{}", uuid::Uuid::new_v4()),
+            generation_id,
             open_sessions: parking_lot::Mutex::new(HashMap::new()),
             active_acp_session: parking_lot::Mutex::new(None),
             switch_lock: tokio::sync::Mutex::new(()),

--- a/apps/daemon/src/runtime/sidecar/mcp.rs
+++ b/apps/daemon/src/runtime/sidecar/mcp.rs
@@ -182,6 +182,39 @@ pub fn assemble(worktree: &str, mcp_config_path: Option<&Path>) -> McpServers {
     out
 }
 
+/// Stamp session-scoped TeamClu MCP tools with an explicit cloud session id for
+/// this query/agent. Used by Claude/Cursor bridges where each SDK session gets
+/// its own `mcpServers` config.
+pub fn stamp_managed_session_context(servers: &mut McpServers, teamclu_session_id: &str) {
+    let id = teamclu_session_id.trim();
+    if id.is_empty() {
+        return;
+    }
+    for name in ["teamclu-introspect", "teamclaw-introspect"] {
+        let Some(server) = servers.get_mut(name) else {
+            continue;
+        };
+        let Some(obj) = server.as_object_mut() else {
+            continue;
+        };
+        let env = obj
+            .entry("env")
+            .or_insert_with(|| json!({}))
+            .as_object_mut();
+        let Some(env) = env else {
+            continue;
+        };
+        env.insert(
+            teamclu_runtime_env::TEAMCLU_SESSION_ID_ENV.to_string(),
+            json!(id),
+        );
+        env.insert(
+            teamclu_runtime_env::TEAMCLU_REQUIRE_EXPLICIT_SESSION_ID_ENV.to_string(),
+            json!("1"),
+        );
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/apps/daemon/src/runtime/supervisor.rs
+++ b/apps/daemon/src/runtime/supervisor.rs
@@ -31,6 +31,9 @@ const LEGACY_MCP_NAMES: &[&str] = &["teamclaw-introspect", "amuxd-send"];
 const INSTRUCTION_PLUGIN_TEMPLATE: &str = include_str!(
     "../../../../packages/app/src/lib/opencode/templates/teamclu-instruction-plugin.mjs.txt"
 );
+const SESSION_CONTEXT_PLUGIN_TEMPLATE: &str = include_str!(
+    "../../../../packages/app/src/lib/opencode/templates/teamclu-session-context-plugin.mjs.txt"
+);
 
 use crate::config::workspace_control::{
     ApplyOutcome, EnvActivationBlocker, EnvActivationDiagnostics, RuntimeStatus,
@@ -228,6 +231,33 @@ fn mutate_instruction_plugin(
     Ok(true)
 }
 
+fn mutate_session_context_plugin(
+    config: &mut serde_json::Value,
+) -> Result<bool, WorkspaceControlError> {
+    use crate::runtime::workspace_runtime::SESSION_CONTEXT_PLUGIN_CONFIG_ENTRY;
+
+    let obj = config.as_object_mut().ok_or_else(|| {
+        WorkspaceControlError::Parse("opencode.json root is not an object".into())
+    })?;
+
+    let plugins = obj.entry("plugin").or_insert_with(|| serde_json::json!([]));
+    let plugin_list = plugins.as_array_mut().ok_or_else(|| {
+        WorkspaceControlError::Parse("opencode.json plugin field is not an array".into())
+    })?;
+
+    let already_registered = plugin_list.iter().any(|entry| {
+        entry
+            .as_str()
+            .map(|value| value.contains("teamclu-session-context"))
+            .unwrap_or(false)
+    });
+    if already_registered {
+        return Ok(false);
+    }
+    plugin_list.push(serde_json::json!(SESSION_CONTEXT_PLUGIN_CONFIG_ENTRY));
+    Ok(true)
+}
+
 /// One read-modify-write for prepare/reload paths.
 pub fn materialize_opencode_for_prepare(
     workspace_path: &Path,
@@ -238,6 +268,7 @@ pub fn materialize_opencode_for_prepare(
         changed |= mutate_default_permissions(config).map_err(ws_to_store_err)?;
         changed |= mutate_inherent_mcp(workspace_path, config).map_err(ws_to_store_err)?;
         changed |= mutate_instruction_plugin(config).map_err(ws_to_store_err)?;
+        changed |= mutate_session_context_plugin(config).map_err(ws_to_store_err)?;
         Ok(changed)
     })
     .map_err(map_store_err)?;
@@ -717,6 +748,36 @@ fn install_instruction_plugin_file(workspace_path: &Path) -> Result<(), Workspac
     Ok(())
 }
 
+fn install_session_context_plugin_file(workspace_path: &Path) -> Result<(), WorkspaceControlError> {
+    use crate::runtime::workspace_runtime::SESSION_CONTEXT_PLUGIN_REL;
+
+    let plugin_path = workspace_path.join(SESSION_CONTEXT_PLUGIN_REL);
+    if let Some(parent) = plugin_path.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| WorkspaceControlError::Io(e.to_string()))?;
+    }
+
+    let should_write = match std::fs::read_to_string(&plugin_path) {
+        Ok(existing) => existing != SESSION_CONTEXT_PLUGIN_TEMPLATE,
+        Err(_) => true,
+    };
+    if should_write {
+        std::fs::write(&plugin_path, SESSION_CONTEXT_PLUGIN_TEMPLATE)
+            .map_err(|e| WorkspaceControlError::Io(e.to_string()))?;
+    }
+    Ok(())
+}
+
+/// Install the TeamClu session-context OpenCode plugin and register it in `opencode.json`.
+pub fn ensure_session_context_plugin(workspace_path: &Path) -> Result<(), WorkspaceControlError> {
+    install_session_context_plugin_file(workspace_path)?;
+
+    teamclu_runtime_env::opencode_config::OpencodeConfigStore::apply(workspace_path, |config| {
+        mutate_session_context_plugin(config).map_err(ws_to_store_err)
+    })
+    .map_err(map_store_err)?;
+    Ok(())
+}
+
 /// Install the TeamClu instruction OpenCode plugin and register it in `opencode.json`.
 pub fn ensure_instruction_plugin(workspace_path: &Path) -> Result<(), WorkspaceControlError> {
     install_instruction_plugin_file(workspace_path)?;
@@ -778,6 +839,7 @@ pub fn prepare_workspace(workspace_path: &Path) -> Result<(), WorkspaceControlEr
     ensure_workspace_knowledge_link(workspace_path);
 
     install_instruction_plugin_file(workspace_path)?;
+    install_session_context_plugin_file(workspace_path)?;
     materialize_opencode_for_prepare(workspace_path)?;
     ensure_inherent_skills_in_dir(&inherent_skills_dir()?)?;
     crate::runtime::claude_skills::ensure_claude_team_skills(workspace_path)?;

--- a/apps/daemon/src/runtime/test_support.rs
+++ b/apps/daemon/src/runtime/test_support.rs
@@ -44,6 +44,7 @@ impl AgentBackend for CapturingBackend {
         _event_tx: mpsc::Sender<AcpEventFrame>,
         permission: PermissionPolicy,
         _forbid_new_session_fallback: bool,
+        _teamclu_session_id: String,
     ) -> crate::error::Result<(mpsc::Sender<AcpCommand>, AcpStartupMetadata)> {
         self.captures.lock().unwrap().push(CapturedAttach {
             domain,
@@ -157,6 +158,7 @@ impl AgentBackend for PoolCapturingBackend {
         _event_tx: mpsc::Sender<AcpEventFrame>,
         permission: PermissionPolicy,
         _forbid_new_session_fallback: bool,
+        _teamclu_session_id: String,
     ) -> crate::error::Result<(mpsc::Sender<AcpCommand>, AcpStartupMetadata)> {
         let lease = self
             .pool

--- a/apps/daemon/src/runtime/workspace_runtime.rs
+++ b/apps/daemon/src/runtime/workspace_runtime.rs
@@ -7,6 +7,9 @@ use crate::proto::amux;
 
 pub const INSTRUCTION_PLUGIN_REL: &str = ".opencode/plugins/teamclu-instruction.mjs";
 pub const INSTRUCTION_PLUGIN_CONFIG_ENTRY: &str = "./.opencode/plugins/teamclu-instruction.mjs";
+pub const SESSION_CONTEXT_PLUGIN_REL: &str = ".opencode/plugins/teamclu-session-context.mjs";
+pub const SESSION_CONTEXT_PLUGIN_CONFIG_ENTRY: &str =
+    "./.opencode/plugins/teamclu-session-context.mjs";
 
 pub fn instruction_plugin_installed(worktree: &Path) -> bool {
     if !worktree.join(INSTRUCTION_PLUGIN_REL).is_file() {

--- a/apps/daemon/tests/http_apps.rs
+++ b/apps/daemon/tests/http_apps.rs
@@ -115,6 +115,7 @@ async fn test_app_inner(backend: Option<Arc<dyn Backend>>) -> (TestApp, tempfile
         None,
         None,
         None,
+        None,
     )
     .await
     .expect("spawn http server");

--- a/apps/daemon/tests/http_default_workspace.rs
+++ b/apps/daemon/tests/http_default_workspace.rs
@@ -62,6 +62,7 @@ async fn test_app(backend: Arc<dyn Backend>, scopes: &[&str]) -> (TestApp, tempf
         None,
         None,
         None,
+        None,
     )
     .await
     .expect("spawn http server");

--- a/apps/daemon/tests/http_sessions_runtime.rs
+++ b/apps/daemon/tests/http_sessions_runtime.rs
@@ -187,6 +187,7 @@ async fn test_app_with_runtime_adapter() -> TestApp {
         None,
         None,
         None,
+        None,
     )
     .await
     .expect("spawn http server");

--- a/apps/daemon/tests/http_workspace_provider_auth.rs
+++ b/apps/daemon/tests/http_workspace_provider_auth.rs
@@ -61,6 +61,7 @@ async fn test_app_with_workspace_store(
         None,
         None,
         None,
+        None,
     )
     .await
     .expect("spawn http server");

--- a/apps/desktop/crates/teamclu-introspect/src/main.rs
+++ b/apps/desktop/crates/teamclu-introspect/src/main.rs
@@ -305,7 +305,7 @@ fn tool_definitions() -> Value {
         },
         {
             "name": "get_session_deeplink",
-            "description": "Export a shareable deep link that opens a TeamClu session in the desktop or mobile app. Returns a URL like teamclu://session/<uuid>. When session_id is omitted, uses the current TeamClu session (TEAMCLU_SESSION_ID env or workspace .teamclu/active-session-id).",
+            "description": "Export a shareable deep link that opens a TeamClu session in the desktop or mobile app. Returns a URL like teamclu://session/<uuid>. When session_id is omitted, daemon-managed agent runtimes inject the current session automatically; standalone CLI may use TEAMCLU_SESSION_ID (legacy workspace active-session-id fallback is deprecated).",
             "inputSchema": {
                 "type": "object",
                 "properties": {
@@ -322,7 +322,7 @@ fn tool_definitions() -> Value {
         },
         {
             "name": "manage_participants",
-            "description": "Read the roster of a TeamClu session, and pull people into it or take them out. Requires the desktop app to be running and the user to be signed in. When session_id is omitted, acts on the current TeamClu session (TEAMCLU_SESSION_ID env or workspace .teamclu/active-session-id). Actions: 'list' (the full roster, people and agents), 'list_candidates' (people who can be added, excluding those already present), 'add', 'remove'. add/remove handle HUMAN MEMBERS ONLY — agents are joined from the app's session member sheet, which also starts their runtime; asking for one here is refused rather than half-done. Adding someone makes the session, including its history, visible to them, so the target is never guessed: pass actor_id, or a name that matches exactly one person. A name matching none or several comes back as the candidate list instead of a write.",
+            "description": "Read the roster of a TeamClu session, and pull people into it or take them out. Requires the desktop app to be running and the user to be signed in. When session_id is omitted, daemon-managed agent runtimes inject the current session automatically; standalone CLI may use TEAMCLU_SESSION_ID (legacy workspace active-session-id fallback is deprecated). Actions: 'list' (the full roster, people and agents), 'list_candidates' (people who can be added, excluding those already present), 'add', 'remove'. add/remove handle HUMAN MEMBERS ONLY — agents are joined from the app's session member sheet, which also starts their runtime; asking for one here is refused rather than half-done. Adding someone makes the session, including its history, visible to them, so the target is never guessed: pass actor_id, or a name that matches exactly one person. A name matching none or several comes back as the candidate list instead of a write.",
             "inputSchema": {
                 "type": "object",
                 "properties": {
@@ -362,7 +362,7 @@ fn tool_definitions() -> Value {
         },
         {
             "name": "archive_session",
-            "description": "Archive a TeamClu cloud session (soft-hide from the active session list). Requires the desktop app to be running and the user to be signed in. When session_id is omitted, archives the current TeamClu session (TEAMCLU_SESSION_ID env or workspace .teamclu/active-session-id).",
+            "description": "Archive a TeamClu cloud session (soft-hide from the active session list). Requires the desktop app to be running and the user to be signed in. When session_id is omitted, daemon-managed agent runtimes inject the current session automatically; standalone CLI may use TEAMCLU_SESSION_ID (legacy workspace active-session-id fallback is deprecated).",
             "inputSchema": {
                 "type": "object",
                 "properties": {

--- a/apps/desktop/crates/teamclu-introspect/src/session.rs
+++ b/apps/desktop/crates/teamclu-introspect/src/session.rs
@@ -1,7 +1,9 @@
 use std::path::Path;
 
 use serde_json::{json, Value};
-use teamclu_runtime_env::{read_active_session_id, TEAMCLU_SESSION_ID_ENV};
+use teamclu_runtime_env::{
+    read_active_session_id, require_explicit_session_id_from_env, TEAMCLU_SESSION_ID_ENV,
+};
 
 const DEFAULT_SCHEME: &str = "teamclu";
 
@@ -58,6 +60,13 @@ pub(crate) fn resolve_session_id(workspace: &str, arguments: &Value) -> Result<S
         return Ok(id.to_string());
     }
 
+    if require_explicit_session_id_from_env() {
+        return Err(
+            "session_id is required: pass session_id explicitly (managed runtime context)"
+                .to_string(),
+        );
+    }
+
     if let Ok(id) = std::env::var(TEAMCLU_SESSION_ID_ENV) {
         let id = id.trim();
         if !id.is_empty() {
@@ -67,6 +76,7 @@ pub(crate) fn resolve_session_id(workspace: &str, arguments: &Value) -> Result<S
     }
 
     if let Some(id) = read_active_session_id(Path::new(workspace)) {
+        teamclu_runtime_env::session_context::warn_deprecated_active_session_file_fallback();
         validate_session_id(&id)?;
         return Ok(id);
     }
@@ -179,10 +189,38 @@ mod tests {
 
     #[test]
     fn handle_reads_active_session_id_file() {
+        let _guard = ENV_TEST_LOCK.lock().unwrap();
+        let prev_managed = std::env::var("TEAMCLU_REQUIRE_EXPLICIT_SESSION_ID").ok();
+        std::env::remove_var("TEAMCLU_REQUIRE_EXPLICIT_SESSION_ID");
         let dir = tempfile::tempdir().unwrap();
         write_active_session_id(dir.path(), UUID).unwrap();
         let result = handle(dir.path().to_str().unwrap(), &json!({})).unwrap();
         assert_eq!(result["session_id"], UUID);
+        match prev_managed {
+            Some(v) => std::env::set_var("TEAMCLU_REQUIRE_EXPLICIT_SESSION_ID", v),
+            None => std::env::remove_var("TEAMCLU_REQUIRE_EXPLICIT_SESSION_ID"),
+        }
+    }
+
+    #[test]
+    fn handle_requires_session_id_in_managed_mode() {
+        let _guard = ENV_TEST_LOCK.lock().unwrap();
+        let prev = std::env::var(TEAMCLU_SESSION_ID_ENV).ok();
+        let prev_managed = std::env::var("TEAMCLU_REQUIRE_EXPLICIT_SESSION_ID").ok();
+        std::env::remove_var(TEAMCLU_SESSION_ID_ENV);
+        std::env::set_var("TEAMCLU_REQUIRE_EXPLICIT_SESSION_ID", "1");
+        let dir = tempfile::tempdir().unwrap();
+        write_active_session_id(dir.path(), UUID).unwrap();
+        let err = handle(dir.path().to_str().unwrap(), &json!({})).unwrap_err();
+        assert!(err.contains("session_id is required"));
+        match prev {
+            Some(v) => std::env::set_var(TEAMCLU_SESSION_ID_ENV, v),
+            None => std::env::remove_var(TEAMCLU_SESSION_ID_ENV),
+        }
+        match prev_managed {
+            Some(v) => std::env::set_var("TEAMCLU_REQUIRE_EXPLICIT_SESSION_ID", v),
+            None => std::env::remove_var("TEAMCLU_REQUIRE_EXPLICIT_SESSION_ID"),
+        }
     }
 
     #[test]

--- a/crates/teamclu-runtime-env/src/lib.rs
+++ b/crates/teamclu-runtime-env/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod active_session;
+pub mod session_context;
 pub mod amuxd_layout;
 pub mod atomic_write;
 pub mod env_activation;
@@ -29,6 +30,12 @@ use std::path::Path;
 pub use active_session::{
     clear_active_session_id_if_matches, read_active_session_id, write_active_session_id,
     ACTIVE_SESSION_ID_FILE, TEAMCLU_SESSION_ID_ENV,
+};
+pub use session_context::{
+    is_session_scoped_mcp_tool, require_explicit_session_id_from_env,
+    SESSION_SCOPED_MCP_TOOLS, TEAMCLU_AGENT_BACKEND_ENV, TEAMCLU_HOST_GENERATION_ID_ENV,
+    TEAMCLU_REQUIRE_EXPLICIT_SESSION_ID_ENV, TEAMCLU_RUNTIME_CONTEXT_TOKEN_ENV,
+    TEAMCLU_RUNTIME_CONTEXT_URL_ENV,
 };
 pub use env_activation::{
     analyze_env_activation, find_unresolved_config_placeholders, EnvActivationAnalysis,

--- a/crates/teamclu-runtime-env/src/session_context.rs
+++ b/crates/teamclu-runtime-env/src/session_context.rs
@@ -1,0 +1,52 @@
+//! Request-scoped TeamClu session context for MCP tools under concurrent sessions.
+//!
+//! Backend adapters resolve a backend session to a TeamClu cloud session via the
+//! daemon's internal loopback API instead of worktree-level ambient state.
+
+pub const TEAMCLU_REQUIRE_EXPLICIT_SESSION_ID_ENV: &str = "TEAMCLU_REQUIRE_EXPLICIT_SESSION_ID";
+pub const TEAMCLU_RUNTIME_CONTEXT_URL_ENV: &str = "TEAMCLU_RUNTIME_CONTEXT_URL";
+pub const TEAMCLU_RUNTIME_CONTEXT_TOKEN_ENV: &str = "TEAMCLU_RUNTIME_CONTEXT_TOKEN";
+pub const TEAMCLU_HOST_GENERATION_ID_ENV: &str = "TEAMCLU_HOST_GENERATION_ID";
+pub const TEAMCLU_AGENT_BACKEND_ENV: &str = "TEAMCLU_AGENT_BACKEND";
+
+/// Session-scoped TeamClu MCP tools that must receive an explicit `session_id`.
+pub const SESSION_SCOPED_MCP_TOOLS: &[&str] = &[
+    "get_session_deeplink",
+    "manage_participants",
+    "archive_session",
+];
+
+pub fn is_session_scoped_mcp_tool(name: &str) -> bool {
+    let base = name
+        .rsplit('/')
+        .next()
+        .unwrap_or(name)
+        .trim();
+    SESSION_SCOPED_MCP_TOOLS.contains(&base)
+}
+
+pub fn require_explicit_session_id_from_env() -> bool {
+    matches!(
+        std::env::var(TEAMCLU_REQUIRE_EXPLICIT_SESSION_ID_ENV)
+            .ok()
+            .as_deref()
+            .map(str::trim),
+        Some("1" | "true" | "yes")
+    )
+}
+
+/// Standalone CLI / legacy paths: warn once per process when falling back to the
+/// workspace `active-session-id` file (Phase 2 deprecation).
+pub fn warn_deprecated_active_session_file_fallback() {
+    use std::sync::atomic::{AtomicBool, Ordering};
+    static WARNED: AtomicBool = AtomicBool::new(false);
+    if WARNED
+        .compare_exchange(false, true, Ordering::Relaxed, Ordering::Relaxed)
+        .is_ok()
+    {
+        eprintln!(
+            "warning: resolving session_id from workspace active-session-id is deprecated; \
+             pass session_id explicitly or run under a daemon-managed agent runtime"
+        );
+    }
+}

--- a/packages/app/src/lib/opencode/templates/teamclu-session-context-plugin.mjs.txt
+++ b/packages/app/src/lib/opencode/templates/teamclu-session-context-plugin.mjs.txt
@@ -1,0 +1,80 @@
+// managed-plugin: teamclu-session-context
+// version: 1
+
+const SESSION_SCOPED_TOOLS = new Set([
+  "get_session_deeplink",
+  "manage_participants",
+  "archive_session",
+])
+
+function isSessionScopedTool(name) {
+  const base = String(name ?? "")
+    .split("/")
+    .pop()
+    .trim()
+  return SESSION_SCOPED_TOOLS.has(base)
+}
+
+async function resolveTeamcluSessionId(backendSessionId) {
+  const baseUrl = process.env.TEAMCLU_RUNTIME_CONTEXT_URL?.trim()?.replace(/\/$/, "")
+  const token = process.env.TEAMCLU_RUNTIME_CONTEXT_TOKEN?.trim()
+  const generationId = process.env.TEAMCLU_HOST_GENERATION_ID?.trim()
+  const backendKind = process.env.TEAMCLU_AGENT_BACKEND?.trim()
+  const sessionId = String(backendSessionId ?? "").trim()
+  if (!baseUrl || !token || !generationId || !backendKind || !sessionId) {
+    throw new Error("session_context_unavailable")
+  }
+  const resp = await fetch(`${baseUrl}/internal/runtime-context/resolve`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      backendSessionId: sessionId,
+      hostGenerationId: generationId,
+      backendKind,
+    }),
+  })
+  if (!resp.ok) {
+    throw new Error("session_context_unavailable")
+  }
+  const body = await resp.json()
+  const teamcluSessionId = String(body?.teamcluSessionId ?? "").trim()
+  if (!teamcluSessionId) {
+    throw new Error("session_context_unavailable")
+  }
+  return teamcluSessionId
+}
+
+async function injectSessionIdForTool(toolName, args, backendSessionId) {
+  if (!isSessionScopedTool(toolName)) {
+    return args ?? {}
+  }
+  const next = { ...(args ?? {}) }
+  const explicit = String(next.session_id ?? next.sessionId ?? "").trim()
+  if (explicit) {
+    return next
+  }
+  next.session_id = await resolveTeamcluSessionId(backendSessionId)
+  return next
+}
+
+export const TeamcluSessionContextPlugin = async () => {
+  return {
+    "tool.execute.before": async (input, output) => {
+      const toolName = output?.tool?.name ?? input?.tool?.name ?? input?.name
+      if (!isSessionScopedTool(toolName)) {
+        return
+      }
+      const sessionId = input?.sessionID ?? input?.sessionId ?? output?.session?.id
+      if (!sessionId) {
+        throw new Error("session_context_unavailable")
+      }
+      const args = output?.arguments ?? input?.arguments ?? {}
+      output.arguments = await injectSessionIdForTool(toolName, args, sessionId)
+    },
+  }
+}
+
+export default TeamcluSessionContextPlugin


### PR DESCRIPTION
## Summary

- 新增 **RuntimeContextRegistry** + loopback `POST /internal/runtime-context/resolve`，将 `(backend_kind, host_generation_id, backend_session_id)` 映射到 TeamClu cloud session，替代 daemon 托管路径对 worktree `active-session-id` 的依赖。
- 为 **OpenCode**（session-context plugin）、**PI**（extension MCP bridge + generation env）、**Claude Code / Cursor**（per-query MCP env stamping）接入 request-scoped session 注入；`teamclu-introspect` 在托管模式（`TEAMCLU_REQUIRE_EXPLICIT_SESSION_ID=1`）下 fail closed。
- **Phase 2**：停止 daemon 写入 `active-session-id`；OpenCode 子 agent 注册 child session 继承；host/PI generation teardown 清理 registry；独立 CLI 保留 legacy 文件回退并输出 deprecated 警告。

## Test plan

- [x] `cargo check -p amuxd`
- [x] `cargo test -p amuxd runtime::context_registry`（含 100× 并发 A/B resolve）
- [x] `cargo test -p amuxd runtime::context_service`
- [x] `cargo test -p teamclu-introspect session`
- [ ] 手动：同一 worktree 并发两个 Session，分别调用 `get_session_deeplink` / `manage_participants`，确认 deeplink 与 roster 不串线
- [ ] 手动：OpenCode 子 agent 调用 session-scoped 工具，确认继承父 Session

## Follow-ups (Phase 3)

- 删除 `teamclu-introspect` 的 `active-session-id` 文件 fallback
- 删除 stop 时 compare-and-clear legacy 文件逻辑
- 各 backend 端到端集成测试（真实进程 100× 并发）


Made with [Cursor](https://cursor.com)