### PR TITLE
Knowledge sync P0/P1: scope lock, implementation, and code-review fixes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -156,10 +156,12 @@ the product.
 producer left in the product — nothing shipped a call that set it — so every team
 created since read as "off", and everything branching on it silently did nothing
 (the sync button, the status poll, the daemon's sync, and a link sweep that
-*removed* the team links it exists to create). Whether a team can sync is decided
-by its **team secret**, checked where the sync runs
-(`sync::dispatch::run_once`): no secret → nothing to encrypt or decrypt with →
-`skipped`; secret → sync.
+*removed* the team links it exists to create). The only remaining precondition
+is the auto-sync toggle checked where the sync runs (`sync::dispatch::run_once`):
+off and not forced → `skipped`; otherwise → sync. The **team secret is fetched,
+not required**: knowledge content is uploaded as **plaintext** (see ADR-0008),
+and the secret is only derived to decrypt blobs written before that switch and
+to seal the local `state/secrets.enc`. A team without a secret syncs fine.
 
 The `teams.share_mode` column and its Postgres enum are still there (in-use enum
 values cannot be dropped, and dropping the column is a one-way door on

--- a/apps/daemon/src/daemon/server.rs
+++ b/apps/daemon/src/daemon/server.rs
@@ -1217,6 +1217,10 @@ impl DaemonServer {
             self.sync_dispatcher.clone(),
             self.backend.team_id().to_string(),
         );
+        crate::sync::watch::spawn(
+            self.sync_dispatcher.clone(),
+            self.backend.team_id().to_string(),
+        );
 
         // Populate the refresh watchers from the cloud workspace list on a
         // background task (moved off the pre-bind path above). The watcher poll

--- a/apps/daemon/src/daemon/server.rs
+++ b/apps/daemon/src/daemon/server.rs
@@ -913,6 +913,28 @@ impl DaemonServer {
                     return Err(format!("teamclu subscription failed: {e}"));
                 }
             }
+            // Optional: ACL for sync/+ may lag token rotation (Task 6). Never
+            // escalate a deny into worker rebuild — timer remains the fallback.
+            if self.config.team_id.is_some() {
+                let sync_topic = self.topics.sync_wildcard();
+                if let Err(e) = self
+                    .publisher_handle
+                    .subscribe_optional(
+                        &sync_topic,
+                        teamclu_transport::DeliveryGuarantee::AtLeastOnce,
+                    )
+                    .await
+                {
+                    // subscribe_optional should not Err on broker reject; log
+                    // any unexpected transport failure without reconnecting.
+                    warn!(
+                        context,
+                        topic = %sync_topic,
+                        error = %e,
+                        "optional sync/+ subscribe failed; continuing without MQTT hints"
+                    );
+                }
+            }
         }
         if !current() {
             return Err("stale MQTT generation before state restore".to_string());

--- a/apps/daemon/src/daemon/server/command_executor.rs
+++ b/apps/daemon/src/daemon/server/command_executor.rs
@@ -112,5 +112,8 @@ fn validate_inbound_message(
                 .map(|_| ())
                 .map_err(|error| format!("invalid Notify: {error}"))
         }
+        // JSON hint — malformed payloads are dropped in the dispatcher, not
+        // dead-lettered here (hints are best-effort; timer is the fallback).
+        IncomingMessage::SyncHint { .. } => Ok(()),
     }
 }

--- a/apps/daemon/src/daemon/server/rpc.rs
+++ b/apps/daemon/src/daemon/server/rpc.rs
@@ -1030,7 +1030,7 @@ impl DaemonServer {
                 payload,
             } => {
                 self.sync_dispatcher
-                    .handle_sync_hint(&team_id, &resource, &payload)
+                    .handle_sync_hint(self.backend.team_id(), &team_id, &resource, &payload)
                     .await;
             }
         }

--- a/apps/daemon/src/daemon/server/rpc.rs
+++ b/apps/daemon/src/daemon/server/rpc.rs
@@ -1024,6 +1024,15 @@ impl DaemonServer {
                     }
                 }
             }
+            subscriber::IncomingMessage::SyncHint {
+                team_id,
+                resource,
+                payload,
+            } => {
+                self.sync_dispatcher
+                    .handle_sync_hint(&team_id, &resource, &payload)
+                    .await;
+            }
         }
         super::command_executor::HandlerOutcome::Success
     }

--- a/apps/daemon/src/http/team_sync.rs
+++ b/apps/daemon/src/http/team_sync.rs
@@ -740,9 +740,32 @@ fn apply_conflict_decision(
         }
     }
 
+    // The sidecar is gone; the mirrored directories it lived in are not. Without
+    // this, `knowledge/.conflicts/a/b/c/` survives every resolution and a vault
+    // that has seen many conflicts keeps a full shadow tree that
+    // `scan_conflict_files` walks on every poll.
+    prune_empty_conflict_dirs(&root, &sidecar);
+
     st.save_at(team_id)
         .map_err(|e| DecisionError::Failed(format!("save sync state: {e}")))?;
     Ok(Some(sidecar))
+}
+
+/// Remove the now-empty directories a resolved sidecar leaves behind.
+///
+/// `remove_dir` only succeeds on an empty directory, so this can never take one
+/// that still holds another conflict — or, for a legacy sidecar that sat beside
+/// its note, the note's own directory. Stops at the sync prefix root, so
+/// `knowledge/` itself always stays.
+fn prune_empty_conflict_dirs(root: &std::path::Path, sidecar_rel: &str) {
+    let mut parts: Vec<&str> = sidecar_rel.split('/').filter(|s| !s.is_empty()).collect();
+    parts.pop(); // the filename
+    while parts.len() > 1 {
+        if std::fs::remove_dir(root.join(parts.join("/"))).is_err() {
+            return;
+        }
+        parts.pop();
+    }
 }
 
 /// Whether a sync path belongs to a prefix the product still carries.

--- a/apps/daemon/src/http/team_sync.rs
+++ b/apps/daemon/src/http/team_sync.rs
@@ -611,9 +611,9 @@ pub struct ResolveResponse {
 ///   version, so there is nothing to write, only the losing copy to clear.
 ///
 /// Both branches delete the sidecar. It is local-only (the scanner never
-/// uploads `*.conflict.*`), so leaving it behind would just accumulate junk in
-/// the user's knowledge tree — which is exactly what happened before this
-/// endpoint did any disk work at all.
+/// uploads anything under `.conflicts/`), so leaving it behind would just
+/// accumulate junk — which is exactly what happened before this endpoint did
+/// any disk work at all.
 pub async fn resolve_conflict(
     principal: Principal,
     State(_state): State<HttpState>,
@@ -1615,24 +1615,27 @@ mod tests {
     fn keep_local_restores_the_users_bytes_and_queues_them_for_push() {
         let fx = ConflictFixture::new();
         fx.write("knowledge/note.md", "remote wins");
-        fx.write("knowledge/note.conflict.1000.aabbccdd.md", "my draft");
+        fx.write(
+            "knowledge/.conflicts/note.conflict.1000.aabbccdd.md",
+            "my draft",
+        );
         fx.seed_state("knowledge/note.md", "hash-of-remote");
 
         let acted = apply_conflict_decision(
             &fx.team_id,
             "knowledge/note.md",
-            Some("knowledge/note.conflict.1000.aabbccdd.md"),
+            Some("knowledge/.conflicts/note.conflict.1000.aabbccdd.md"),
             crate::sync::oss::ConflictChoice::KeepLocal,
         )
         .unwrap();
 
         assert_eq!(
             acted.as_deref(),
-            Some("knowledge/note.conflict.1000.aabbccdd.md")
+            Some("knowledge/.conflicts/note.conflict.1000.aabbccdd.md")
         );
         // The document now holds what the user wrote, not what the remote sent.
         assert_eq!(fx.read("knowledge/note.md"), "my draft");
-        assert!(!fx.exists("knowledge/note.conflict.1000.aabbccdd.md"));
+        assert!(!fx.exists("knowledge/.conflicts/note.conflict.1000.aabbccdd.md"));
         let entry = fx.state_for("knowledge/note.md");
         assert!(entry.dirty, "the restored copy has to be pushed");
         assert!(!entry.deleted_local);
@@ -1645,19 +1648,22 @@ mod tests {
     fn keep_remote_clears_the_losing_copy_and_leaves_the_document_alone() {
         let fx = ConflictFixture::new();
         fx.write("knowledge/note.md", "remote wins");
-        fx.write("knowledge/note.conflict.1000.aabbccdd.md", "my draft");
+        fx.write(
+            "knowledge/.conflicts/note.conflict.1000.aabbccdd.md",
+            "my draft",
+        );
         fx.seed_state("knowledge/note.md", "hash-of-remote");
 
         apply_conflict_decision(
             &fx.team_id,
             "knowledge/note.md",
-            Some("knowledge/note.conflict.1000.aabbccdd.md"),
+            Some("knowledge/.conflicts/note.conflict.1000.aabbccdd.md"),
             crate::sync::oss::ConflictChoice::KeepRemote,
         )
         .unwrap();
 
         assert_eq!(fx.read("knowledge/note.md"), "remote wins");
-        assert!(!fx.exists("knowledge/note.conflict.1000.aabbccdd.md"));
+        assert!(!fx.exists("knowledge/.conflicts/note.conflict.1000.aabbccdd.md"));
         let entry = fx.state_for("knowledge/note.md");
         assert!(!entry.dirty);
         assert_eq!(entry.local_plain_hash, entry.synced_plain_hash);
@@ -1667,14 +1673,17 @@ mod tests {
     fn resolving_the_same_conflict_twice_is_idempotent() {
         let fx = ConflictFixture::new();
         fx.write("knowledge/note.md", "remote wins");
-        fx.write("knowledge/note.conflict.1000.aabbccdd.md", "my draft");
+        fx.write(
+            "knowledge/.conflicts/note.conflict.1000.aabbccdd.md",
+            "my draft",
+        );
 
         for _ in 0..2 {
             // A double click, or two windows racing, must not 500 the second one.
             apply_conflict_decision(
                 &fx.team_id,
                 "knowledge/note.md",
-                Some("knowledge/note.conflict.1000.aabbccdd.md"),
+                Some("knowledge/.conflicts/note.conflict.1000.aabbccdd.md"),
                 crate::sync::oss::ConflictChoice::KeepRemote,
             )
             .unwrap();
@@ -1700,7 +1709,7 @@ mod tests {
         let acted = apply_conflict_decision(
             &fx.team_id,
             "knowledge/note.md",
-            Some("knowledge/note.conflict.1000.aabbccdd.md"),
+            Some("knowledge/.conflicts/note.conflict.1000.aabbccdd.md"),
             crate::sync::oss::ConflictChoice::KeepLocal,
         )
         .unwrap();
@@ -1716,8 +1725,14 @@ mod tests {
     fn the_newest_sidecar_is_taken_when_the_caller_names_none() {
         let fx = ConflictFixture::new();
         fx.write("knowledge/note.md", "remote wins");
-        fx.write("knowledge/note.conflict.1000.aaaaaaaa.md", "older draft");
-        fx.write("knowledge/note.conflict.2000.bbbbbbbb.md", "newer draft");
+        fx.write(
+            "knowledge/.conflicts/note.conflict.1000.aaaaaaaa.md",
+            "older draft",
+        );
+        fx.write(
+            "knowledge/.conflicts/note.conflict.2000.bbbbbbbb.md",
+            "newer draft",
+        );
 
         let acted = apply_conflict_decision(
             &fx.team_id,
@@ -1729,11 +1744,11 @@ mod tests {
 
         assert_eq!(
             acted.as_deref(),
-            Some("knowledge/note.conflict.2000.bbbbbbbb.md")
+            Some("knowledge/.conflicts/note.conflict.2000.bbbbbbbb.md")
         );
         assert_eq!(fx.read("knowledge/note.md"), "newer draft");
         // The older one survives as its own pending decision.
-        assert!(fx.exists("knowledge/note.conflict.1000.aaaaaaaa.md"));
+        assert!(fx.exists("knowledge/.conflicts/note.conflict.1000.aaaaaaaa.md"));
     }
 
     #[test]
@@ -1741,20 +1756,23 @@ mod tests {
         let fx = ConflictFixture::new();
         fx.write("knowledge/note.md", "remote wins");
         fx.write("knowledge/secret.md", "someone else's document");
-        fx.write("knowledge/secret.conflict.1000.aabbccdd.md", "draft");
+        fx.write(
+            "knowledge/.conflicts/secret.conflict.1000.aabbccdd.md",
+            "draft",
+        );
 
         // This endpoint deletes (and overwrites) what it is handed, so a
         // mismatched pair is the one thing it must never carry out.
         let err = apply_conflict_decision(
             &fx.team_id,
             "knowledge/note.md",
-            Some("knowledge/secret.conflict.1000.aabbccdd.md"),
+            Some("knowledge/.conflicts/secret.conflict.1000.aabbccdd.md"),
             crate::sync::oss::ConflictChoice::KeepLocal,
         )
         .unwrap_err();
         assert!(matches!(err, DecisionError::Invalid(_)), "{err:?}");
         assert_eq!(fx.read("knowledge/secret.md"), "someone else's document");
-        assert!(fx.exists("knowledge/secret.conflict.1000.aabbccdd.md"));
+        assert!(fx.exists("knowledge/.conflicts/secret.conflict.1000.aabbccdd.md"));
     }
 
     #[test]
@@ -1765,7 +1783,7 @@ mod tests {
         let fx = ConflictFixture::new();
         fx.write("knowledge/merge.conflict.md", "a note about merging");
         fx.write(
-            "knowledge/real.conflict.1000.aabbccdd.md",
+            "knowledge/.conflicts/real.conflict.1000.aabbccdd.md",
             "the losing copy",
         );
 
@@ -1773,6 +1791,10 @@ mod tests {
 
         assert_eq!(entries.len(), 1, "{entries:?}");
         assert_eq!(entries[0].path, "knowledge/real.md");
+        assert_eq!(
+            entries[0].sidecar,
+            "knowledge/.conflicts/real.conflict.1000.aabbccdd.md"
+        );
     }
 
     #[test]
@@ -1832,8 +1854,14 @@ mod tests {
     fn conflict_entries_name_the_document_not_the_sidecar() {
         let fx = ConflictFixture::new();
         fx.write("knowledge/note.md", "remote wins");
-        fx.write("knowledge/note.conflict.1000.aaaaaaaa.md", "older");
-        fx.write("knowledge/note.conflict.2000.bbbbbbbb.md", "newer");
+        fx.write(
+            "knowledge/.conflicts/note.conflict.1000.aaaaaaaa.md",
+            "older",
+        );
+        fx.write(
+            "knowledge/.conflicts/note.conflict.2000.bbbbbbbb.md",
+            "newer",
+        );
         fx.write("knowledge/plain.md", "no conflict here");
 
         let entries = conflict_entries(&fx.root);
@@ -1845,7 +1873,7 @@ mod tests {
         assert_eq!(entries[1].conflicted_at, Some(1000));
         assert_eq!(
             entries[0].sidecar,
-            "knowledge/note.conflict.2000.bbbbbbbb.md"
+            "knowledge/.conflicts/note.conflict.2000.bbbbbbbb.md"
         );
     }
 

--- a/apps/daemon/src/mqtt/subscriber.rs
+++ b/apps/daemon/src/mqtt/subscriber.rs
@@ -29,6 +29,12 @@ pub enum IncomingMessage {
         session_id: String,
         payload: Vec<u8>,
     },
+    /// Team-scoped sync hint: `amux/{team}/sync/{resource}`.
+    SyncHint {
+        team_id: String,
+        resource: String,
+        payload: Vec<u8>,
+    },
 }
 
 pub fn parse_incoming(publish: &Publish) -> Option<IncomingMessage> {
@@ -76,6 +82,23 @@ pub fn parse_frame(frame: &IncomingFrame) -> Option<IncomingMessage> {
                 actor_id: parts[2].to_string(),
                 payload: payload.clone(),
             });
+        }
+    }
+
+    // Sync hint: amux/{team}/sync/{resource} (4 segments). Unknown resources
+    // are ignored so an older daemon does not log on future topic families.
+    if topic.starts_with("amux/") {
+        let parts: Vec<&str> = topic.split('/').collect();
+        if parts.len() == 4 && parts[2] == "sync" {
+            let resource = parts[3];
+            if resource == "knowledge" {
+                return Some(IncomingMessage::SyncHint {
+                    team_id: parts[1].to_string(),
+                    resource: resource.to_string(),
+                    payload: payload.clone(),
+                });
+            }
+            return None;
         }
     }
 
@@ -176,5 +199,47 @@ mod tests {
             }
             _ => panic!("wrong variant"),
         }
+    }
+
+    #[test]
+    fn parse_sync_knowledge_hint() {
+        let payload = br#"{"v":1,"changeSeq":42,"originNodeId":"n1"}"#.to_vec();
+        let frame = IncomingFrame {
+            topic: "amux/team-a/sync/knowledge".to_string(),
+            payload: payload.clone(),
+            retained: false,
+        };
+        match parse_frame(&frame).expect("should parse") {
+            IncomingMessage::SyncHint {
+                team_id,
+                resource,
+                payload: got,
+            } => {
+                assert_eq!(team_id, "team-a");
+                assert_eq!(resource, "knowledge");
+                assert_eq!(got, payload);
+            }
+            _ => panic!("wrong variant"),
+        }
+    }
+
+    #[test]
+    fn parse_sync_unknown_resource_is_ignored() {
+        let frame = IncomingFrame {
+            topic: "amux/team-a/sync/skills".to_string(),
+            payload: br#"{"v":1,"changeSeq":1}"#.to_vec(),
+            retained: false,
+        };
+        assert!(parse_frame(&frame).is_none());
+    }
+
+    #[test]
+    fn parse_sync_wrong_segment_count_is_ignored() {
+        let frame = IncomingFrame {
+            topic: "amux/team-a/sync/knowledge/extra".to_string(),
+            payload: br#"{}"#.to_vec(),
+            retained: false,
+        };
+        assert!(parse_frame(&frame).is_none());
     }
 }

--- a/apps/daemon/src/mqtt/supervisor.rs
+++ b/apps/daemon/src/mqtt/supervisor.rs
@@ -1726,7 +1726,16 @@ impl MqttWorker {
                                     generation,
                                     worker_generation: self.worker_generation,
                                 })).await;
-                                if !auto_restore_subscriptions {
+                                // Announce when nothing is left to wait for. The
+                                // SUBACK handler is the other announce site, and
+                                // it only runs if something was actually queued:
+                                // when every restore was rejected at the queue
+                                // AND every one of them was optional (tolerated,
+                                // no forced rebuild), no SUBACK ever arrives and
+                                // the worker would sit un-announced forever.
+                                if !auto_restore_subscriptions
+                                    || subscribe_waiting_for_write.is_empty()
+                                {
                                     self.announce_subscriptions_ready(
                                         generation,
                                         &mut subscriptions_ready_announced,

--- a/apps/daemon/src/mqtt/supervisor.rs
+++ b/apps/daemon/src/mqtt/supervisor.rs
@@ -5,10 +5,10 @@
 //! stable `MqttPublisher` proxy, so a reconnect cannot leave a
 //! `SessionManager` or `LivePublisher` holding a dead client generation.
 
-use std::collections::{BTreeMap, HashMap, VecDeque};
+use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
 use std::sync::{
     atomic::{AtomicBool, AtomicU64, Ordering},
-    Arc,
+    Arc, Mutex, OnceLock,
 };
 use std::time::{Duration, Instant};
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -45,6 +45,44 @@ const RECOVERY_SIGNAL_TIMEOUT: Duration = Duration::from_secs(2);
 const WAKE_GAP_THRESHOLD: Duration = Duration::from_secs(120);
 const INBOUND_RETRY_MAX: Duration = Duration::from_secs(30);
 const DURABLE_STORE_FAILURE_PREFIX: &str = "durable_store:";
+
+/// Tracked MQTT subscription restored after every CONNACK.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct TrackedSubscription {
+    qos: QoS,
+    /// When true, SUBACK Failure / restore queue errors warn once and never
+    /// force a worker rebuild (ACL migration lag for `sync/+`).
+    optional: bool,
+}
+
+/// Decision after a SUBACK Failure (or restore `try_subscribe` queue reject).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SubackFailureAction {
+    /// Required topic — schedule `forced_rebuild` during auto-restore.
+    ForceRebuild,
+    /// Optional topic — warn once, keep the worker.
+    Tolerate,
+}
+
+fn suback_failure_action(optional: bool) -> SubackFailureAction {
+    if optional {
+        SubackFailureAction::Tolerate
+    } else {
+        SubackFailureAction::ForceRebuild
+    }
+}
+
+fn warn_optional_subscribe_rejected(topic: &str) {
+    static WARNED: OnceLock<Mutex<HashSet<String>>> = OnceLock::new();
+    let set = WARNED.get_or_init(|| Mutex::new(HashSet::new()));
+    let mut guard = set.lock().unwrap_or_else(|e| e.into_inner());
+    if guard.insert(topic.to_string()) {
+        warn!(
+            topic,
+            "optional MQTT subscription rejected by broker; will retry on next reconnect"
+        );
+    }
+}
 
 /// The one snapshot published to `/v1/info`. Keeping the fields together
 /// prevents the UI from observing `connected=true` with a stale recovery phase.
@@ -276,6 +314,9 @@ pub enum MqttCommand {
     Subscribe {
         topic: String,
         delivery: DeliveryGuarantee,
+        /// Best-effort: broker rejection does not rebuild the worker or
+        /// escalate `PublisherError::Unavailable` to the caller.
+        optional: bool,
         reply: oneshot::Sender<Result<(), PublisherError>>,
     },
     Unsubscribe {
@@ -355,16 +396,15 @@ impl MessagePublisher for MqttPublisher {
         topic: &str,
         delivery: DeliveryGuarantee,
     ) -> Result<(), PublisherError> {
-        let (reply, rx) = oneshot::channel();
-        self.send(
-            MqttCommand::Subscribe {
-                topic: topic.to_string(),
-                delivery,
-                reply,
-            },
-            rx,
-        )
-        .await
+        self.subscribe_inner(topic, delivery, false).await
+    }
+
+    async fn subscribe_optional(
+        &self,
+        topic: &str,
+        delivery: DeliveryGuarantee,
+    ) -> Result<(), PublisherError> {
+        self.subscribe_inner(topic, delivery, true).await
     }
 
     async fn unsubscribe(&self, topic: &str) -> Result<(), PublisherError> {
@@ -372,6 +412,27 @@ impl MessagePublisher for MqttPublisher {
         self.send(
             MqttCommand::Unsubscribe {
                 topic: topic.to_string(),
+                reply,
+            },
+            rx,
+        )
+        .await
+    }
+}
+
+impl MqttPublisher {
+    async fn subscribe_inner(
+        &self,
+        topic: &str,
+        delivery: DeliveryGuarantee,
+        optional: bool,
+    ) -> Result<(), PublisherError> {
+        let (reply, rx) = oneshot::channel();
+        self.send(
+            MqttCommand::Subscribe {
+                topic: topic.to_string(),
+                delivery,
+                optional,
                 reply,
             },
             rx,
@@ -801,7 +862,7 @@ async fn run_supervisor(
         connected.clone(),
         heartbeat.clone(),
     ));
-    let mut subscriptions = BTreeMap::<String, QoS>::new();
+    let mut subscriptions = BTreeMap::<String, TrackedSubscription>::new();
     let mut pending_commands = VecDeque::<MqttCommand>::new();
     let mut pending_dispositions = VecDeque::<(u64, MqttInboundDisposition)>::new();
     let mut generation = 0_u64;
@@ -979,8 +1040,19 @@ async fn run_supervisor(
                     fail_command(command, "MQTT worker command queue is full");
                 } else {
                     match &command {
-                        MqttCommand::Subscribe { topic, delivery, .. } => {
-                            subscriptions.insert(topic.clone(), delivery.clone().into());
+                        MqttCommand::Subscribe {
+                            topic,
+                            delivery,
+                            optional,
+                            ..
+                        } => {
+                            subscriptions.insert(
+                                topic.clone(),
+                                TrackedSubscription {
+                                    qos: delivery.clone().into(),
+                                    optional: *optional,
+                                },
+                            );
                         }
                         MqttCommand::Unsubscribe { topic, .. } => {
                             subscriptions.remove(topic);
@@ -1373,7 +1445,7 @@ fn spawn_worker(
     backend: Arc<dyn Backend>,
     generation_seed: u64,
     worker_generation: u64,
-    initial_subscriptions: BTreeMap<String, QoS>,
+    initial_subscriptions: BTreeMap<String, TrackedSubscription>,
     events_tx: mpsc::Sender<WorkerEvent>,
     inbound_tx: mpsc::Sender<MqttInbound>,
     connected: Arc<AtomicBool>,
@@ -1456,7 +1528,7 @@ struct MqttWorker {
     heartbeat: Arc<MqttHeartbeat>,
     generation_seed: u64,
     worker_generation: u64,
-    initial_subscriptions: BTreeMap<String, QoS>,
+    initial_subscriptions: BTreeMap<String, TrackedSubscription>,
 }
 
 impl MqttWorker {
@@ -1621,13 +1693,26 @@ impl MqttWorker {
                                 auto_restore_subscriptions = !subscriptions.is_empty();
                                 subscriptions_ready_announced = !auto_restore_subscriptions;
                                 if auto_restore_subscriptions {
-                                    for (topic, qos) in &subscriptions {
-                                        if let Err(error) = active.client.try_subscribe(topic.clone(), *qos) {
+                                    for (topic, tracked) in &subscriptions {
+                                        if let Err(error) =
+                                            active.client.try_subscribe(topic.clone(), tracked.qos)
+                                        {
                                             warn!(%error, topic, generation, "failed to queue MQTT subscription restore");
-                                            forced_rebuild = Some("subscription restore queue rejected".to_string());
+                                            match suback_failure_action(tracked.optional) {
+                                                SubackFailureAction::Tolerate => {
+                                                    warn_optional_subscribe_rejected(topic);
+                                                }
+                                                SubackFailureAction::ForceRebuild => {
+                                                    forced_rebuild = Some(
+                                                        "subscription restore queue rejected"
+                                                            .to_string(),
+                                                    );
+                                                }
+                                            }
                                         } else {
                                             subscribe_waiting_for_write.push_back(PendingSubscribe {
                                                 topic: topic.clone(),
+                                                optional: tracked.optional,
                                                 reply: None,
                                             });
                                         }
@@ -1717,29 +1802,47 @@ impl MqttWorker {
                             Ok(Event::Incoming(Packet::SubAck(ack))) => {
                                 self.heartbeat.end_poll();
                                 if let Some(request) = subscribe_inflight.remove(&ack.pkid) {
-                                    let success = !ack.return_codes.iter().any(|code| matches!(code, rumqttc::SubscribeReasonCode::Failure));
-                                    let result = if success {
+                                    let success = !ack.return_codes.iter().any(|code| {
+                                        matches!(code, rumqttc::SubscribeReasonCode::Failure)
+                                    });
+                                    let tolerate_failure = !success
+                                        && matches!(
+                                            suback_failure_action(request.optional),
+                                            SubackFailureAction::Tolerate
+                                        );
+                                    if tolerate_failure {
+                                        warn_optional_subscribe_rejected(&request.topic);
+                                    }
+                                    // Optional reject: Ok to caller so mqtt_resubscribe
+                                    // does not escalate into a generation rebuild.
+                                    let result = if success || request.optional {
                                         Ok(())
                                     } else {
-                                        Err(PublisherError::Unavailable(format!("MQTT broker rejected subscription for {}", request.topic)))
+                                        Err(PublisherError::Unavailable(format!(
+                                            "MQTT broker rejected subscription for {}",
+                                            request.topic
+                                        )))
                                     };
                                     if let Some(reply) = request.reply {
                                         let _ = reply.send(result);
                                     }
-                                    if success
-                                        && auto_restore_subscriptions
+                                    let restore_drained = auto_restore_subscriptions
                                         && subscribe_waiting_for_write.is_empty()
-                                        && subscribe_inflight.is_empty()
+                                        && subscribe_inflight.is_empty();
+                                    if !success
+                                        && auto_restore_subscriptions
+                                        && !request.optional
                                     {
-                                        self.announce_subscriptions_ready(
-                                            generation,
-                                            &mut subscriptions_ready_announced,
-                                        ).await;
-                                    } else if !success && auto_restore_subscriptions {
                                         forced_rebuild = Some(format!(
                                             "broker rejected restored subscription {}",
                                             request.topic
                                         ));
+                                    } else if (success || tolerate_failure) && restore_drained {
+                                        self.announce_subscriptions_ready(
+                                            generation,
+                                            &mut subscriptions_ready_announced,
+                                        )
+                                        .await;
                                     }
                                 } else {
                                     debug!(pkid = ack.pkid, "received MQTT SUBACK without a tracked request");
@@ -1950,7 +2053,7 @@ impl MqttWorker {
         command: Option<MqttCommand>,
         connected: bool,
         mqtt_client: Option<rumqttc::AsyncClient>,
-        subscriptions: &mut BTreeMap<String, QoS>,
+        subscriptions: &mut BTreeMap<String, TrackedSubscription>,
         pending: &mut VecDeque<PendingPublish>,
         store: &mut DurableMqttStore,
         subscribe_waiting_for_write: &mut VecDeque<PendingSubscribe>,
@@ -1963,10 +2066,14 @@ impl MqttWorker {
             MqttCommand::Subscribe {
                 topic,
                 delivery,
+                optional,
                 reply,
             } => {
                 let qos: QoS = delivery.clone().into();
-                subscriptions.insert(topic.clone(), qos);
+                subscriptions.insert(
+                    topic.clone(),
+                    TrackedSubscription { qos, optional },
+                );
                 let result = if connected {
                     let result = mqtt_client
                         .expect("connected MQTT command must have a client")
@@ -1975,11 +2082,18 @@ impl MqttWorker {
                     if result.is_ok() {
                         subscribe_waiting_for_write.push_back(PendingSubscribe {
                             topic,
+                            optional,
                             reply: Some(reply),
                         });
                         return true;
                     }
-                    result
+                    // Queue reject for optional: do not escalate Unavailable.
+                    if optional {
+                        warn_optional_subscribe_rejected(&topic);
+                        Ok(())
+                    } else {
+                        result
+                    }
                 } else {
                     Ok(())
                 };
@@ -2295,6 +2409,7 @@ struct PendingPublish {
 
 struct PendingSubscribe {
     topic: String,
+    optional: bool,
     reply: Option<oneshot::Sender<Result<(), PublisherError>>>,
 }
 
@@ -2675,6 +2790,80 @@ mod tests {
     fn stale_worker_exit_events_are_rejected_by_generation() {
         assert!(!worker_exit_matches_generation(2, 1));
         assert!(worker_exit_matches_generation(2, 2));
+    }
+
+    #[test]
+    fn optional_suback_failure_does_not_force_rebuild() {
+        assert_eq!(
+            suback_failure_action(true),
+            SubackFailureAction::Tolerate
+        );
+        assert_eq!(
+            suback_failure_action(false),
+            SubackFailureAction::ForceRebuild
+        );
+    }
+
+    /// Optional reject must not schedule a rebuild; required still does.
+    /// Mirrors the CONNACK restore / live-subscribe decision used above.
+    #[test]
+    fn rejected_optional_subscribe_skips_forced_rebuild_while_required_still_rebuilds() {
+        fn forced_rebuild_reason(
+            optional: bool,
+            auto_restore: bool,
+            topic: &str,
+        ) -> Option<String> {
+            if !auto_restore {
+                return None;
+            }
+            match suback_failure_action(optional) {
+                SubackFailureAction::Tolerate => None,
+                SubackFailureAction::ForceRebuild => {
+                    Some(format!("broker rejected restored subscription {topic}"))
+                }
+            }
+        }
+
+        assert_eq!(
+            forced_rebuild_reason(true, true, "amux/t/sync/+"),
+            None,
+            "optional sync/+ deny must not rebuild the worker (#1073 auth-reject context)"
+        );
+        assert_eq!(
+            forced_rebuild_reason(false, true, "amux/t/actor/rpc/req"),
+            Some("broker rejected restored subscription amux/t/actor/rpc/req".into())
+        );
+        assert_eq!(
+            forced_rebuild_reason(false, false, "amux/t/actor/rpc/req"),
+            None,
+            "live (non-restore) path escalates via reply Err, not forced_rebuild"
+        );
+    }
+
+    #[tokio::test]
+    async fn stable_publisher_optional_subscribe_sets_optional_flag() {
+        let (publisher, mut commands) = MqttPublisher::channel();
+        let task = tokio::spawn(async move {
+            publisher
+                .subscribe_optional("amux/team/sync/+", DeliveryGuarantee::AtLeastOnce)
+                .await
+        });
+
+        let command = commands.recv().await.expect("subscribe command");
+        match command {
+            MqttCommand::Subscribe {
+                topic,
+                optional,
+                reply,
+                ..
+            } => {
+                assert_eq!(topic, "amux/team/sync/+");
+                assert!(optional);
+                reply.send(Ok(())).expect("reply");
+            }
+            _ => panic!("unexpected command"),
+        }
+        assert!(task.await.expect("task").is_ok());
     }
 
     #[tokio::test]

--- a/apps/daemon/src/sync/dispatch.rs
+++ b/apps/daemon/src/sync/dispatch.rs
@@ -76,10 +76,19 @@ pub fn evaluate_sync_hint(
 }
 
 fn warn_unknown_hint_version_once(v: i64) {
-    use std::sync::atomic::{AtomicBool, Ordering};
     static WARNED: AtomicBool = AtomicBool::new(false);
     if !WARNED.swap(true, Ordering::Relaxed) {
         tracing::warn!(v, "dropping knowledge sync hint with unknown version");
+    }
+}
+
+/// A hint whose topic names a team this daemon is not onboarded to. Never
+/// expected; warn once rather than per message so a misconfigured broker cannot
+/// flood the log.
+fn warn_foreign_hint_team_once() {
+    static WARNED: AtomicBool = AtomicBool::new(false);
+    if !WARNED.swap(true, Ordering::Relaxed) {
+        tracing::warn!("dropping knowledge sync hint addressed to another team");
     }
 }
 
@@ -192,7 +201,27 @@ impl SyncDispatcher {
     /// works / no rebuild loop beyond backoff; pre-migration token → one warn,
     /// worker not rebuilt; payload has no paths; rate / coalesce / pull
     /// self-write checks from the plan.
-    pub async fn handle_sync_hint(&self, team_id: &str, resource: &str, payload: &[u8]) {
+    ///
+    /// `own_team_id` is the team this daemon is onboarded to. The hint's team
+    /// comes from a topic segment, and a topic segment is not a capability: a
+    /// misrouted or hostile publish carrying `..` would otherwise resolve
+    /// `sync_content_root("..")` to the amuxd home itself, and every distinct
+    /// value would permanently allocate a scheduler slot plus a driver task that
+    /// never exits. A correct broker cannot deliver one — the subscribe filter
+    /// pins the team — so this is defence in depth, and cheap.
+    pub async fn handle_sync_hint(
+        &self,
+        own_team_id: &str,
+        team_id: &str,
+        resource: &str,
+        payload: &[u8],
+    ) {
+        if team_id.trim().is_empty() || team_id != own_team_id.trim() {
+            warn_foreign_hint_team_once();
+            return;
+        }
+        // `subscriber::parse_frame` already drops every other resource; this is
+        // the public entry point's own contract, not a duplicate of that filter.
         if resource != "knowledge" {
             return;
         }
@@ -753,12 +782,44 @@ mod tests {
 
         let d = SyncDispatcher::new(crate::sync::secret_store::SecretStore::new(), None);
         let payload = br#"{"v":1,"changeSeq":55,"originNodeId":"other-node"}"#;
-        d.handle_sync_hint("team-hint", "knowledge", payload).await;
+        d.handle_sync_hint("team-hint", "team-hint", "knowledge", payload)
+            .await;
 
         let map = d.team_schedulers.lock().await;
         let slot = map.get("team-hint").expect("scheduler armed");
         let logic = slot.logic.lock().unwrap_or_else(|e| e.into_inner());
         assert_eq!(logic.pending_remote_seq(), Some(55));
+
+        if let Some(v) = orig {
+            std::env::set_var("AMUXD_HOME", v);
+        } else {
+            std::env::remove_var("AMUXD_HOME");
+        }
+    }
+
+    /// A hint whose topic names another team (or a traversal segment) must not
+    /// allocate a scheduler slot — each one would also spawn a driver task that
+    /// never exits, and `..` resolves the content root to the amuxd home.
+    #[tokio::test]
+    async fn handle_sync_hint_rejects_foreign_team() {
+        let _lock = crate::config::global_team_store::TEST_HOME_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let tmp = tempfile::tempdir().unwrap();
+        let orig = std::env::var("AMUXD_HOME").ok();
+        std::env::set_var("AMUXD_HOME", tmp.path());
+
+        let d = SyncDispatcher::new(crate::sync::secret_store::SecretStore::new(), None);
+        let payload = br#"{"v":1,"changeSeq":55,"originNodeId":"other-node"}"#;
+        for foreign in ["..", "someone-elses-team", ""] {
+            d.handle_sync_hint("my-team", foreign, "knowledge", payload)
+                .await;
+        }
+
+        assert!(
+            d.team_schedulers.lock().await.is_empty(),
+            "a hint for another team must not arm a scheduler"
+        );
 
         if let Some(v) = orig {
             std::env::set_var("AMUXD_HOME", v);

--- a/apps/daemon/src/sync/dispatch.rs
+++ b/apps/daemon/src/sync/dispatch.rs
@@ -2,10 +2,22 @@
 //! per-team mutex, and caches the last status for the HTTP status endpoint.
 
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
-use tokio::sync::Mutex;
+use std::time::{Duration, Instant};
+use tokio::sync::{Mutex, Notify};
 
+use crate::sync::scheduler::{SyncScheduler, SystemClock, Trigger};
 use crate::sync::secret_store::SecretStore;
+
+/// Per-team coalescing state + wake handle for the background fire driver.
+///
+/// The 300s timer and manual force sync bypass this path entirely.
+struct TeamSchedulerSlot {
+    logic: std::sync::Mutex<SyncScheduler>,
+    wake: Notify,
+    driver_started: AtomicBool,
+}
 
 #[derive(Debug, Clone, Default, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -63,6 +75,9 @@ pub struct SyncDispatcher {
     /// this struct uses: the engine reports from inside its transfer loops, in
     /// sync code, and this lock is only ever held for one map write.
     progress: Arc<std::sync::Mutex<HashMap<String, crate::sync::oss::SyncProgress>>>,
+    /// One coalescing scheduler per team. Fed by fs-watch / MQTT hint (Tasks 3
+    /// & 8); fires call [`Self::sync_team`] with `force: false`.
+    team_schedulers: Arc<Mutex<HashMap<String, Arc<TeamSchedulerSlot>>>>,
 }
 
 impl SyncDispatcher {
@@ -73,7 +88,100 @@ impl SyncDispatcher {
             locks: Arc::new(Mutex::new(HashMap::new())),
             status: Arc::new(Mutex::new(HashMap::new())),
             progress: Arc::new(std::sync::Mutex::new(HashMap::new())),
+            team_schedulers: Arc::new(Mutex::new(HashMap::new())),
         }
+    }
+
+    /// Feed a Local / Remote trigger into the per-team coalescing scheduler.
+    ///
+    /// Does not run sync inline: the team driver wakes at the scheduled fire
+    /// time and calls [`Self::sync_team`]. The 300s timer and `POST /v1/team/sync`
+    /// (force) must not call this.
+    pub async fn trigger_sync(&self, team_id: &str, trigger: Trigger) {
+        let team_id = team_id.trim();
+        if team_id.is_empty() {
+            return;
+        }
+        let slot = self.scheduler_slot(team_id).await;
+        {
+            let mut logic = slot.logic.lock().unwrap_or_else(|e| e.into_inner());
+            logic.trigger(&SystemClock, trigger);
+        }
+        self.ensure_scheduler_driver(team_id, slot.clone());
+        slot.wake.notify_one();
+    }
+
+    async fn scheduler_slot(&self, team_id: &str) -> Arc<TeamSchedulerSlot> {
+        let mut map = self.team_schedulers.lock().await;
+        map.entry(team_id.to_string())
+            .or_insert_with(|| {
+                Arc::new(TeamSchedulerSlot {
+                    logic: std::sync::Mutex::new(SyncScheduler::new()),
+                    wake: Notify::new(),
+                    driver_started: AtomicBool::new(false),
+                })
+            })
+            .clone()
+    }
+
+    fn ensure_scheduler_driver(&self, team_id: &str, slot: Arc<TeamSchedulerSlot>) {
+        if slot.driver_started.swap(true, Ordering::SeqCst) {
+            return;
+        }
+        let dispatcher = self.clone();
+        let team_id = team_id.to_string();
+        tokio::spawn(async move {
+            loop {
+                let wait = {
+                    let logic = slot.logic.lock().unwrap_or_else(|e| e.into_inner());
+                    match logic.next_fire_at() {
+                        Some(at) => Some(at.saturating_duration_since(Instant::now())),
+                        None => None,
+                    }
+                };
+                match wait {
+                    None => {
+                        slot.wake.notified().await;
+                        continue;
+                    }
+                    Some(Duration::ZERO) => {}
+                    Some(d) => {
+                        tokio::select! {
+                            _ = slot.wake.notified() => continue,
+                            _ = tokio::time::sleep(d) => {}
+                        }
+                    }
+                }
+
+                let should_run = {
+                    let mut logic = slot.logic.lock().unwrap_or_else(|e| e.into_inner());
+                    logic.try_begin_tick(&SystemClock)
+                };
+                if !should_run {
+                    continue;
+                }
+
+                let st = dispatcher
+                    .sync_team(
+                        &team_id,
+                        SyncOptions {
+                            force: false,
+                            allow_bulk_add: false,
+                        },
+                    )
+                    .await;
+                if let Some(err) = &st.last_error {
+                    tracing::warn!(team_id, "scheduler sync error: {err}");
+                }
+
+                {
+                    let mut logic = slot.logic.lock().unwrap_or_else(|e| e.into_inner());
+                    logic.end_tick(&SystemClock);
+                }
+                // Re-check immediately: mid-tick triggers may already be due on floor.
+                slot.wake.notify_one();
+            }
+        });
     }
 
     pub fn secrets(&self) -> &SecretStore {
@@ -441,5 +549,23 @@ mod tests {
     fn fc_endpoint_errors_without_backend() {
         let d = SyncDispatcher::new(crate::sync::secret_store::SecretStore::new(), None);
         assert!(d.fc_endpoint().is_err());
+    }
+
+    /// Tasks 3/8 will call this; until then the smoke test pins the wiring:
+    /// one slot per team, driver armed, pure scheduler holding a next fire.
+    #[tokio::test]
+    async fn trigger_sync_arms_per_team_scheduler() {
+        let d = SyncDispatcher::new(crate::sync::secret_store::SecretStore::new(), None);
+        d.trigger_sync("team-a", Trigger::Local).await;
+        d.trigger_sync("team-a", Trigger::Remote { seq: 9 }).await;
+
+        let map = d.team_schedulers.lock().await;
+        assert_eq!(map.len(), 1);
+        let slot = map.get("team-a").expect("slot");
+        assert!(slot.driver_started.load(Ordering::SeqCst));
+        let logic = slot.logic.lock().unwrap_or_else(|e| e.into_inner());
+        assert!(logic.next_fire_at().is_some());
+        assert_eq!(logic.pending_remote_seq(), Some(9));
+        assert!(!logic.in_tick());
     }
 }

--- a/apps/daemon/src/sync/dispatch.rs
+++ b/apps/daemon/src/sync/dispatch.rs
@@ -7,8 +7,81 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::sync::{Mutex, Notify};
 
+use crate::sync::oss::state::LocalSyncState;
 use crate::sync::scheduler::{SyncScheduler, SystemClock, Trigger};
 use crate::sync::secret_store::SecretStore;
+
+/// Decoded MQTT knowledge sync hint (`amux/<team>/sync/knowledge`).
+#[derive(Debug, Clone, PartialEq)]
+pub struct SyncHintPayload {
+    pub v: i64,
+    pub change_seq: i64,
+    pub origin_node_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SyncHintDecision {
+    /// Schedule a Remote trigger with this seq.
+    Accept { seq: i64 },
+    /// Our own upload echoed back — drop.
+    DropEcho,
+    /// Already covered by local high-water — drop.
+    DropStale,
+    /// Unknown wire version — drop (caller warns once).
+    DropUnknownVersion,
+}
+
+/// Parse the JSON body published by FC. Missing/invalid fields → `None`.
+pub fn parse_sync_hint_payload(bytes: &[u8]) -> Option<SyncHintPayload> {
+    let value: serde_json::Value = serde_json::from_slice(bytes).ok()?;
+    let v = value.get("v")?.as_i64()?;
+    let change_seq = value.get("changeSeq")?.as_i64()?;
+    if change_seq <= 0 {
+        return None;
+    }
+    let origin_node_id = value
+        .get("originNodeId")
+        .and_then(|n| n.as_str())
+        .filter(|s| !s.is_empty())
+        .map(str::to_string);
+    Some(SyncHintPayload {
+        v,
+        change_seq,
+        origin_node_id,
+    })
+}
+
+/// Echo / high-water / version filters before the per-team scheduler.
+pub fn evaluate_sync_hint(
+    hint: &SyncHintPayload,
+    high_water: i64,
+    self_node_id: &str,
+) -> SyncHintDecision {
+    if hint.v != 1 {
+        return SyncHintDecision::DropUnknownVersion;
+    }
+    if hint
+        .origin_node_id
+        .as_deref()
+        .is_some_and(|id| id == self_node_id)
+    {
+        return SyncHintDecision::DropEcho;
+    }
+    if hint.change_seq <= high_water {
+        return SyncHintDecision::DropStale;
+    }
+    SyncHintDecision::Accept {
+        seq: hint.change_seq,
+    }
+}
+
+fn warn_unknown_hint_version_once(v: i64) {
+    use std::sync::atomic::{AtomicBool, Ordering};
+    static WARNED: AtomicBool = AtomicBool::new(false);
+    if !WARNED.swap(true, Ordering::Relaxed) {
+        tracing::warn!(v, "dropping knowledge sync hint with unknown version");
+    }
+}
 
 /// Per-team coalescing state + wake handle for the background fire driver.
 ///
@@ -109,6 +182,36 @@ impl SyncDispatcher {
         }
         self.ensure_scheduler_driver(team_id, slot.clone());
         slot.wake.notify_one();
+    }
+
+    /// Apply MQTT sync-hint filters, then [`Self::trigger_sync`] with
+    /// [`Trigger::Remote`] when the hint is actionable.
+    ///
+    /// Manual checklist (do not automate): A→B ≤10s; ≤10 hints for 2000 files;
+    /// no re-tick on own echo once nodeId set; EMQX down → 300s timer still
+    /// works / no rebuild loop beyond backoff; pre-migration token → one warn,
+    /// worker not rebuilt; payload has no paths; rate / coalesce / pull
+    /// self-write checks from the plan.
+    pub async fn handle_sync_hint(&self, team_id: &str, resource: &str, payload: &[u8]) {
+        if resource != "knowledge" {
+            return;
+        }
+        let Some(hint) = parse_sync_hint_payload(payload) else {
+            return;
+        };
+        let high_water = LocalSyncState::load_at(team_id)
+            .map(|s| s.last_server_seq)
+            .unwrap_or(0);
+        let self_id = crate::device_id::daemon_device_id();
+        match evaluate_sync_hint(&hint, high_water, &self_id) {
+            SyncHintDecision::Accept { seq } => {
+                self.trigger_sync(team_id, Trigger::Remote { seq }).await;
+            }
+            SyncHintDecision::DropEcho | SyncHintDecision::DropStale => {}
+            SyncHintDecision::DropUnknownVersion => {
+                warn_unknown_hint_version_once(hint.v);
+            }
+        }
     }
 
     async fn scheduler_slot(&self, team_id: &str) -> Arc<TeamSchedulerSlot> {
@@ -567,5 +670,101 @@ mod tests {
         assert!(logic.next_fire_at().is_some());
         assert_eq!(logic.pending_remote_seq(), Some(9));
         assert!(!logic.in_tick());
+    }
+
+    #[test]
+    fn sync_hint_drops_own_echo() {
+        let hint = SyncHintPayload {
+            v: 1,
+            change_seq: 99,
+            origin_node_id: Some("node-self".into()),
+        };
+        assert_eq!(
+            evaluate_sync_hint(&hint, 0, "node-self"),
+            SyncHintDecision::DropEcho
+        );
+    }
+
+    #[test]
+    fn sync_hint_drops_stale_or_equal_seq() {
+        let hint = SyncHintPayload {
+            v: 1,
+            change_seq: 10,
+            origin_node_id: Some("peer".into()),
+        };
+        assert_eq!(
+            evaluate_sync_hint(&hint, 10, "self"),
+            SyncHintDecision::DropStale
+        );
+        assert_eq!(
+            evaluate_sync_hint(&hint, 11, "self"),
+            SyncHintDecision::DropStale
+        );
+    }
+
+    #[test]
+    fn sync_hint_drops_unknown_version() {
+        let hint = SyncHintPayload {
+            v: 2,
+            change_seq: 99,
+            origin_node_id: None,
+        };
+        assert_eq!(
+            evaluate_sync_hint(&hint, 0, "self"),
+            SyncHintDecision::DropUnknownVersion
+        );
+    }
+
+    #[test]
+    fn sync_hint_accepts_newer_peer_change() {
+        let hint = SyncHintPayload {
+            v: 1,
+            change_seq: 42,
+            origin_node_id: Some("peer".into()),
+        };
+        assert_eq!(
+            evaluate_sync_hint(&hint, 10, "self"),
+            SyncHintDecision::Accept { seq: 42 }
+        );
+    }
+
+    #[test]
+    fn parse_sync_hint_payload_reads_fc_shape() {
+        let raw = br#"{"v":1,"changeSeq":7,"originNodeId":"mac-1","at":"2026-08-26T07:12:00Z"}"#;
+        let hint = parse_sync_hint_payload(raw).expect("parse");
+        assert_eq!(hint.v, 1);
+        assert_eq!(hint.change_seq, 7);
+        assert_eq!(hint.origin_node_id.as_deref(), Some("mac-1"));
+    }
+
+    #[test]
+    fn parse_sync_hint_payload_rejects_non_positive_seq() {
+        assert!(parse_sync_hint_payload(br#"{"v":1,"changeSeq":0}"#).is_none());
+        assert!(parse_sync_hint_payload(br#"{"v":1}"#).is_none());
+    }
+
+    #[tokio::test]
+    async fn handle_sync_hint_triggers_remote_when_accepted() {
+        let _lock = crate::config::global_team_store::TEST_HOME_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let tmp = tempfile::tempdir().unwrap();
+        let orig = std::env::var("AMUXD_HOME").ok();
+        std::env::set_var("AMUXD_HOME", tmp.path());
+
+        let d = SyncDispatcher::new(crate::sync::secret_store::SecretStore::new(), None);
+        let payload = br#"{"v":1,"changeSeq":55,"originNodeId":"other-node"}"#;
+        d.handle_sync_hint("team-hint", "knowledge", payload).await;
+
+        let map = d.team_schedulers.lock().await;
+        let slot = map.get("team-hint").expect("scheduler armed");
+        let logic = slot.logic.lock().unwrap_or_else(|e| e.into_inner());
+        assert_eq!(logic.pending_remote_seq(), Some(55));
+
+        if let Some(v) = orig {
+            std::env::set_var("AMUXD_HOME", v);
+        } else {
+            std::env::remove_var("AMUXD_HOME");
+        }
     }
 }

--- a/apps/daemon/src/sync/dispatch.rs
+++ b/apps/daemon/src/sync/dispatch.rs
@@ -548,9 +548,9 @@ mod tests {
             .unwrap();
 
         let store = SecretStore::with_base(tmp.path().to_path_buf());
-        // A team secret is the precondition for syncing at all; without one the
-        // tick skips instead of erroring, and this test needs a real error to
-        // cache. With the secret in place it gets one from the missing backend.
+        // Secret is optional (plaintext knowledge); this test still plants one
+        // so the tick proceeds far enough to hit the missing-backend error that
+        // we then assert stays cached when auto_sync flips off.
         store
             .save(
                 "t",
@@ -597,10 +597,9 @@ mod tests {
         }
     }
 
-    /// A team that never set up sharing has nothing to sync. That used to be
-    /// decided by the cloud `share_mode` flag — which nothing sets any more — so
-    /// the honest precondition is the team secret: without it there is nothing
-    /// to encrypt or decrypt with, and a red banner would be noise.
+    /// Knowledge uploads are plaintext now, so a missing team secret must not
+    /// skip the tick. Skipping here used to leave a device permanently idle
+    /// with no banner — the same trap `share_mode` had when nothing set it.
     #[tokio::test]
     async fn a_team_without_a_secret_still_syncs() {
         let _lock = crate::config::global_team_store::TEST_HOME_LOCK

--- a/apps/daemon/src/sync/mod.rs
+++ b/apps/daemon/src/sync/mod.rs
@@ -13,3 +13,4 @@ pub mod scheduler;
 pub mod secret_store;
 pub mod timer;
 pub mod versions;
+pub mod watch;

--- a/apps/daemon/src/sync/mod.rs
+++ b/apps/daemon/src/sync/mod.rs
@@ -9,6 +9,7 @@ pub mod app_seed;
 pub mod app_templates;
 pub mod dispatch;
 pub mod oss;
+pub mod scheduler;
 pub mod secret_store;
 pub mod timer;
 pub mod versions;

--- a/apps/daemon/src/sync/oss/conflict.rs
+++ b/apps/daemon/src/sync/oss/conflict.rs
@@ -19,16 +19,28 @@
 //! scanner relocates them on sight.
 
 use super::path_validator::ALLOWED_PREFIXES;
-use std::path::{Component, Path, PathBuf};
+use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 /// Directory name under each sync prefix that holds conflict copies.
 pub const CONFLICTS_DIR: &str = ".conflicts";
 
-/// Write a conflict sidecar file containing `data` for the original `abs_path`.
-/// Returns the path of the conflict file written (under `.conflicts/`).
+/// Write a conflict sidecar holding `data` for the document at `rel_path`
+/// (content-root relative, e.g. `knowledge/a/foo.md`).
+///
+/// Takes the **relative** path deliberately. The sidecar's home is derived by
+/// inserting `.conflicts` after the sync-prefix segment, and every reader
+/// ([`original_from_conflict`], [`is_under_conflicts_dir`],
+/// [`legacy_rel_to_conflicts_rel`]) anchors on the relative path the same way.
+/// Deriving it from the absolute path instead matches a `knowledge` component
+/// in the daemon's own home (`AMUXD_HOME=/data/knowledge/…`) and parks the
+/// sidecar outside the synced tree, where `scan_conflict_files` never finds it
+/// and the user's overwritten bytes disappear from the conflicts UI.
+///
+/// Returns the absolute path written.
 pub async fn write_conflict_sidecar(
-    abs_path: &Path,
+    content_root: &Path,
+    rel_path: &str,
     data: &[u8],
     cipher_hash: &str,
 ) -> Result<PathBuf, String> {
@@ -37,7 +49,7 @@ pub async fn write_conflict_sidecar(
         .map(|d| d.as_secs())
         .unwrap_or(0);
 
-    let conflict_path = conflict_filename(abs_path, ts, cipher_hash);
+    let conflict_path = content_root.join(conflict_rel_path(rel_path, ts, cipher_hash));
 
     if let Some(parent) = conflict_path.parent() {
         tokio::fs::create_dir_all(parent)
@@ -52,80 +64,65 @@ pub async fn write_conflict_sidecar(
     Ok(conflict_path)
 }
 
-/// Construct the conflict path for a given original path, timestamp and cipher_hash.
+/// Sidecar path for the document at `rel_path`, content-root relative.
 ///
-/// The sidecar lands under `<prefix>/.conflicts/<mirrored relative dirs>/`, not
-/// beside the original. Public so scanner tests can exercise the mapping.
-pub fn conflict_filename(original: &Path, unix_ts: u64, cipher_hash: &str) -> PathBuf {
-    let filename = original
-        .file_name()
-        .map(|n| n.to_string_lossy().into_owned())
-        .unwrap_or_default();
+/// `knowledge/a/foo.md` → `knowledge/.conflicts/a/foo.conflict.<ts>.<hash>.md`
+/// `knowledge/foo.md`   → `knowledge/.conflicts/foo.conflict.<ts>.<hash>.md`
+///
+/// A path under no known sync prefix keeps its sidecar beside the original,
+/// rather than inventing a root-level `.conflicts/` nothing else reads.
+pub fn conflict_rel_path(rel_path: &str, unix_ts: u64, cipher_hash: &str) -> String {
+    let rel = rel_path.replace('\\', "/");
+    let (dir, filename) = match rel.rsplit_once('/') {
+        Some((d, f)) => (Some(d), f),
+        None => (None, rel.as_str()),
+    };
+    let conflict_name = conflict_file_name(filename, unix_ts, cipher_hash);
+    match dir {
+        Some(d) => match insert_conflicts_rel(d) {
+            Some(with_conflicts) => format!("{with_conflicts}/{conflict_name}"),
+            None => format!("{d}/{conflict_name}"),
+        },
+        None => conflict_name,
+    }
+}
 
-    // Split into stem and extension
-    // e.g. "foo.md" → stem="foo", ext=Some("md")
-    //      "foo"    → stem="foo", ext=None
-    //      "foo.tar.gz" → stem="foo.tar", ext=Some("gz")
-    let (stem, ext) = if let Some(dot_pos) = filename.rfind('.') {
-        let (s, e) = filename.split_at(dot_pos);
-        (s.to_string(), Some(e[1..].to_string())) // e[1..] skips the dot
-    } else {
-        (filename, None)
+/// `foo.md` → `foo.conflict.<ts>.<hash>.md`
+///
+/// `foo` → `foo.conflict.<ts>.<hash>`; `foo.tar.gz` keeps `foo.tar` as the stem;
+/// `.gitignore` has an empty stem, which [`original_from_conflict`] reverses.
+fn conflict_file_name(filename: &str, unix_ts: u64, cipher_hash: &str) -> String {
+    let (stem, ext) = match filename.rfind('.') {
+        Some(dot_pos) => {
+            let (s, e) = filename.split_at(dot_pos);
+            (s.to_string(), Some(e[1..].to_string())) // e[1..] skips the dot
+        }
+        None => (filename.to_string(), None),
     };
 
     let short_hash = &cipher_hash[..cipher_hash.len().min(8)];
 
-    let conflict_name = match &ext {
+    match &ext {
         Some(e) if !e.is_empty() => {
-            format!("{}.conflict.{}.{}.{}", stem, unix_ts, short_hash, e)
+            format!("{stem}.conflict.{unix_ts}.{short_hash}.{e}")
         }
-        _ => {
-            format!("{}.conflict.{}.{}", stem, unix_ts, short_hash)
-        }
-    };
-
-    conflict_parent_dir(original).join(conflict_name)
+        _ => format!("{stem}.conflict.{unix_ts}.{short_hash}"),
+    }
 }
 
-/// Directory that should hold the sidecar for `original` — the original's
-/// parent with `.conflicts` inserted after the sync-prefix segment.
+/// Insert `.conflicts` after the first sync-prefix component of a relative dir.
 ///
-/// `…/knowledge/a/foo.md` → `…/knowledge/.conflicts/a`
-/// `…/knowledge/foo.md`   → `…/knowledge/.conflicts`
-fn conflict_parent_dir(original: &Path) -> PathBuf {
-    let parent = original.parent().unwrap_or_else(|| Path::new("."));
-    insert_conflicts_component(parent)
-}
-
-/// Insert `.conflicts` after the first sync-prefix path component.
-fn insert_conflicts_component(path: &Path) -> PathBuf {
-    let mut out = PathBuf::new();
-    let mut inserted = false;
-    for comp in path.components() {
-        out.push(comp);
-        if inserted {
-            continue;
-        }
-        if let Component::Normal(name) = comp {
-            if is_sync_prefix_name(name) {
-                out.push(CONFLICTS_DIR);
-                inserted = true;
-            }
-        }
-    }
-    if inserted {
-        out
-    } else {
-        // Not under a known prefix — keep beside the file rather than invent a
-        // root-level `.conflicts/` that nothing else knows about.
-        path.to_path_buf()
-    }
-}
-
-fn is_sync_prefix_name(name: &std::ffi::OsStr) -> bool {
-    ALLOWED_PREFIXES
-        .iter()
-        .any(|p| name == p.trim_end_matches('/'))
+/// `knowledge/a` → `knowledge/.conflicts/a`; `knowledge` → `knowledge/.conflicts`.
+/// `None` when the dir is not under a prefix this client mirrors.
+fn insert_conflicts_rel(dir: &str) -> Option<String> {
+    let mut parts: Vec<&str> = dir.split('/').filter(|s| !s.is_empty()).collect();
+    let idx = parts.iter().position(|p| {
+        ALLOWED_PREFIXES
+            .iter()
+            .any(|a| *p == a.trim_end_matches('/'))
+    })?;
+    parts.insert(idx + 1, CONFLICTS_DIR);
+    Some(parts.join("/"))
 }
 
 /// Whether a relative sync path sits under `<prefix>/.conflicts/` (the dir
@@ -200,30 +197,16 @@ pub fn migrate_legacy_conflict_sidecar(root: &Path, rel: &str) -> MigrateOutcome
 }
 
 /// `knowledge/a/foo.conflict.ts.hash.md` → `knowledge/.conflicts/a/foo.conflict.ts.hash.md`
+///
+/// Same anchoring as [`conflict_rel_path`], so a legacy sidecar lands exactly
+/// where a freshly written one would.
 fn legacy_rel_to_conflicts_rel(rel: &str) -> Option<String> {
-    let (dir, filename) = match rel.rsplit_once('/') {
-        Some((d, f)) => (d, f),
-        None => return None,
-    };
-    let mut parts: Vec<&str> = dir.split('/').collect();
-    let mut i = 0;
-    let mut inserted = false;
-    while i < parts.len() {
-        if !inserted && ALLOWED_PREFIXES.iter().any(|p| parts[i] == p.trim_end_matches('/')) {
-            parts.insert(i + 1, CONFLICTS_DIR);
-            inserted = true;
-            break;
-        }
-        i += 1;
-    }
-    if !inserted {
-        return None;
-    }
-    Some(format!("{}/{filename}", parts.join("/")))
+    let (dir, filename) = rel.rsplit_once('/')?;
+    Some(format!("{}/{filename}", insert_conflicts_rel(dir)?))
 }
 
 /// Reconstruct the original file's relative path from a conflict sidecar's
-/// relative path. Inverse of [`conflict_filename`].
+/// relative path. Inverse of [`conflict_rel_path`].
 ///
 /// `knowledge/.conflicts/a/<stem>.conflict.<ts>.<hash>[.<ext>]` → `knowledge/a/<stem>[.<ext>]`
 ///
@@ -296,87 +279,102 @@ mod tests {
 
     #[test]
     fn test_conflict_name_with_extension() {
-        let path = Path::new("/ws/knowledge/foo.md");
-        let name = conflict_filename(path, 1748332800, "abc123defxxx");
-        let filename = name.file_name().unwrap().to_str().unwrap();
-        assert_eq!(filename, "foo.conflict.1748332800.abc123de.md");
         assert_eq!(
-            name.parent().unwrap(),
-            Path::new("/ws/knowledge/.conflicts")
+            conflict_rel_path("knowledge/foo.md", 1748332800, "abc123defxxx"),
+            "knowledge/.conflicts/foo.conflict.1748332800.abc123de.md"
         );
     }
 
     #[test]
     fn test_conflict_name_nested_dir() {
-        let path = Path::new("/ws/knowledge/a/b/foo.md");
-        let name = conflict_filename(path, 1748332800, "abc123defxxx");
         assert_eq!(
-            name,
-            Path::new("/ws/knowledge/.conflicts/a/b/foo.conflict.1748332800.abc123de.md")
+            conflict_rel_path("knowledge/a/b/foo.md", 1748332800, "abc123defxxx"),
+            "knowledge/.conflicts/a/b/foo.conflict.1748332800.abc123de.md"
         );
     }
 
     #[test]
     fn test_conflict_name_no_extension() {
-        let path = Path::new("/ws/knowledge/Makefile");
-        let name = conflict_filename(path, 9999, "deadbeefabcd");
-        let filename = name.file_name().unwrap().to_str().unwrap();
-        assert_eq!(filename, "Makefile.conflict.9999.deadbeef");
         assert_eq!(
-            name.parent().unwrap(),
-            Path::new("/ws/knowledge/.conflicts")
+            conflict_rel_path("knowledge/Makefile", 9999, "deadbeefabcd"),
+            "knowledge/.conflicts/Makefile.conflict.9999.deadbeef"
         );
     }
 
     #[test]
     fn test_conflict_name_cjk() {
-        let path = Path::new("/ws/knowledge/笔记/你好.md");
-        let name = conflict_filename(path, 100, "aabbccdd1234");
         assert_eq!(
-            name,
-            Path::new("/ws/knowledge/.conflicts/笔记/你好.conflict.100.aabbccdd.md")
+            conflict_rel_path("knowledge/笔记/你好.md", 100, "aabbccdd1234"),
+            "knowledge/.conflicts/笔记/你好.conflict.100.aabbccdd.md"
         );
     }
 
     #[test]
     fn test_conflict_name_dotfile() {
-        // e.g. ".gitignore" — stem is "", ext is "gitignore"
-        // rfind('.') at 0 → stem="", ext="gitignore"
-        let path = Path::new("/ws/knowledge/.gitignore");
-        let name = conflict_filename(path, 100, "aabbccdd1234");
-        let filename = name.file_name().unwrap().to_str().unwrap();
-        // stem="" ext="gitignore" → ".conflict.100.aabbccdd.gitignore"
-        assert!(filename.contains(".conflict."));
-        assert!(filename.ends_with(".gitignore"));
+        // ".gitignore" — rfind('.') at 0 → stem="", ext="gitignore"
         assert_eq!(
-            name.parent().unwrap(),
-            Path::new("/ws/knowledge/.conflicts")
+            conflict_rel_path("knowledge/.gitignore", 100, "aabbccdd1234"),
+            "knowledge/.conflicts/.conflict.100.aabbccdd.gitignore"
         );
     }
 
     #[test]
     fn test_conflict_name_short_hash() {
         // If hash is shorter than 8 chars, take all of it
-        let path = Path::new("/ws/knowledge/x.md");
-        let name = conflict_filename(path, 1, "ab");
-        let filename = name.file_name().unwrap().to_str().unwrap();
-        assert!(filename.contains(".conflict.1.ab.md"));
+        assert_eq!(
+            conflict_rel_path("knowledge/x.md", 1, "ab"),
+            "knowledge/.conflicts/x.conflict.1.ab.md"
+        );
     }
 
     #[test]
     fn test_same_ts_produces_deterministic_name() {
-        let path = Path::new("/ws/knowledge/doc.txt");
-        let name1 = conflict_filename(path, 1234567890, "hash1111aaaa");
-        let name2 = conflict_filename(path, 1234567890, "hash1111aaaa");
-        assert_eq!(name1, name2);
+        let a = conflict_rel_path("knowledge/doc.txt", 1234567890, "hash1111aaaa");
+        let b = conflict_rel_path("knowledge/doc.txt", 1234567890, "hash1111aaaa");
+        assert_eq!(a, b);
     }
 
     #[test]
     fn test_different_hashes_produce_different_names() {
-        let path = Path::new("/ws/knowledge/doc.txt");
-        let name1 = conflict_filename(path, 1000, "aaaa1111bbbb");
-        let name2 = conflict_filename(path, 1000, "xxxx9999yyyy");
-        assert_ne!(name1, name2);
+        let a = conflict_rel_path("knowledge/doc.txt", 1000, "aaaa1111bbbb");
+        let b = conflict_rel_path("knowledge/doc.txt", 1000, "xxxx9999yyyy");
+        assert_ne!(a, b);
+    }
+
+    /// Regression: the sidecar path is derived from the RELATIVE sync path, so a
+    /// content root that itself contains a `knowledge` component (e.g.
+    /// `AMUXD_HOME=/data/knowledge/amuxd`) cannot pull `.conflicts/` out of the
+    /// synced tree. Anchoring on the absolute path matched `/data/knowledge`
+    /// first and wrote the sidecar where `scan_conflict_files` never looks.
+    #[test]
+    fn content_root_containing_knowledge_still_writes_inside_the_tree() {
+        let content_root = Path::new("/data/knowledge/amuxd/teams/t1/shared");
+        let rel = conflict_rel_path("knowledge/a/foo.md", 42, "abcdef012345");
+        assert_eq!(
+            rel, "knowledge/.conflicts/a/foo.conflict.42.abcdef01.md",
+            "sidecar must mirror the relative path, not the absolute one"
+        );
+        assert_eq!(
+            content_root.join(&rel),
+            Path::new(
+                "/data/knowledge/amuxd/teams/t1/shared/knowledge/.conflicts/a/foo.conflict.42.abcdef01.md"
+            )
+        );
+        assert!(is_under_conflicts_dir(&rel));
+        assert_eq!(
+            original_from_conflict(&rel).as_deref(),
+            Some("knowledge/a/foo.md")
+        );
+    }
+
+    /// Not under a mirrored prefix → keep the sidecar beside the original rather
+    /// than invent a root-level `.conflicts/` no reader knows about.
+    #[test]
+    fn unknown_prefix_keeps_sidecar_beside_original() {
+        assert_eq!(
+            conflict_rel_path("elsewhere/foo.md", 7, "aabbccdd"),
+            "elsewhere/foo.conflict.7.aabbccdd.md"
+        );
     }
 
     #[test]
@@ -431,23 +429,14 @@ mod tests {
 
     #[test]
     fn test_filename_conflict_roundtrip_via_helpers() {
-        // conflict_filename → strip workspace → original_from_conflict
+        // conflict_rel_path → original_from_conflict
         for original in [
             "knowledge/foo.md",
             "knowledge/Makefile",
             "knowledge/a/b/note.txt",
             "knowledge/笔记/你好.md",
         ] {
-            let conflict = conflict_filename(
-                Path::new(&format!("/ws/{original}")),
-                1748332800,
-                "abc123defxxx",
-            );
-            let conflict_rel = conflict
-                .strip_prefix("/ws/")
-                .unwrap()
-                .to_string_lossy()
-                .replace('\\', "/");
+            let conflict_rel = conflict_rel_path(original, 1748332800, "abc123defxxx");
             assert!(
                 conflict_rel.contains("/.conflicts/"),
                 "expected .conflicts/ in {conflict_rel}"
@@ -627,9 +616,14 @@ mod tests {
         std::fs::create_dir_all(original.parent().unwrap()).unwrap();
         std::fs::write(&original, b"original").unwrap();
 
-        let sidecar = write_conflict_sidecar(&original, b"remote content", "abcdef1234567890")
-            .await
-            .unwrap();
+        let sidecar = write_conflict_sidecar(
+            dir.path(),
+            "knowledge/a/test.md",
+            b"remote content",
+            "abcdef1234567890",
+        )
+        .await
+        .unwrap();
 
         assert!(sidecar.exists());
         let content = std::fs::read(&sidecar).unwrap();

--- a/apps/daemon/src/sync/oss/conflict.rs
+++ b/apps/daemon/src/sync/oss/conflict.rs
@@ -141,36 +141,62 @@ pub fn is_under_conflicts_dir(rel_path: &str) -> bool {
     false
 }
 
+/// Result of trying to move a legacy sidecar into `.conflicts/`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MigrateOutcome {
+    /// Sidecar is under `.conflicts/` (was already, or move/cleanup succeeded).
+    UnderConflicts(String),
+    /// Move could not finish; the legacy file is still on disk at this path and
+    /// must stay visible in the conflicts list.
+    StillLegacy(String),
+    /// Not a sidecar, or the path is gone — nothing to list.
+    NotApplicable,
+}
+
 /// Relocate a legacy sidecar (`knowledge/a/foo.conflict…` beside the note) into
 /// the mirrored `.conflicts/` path. No-op when already there or not a sidecar.
 ///
 /// Sidecars were never uploaded, so this is a local rename with no tombstone.
-/// Returns the destination relative path when the file is (or becomes) a
-/// sidecar under `.conflicts/`.
-pub fn migrate_legacy_conflict_sidecar(root: &Path, rel: &str) -> Option<String> {
+/// Callers that list conflicts must treat [`MigrateOutcome::StillLegacy`] as a
+/// path to emit — swallowing the failure and only walking `.conflicts/` would
+/// hide the decision from the UI.
+pub fn migrate_legacy_conflict_sidecar(root: &Path, rel: &str) -> MigrateOutcome {
     if !crate::sync::oss::scanner::is_conflict_file(rel) {
-        return None;
+        return MigrateOutcome::NotApplicable;
     }
     if is_under_conflicts_dir(rel) {
-        return Some(rel.to_string());
+        return MigrateOutcome::UnderConflicts(rel.to_string());
     }
 
-    let new_rel = legacy_rel_to_conflicts_rel(rel)?;
+    let Some(new_rel) = legacy_rel_to_conflicts_rel(rel) else {
+        // Shaped like a sidecar but not under a sync prefix we know how to
+        // mirror — keep listing it where it is.
+        return MigrateOutcome::StillLegacy(rel.to_string());
+    };
     let src = root.join(rel);
     let dst = root.join(&new_rel);
     if !src.is_file() {
-        return None;
+        return MigrateOutcome::NotApplicable;
     }
     if let Some(parent) = dst.parent() {
-        let _ = std::fs::create_dir_all(parent);
+        if std::fs::create_dir_all(parent).is_err() {
+            return MigrateOutcome::StillLegacy(rel.to_string());
+        }
     }
     if dst.exists() {
-        // Destination already holds a copy — drop the legacy leftover.
-        let _ = std::fs::remove_file(&src);
-    } else if std::fs::rename(&src, &dst).is_err() {
-        return None;
+        // Destination already holds a copy — drop the legacy leftover. If the
+        // delete fails, do not claim the move succeeded: the conflicts list
+        // must still see the legacy path (and will also see `dst` when it
+        // walks `.conflicts/`).
+        if std::fs::remove_file(&src).is_err() {
+            return MigrateOutcome::StillLegacy(rel.to_string());
+        }
+        return MigrateOutcome::UnderConflicts(new_rel);
     }
-    Some(new_rel)
+    match std::fs::rename(&src, &dst) {
+        Ok(()) => MigrateOutcome::UnderConflicts(new_rel),
+        Err(_) => MigrateOutcome::StillLegacy(rel.to_string()),
+    }
 }
 
 /// `knowledge/a/foo.conflict.ts.hash.md` → `knowledge/.conflicts/a/foo.conflict.ts.hash.md`
@@ -481,23 +507,117 @@ mod tests {
         let legacy = knowledge.join("foo.conflict.1000.aabbccdd.md");
         std::fs::write(&legacy, b"local copy").unwrap();
 
-        let new_rel =
-            migrate_legacy_conflict_sidecar(root, "knowledge/a/foo.conflict.1000.aabbccdd.md")
-                .unwrap();
+        let outcome =
+            migrate_legacy_conflict_sidecar(root, "knowledge/a/foo.conflict.1000.aabbccdd.md");
         assert_eq!(
-            new_rel,
-            "knowledge/.conflicts/a/foo.conflict.1000.aabbccdd.md"
+            outcome,
+            MigrateOutcome::UnderConflicts(
+                "knowledge/.conflicts/a/foo.conflict.1000.aabbccdd.md".into()
+            )
         );
         assert!(!legacy.exists());
         assert_eq!(
-            std::fs::read(root.join(&new_rel)).unwrap(),
+            std::fs::read(root.join("knowledge/.conflicts/a/foo.conflict.1000.aabbccdd.md"))
+                .unwrap(),
             b"local copy"
         );
         // Idempotent when already under .conflicts/
         assert_eq!(
-            migrate_legacy_conflict_sidecar(root, &new_rel).as_deref(),
-            Some(new_rel.as_str())
+            migrate_legacy_conflict_sidecar(
+                root,
+                "knowledge/.conflicts/a/foo.conflict.1000.aabbccdd.md"
+            ),
+            MigrateOutcome::UnderConflicts(
+                "knowledge/.conflicts/a/foo.conflict.1000.aabbccdd.md".into()
+            )
         );
+    }
+
+    /// Destination already has the sidecar: remove the legacy leftover. Claiming
+    /// success while `remove_file` failed would hide the leftover from listing.
+    #[test]
+    fn migrate_collision_removes_legacy_when_dst_exists() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        std::fs::create_dir_all(root.join("knowledge/.conflicts")).unwrap();
+        std::fs::write(
+            root.join("knowledge/foo.conflict.1000.aabbccdd.md"),
+            b"legacy leftover",
+        )
+        .unwrap();
+        std::fs::write(
+            root.join("knowledge/.conflicts/foo.conflict.1000.aabbccdd.md"),
+            b"already there",
+        )
+        .unwrap();
+
+        let outcome =
+            migrate_legacy_conflict_sidecar(root, "knowledge/foo.conflict.1000.aabbccdd.md");
+        assert_eq!(
+            outcome,
+            MigrateOutcome::UnderConflicts(
+                "knowledge/.conflicts/foo.conflict.1000.aabbccdd.md".into()
+            )
+        );
+        assert!(!root.join("knowledge/foo.conflict.1000.aabbccdd.md").exists());
+        assert_eq!(
+            std::fs::read(root.join("knowledge/.conflicts/foo.conflict.1000.aabbccdd.md"))
+                .unwrap(),
+            b"already there"
+        );
+    }
+
+    /// Same collision, but the legacy file cannot be deleted: must report
+    /// StillLegacy so the conflicts list keeps seeing it.
+    #[test]
+    fn migrate_collision_still_legacy_when_remove_fails() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        let knowledge = root.join("knowledge");
+        std::fs::create_dir_all(knowledge.join(".conflicts")).unwrap();
+        let legacy = "knowledge/foo.conflict.1000.aabbccdd.md";
+        std::fs::write(root.join(legacy), b"legacy leftover").unwrap();
+        std::fs::write(
+            root.join("knowledge/.conflicts/foo.conflict.1000.aabbccdd.md"),
+            b"already there",
+        )
+        .unwrap();
+
+        // Deleting a file needs write on the parent directory.
+        let mut perms = std::fs::metadata(&knowledge).unwrap().permissions();
+        perms.set_readonly(true);
+        std::fs::set_permissions(&knowledge, perms.clone()).unwrap();
+
+        let outcome = migrate_legacy_conflict_sidecar(root, legacy);
+
+        perms.set_readonly(false);
+        std::fs::set_permissions(&knowledge, perms).unwrap();
+
+        assert_eq!(outcome, MigrateOutcome::StillLegacy(legacy.into()));
+        assert!(root.join(legacy).is_file());
+    }
+
+    /// `create_dir_all` must not be swallowed: a file blocking the `.conflicts`
+    /// path leaves the legacy sidecar in place and reports StillLegacy.
+    #[test]
+    fn migrate_returns_still_legacy_when_conflicts_path_is_a_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        std::fs::create_dir_all(root.join("knowledge/a")).unwrap();
+        // Block mkdir of knowledge/.conflicts/a — `.conflicts` is a regular file.
+        std::fs::write(root.join("knowledge/.conflicts"), b"not a directory").unwrap();
+        std::fs::write(
+            root.join("knowledge/a/foo.conflict.1000.aabbccdd.md"),
+            b"stuck",
+        )
+        .unwrap();
+
+        let legacy = "knowledge/a/foo.conflict.1000.aabbccdd.md";
+        assert_eq!(
+            migrate_legacy_conflict_sidecar(root, legacy),
+            MigrateOutcome::StillLegacy(legacy.into())
+        );
+        assert!(root.join(legacy).is_file());
     }
 
     #[tokio::test]

--- a/apps/daemon/src/sync/oss/conflict.rs
+++ b/apps/daemon/src/sync/oss/conflict.rs
@@ -1,30 +1,49 @@
-//! Conflict sidecar file management (spec §4.4).
+//! Conflict sidecar file management (spec §4.4 / ADR-0008 §5.2 A).
 //!
-//! Name format: `<dir>/<stem>.conflict.<unix_ts>.<short_cipher_hash[0..8]>.<ext>`
-//! (or no ext if original had none).
+//! Layout:
+//! ```text
+//! knowledge/a/foo.md
+//! knowledge/.conflicts/a/foo.conflict.<unix_ts>.<short_hash[0..8]>[.<ext>]
+//! ```
 //!
-//! Scanner skips all `*.conflict.*` files so they are never uploaded.
+//! The filename format is unchanged; only the directory is. Obsidian ignores
+//! dot-directories by default, so parking copies under `.conflicts/` keeps the
+//! vault tree and graph clean. Scanner skips the whole directory (hard rule,
+//! not via IgnoreRules) so a team `.amuxignore` `!.conflicts/` cannot re-include
+//! them; they are never uploaded.
 //!
 //! [`original_from_conflict`] and [`conflict_timestamp`] are the read side:
 //! `GET /v1/team/conflicts` turns a sidecar back into "which document conflicted,
-//! and when", which is what the resolution UI decides against.
+//! and when", which is what the resolution UI decides against. Legacy sidecars
+//! that still sit beside a note (pre-migration) reverse the same way — the
+//! scanner relocates them on sight.
 
-use std::path::Path;
+use super::path_validator::ALLOWED_PREFIXES;
+use std::path::{Component, Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 
-/// Write a conflict sidecar file containing `data` alongside the original `abs_path`.
-/// Returns the path of the conflict file written.
+/// Directory name under each sync prefix that holds conflict copies.
+pub const CONFLICTS_DIR: &str = ".conflicts";
+
+/// Write a conflict sidecar file containing `data` for the original `abs_path`.
+/// Returns the path of the conflict file written (under `.conflicts/`).
 pub async fn write_conflict_sidecar(
     abs_path: &Path,
     data: &[u8],
     cipher_hash: &str,
-) -> Result<std::path::PathBuf, String> {
+) -> Result<PathBuf, String> {
     let ts = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map(|d| d.as_secs())
         .unwrap_or(0);
 
     let conflict_path = conflict_filename(abs_path, ts, cipher_hash);
+
+    if let Some(parent) = conflict_path.parent() {
+        tokio::fs::create_dir_all(parent)
+            .await
+            .map_err(|e| format!("conflict: mkdir {}: {e}", parent.display()))?;
+    }
 
     tokio::fs::write(&conflict_path, data)
         .await
@@ -33,10 +52,11 @@ pub async fn write_conflict_sidecar(
     Ok(conflict_path)
 }
 
-/// Construct the conflict filename for a given original path, timestamp and cipher_hash.
-/// This is public so the scanner test can exercise it.
-pub fn conflict_filename(original: &Path, unix_ts: u64, cipher_hash: &str) -> std::path::PathBuf {
-    let dir = original.parent().unwrap_or_else(|| Path::new("."));
+/// Construct the conflict path for a given original path, timestamp and cipher_hash.
+///
+/// The sidecar lands under `<prefix>/.conflicts/<mirrored relative dirs>/`, not
+/// beside the original. Public so scanner tests can exercise the mapping.
+pub fn conflict_filename(original: &Path, unix_ts: u64, cipher_hash: &str) -> PathBuf {
     let filename = original
         .file_name()
         .map(|n| n.to_string_lossy().into_owned())
@@ -64,13 +84,125 @@ pub fn conflict_filename(original: &Path, unix_ts: u64, cipher_hash: &str) -> st
         }
     };
 
-    dir.join(conflict_name)
+    conflict_parent_dir(original).join(conflict_name)
+}
+
+/// Directory that should hold the sidecar for `original` — the original's
+/// parent with `.conflicts` inserted after the sync-prefix segment.
+///
+/// `…/knowledge/a/foo.md` → `…/knowledge/.conflicts/a`
+/// `…/knowledge/foo.md`   → `…/knowledge/.conflicts`
+fn conflict_parent_dir(original: &Path) -> PathBuf {
+    let parent = original.parent().unwrap_or_else(|| Path::new("."));
+    insert_conflicts_component(parent)
+}
+
+/// Insert `.conflicts` after the first sync-prefix path component.
+fn insert_conflicts_component(path: &Path) -> PathBuf {
+    let mut out = PathBuf::new();
+    let mut inserted = false;
+    for comp in path.components() {
+        out.push(comp);
+        if inserted {
+            continue;
+        }
+        if let Component::Normal(name) = comp {
+            if is_sync_prefix_name(name) {
+                out.push(CONFLICTS_DIR);
+                inserted = true;
+            }
+        }
+    }
+    if inserted {
+        out
+    } else {
+        // Not under a known prefix — keep beside the file rather than invent a
+        // root-level `.conflicts/` that nothing else knows about.
+        path.to_path_buf()
+    }
+}
+
+fn is_sync_prefix_name(name: &std::ffi::OsStr) -> bool {
+    ALLOWED_PREFIXES
+        .iter()
+        .any(|p| name == p.trim_end_matches('/'))
+}
+
+/// Whether a relative sync path sits under `<prefix>/.conflicts/` (the dir
+/// itself or anything beneath it). Hard-skip target for scanner + pull.
+pub fn is_under_conflicts_dir(rel_path: &str) -> bool {
+    for prefix in ALLOWED_PREFIXES {
+        let p = prefix.trim_end_matches('/');
+        let marker = format!("{p}/{CONFLICTS_DIR}");
+        if rel_path == marker || rel_path.starts_with(&format!("{marker}/")) {
+            return true;
+        }
+    }
+    false
+}
+
+/// Relocate a legacy sidecar (`knowledge/a/foo.conflict…` beside the note) into
+/// the mirrored `.conflicts/` path. No-op when already there or not a sidecar.
+///
+/// Sidecars were never uploaded, so this is a local rename with no tombstone.
+/// Returns the destination relative path when the file is (or becomes) a
+/// sidecar under `.conflicts/`.
+pub fn migrate_legacy_conflict_sidecar(root: &Path, rel: &str) -> Option<String> {
+    if !crate::sync::oss::scanner::is_conflict_file(rel) {
+        return None;
+    }
+    if is_under_conflicts_dir(rel) {
+        return Some(rel.to_string());
+    }
+
+    let new_rel = legacy_rel_to_conflicts_rel(rel)?;
+    let src = root.join(rel);
+    let dst = root.join(&new_rel);
+    if !src.is_file() {
+        return None;
+    }
+    if let Some(parent) = dst.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    if dst.exists() {
+        // Destination already holds a copy — drop the legacy leftover.
+        let _ = std::fs::remove_file(&src);
+    } else if std::fs::rename(&src, &dst).is_err() {
+        return None;
+    }
+    Some(new_rel)
+}
+
+/// `knowledge/a/foo.conflict.ts.hash.md` → `knowledge/.conflicts/a/foo.conflict.ts.hash.md`
+fn legacy_rel_to_conflicts_rel(rel: &str) -> Option<String> {
+    let (dir, filename) = match rel.rsplit_once('/') {
+        Some((d, f)) => (d, f),
+        None => return None,
+    };
+    let mut parts: Vec<&str> = dir.split('/').collect();
+    let mut i = 0;
+    let mut inserted = false;
+    while i < parts.len() {
+        if !inserted && ALLOWED_PREFIXES.iter().any(|p| parts[i] == p.trim_end_matches('/')) {
+            parts.insert(i + 1, CONFLICTS_DIR);
+            inserted = true;
+            break;
+        }
+        i += 1;
+    }
+    if !inserted {
+        return None;
+    }
+    Some(format!("{}/{filename}", parts.join("/")))
 }
 
 /// Reconstruct the original file's relative path from a conflict sidecar's
 /// relative path. Inverse of [`conflict_filename`].
 ///
-/// `<dir>/<stem>.conflict.<ts>.<hash>[.<ext>]` → `<dir>/<stem>[.<ext>]`
+/// `knowledge/.conflicts/a/<stem>.conflict.<ts>.<hash>[.<ext>]` → `knowledge/a/<stem>[.<ext>]`
+///
+/// Also accepts the pre-migration layout (sidecar beside the note) so resolve
+/// and move-on-scan keep working until the rename lands.
 ///
 /// Returns `None` if `rel_path` is not a conflict sidecar.
 pub fn original_from_conflict(rel_path: &str) -> Option<String> {
@@ -90,10 +222,34 @@ pub fn original_from_conflict(rel_path: &str) -> Option<String> {
         _ => return None,
     };
 
+    let dir = dir.map(strip_conflicts_segment);
     Some(match dir {
-        Some(d) => format!("{d}/{original_name}"),
-        None => original_name,
+        Some(d) if !d.is_empty() => format!("{d}/{original_name}"),
+        _ => original_name,
     })
+}
+
+/// Drop the `.conflicts` segment that sits under a sync prefix.
+///
+/// `knowledge/.conflicts/a` → `knowledge/a`
+/// `knowledge/.conflicts`   → `knowledge`
+/// `knowledge/a` (legacy)   → `knowledge/a`
+fn strip_conflicts_segment(dir: &str) -> String {
+    let parts: Vec<&str> = dir.split('/').filter(|s| !s.is_empty()).collect();
+    let mut out: Vec<&str> = Vec::with_capacity(parts.len());
+    let mut i = 0;
+    while i < parts.len() {
+        out.push(parts[i]);
+        let is_prefix = ALLOWED_PREFIXES
+            .iter()
+            .any(|p| parts[i] == p.trim_end_matches('/'));
+        if is_prefix && i + 1 < parts.len() && parts[i + 1] == CONFLICTS_DIR {
+            i += 2; // skip the `.conflicts` we just looked past
+            continue;
+        }
+        i += 1;
+    }
+    out.join("/")
 }
 
 /// The unix timestamp a sidecar records in its name, or `None` when the name is
@@ -114,37 +270,68 @@ mod tests {
 
     #[test]
     fn test_conflict_name_with_extension() {
-        let path = Path::new("/ws/skills/foo.md");
+        let path = Path::new("/ws/knowledge/foo.md");
         let name = conflict_filename(path, 1748332800, "abc123defxxx");
         let filename = name.file_name().unwrap().to_str().unwrap();
         assert_eq!(filename, "foo.conflict.1748332800.abc123de.md");
-        assert_eq!(name.parent().unwrap(), Path::new("/ws/skills"));
+        assert_eq!(
+            name.parent().unwrap(),
+            Path::new("/ws/knowledge/.conflicts")
+        );
+    }
+
+    #[test]
+    fn test_conflict_name_nested_dir() {
+        let path = Path::new("/ws/knowledge/a/b/foo.md");
+        let name = conflict_filename(path, 1748332800, "abc123defxxx");
+        assert_eq!(
+            name,
+            Path::new("/ws/knowledge/.conflicts/a/b/foo.conflict.1748332800.abc123de.md")
+        );
     }
 
     #[test]
     fn test_conflict_name_no_extension() {
-        let path = Path::new("/ws/skills/Makefile");
+        let path = Path::new("/ws/knowledge/Makefile");
         let name = conflict_filename(path, 9999, "deadbeefabcd");
         let filename = name.file_name().unwrap().to_str().unwrap();
         assert_eq!(filename, "Makefile.conflict.9999.deadbeef");
+        assert_eq!(
+            name.parent().unwrap(),
+            Path::new("/ws/knowledge/.conflicts")
+        );
+    }
+
+    #[test]
+    fn test_conflict_name_cjk() {
+        let path = Path::new("/ws/knowledge/笔记/你好.md");
+        let name = conflict_filename(path, 100, "aabbccdd1234");
+        assert_eq!(
+            name,
+            Path::new("/ws/knowledge/.conflicts/笔记/你好.conflict.100.aabbccdd.md")
+        );
     }
 
     #[test]
     fn test_conflict_name_dotfile() {
         // e.g. ".gitignore" — stem is "", ext is "gitignore"
         // rfind('.') at 0 → stem="", ext="gitignore"
-        let path = Path::new("/ws/skills/.gitignore");
+        let path = Path::new("/ws/knowledge/.gitignore");
         let name = conflict_filename(path, 100, "aabbccdd1234");
         let filename = name.file_name().unwrap().to_str().unwrap();
         // stem="" ext="gitignore" → ".conflict.100.aabbccdd.gitignore"
         assert!(filename.contains(".conflict."));
         assert!(filename.ends_with(".gitignore"));
+        assert_eq!(
+            name.parent().unwrap(),
+            Path::new("/ws/knowledge/.conflicts")
+        );
     }
 
     #[test]
     fn test_conflict_name_short_hash() {
         // If hash is shorter than 8 chars, take all of it
-        let path = Path::new("/ws/skills/x.md");
+        let path = Path::new("/ws/knowledge/x.md");
         let name = conflict_filename(path, 1, "ab");
         let filename = name.file_name().unwrap().to_str().unwrap();
         assert!(filename.contains(".conflict.1.ab.md"));
@@ -152,7 +339,7 @@ mod tests {
 
     #[test]
     fn test_same_ts_produces_deterministic_name() {
-        let path = Path::new("/ws/skills/doc.txt");
+        let path = Path::new("/ws/knowledge/doc.txt");
         let name1 = conflict_filename(path, 1234567890, "hash1111aaaa");
         let name2 = conflict_filename(path, 1234567890, "hash1111aaaa");
         assert_eq!(name1, name2);
@@ -160,7 +347,7 @@ mod tests {
 
     #[test]
     fn test_different_hashes_produce_different_names() {
-        let path = Path::new("/ws/skills/doc.txt");
+        let path = Path::new("/ws/knowledge/doc.txt");
         let name1 = conflict_filename(path, 1000, "aaaa1111bbbb");
         let name2 = conflict_filename(path, 1000, "xxxx9999yyyy");
         assert_ne!(name1, name2);
@@ -168,30 +355,49 @@ mod tests {
 
     #[test]
     fn test_original_from_conflict_roundtrip() {
-        // With extension
+        // New layout under `.conflicts/`
         assert_eq!(
-            original_from_conflict("knowledge/foo.conflict.1748332800.abc123de.md").as_deref(),
+            original_from_conflict("knowledge/.conflicts/foo.conflict.1748332800.abc123de.md")
+                .as_deref(),
             Some("knowledge/foo.md")
+        );
+        assert_eq!(
+            original_from_conflict("knowledge/.conflicts/a/b/foo.conflict.1.aabbccdd.md")
+                .as_deref(),
+            Some("knowledge/a/b/foo.md")
         );
         // No extension
         assert_eq!(
-            original_from_conflict("knowledge/Makefile.conflict.9999.deadbeef").as_deref(),
+            original_from_conflict("knowledge/.conflicts/Makefile.conflict.9999.deadbeef")
+                .as_deref(),
             Some("knowledge/Makefile")
         );
         // Multi-dot original (only the last segment is the recorded ext)
         assert_eq!(
-            original_from_conflict("k/foo.tar.conflict.1.aabbccdd.gz").as_deref(),
-            Some("k/foo.tar.gz")
+            original_from_conflict("knowledge/.conflicts/k/foo.tar.conflict.1.aabbccdd.gz")
+                .as_deref(),
+            Some("knowledge/k/foo.tar.gz")
         );
         // Dotfile
         assert_eq!(
-            original_from_conflict("knowledge/.conflict.100.aabbccdd.gitignore").as_deref(),
+            original_from_conflict("knowledge/.conflicts/.conflict.100.aabbccdd.gitignore")
+                .as_deref(),
             Some("knowledge/.gitignore")
         );
-        // Root-level (no dir)
+        // CJK
         assert_eq!(
-            original_from_conflict("foo.conflict.1.abcd1234.md").as_deref(),
-            Some("foo.md")
+            original_from_conflict("knowledge/.conflicts/笔记/你好.conflict.100.aabbccdd.md")
+                .as_deref(),
+            Some("knowledge/笔记/你好.md")
+        );
+        // Legacy layout (beside the note) still reverses — resolve + migrate
+        assert_eq!(
+            original_from_conflict("knowledge/foo.conflict.1748332800.abc123de.md").as_deref(),
+            Some("knowledge/foo.md")
+        );
+        assert_eq!(
+            original_from_conflict("knowledge/a/foo.conflict.1.aabbccdd.md").as_deref(),
+            Some("knowledge/a/foo.md")
         );
         // Not a conflict file
         assert_eq!(original_from_conflict("knowledge/foo.md"), None);
@@ -199,8 +405,13 @@ mod tests {
 
     #[test]
     fn test_filename_conflict_roundtrip_via_helpers() {
-        // conflict_filename → original_from_conflict should recover the original.
-        for original in ["knowledge/foo.md", "k/Makefile", "a/b/note.txt"] {
+        // conflict_filename → strip workspace → original_from_conflict
+        for original in [
+            "knowledge/foo.md",
+            "knowledge/Makefile",
+            "knowledge/a/b/note.txt",
+            "knowledge/笔记/你好.md",
+        ] {
             let conflict = conflict_filename(
                 Path::new(&format!("/ws/{original}")),
                 1748332800,
@@ -211,6 +422,10 @@ mod tests {
                 .unwrap()
                 .to_string_lossy()
                 .replace('\\', "/");
+            assert!(
+                conflict_rel.contains("/.conflicts/"),
+                "expected .conflicts/ in {conflict_rel}"
+            );
             assert_eq!(
                 original_from_conflict(&conflict_rel).as_deref(),
                 Some(original),
@@ -222,24 +437,73 @@ mod tests {
     #[test]
     fn test_conflict_timestamp() {
         assert_eq!(
+            conflict_timestamp("knowledge/.conflicts/foo.conflict.1748332800.abc123de.md"),
+            Some(1748332800)
+        );
+        // Legacy path still parses
+        assert_eq!(
             conflict_timestamp("knowledge/foo.conflict.1748332800.abc123de.md"),
             Some(1748332800)
         );
         // No extension
         assert_eq!(
-            conflict_timestamp("knowledge/Makefile.conflict.9999.deadbeef"),
+            conflict_timestamp("knowledge/.conflicts/Makefile.conflict.9999.deadbeef"),
             Some(9999)
         );
         // Not a sidecar
         assert_eq!(conflict_timestamp("knowledge/foo.md"), None);
         // Sidecar-shaped but the timestamp slot is not a number
-        assert_eq!(conflict_timestamp("knowledge/foo.conflict.x.abc.md"), None);
+        assert_eq!(
+            conflict_timestamp("knowledge/.conflicts/foo.conflict.x.abc.md"),
+            None
+        );
+    }
+
+    #[test]
+    fn test_is_under_conflicts_dir() {
+        assert!(is_under_conflicts_dir("knowledge/.conflicts"));
+        assert!(is_under_conflicts_dir(
+            "knowledge/.conflicts/a/foo.conflict.1.aabbccdd.md"
+        ));
+        assert!(!is_under_conflicts_dir("knowledge/foo.md"));
+        assert!(!is_under_conflicts_dir("knowledge/a/.conflicts-not"));
+        assert!(!is_under_conflicts_dir(
+            "knowledge/foo.conflict.1.aabbccdd.md"
+        ));
+    }
+
+    #[test]
+    fn test_migrate_legacy_conflict_sidecar() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        let knowledge = root.join("knowledge/a");
+        std::fs::create_dir_all(&knowledge).unwrap();
+        let legacy = knowledge.join("foo.conflict.1000.aabbccdd.md");
+        std::fs::write(&legacy, b"local copy").unwrap();
+
+        let new_rel =
+            migrate_legacy_conflict_sidecar(root, "knowledge/a/foo.conflict.1000.aabbccdd.md")
+                .unwrap();
+        assert_eq!(
+            new_rel,
+            "knowledge/.conflicts/a/foo.conflict.1000.aabbccdd.md"
+        );
+        assert!(!legacy.exists());
+        assert_eq!(
+            std::fs::read(root.join(&new_rel)).unwrap(),
+            b"local copy"
+        );
+        // Idempotent when already under .conflicts/
+        assert_eq!(
+            migrate_legacy_conflict_sidecar(root, &new_rel).as_deref(),
+            Some(new_rel.as_str())
+        );
     }
 
     #[tokio::test]
     async fn test_write_conflict_sidecar() {
         let dir = tempfile::tempdir().unwrap();
-        let original = dir.path().join("knowledge").join("test.md");
+        let original = dir.path().join("knowledge").join("a").join("test.md");
         std::fs::create_dir_all(original.parent().unwrap()).unwrap();
         std::fs::write(&original, b"original").unwrap();
 
@@ -253,5 +517,10 @@ mod tests {
         let name = sidecar.file_name().unwrap().to_str().unwrap();
         assert!(name.contains(".conflict."));
         assert!(name.ends_with(".md"));
+        // Lands under knowledge/.conflicts/a/, not beside the note
+        assert_eq!(
+            sidecar.parent().unwrap(),
+            dir.path().join("knowledge/.conflicts/a")
+        );
     }
 }

--- a/apps/daemon/src/sync/oss/engine.rs
+++ b/apps/daemon/src/sync/oss/engine.rs
@@ -740,6 +740,9 @@ async fn pull_phase(
                         let plaintext =
                             decode_pulled_blob(blob, key_copy.as_ref()).map_err(&fail)?;
                         let abs = Path::new(content_root).join(&path);
+                        // MUST precede create_dir_all / write: inotify can deliver
+                        // Local before this task resumes after an await.
+                        crate::sync::watch::record_pull_write(&team_id, &path);
                         if let Some(parent) = abs.parent() {
                             tokio::fs::create_dir_all(parent)
                                 .await
@@ -748,8 +751,6 @@ async fn pull_phase(
                         tokio::fs::write(&abs, &plaintext)
                             .await
                             .map_err(|e| fail(SyncError::Io(e.to_string())))?;
-                        // Suppress fs-watch Local triggers for this path for 3s.
-                        crate::sync::watch::record_pull_write(&team_id, &path);
                         let meta = std::fs::metadata(&abs)
                             .map_err(|e| fail(SyncError::Io(e.to_string())))?;
                         let mtime = meta
@@ -1269,6 +1270,9 @@ pub async fn download_and_write(
     let plain_hash = sha256_hex(&plaintext);
 
     let abs_path = Path::new(content_root).join(rel_path);
+    // MUST precede create_dir_all / write: inotify can deliver Local before
+    // this task resumes after an await.
+    crate::sync::watch::record_pull_write(&team_id, rel_path);
     if let Some(parent) = abs_path.parent() {
         tokio::fs::create_dir_all(parent)
             .await
@@ -1277,8 +1281,6 @@ pub async fn download_and_write(
     tokio::fs::write(&abs_path, &plaintext)
         .await
         .map_err(|e| SyncError::Io(e.to_string()))?;
-    // Suppress fs-watch Local triggers for this path for 3s (path-set, not blanket).
-    crate::sync::watch::record_pull_write(&team_id, rel_path);
 
     let meta = std::fs::metadata(&abs_path).map_err(SyncError::from)?;
     let mtime = meta

--- a/apps/daemon/src/sync/oss/engine.rs
+++ b/apps/daemon/src/sync/oss/engine.rs
@@ -29,6 +29,36 @@ use super::{
 /// (`MAX_SYNC_BATCH`). The daemon auto-splits larger working sets into chunks.
 const MAX_BATCH: usize = 200;
 
+/// Stable node id stamped on prepare/delete so FC can set `created_by_node_id`
+/// and (via top-level `nodeId` on complete/delete-batch) publish MQTT hints
+/// with a filterable `originNodeId`. Peers drop echoes matching this value.
+fn knowledge_created_by_node_id() -> Option<String> {
+    Some(crate::device_id::daemon_device_id())
+}
+
+fn prepare_batch_item_for(
+    path: &str,
+    parent_version: i32,
+    content_hash: &str,
+    size: u64,
+) -> PrepareBatchItem {
+    PrepareBatchItem {
+        path: path.to_string(),
+        parent_version,
+        content_hash: content_hash.to_string(),
+        size,
+        node_id: knowledge_created_by_node_id(),
+    }
+}
+
+fn delete_batch_item_for(path: &str, parent_version: i32) -> DeleteBatchItem {
+    DeleteBatchItem {
+        path: path.to_string(),
+        parent_version,
+        node_id: knowledge_created_by_node_id(),
+    }
+}
+
 /// Largest single file the sync will carry.
 ///
 /// The ignore rules match on names, so they only stop what someone thought to
@@ -840,12 +870,8 @@ async fn push_phase(
         // Stage 1: prepare-batch (session + presigned PUT per item).
         let items: Vec<PrepareBatchItem> = prepared
             .iter()
-            .map(|pu| PrepareBatchItem {
-                path: pu.path.clone(),
-                parent_version: pu.parent_version,
-                content_hash: pu.cipher_hash.clone(),
-                size: pu.size,
-                node_id: None,
+            .map(|pu| {
+                prepare_batch_item_for(&pu.path, pu.parent_version, &pu.cipher_hash, pu.size)
             })
             .collect();
 
@@ -954,54 +980,61 @@ async fn push_phase(
             continue;
         }
         let session_ids: Vec<String> = ready.iter().map(|r| r.session_id.clone()).collect();
-        let comp_outcomes =
-            match with_batch_retry(|| fc.upload_complete_batch(team_id, &session_ids)).await {
-                Ok(o) => o,
-                Err(SyncError::BatchUnsupported) => {
-                    // prepare-batch worked but complete-batch 404 — vanishingly
-                    // unlikely, but degrade per-item rather than lose the uploads.
-                    for r in &ready {
-                        let pu = &prepared[r.idx];
-                        match fc.upload_complete(team_id, &r.session_id).await {
-                            Ok(c) => finalize_upload(content_root, pu, c, state, &mut stats),
-                            Err(SyncError::Conflict {
+        let node_id = knowledge_created_by_node_id();
+        let comp_outcomes = match with_batch_retry(|| {
+            fc.upload_complete_batch(team_id, &session_ids, node_id.as_deref())
+        })
+        .await
+        {
+            Ok(o) => o,
+            Err(SyncError::BatchUnsupported) => {
+                // prepare-batch worked but complete-batch 404 — vanishingly
+                // unlikely, but degrade per-item rather than lose the uploads.
+                for r in &ready {
+                    let pu = &prepared[r.idx];
+                    match fc
+                        .upload_complete(team_id, &r.session_id, node_id.as_deref())
+                        .await
+                    {
+                        Ok(c) => finalize_upload(content_root, pu, c, state, &mut stats),
+                        Err(SyncError::Conflict {
+                            remote_version,
+                            remote_cipher_hash,
+                        }) => {
+                            handle_push_conflict(
+                                content_root,
+                                &pu.path,
                                 remote_version,
                                 remote_cipher_hash,
-                            }) => {
-                                handle_push_conflict(
-                                    content_root,
-                                    &pu.path,
-                                    remote_version,
-                                    remote_cipher_hash,
-                                    key,
-                                    fc,
-                                    state,
-                                    &mut stats,
-                                )
-                                .await
-                            }
-                            Err(e) => {
-                                if is_transient(&e) {
-                                    stats.deferred += 1;
-                                    stats.last_transient = Some(e);
-                                } else {
-                                    tracing::warn!("[oss_sync] complete {}: {e}", pu.path);
-                                }
+                                key,
+                                fc,
+                                state,
+                                &mut stats,
+                            )
+                            .await
+                        }
+                        Err(e) => {
+                            if is_transient(&e) {
+                                stats.deferred += 1;
+                                stats.last_transient = Some(e);
+                            } else {
+                                tracing::warn!("[oss_sync] complete {}: {e}", pu.path);
                             }
                         }
                     }
-                    continue;
                 }
-                Err(e) => {
-                    if is_transient(&e) {
-                        stats.deferred += ready.len() as u32;
-                        stats.last_transient = Some(e);
-                    } else {
-                        tracing::warn!("[oss_sync] complete-batch: {e}");
-                    }
-                    continue;
+                continue;
+            }
+            Err(e) => {
+                if is_transient(&e) {
+                    stats.deferred += ready.len() as u32;
+                    stats.last_transient = Some(e);
+                } else {
+                    tracing::warn!("[oss_sync] complete-batch: {e}");
                 }
-            };
+                continue;
+            }
+        };
 
         for (r, oc) in ready.iter().zip(comp_outcomes.into_iter()) {
             let pu = &prepared[r.idx];
@@ -1191,46 +1224,45 @@ async fn delete_phase(
     for chunk in dels.chunks(MAX_BATCH) {
         let items: Vec<DeleteBatchItem> = chunk
             .iter()
-            .map(|(p, v)| DeleteBatchItem {
-                path: p.clone(),
-                parent_version: *v,
-                node_id: None,
-            })
+            .map(|(p, v)| delete_batch_item_for(p, *v))
             .collect();
+        let node_id = knowledge_created_by_node_id();
 
-        let outcomes = match with_batch_retry(|| fc.delete_batch(team_id, &items)).await {
-            Ok(o) => o,
-            Err(SyncError::BatchUnsupported) => {
-                for (p, v) in chunk {
-                    match delete_file_retrying(fc, team_id, p, *v).await {
-                        Ok(version) => {
-                            state.mark_tombstoned(p, version);
-                            prune_empty_parents(Path::new(content_root), p).await;
-                            stats.pushed += 1;
-                        }
-                        Err(SyncError::Conflict { .. }) => stats.conflicts += 1,
-                        Err(e) => {
-                            if is_transient(&e) {
-                                stats.deferred += 1;
-                                stats.last_transient = Some(e);
-                            } else {
-                                tracing::warn!("[oss_sync] delete {p}: {e}");
+        let outcomes =
+            match with_batch_retry(|| fc.delete_batch(team_id, &items, node_id.as_deref())).await
+            {
+                Ok(o) => o,
+                Err(SyncError::BatchUnsupported) => {
+                    for (p, v) in chunk {
+                        match delete_file_retrying(fc, team_id, p, *v).await {
+                            Ok(version) => {
+                                state.mark_tombstoned(p, version);
+                                prune_empty_parents(Path::new(content_root), p).await;
+                                stats.pushed += 1;
+                            }
+                            Err(SyncError::Conflict { .. }) => stats.conflicts += 1,
+                            Err(e) => {
+                                if is_transient(&e) {
+                                    stats.deferred += 1;
+                                    stats.last_transient = Some(e);
+                                } else {
+                                    tracing::warn!("[oss_sync] delete {p}: {e}");
+                                }
                             }
                         }
                     }
+                    continue;
                 }
-                continue;
-            }
-            Err(e) => {
-                if is_transient(&e) {
-                    stats.deferred += chunk.len() as u32;
-                    stats.last_transient = Some(e);
-                } else {
-                    tracing::warn!("[oss_sync] delete-batch: {e}");
+                Err(e) => {
+                    if is_transient(&e) {
+                        stats.deferred += chunk.len() as u32;
+                        stats.last_transient = Some(e);
+                    } else {
+                        tracing::warn!("[oss_sync] delete-batch: {e}");
+                    }
+                    continue;
                 }
-                continue;
-            }
-        };
+            };
 
         for ((p, _v), oc) in chunk.iter().zip(outcomes.into_iter()) {
             match oc {
@@ -1333,7 +1365,7 @@ async fn upload_one(
             parent_version,
             &remote_cipher_hash,
             blob.len() as u64,
-            None,
+            knowledge_created_by_node_id().as_deref(),
         )
         .await?;
 
@@ -1344,7 +1376,11 @@ async fn upload_one(
     }
 
     let complete = fc
-        .upload_complete(team_id, &prepare.upload_session_id)
+        .upload_complete(
+            team_id,
+            &prepare.upload_session_id,
+            knowledge_created_by_node_id().as_deref(),
+        )
         .await?;
 
     let meta = std::fs::metadata(&abs_path).map_err(SyncError::from)?;
@@ -1419,7 +1455,15 @@ async fn delete_file_retrying(
 ) -> Result<i32, SyncError> {
     let mut attempt = 0u32;
     loop {
-        match fc.delete_file(team_id, path, parent_version, None).await {
+        match fc
+            .delete_file(
+                team_id,
+                path,
+                parent_version,
+                knowledge_created_by_node_id().as_deref(),
+            )
+            .await
+        {
             Err(e) if is_transient(&e) && attempt < MAX_TRANSIENT_RETRIES => {
                 attempt += 1;
                 backoff_sleep(attempt).await;
@@ -2120,5 +2164,22 @@ mod tests {
             pu.parent_version, 2,
             "re-add must CAS against the tombstone version, not 0"
         );
+    }
+
+    #[test]
+    fn prepare_and_delete_payloads_carry_daemon_device_id() {
+        let expected = crate::device_id::daemon_device_id();
+        assert!(!expected.is_empty());
+
+        let prep = prepare_batch_item_for("knowledge/a.md", 0, "abc", 3);
+        let del = delete_batch_item_for("knowledge/a.md", 1);
+
+        assert_eq!(prep.node_id.as_deref(), Some(expected.as_str()));
+        assert_eq!(del.node_id.as_deref(), Some(expected.as_str()));
+
+        let prep_json = serde_json::to_value(&prep).unwrap();
+        assert_eq!(prep_json["nodeId"], expected);
+        let del_json = serde_json::to_value(&del).unwrap();
+        assert_eq!(del_json["nodeId"], expected);
     }
 }

--- a/apps/daemon/src/sync/oss/engine.rs
+++ b/apps/daemon/src/sync/oss/engine.rs
@@ -509,18 +509,18 @@ struct PullItem {
     version: i32,
 }
 
-/// Front half of an upload — read + encrypt + hash, with no network. Computed
+/// Front half of an upload — read + hash, with no network. Computed
 /// before the prepare/complete batch round-trips so the blob is ready to PUT.
 struct PreparedUpload {
     path: String,
     /// sha256 of the plaintext (what local dirty-detection compares against).
     plain_hash: String,
-    /// encrypted bytes uploaded to OSS.
+    /// plaintext bytes uploaded to OSS (knowledge blobs are not encrypted).
     blob: Vec<u8>,
     /// sha256 of `blob` — the content hash the FC CAS keys on.
     cipher_hash: String,
     parent_version: i32,
-    /// ciphertext length — the `size` the FC HEAD-check verifies on the OSS blob.
+    /// blob length — the `size` the FC HEAD-check verifies on the OSS object.
     size: u64,
 }
 
@@ -831,7 +831,7 @@ async fn pull_phase(
     pulled
 }
 
-/// Batched PUSH: encrypt locally → prepare-batch → concurrent blob PUT →
+/// Batched PUSH: hash locally → prepare-batch → concurrent blob PUT →
 /// complete-batch → per-item apply. Per-file fallback on a pre-batch FC.
 async fn push_phase(
     content_root: &str,
@@ -855,12 +855,12 @@ async fn push_phase(
     let uploaded = Arc::new(AtomicU32::new(0));
 
     for chunk in paths.chunks(MAX_BATCH) {
-        // Stage 0: encrypt + hash. Unreadable files are skipped (stay dirty).
+        // Stage 0: read + hash. Unreadable files are skipped (stay dirty).
         let mut prepared: Vec<PreparedUpload> = Vec::new();
         for p in chunk {
             match prepare_upload(content_root, p, state) {
                 Ok(pu) => prepared.push(pu),
-                Err(e) => tracing::warn!("[oss_sync] encrypt {p}: {e}"),
+                Err(e) => tracing::warn!("[oss_sync] prepare {p}: {e}"),
             }
         }
         if prepared.is_empty() {

--- a/apps/daemon/src/sync/oss/engine.rs
+++ b/apps/daemon/src/sync/oss/engine.rs
@@ -283,8 +283,13 @@ pub async fn tick_with_progress(
             if ls.dirty && item.version > ls.synced_version {
                 // Write local content as a conflict sidecar before overwriting.
                 if let Ok(local_bytes) = std::fs::read(&abs_path) {
-                    let _ = write_conflict_sidecar(&abs_path, &local_bytes, &ls.synced_cipher_hash)
-                        .await;
+                    let _ = write_conflict_sidecar(
+                        Path::new(content_root),
+                        &item.path,
+                        &local_bytes,
+                        &ls.synced_cipher_hash,
+                    )
+                    .await;
                     pull_conflicts += 1;
                 }
             }
@@ -1121,7 +1126,13 @@ async fn handle_push_conflict(
             .get(path)
             .map(|f| f.synced_cipher_hash.as_str())
             .unwrap_or("unknown");
-        let _ = write_conflict_sidecar(&abs_path, &local_bytes, local_cipher_hash).await;
+        let _ = write_conflict_sidecar(
+            Path::new(content_root),
+            path,
+            &local_bytes,
+            local_cipher_hash,
+        )
+        .await;
     }
     if let Some(hash) = remote_cipher_hash {
         let version = remote_version.unwrap_or(0);

--- a/apps/daemon/src/sync/oss/engine.rs
+++ b/apps/daemon/src/sync/oss/engine.rs
@@ -179,6 +179,13 @@ pub async fn tick_with_progress(
         if super::path_validator::is_retired(&item.path) {
             continue;
         }
+        // Conflict copies live under `.conflicts/` and must never be pulled —
+        // even if a buggy older client somehow pushed one. `continue`, never
+        // `return Err` (§4.5): rejecting a single manifest row used to abort
+        // the whole apply.
+        if super::conflict::is_under_conflicts_dir(&item.path) {
+            continue;
+        }
         // Ignored here means "this device does not want this file on disk" —
         // an older client, or one with looser rules, can still have pushed it.
         // `continue`, never `?`: the retired-prefix comment above records what

--- a/apps/daemon/src/sync/oss/engine.rs
+++ b/apps/daemon/src/sync/oss/engine.rs
@@ -720,6 +720,7 @@ async fn pull_phase(
                 .into_iter()
                 .map(|(path, cipher_hash, version, url)| {
                     let transferred = transferred.clone();
+                    let team_id = team_id.clone();
                     async move {
                         let _guard = ReportOnDrop {
                             progress,
@@ -747,6 +748,8 @@ async fn pull_phase(
                         tokio::fs::write(&abs, &plaintext)
                             .await
                             .map_err(|e| fail(SyncError::Io(e.to_string())))?;
+                        // Suppress fs-watch Local triggers for this path for 3s.
+                        crate::sync::watch::record_pull_write(&team_id, &path);
                         let meta = std::fs::metadata(&abs)
                             .map_err(|e| fail(SyncError::Io(e.to_string())))?;
                         let mtime = meta
@@ -1274,6 +1277,8 @@ pub async fn download_and_write(
     tokio::fs::write(&abs_path, &plaintext)
         .await
         .map_err(|e| SyncError::Io(e.to_string()))?;
+    // Suppress fs-watch Local triggers for this path for 3s (path-set, not blanket).
+    crate::sync::watch::record_pull_write(&team_id, rel_path);
 
     let meta = std::fs::metadata(&abs_path).map_err(SyncError::from)?;
     let mtime = meta

--- a/apps/daemon/src/sync/oss/fc_client.rs
+++ b/apps/daemon/src/sync/oss/fc_client.rs
@@ -262,11 +262,15 @@ impl FcClient {
         &self,
         team_id: &str,
         upload_session_id: &str,
+        node_id: Option<&str>,
     ) -> Result<CompleteResult, SyncError> {
-        let body = serde_json::json!({
+        let mut body = serde_json::json!({
             "teamId": team_id,
             "uploadSessionId": upload_session_id,
         });
+        if let Some(nid) = node_id {
+            body["nodeId"] = Value::String(nid.to_string());
+        }
         self.post("/v1/sync/upload/complete", &body).await
     }
 
@@ -366,16 +370,24 @@ impl FcClient {
     }
 
     /// POST /sync/upload/complete-batch
+    ///
+    /// `node_id` is sent as a **top-level** body field. FC's knowledge-sync hint
+    /// reads `originNodeId` from `body.nodeId` (not from per-item fields), so
+    /// omitting it leaves peers unable to filter own-push echoes.
     pub async fn upload_complete_batch(
         &self,
         team_id: &str,
         session_ids: &[String],
+        node_id: Option<&str>,
     ) -> Result<Vec<BatchItemOutcome<CompleteResult>>, SyncError> {
         let items: Vec<Value> = session_ids
             .iter()
             .map(|s| serde_json::json!({ "uploadSessionId": s }))
             .collect();
-        let body = serde_json::json!({ "teamId": team_id, "items": items });
+        let mut body = serde_json::json!({ "teamId": team_id, "items": items });
+        if let Some(nid) = node_id {
+            body["nodeId"] = Value::String(nid.to_string());
+        }
         let results = self
             .post_batch_raw("/v1/sync/upload/complete-batch", &body, session_ids.len())
             .await?;
@@ -400,12 +412,20 @@ impl FcClient {
     }
 
     /// POST /sync/delete-batch
+    ///
+    /// Per-item `node_id` stamps `created_by_node_id` on the tombstone; the
+    /// optional top-level `node_id` is what FC copies into the MQTT hint's
+    /// `originNodeId` (same contract as complete-batch).
     pub async fn delete_batch(
         &self,
         team_id: &str,
         items: &[DeleteBatchItem],
+        node_id: Option<&str>,
     ) -> Result<Vec<BatchItemOutcome<DeleteResult>>, SyncError> {
-        let body = serde_json::json!({ "teamId": team_id, "items": items });
+        let mut body = serde_json::json!({ "teamId": team_id, "items": items });
+        if let Some(nid) = node_id {
+            body["nodeId"] = Value::String(nid.to_string());
+        }
         let results = self
             .post_batch_raw("/v1/sync/delete-batch", &body, items.len())
             .await?;
@@ -774,5 +794,82 @@ mod tests {
             }
             other => panic!("expected Ok, got {other:?}"),
         }
+    }
+
+    /// FC publishes `originNodeId` from the **top-level** `body.nodeId` on
+    /// complete-batch / delete-batch — not from per-item fields. These tests
+    /// lock that request shape so MQTT echo filtering can work.
+    #[tokio::test]
+    async fn complete_batch_sends_top_level_node_id() {
+        use wiremock::matchers::{body_partial_json, method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let srv = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/sync/upload/complete-batch"))
+            .and(body_partial_json(json!({
+                "teamId": "t1",
+                "nodeId": "mac-9f3c",
+                "items": [{ "uploadSessionId": "sess-1" }],
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "results": [{
+                    "ok": true,
+                    "version": 1,
+                    "contentHash": "abc",
+                    "changeSeq": 10,
+                }],
+            })))
+            .expect(1)
+            .mount(&srv)
+            .await;
+
+        let fc = FcClient::new(srv.uri(), "jwt".into());
+        let out = fc
+            .upload_complete_batch("t1", &["sess-1".into()], Some("mac-9f3c"))
+            .await
+            .expect("complete-batch");
+        assert!(matches!(out.as_slice(), [BatchItemOutcome::Ok(_)]));
+    }
+
+    #[tokio::test]
+    async fn delete_batch_sends_top_level_node_id() {
+        use wiremock::matchers::{body_partial_json, method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let srv = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/sync/delete-batch"))
+            .and(body_partial_json(json!({
+                "teamId": "t1",
+                "nodeId": "del-node",
+                "items": [{
+                    "path": "knowledge/a.md",
+                    "parentVersion": 1,
+                    "nodeId": "del-node",
+                }],
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "results": [{
+                    "ok": true,
+                    "version": 2,
+                    "changeSeq": 11,
+                }],
+            })))
+            .expect(1)
+            .mount(&srv)
+            .await;
+
+        let fc = FcClient::new(srv.uri(), "jwt".into());
+        let items = [DeleteBatchItem {
+            path: "knowledge/a.md".into(),
+            parent_version: 1,
+            node_id: Some("del-node".into()),
+        }];
+        let out = fc
+            .delete_batch("t1", &items, Some("del-node"))
+            .await
+            .expect("delete-batch");
+        assert!(matches!(out.as_slice(), [BatchItemOutcome::Ok(_)]));
     }
 }

--- a/apps/daemon/src/sync/oss/scanner.rs
+++ b/apps/daemon/src/sync/oss/scanner.rs
@@ -53,6 +53,8 @@ pub fn scan_workspace_with(
 ) -> Vec<ScannedFile> {
     let root = Path::new(workspace_path);
     let mut results = Vec::new();
+    // Collected during the walk, relocated after it — see the push site.
+    let mut legacy_sidecars: Vec<String> = Vec::new();
 
     for prefix in ALLOWED_PREFIXES {
         let prefix_dir = root.join(prefix.trim_end_matches('/'));
@@ -91,12 +93,14 @@ pub fn scan_workspace_with(
                 continue;
             }
 
-            // Legacy sidecar beside a note: relocate under `.conflicts/` and
-            // keep scanning (whether or not the move succeeds — sync must not
-            // upload it either way). Sidecars were never uploaded, so a
-            // successful move is a local rename with no tombstone side effect.
+            // Legacy sidecar beside a note: note it and keep scanning (sync must
+            // not upload it either way). The relocate happens AFTER the walk —
+            // renaming entries out of the directory `readdir` is currently
+            // reading has unspecified behaviour, and on ext4 with dir_index it
+            // reliably skips siblings, which would silently drop notes from this
+            // tick's dirty list.
             if is_conflict_file(&rel) {
-                let _ = conflict::migrate_legacy_conflict_sidecar(root, &rel);
+                legacy_sidecars.push(rel);
                 continue;
             }
 
@@ -148,6 +152,13 @@ pub fn scan_workspace_with(
                 dirty,
             });
         }
+    }
+
+    // Walk is finished: no `readdir` is in flight, so renaming these out of
+    // their directories cannot make the walk skip anything. Sidecars were never
+    // uploaded, so each move is a local rename with no tombstone side effect.
+    for rel in legacy_sidecars {
+        let _ = conflict::migrate_legacy_conflict_sidecar(root, &rel);
     }
 
     results

--- a/apps/daemon/src/sync/oss/scanner.rs
+++ b/apps/daemon/src/sync/oss/scanner.rs
@@ -4,14 +4,19 @@
 //! - Walk the workspace looking for files under allowed prefixes.
 //! - Prune ignored entries ([`IgnoreRules`]) without descending into them —
 //!   never walking `node_modules/` is most of why this stays cheap.
-//! - Skip conflict sidecar files (`*.conflict.*`).
+//! - Hard-skip the `.conflicts/` directory (not via IgnoreRules — a team
+//!   `!.conflicts/` must not re-include it) and relocate any legacy sidecar
+//!   still sitting beside a note into that directory (move-on-scan).
 //! - Cheap dirty check: if mtime+size match state, assume clean.
 //! - If mtime/size differ, recompute sha256(plaintext) and compare against
 //!   `local_plain_hash` in state to detect real changes.
 //! - Returns the list of relative paths that are dirty (or new).
 
 use super::{
-    crypto::sha256_hex, ignore_rules::IgnoreRules, path_validator::ALLOWED_PREFIXES,
+    conflict::{self, CONFLICTS_DIR},
+    crypto::sha256_hex,
+    ignore_rules::IgnoreRules,
+    path_validator::ALLOWED_PREFIXES,
     state::LocalSyncState,
 };
 use std::path::Path;
@@ -60,7 +65,16 @@ pub fn scan_workspace_with(
             // Prune at the directory, so an ignored tree costs one stat instead
             // of a full walk. This is also what makes the rules affordable at
             // all: `node_modules/` is the case they exist for.
-            .filter_entry(|e| !is_ignored_entry(root, e, rules))
+            //
+            // `.conflicts/` is pruned here as a HARD rule (checked before
+            // IgnoreRules) so a team `.amuxignore` `!.conflicts/` cannot put
+            // conflict copies back on the sync path.
+            .filter_entry(|e| {
+                if is_conflicts_dir_entry(root, e) {
+                    return false;
+                }
+                !is_ignored_entry(root, e, rules)
+            })
             .filter_map(|e| e.ok())
         {
             if !entry.file_type().is_file() {
@@ -72,8 +86,16 @@ pub fn scan_workspace_with(
                 Err(_) => continue,
             };
 
-            // Skip conflict sidecar files
+            // Defense in depth — should already be pruned by filter_entry.
+            if conflict::is_under_conflicts_dir(&rel) {
+                continue;
+            }
+
+            // Legacy sidecar beside a note: relocate under `.conflicts/` and
+            // keep scanning. Sidecars were never uploaded, so this is a local
+            // rename with no tombstone side effect.
             if is_conflict_file(&rel) {
+                let _ = conflict::migrate_legacy_conflict_sidecar(root, &rel);
                 continue;
             }
 
@@ -130,21 +152,26 @@ pub fn scan_workspace_with(
     results
 }
 
-/// Walk the workspace under allowed prefixes and return the relative paths of
-/// all conflict sidecar files (`*.conflict.*`) currently on disk.
+/// Walk each prefix's `.conflicts/` directory and return the relative paths of
+/// all conflict sidecar files currently on disk.
 ///
-/// Used by `oss_sync_status` to surface conflicted files in the file tree;
-/// `scan_workspace_with` deliberately skips these, so they need a separate pass.
+/// Relocates any legacy sidecars still sitting beside notes first (move-on-scan),
+/// so the conflicts UI sees a consistent layout even before the next full sync
+/// tick. Used by `GET /v1/team/conflicts`; `scan_workspace_with` deliberately
+/// skips these, so they need a separate pass.
 pub fn scan_conflict_files(workspace_path: &str) -> Vec<String> {
     let root = Path::new(workspace_path);
-    let mut results = Vec::new();
+    migrate_legacy_sidecars_under(root);
 
+    let mut results = Vec::new();
     for prefix in ALLOWED_PREFIXES {
-        let prefix_dir = root.join(prefix.trim_end_matches('/'));
-        if !prefix_dir.exists() {
+        let conflicts_dir = root
+            .join(prefix.trim_end_matches('/'))
+            .join(CONFLICTS_DIR);
+        if !conflicts_dir.exists() {
             continue;
         }
-        for entry in WalkDir::new(&prefix_dir)
+        for entry in WalkDir::new(&conflicts_dir)
             .follow_links(false)
             .into_iter()
             .filter_map(|e| e.ok())
@@ -163,6 +190,34 @@ pub fn scan_conflict_files(workspace_path: &str) -> Vec<String> {
     }
 
     results
+}
+
+/// Relocate every legacy sidecar under allowed prefixes into `.conflicts/`.
+/// Does not descend into `.conflicts/` itself.
+fn migrate_legacy_sidecars_under(root: &Path) {
+    for prefix in ALLOWED_PREFIXES {
+        let prefix_dir = root.join(prefix.trim_end_matches('/'));
+        if !prefix_dir.exists() {
+            continue;
+        }
+        for entry in WalkDir::new(&prefix_dir)
+            .follow_links(false)
+            .into_iter()
+            .filter_entry(|e| !is_conflicts_dir_entry(root, e))
+            .filter_map(|e| e.ok())
+        {
+            if !entry.file_type().is_file() {
+                continue;
+            }
+            let Ok(rel) = entry.path().strip_prefix(root) else {
+                continue;
+            };
+            let rel = rel.to_string_lossy().replace('\\', "/");
+            if is_conflict_file(&rel) {
+                let _ = conflict::migrate_legacy_conflict_sidecar(root, &rel);
+            }
+        }
+    }
 }
 
 /// Entries the rules exclude, as the shallowest paths that explain the
@@ -227,6 +282,18 @@ fn is_ignored_entry(root: &Path, entry: &walkdir::DirEntry, rules: &IgnoreRules)
         return false;
     }
     rules.is_ignored(&rel, entry.file_type().is_dir())
+}
+
+/// Whether this walk entry is the `.conflicts/` directory (or under it).
+///
+/// Checked independently of [`IgnoreRules`] so a negation rule cannot re-open
+/// the tree. Used by `filter_entry` to prune before descending.
+fn is_conflicts_dir_entry(root: &Path, entry: &walkdir::DirEntry) -> bool {
+    let Ok(rel) = entry.path().strip_prefix(root) else {
+        return false;
+    };
+    let rel = rel.to_string_lossy().replace('\\', "/");
+    conflict::is_under_conflicts_dir(&rel)
 }
 
 /// Returns true if the relative path is a conflict sidecar.
@@ -309,39 +376,110 @@ mod tests {
     fn test_scan_skips_conflict_files() {
         let dir = tempfile::tempdir().unwrap();
         let ws = dir.path().to_str().unwrap();
-        let skills_dir = dir.path().join("knowledge");
-        std::fs::create_dir_all(&skills_dir).unwrap();
+        let knowledge = dir.path().join("knowledge");
+        std::fs::create_dir_all(knowledge.join(".conflicts/a")).unwrap();
         std::fs::write(
-            skills_dir.join("foo.conflict.1234567890.abc12345.md"),
+            knowledge.join(".conflicts/a/foo.conflict.1234567890.abc12345.md"),
             b"conflict",
         )
         .unwrap();
-        std::fs::write(skills_dir.join("real.md"), b"real").unwrap();
+        // Legacy sidecar beside the note — relocated then skipped
+        std::fs::write(
+            knowledge.join("legacy.conflict.1234567890.abc12345.md"),
+            b"legacy",
+        )
+        .unwrap();
+        std::fs::write(knowledge.join("real.md"), b"real").unwrap();
 
         let state = LocalSyncState::load(ws, "team-test").unwrap();
         let files = scan_workspace_with(ws, &state, &IgnoreRules::load(dir.path()));
 
         assert!(files.iter().any(|f| f.rel_path == "knowledge/real.md"));
-        assert!(!files.iter().any(|f| f.rel_path.contains(".conflict.")));
+        assert!(
+            !files
+                .iter()
+                .any(|f| f.rel_path.contains(".conflict.") || f.rel_path.contains("/.conflicts/")),
+            "sidecars must not appear in the sync scan, got {files:?}"
+        );
+        // Legacy was moved under .conflicts/
+        assert!(!knowledge.join("legacy.conflict.1234567890.abc12345.md").exists());
+        assert!(knowledge
+            .join(".conflicts/legacy.conflict.1234567890.abc12345.md")
+            .exists());
     }
 
     #[test]
     fn test_scan_conflict_files_collects_sidecars() {
         let dir = tempfile::tempdir().unwrap();
         let ws = dir.path().to_str().unwrap();
-        let skills_dir = dir.path().join("knowledge");
-        std::fs::create_dir_all(&skills_dir).unwrap();
-        std::fs::write(skills_dir.join("real.md"), b"real").unwrap();
+        let knowledge = dir.path().join("knowledge");
+        std::fs::create_dir_all(knowledge.join(".conflicts/a")).unwrap();
+        std::fs::write(knowledge.join("real.md"), b"real").unwrap();
         std::fs::write(
-            skills_dir.join("foo.conflict.1234567890.abc12345.md"),
+            knowledge.join(".conflicts/a/foo.conflict.1234567890.abc12345.md"),
             b"conflict",
+        )
+        .unwrap();
+        // Legacy beside the note — scan_conflict_files migrates then lists it
+        std::fs::write(
+            knowledge.join("bar.conflict.1234567890.def67890.md"),
+            b"legacy",
         )
         .unwrap();
 
         let conflicts = scan_conflict_files(ws);
-        assert_eq!(conflicts.len(), 1);
-        assert!(conflicts[0].contains(".conflict."));
+        assert_eq!(conflicts.len(), 2, "{conflicts:?}");
+        assert!(conflicts.contains(&"knowledge/.conflicts/a/foo.conflict.1234567890.abc12345.md".to_string()));
+        assert!(conflicts.contains(&"knowledge/.conflicts/bar.conflict.1234567890.def67890.md".to_string()));
         assert!(!conflicts.iter().any(|c| c == "knowledge/real.md"));
+        assert!(!knowledge.join("bar.conflict.1234567890.def67890.md").exists());
+    }
+
+    /// `.conflicts/` is a hard skip — a team negation rule must not re-include it.
+    #[test]
+    fn scan_never_yields_conflicts_dir_even_with_negation_rule() {
+        let dir = tempfile::tempdir().unwrap();
+        let ws = dir.path().to_str().unwrap();
+        let knowledge = dir.path().join("knowledge");
+        std::fs::create_dir_all(knowledge.join(".conflicts")).unwrap();
+        std::fs::write(
+            knowledge.join(".conflicts/foo.conflict.1.aabbccdd.md"),
+            b"sidecar",
+        )
+        .unwrap();
+        std::fs::write(knowledge.join("real.md"), b"real").unwrap();
+        // Team rule that would un-ignore `.conflicts/` if we went through IgnoreRules.
+        std::fs::write(knowledge.join(".amuxignore"), b"!.conflicts/\n").unwrap();
+
+        let state = LocalSyncState::load(ws, "team-test").unwrap();
+        let found: Vec<String> = scan_workspace_with(ws, &state, &IgnoreRules::load(dir.path()))
+            .into_iter()
+            .map(|f| f.rel_path)
+            .collect();
+
+        assert!(found.contains(&"knowledge/real.md".to_string()));
+        assert!(
+            !found.iter().any(|p| p.contains(".conflicts")),
+            "!.conflicts/ must not re-include the hard-skipped dir, got {found:?}"
+        );
+    }
+
+    #[test]
+    fn scan_does_not_descend_into_conflicts_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        let ws = dir.path().to_str().unwrap();
+        let knowledge = dir.path().join("knowledge");
+        std::fs::create_dir_all(knowledge.join(".conflicts/deep")).unwrap();
+        std::fs::write(knowledge.join(".conflicts/deep/x.md"), b"should not sync").unwrap();
+        std::fs::write(knowledge.join("ok.md"), b"ok").unwrap();
+
+        let state = LocalSyncState::load(ws, "team-test").unwrap();
+        let found: Vec<String> = scan_workspace_with(ws, &state, &IgnoreRules::load(dir.path()))
+            .into_iter()
+            .map(|f| f.rel_path)
+            .collect();
+
+        assert_eq!(found, vec!["knowledge/ok.md".to_string()]);
     }
 
     #[test]

--- a/apps/daemon/src/sync/oss/scanner.rs
+++ b/apps/daemon/src/sync/oss/scanner.rs
@@ -92,8 +92,9 @@ pub fn scan_workspace_with(
             }
 
             // Legacy sidecar beside a note: relocate under `.conflicts/` and
-            // keep scanning. Sidecars were never uploaded, so this is a local
-            // rename with no tombstone side effect.
+            // keep scanning (whether or not the move succeeds — sync must not
+            // upload it either way). Sidecars were never uploaded, so a
+            // successful move is a local rename with no tombstone side effect.
             if is_conflict_file(&rel) {
                 let _ = conflict::migrate_legacy_conflict_sidecar(root, &rel);
                 continue;
@@ -157,13 +158,14 @@ pub fn scan_workspace_with(
 ///
 /// Relocates any legacy sidecars still sitting beside notes first (move-on-scan),
 /// so the conflicts UI sees a consistent layout even before the next full sync
-/// tick. Used by `GET /v1/team/conflicts`; `scan_workspace_with` deliberately
-/// skips these, so they need a separate pass.
+/// tick. If a relocate fails, the legacy path is still returned — otherwise a
+/// stuck rename would hide the decision entirely. Used by
+/// `GET /v1/team/conflicts`; `scan_workspace_with` deliberately skips these, so
+/// they need a separate pass.
 pub fn scan_conflict_files(workspace_path: &str) -> Vec<String> {
     let root = Path::new(workspace_path);
-    migrate_legacy_sidecars_under(root);
+    let mut results = migrate_legacy_sidecars_under(root);
 
-    let mut results = Vec::new();
     for prefix in ALLOWED_PREFIXES {
         let conflicts_dir = root
             .join(prefix.trim_end_matches('/'))
@@ -189,12 +191,17 @@ pub fn scan_conflict_files(workspace_path: &str) -> Vec<String> {
         }
     }
 
+    results.sort();
+    results.dedup();
     results
 }
 
 /// Relocate every legacy sidecar under allowed prefixes into `.conflicts/`.
 /// Does not descend into `.conflicts/` itself.
-fn migrate_legacy_sidecars_under(root: &Path) {
+///
+/// Returns relative paths that could not be moved and must still be listed.
+fn migrate_legacy_sidecars_under(root: &Path) -> Vec<String> {
+    let mut leftovers = Vec::new();
     for prefix in ALLOWED_PREFIXES {
         let prefix_dir = root.join(prefix.trim_end_matches('/'));
         if !prefix_dir.exists() {
@@ -213,11 +220,17 @@ fn migrate_legacy_sidecars_under(root: &Path) {
                 continue;
             };
             let rel = rel.to_string_lossy().replace('\\', "/");
-            if is_conflict_file(&rel) {
-                let _ = conflict::migrate_legacy_conflict_sidecar(root, &rel);
+            if !is_conflict_file(&rel) {
+                continue;
+            }
+            match conflict::migrate_legacy_conflict_sidecar(root, &rel) {
+                conflict::MigrateOutcome::StillLegacy(path) => leftovers.push(path),
+                conflict::MigrateOutcome::UnderConflicts(_)
+                | conflict::MigrateOutcome::NotApplicable => {}
             }
         }
     }
+    leftovers
 }
 
 /// Entries the rules exclude, as the shallowest paths that explain the
@@ -433,6 +446,35 @@ mod tests {
         assert!(conflicts.contains(&"knowledge/.conflicts/bar.conflict.1234567890.def67890.md".to_string()));
         assert!(!conflicts.iter().any(|c| c == "knowledge/real.md"));
         assert!(!knowledge.join("bar.conflict.1234567890.def67890.md").exists());
+    }
+
+    /// If relocate cannot create `.conflicts/`, the legacy path must still show
+    /// up in the conflicts list — otherwise the decision disappears entirely.
+    #[test]
+    fn scan_conflict_files_lists_legacy_when_migrate_fails() {
+        let dir = tempfile::tempdir().unwrap();
+        let ws = dir.path().to_str().unwrap();
+        let knowledge = dir.path().join("knowledge");
+        std::fs::create_dir_all(knowledge.join("a")).unwrap();
+        // Block knowledge/.conflicts/ as a directory.
+        std::fs::write(knowledge.join(".conflicts"), b"blocker").unwrap();
+        std::fs::write(
+            knowledge.join("a/stuck.conflict.1234567890.abc12345.md"),
+            b"local",
+        )
+        .unwrap();
+        // A note that is not a sidecar must not appear.
+        std::fs::write(knowledge.join("real.md"), b"real").unwrap();
+
+        let conflicts = scan_conflict_files(ws);
+        assert_eq!(
+            conflicts,
+            vec!["knowledge/a/stuck.conflict.1234567890.abc12345.md".to_string()],
+            "{conflicts:?}"
+        );
+        assert!(knowledge
+            .join("a/stuck.conflict.1234567890.abc12345.md")
+            .exists());
     }
 
     /// `.conflicts/` is a hard skip — a team negation rule must not re-include it.

--- a/apps/daemon/src/sync/scheduler.rs
+++ b/apps/daemon/src/sync/scheduler.rs
@@ -1,0 +1,366 @@
+//! Per-team sync trigger coalescing scheduler (pure logic, no I/O).
+//!
+//! Coalescing window + floor — not debounce. See
+//! `docs/architecture/knowledge-sync-push-notify.md` §7 and ADR-0008.
+//!
+//! - First trigger opens a fixed 2s window; further triggers inside it merge;
+//!   the window never resets.
+//! - Floor from last tick **end**: Local 5s, Remote 15s; both pending → min.
+//! - If the window closes before the floor, schedule at the floor (never drop).
+
+use std::time::{Duration, Instant};
+
+/// Fixed coalescing window after the first trigger in a batch.
+pub const COALESCE_WINDOW: Duration = Duration::from_secs(2);
+/// Minimum gap after a tick ends before a Local-driven fire.
+pub const LOCAL_FLOOR: Duration = Duration::from_secs(5);
+/// Minimum gap after a tick ends before a Remote-only fire.
+pub const REMOTE_FLOOR: Duration = Duration::from_secs(15);
+
+/// Why a sync was requested. Tasks 3 (fs watch) and 8 (MQTT hint) feed these.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Trigger {
+    Local,
+    Remote { seq: i64 },
+}
+
+/// Deterministic time source for the pure scheduler.
+pub trait Clock {
+    fn now(&self) -> Instant;
+}
+
+/// Wall-clock adapter for production drivers.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct SystemClock;
+
+impl Clock for SystemClock {
+    fn now(&self) -> Instant {
+        Instant::now()
+    }
+}
+
+/// Pure per-team coalescing state. No I/O; the dispatch layer calls
+/// `sync_team` when [`Self::try_begin_tick`] returns true.
+#[derive(Debug, Default)]
+pub struct SyncScheduler {
+    /// When the open coalescing window started. `None` when idle.
+    window_opened_at: Option<Instant>,
+    pending_local: bool,
+    pending_remote: bool,
+    /// Highest remote seq seen while pending (informational for later consumers).
+    pending_remote_seq: Option<i64>,
+    last_tick_end: Option<Instant>,
+    in_tick: bool,
+}
+
+impl SyncScheduler {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn in_tick(&self) -> bool {
+        self.in_tick
+    }
+
+    pub fn pending_remote_seq(&self) -> Option<i64> {
+        self.pending_remote_seq
+    }
+
+    fn has_pending(&self) -> bool {
+        self.pending_local || self.pending_remote
+    }
+
+    fn floor_duration(&self) -> Duration {
+        match (self.pending_local, self.pending_remote) {
+            (true, true) => LOCAL_FLOOR.min(REMOTE_FLOOR),
+            (true, false) => LOCAL_FLOOR,
+            (false, true) => REMOTE_FLOOR,
+            (false, false) => Duration::ZERO,
+        }
+    }
+
+    /// Earliest allowed fire given an open window and pending kinds.
+    fn compute_fire_at(&self) -> Option<Instant> {
+        if self.in_tick || !self.has_pending() {
+            return None;
+        }
+        let window_opened = self.window_opened_at?;
+        let window_deadline = window_opened + COALESCE_WINDOW;
+        let floor_deadline = self
+            .last_tick_end
+            .map(|end| end + self.floor_duration())
+            .unwrap_or(window_deadline);
+        Some(window_deadline.max(floor_deadline))
+    }
+
+    /// Record a trigger. Returns the next fire instant when work is pending
+    /// and we are not mid-tick (mid-tick callers still accumulate pending;
+    /// [`Self::end_tick`] returns the schedule).
+    pub fn trigger<C: Clock>(&mut self, clock: &C, trigger: Trigger) -> Option<Instant> {
+        let now = clock.now();
+        match trigger {
+            Trigger::Local => {
+                self.pending_local = true;
+            }
+            Trigger::Remote { seq } => {
+                self.pending_remote = true;
+                self.pending_remote_seq = Some(match self.pending_remote_seq {
+                    Some(prev) => prev.max(seq),
+                    None => seq,
+                });
+            }
+        }
+        // First trigger of a batch opens a fixed window; further triggers merge.
+        if self.window_opened_at.is_none() {
+            self.window_opened_at = Some(now);
+        }
+        self.compute_fire_at()
+    }
+
+    /// Next scheduled fire, if any pending work exists and we are not in a tick.
+    pub fn next_fire_at(&self) -> Option<Instant> {
+        self.compute_fire_at()
+    }
+
+    /// If due at `clock.now()`, consume pending and enter `in_tick`.
+    pub fn try_begin_tick<C: Clock>(&mut self, clock: &C) -> bool {
+        if self.in_tick {
+            return false;
+        }
+        let Some(fire_at) = self.compute_fire_at() else {
+            return false;
+        };
+        if clock.now() < fire_at {
+            return false;
+        }
+        self.pending_local = false;
+        self.pending_remote = false;
+        self.pending_remote_seq = None;
+        self.window_opened_at = None;
+        self.in_tick = true;
+        true
+    }
+
+    /// Mark the tick finished. May return a new `next_fire_at` if triggers
+    /// arrived during the tick.
+    pub fn end_tick<C: Clock>(&mut self, clock: &C) -> Option<Instant> {
+        let now = clock.now();
+        self.in_tick = false;
+        self.last_tick_end = Some(now);
+        // Pending work that arrived mid-tick already opened a window; if somehow
+        // pending without a window, open one now so we never drop.
+        if self.has_pending() && self.window_opened_at.is_none() {
+            self.window_opened_at = Some(now);
+        }
+        self.compute_fire_at()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cell::Cell;
+
+    struct FakeClock {
+        start: Instant,
+        now: Cell<Instant>,
+    }
+
+    impl FakeClock {
+        fn new() -> Self {
+            let start = Instant::now();
+            Self {
+                start,
+                now: Cell::new(start),
+            }
+        }
+
+        fn advance(&self, d: Duration) {
+            self.now.set(self.now.get() + d);
+        }
+
+        fn set_elapsed(&self, d: Duration) {
+            self.now.set(self.start + d);
+        }
+
+        fn elapsed(&self) -> Duration {
+            self.now.get().saturating_duration_since(self.start)
+        }
+    }
+
+    impl Clock for FakeClock {
+        fn now(&self) -> Instant {
+            self.now.get()
+        }
+    }
+
+    /// Drain due ticks at the current clock time (instantaneous ticks).
+    fn drain_instant(sched: &mut SyncScheduler, clock: &FakeClock, fires: &mut Vec<Duration>) {
+        while sched.try_begin_tick(clock) {
+            fires.push(clock.elapsed());
+            sched.end_tick(clock);
+        }
+    }
+
+    #[test]
+    fn quiet_one_local_fires_at_plus_2s() {
+        let clock = FakeClock::new();
+        let mut sched = SyncScheduler::new();
+
+        let next = sched.trigger(&clock, Trigger::Local);
+        assert_eq!(next, Some(clock.start + COALESCE_WINDOW));
+
+        clock.advance(Duration::from_millis(1999));
+        assert!(!sched.try_begin_tick(&clock));
+
+        clock.advance(Duration::from_millis(1));
+        assert!(sched.try_begin_tick(&clock));
+        sched.end_tick(&clock);
+    }
+
+    #[test]
+    fn burst_fifty_triggers_in_1_5s_exactly_one_fire() {
+        let clock = FakeClock::new();
+        let mut sched = SyncScheduler::new();
+        let mut fires = Vec::new();
+
+        for i in 0..50 {
+            let t = Duration::from_millis(i * 1500 / 49);
+            clock.set_elapsed(t);
+            sched.trigger(&clock, Trigger::Local);
+            drain_instant(&mut sched, &clock, &mut fires);
+        }
+
+        clock.set_elapsed(Duration::from_millis(1500));
+        drain_instant(&mut sched, &clock, &mut fires);
+        assert!(fires.is_empty(), "must not fire inside the 2s window: {fires:?}");
+
+        clock.set_elapsed(COALESCE_WINDOW);
+        drain_instant(&mut sched, &clock, &mut fires);
+        assert_eq!(fires.len(), 1, "expected exactly one fire, got {fires:?}");
+        assert_eq!(fires[0], COALESCE_WINDOW);
+
+        clock.advance(Duration::from_secs(60));
+        drain_instant(&mut sched, &clock, &mut fires);
+        assert_eq!(fires.len(), 1, "no further fires without new triggers");
+    }
+
+    #[test]
+    fn continuous_local_every_500ms_fires_at_2s_then_every_5s() {
+        let clock = FakeClock::new();
+        let mut sched = SyncScheduler::new();
+        let mut fires = Vec::new();
+
+        let mut t = Duration::ZERO;
+        let end = Duration::from_secs(60);
+        let step = Duration::from_millis(500);
+        while t <= end {
+            clock.set_elapsed(t);
+            sched.trigger(&clock, Trigger::Local);
+            drain_instant(&mut sched, &clock, &mut fires);
+            t += step;
+        }
+
+        assert!(
+            !fires.is_empty() && fires[0] == COALESCE_WINDOW,
+            "first fire at ~2s, got {fires:?}"
+        );
+
+        // After the first fire, Local floor is 5s — never back-to-back (0 gap).
+        for w in fires.windows(2) {
+            let gap = w[1].saturating_sub(w[0]);
+            assert!(
+                gap >= LOCAL_FLOOR,
+                "gap {gap:?} between {:?} and {:?} < local floor",
+                w[0],
+                w[1]
+            );
+            // Continuous writes keep the floor saturated: gaps ≈ 5s, not much more.
+            assert!(
+                gap <= LOCAL_FLOOR + step,
+                "gap {gap:?} much larger than floor — coalescing stalled?"
+            );
+        }
+
+        // Roughly one fire every 5s after the first: (60 - 2) / 5 ≈ 11 more → ~12 total.
+        assert!(
+            fires.len() >= 11 && fires.len() <= 13,
+            "expected ~12 fires over 60s, got {} ({fires:?})",
+            fires.len()
+        );
+    }
+
+    #[test]
+    fn remote_right_after_tick_ends_fires_at_plus_15s_not_2s() {
+        let clock = FakeClock::new();
+        let mut sched = SyncScheduler::new();
+
+        sched.trigger(&clock, Trigger::Local);
+        clock.advance(COALESCE_WINDOW);
+        assert!(sched.try_begin_tick(&clock));
+        sched.end_tick(&clock);
+
+        let after_tick = clock.now();
+        let next = sched.trigger(&clock, Trigger::Remote { seq: 42 });
+        assert_eq!(next, Some(after_tick + REMOTE_FLOOR));
+
+        clock.advance(COALESCE_WINDOW);
+        assert!(
+            !sched.try_begin_tick(&clock),
+            "must not fire at window close when floor is 15s"
+        );
+
+        clock.set_elapsed(COALESCE_WINDOW + REMOTE_FLOOR);
+        assert!(sched.try_begin_tick(&clock));
+        sched.end_tick(&clock);
+    }
+
+    #[test]
+    fn mixed_local_and_remote_pending_uses_5s_floor() {
+        let clock = FakeClock::new();
+        let mut sched = SyncScheduler::new();
+
+        sched.trigger(&clock, Trigger::Local);
+        clock.advance(COALESCE_WINDOW);
+        assert!(sched.try_begin_tick(&clock));
+        sched.end_tick(&clock);
+
+        let after_tick = clock.now();
+        sched.trigger(&clock, Trigger::Remote { seq: 1 });
+        let next = sched.trigger(&clock, Trigger::Local);
+        assert_eq!(
+            next,
+            Some(after_tick + LOCAL_FLOOR),
+            "mixed pending must use the smaller (Local) floor"
+        );
+
+        clock.advance(LOCAL_FLOOR);
+        assert!(sched.try_begin_tick(&clock));
+        sched.end_tick(&clock);
+    }
+
+    #[test]
+    fn slow_tick_next_fire_at_least_15s_after_end() {
+        let clock = FakeClock::new();
+        let mut sched = SyncScheduler::new();
+
+        sched.trigger(&clock, Trigger::Remote { seq: 1 });
+        clock.advance(COALESCE_WINDOW);
+        assert!(sched.try_begin_tick(&clock));
+
+        // Triggers during the long tick must not be dropped.
+        clock.advance(Duration::from_secs(10));
+        sched.trigger(&clock, Trigger::Remote { seq: 2 });
+        clock.advance(Duration::from_secs(10));
+        let end = clock.now();
+        let next = sched.end_tick(&clock);
+        assert_eq!(next, Some(end + REMOTE_FLOOR));
+
+        clock.advance(Duration::from_secs(14));
+        assert!(!sched.try_begin_tick(&clock));
+
+        clock.advance(Duration::from_secs(1));
+        assert!(sched.try_begin_tick(&clock));
+        sched.end_tick(&clock);
+    }
+}

--- a/apps/daemon/src/sync/watch.rs
+++ b/apps/daemon/src/sync/watch.rs
@@ -1,0 +1,521 @@
+//! Filesystem watch on each team's `knowledge/` root → Local sync triggers.
+//!
+//! Independent of [`crate::runtime::refresh_watch`]: that classifier feeds
+//! runtime refresh. This module only asks the sync scheduler to fire.
+//!
+//! ## Acceptance (Obsidian → push)
+//!
+//! Obsidian (or any editor) saves under `<content root>/knowledge`. Surviving
+//! events call [`SyncDispatcher::trigger_sync`] with [`Trigger::Local`], which
+//! opens the scheduler's fixed **2s** coalescing window (never reset by further
+//! keystrokes). After the window + Local floor (5s from last tick end), a tick
+//! runs and pushes. With the app closed, headless daemon still sees the save.
+//!
+//! `node_modules/` (and other ignore rules) cannot limit `notify`'s recursive
+//! registration. Events under ignored subtrees are dropped; if the OS watcher
+//! errors (e.g. Linux inotify exhaustion), we `warn!` once, stop watching that
+//! team, and rely on the 300s timer — the daemon keeps running.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::{Mutex, OnceLock};
+use std::time::{Duration, Instant};
+
+use notify::{Config, Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
+use tokio::time::MissedTickBehavior;
+use tracing::warn;
+
+use crate::sync::dispatch::SyncDispatcher;
+use crate::sync::oss::ignore_rules::IgnoreRules;
+use crate::sync::scheduler::Trigger;
+
+/// How often we re-arm watches for roots that appear after spawn (team join /
+/// re-onboard creating `knowledge/`).
+const WATCH_RECONCILE_INTERVAL: Duration = Duration::from_secs(2);
+
+/// Pull-written paths are ignored by the watcher for this long.
+const PULL_WRITE_SUPPRESS: Duration = Duration::from_secs(3);
+
+static PULL_WRITES: OnceLock<Mutex<PullWriteSuppress>> = OnceLock::new();
+
+fn pull_writes() -> &'static Mutex<PullWriteSuppress> {
+    PULL_WRITES.get_or_init(|| Mutex::new(PullWriteSuppress::new()))
+}
+
+/// Record that pull just wrote `rel_path` (content-root relative, e.g.
+/// `knowledge/notes/a.md`). Events on that path within 3s are dropped.
+pub fn record_pull_write(team_id: &str, rel_path: &str) {
+    let mut guard = pull_writes()
+        .lock()
+        .unwrap_or_else(|e| e.into_inner());
+    guard.record(team_id, rel_path, Instant::now());
+}
+
+/// Test / internal: clear all recorded pull writes.
+#[cfg(test)]
+fn clear_pull_writes() {
+    let mut guard = pull_writes()
+        .lock()
+        .unwrap_or_else(|e| e.into_inner());
+    *guard = PullWriteSuppress::new();
+}
+
+/// Per-path pull self-write suppression (not a blanket time window).
+#[derive(Debug, Default)]
+pub struct PullWriteSuppress {
+    /// team_id → (rel_path → written_at)
+    by_team: HashMap<String, HashMap<String, Instant>>,
+}
+
+impl PullWriteSuppress {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn record(&mut self, team_id: &str, rel_path: &str, now: Instant) {
+        self.by_team
+            .entry(team_id.to_string())
+            .or_default()
+            .insert(normalize_rel(rel_path), now);
+    }
+
+    pub fn is_suppressed(&mut self, team_id: &str, rel_path: &str, now: Instant) -> bool {
+        let Some(paths) = self.by_team.get_mut(team_id) else {
+            return false;
+        };
+        paths.retain(|_, at| now.duration_since(*at) < PULL_WRITE_SUPPRESS);
+        if paths.is_empty() {
+            self.by_team.remove(team_id);
+            return false;
+        }
+        paths.contains_key(&normalize_rel(rel_path))
+    }
+}
+
+fn normalize_rel(rel: &str) -> String {
+    rel.replace('\\', "/")
+}
+
+/// Access events are noise for sync (opens/reads).
+fn is_relevant_event(kind: &EventKind) -> bool {
+    !matches!(kind, EventKind::Access(_))
+}
+
+/// Map an absolute OS path to a content-root-relative path, if under the root.
+pub fn rel_under_content_root(content_root: &Path, abs: &Path) -> Option<String> {
+    if let Ok(rel) = abs.strip_prefix(content_root) {
+        let s = normalize_rel(&rel.to_string_lossy());
+        if !s.is_empty() {
+            return Some(s);
+        }
+    }
+    let root = content_root
+        .canonicalize()
+        .unwrap_or_else(|_| content_root.to_path_buf());
+    let path = abs.canonicalize().unwrap_or_else(|_| abs.to_path_buf());
+    path.strip_prefix(&root).ok().and_then(|rel| {
+        let s = normalize_rel(&rel.to_string_lossy());
+        (!s.is_empty()).then_some(s)
+    })
+}
+
+/// Whether a filesystem event should schedule a Local sync trigger.
+///
+/// Returns `false` for ignored subtrees, pull-written paths within 3s, and
+/// paths outside `knowledge/`.
+pub fn should_schedule_local(
+    team_id: &str,
+    content_root: &Path,
+    abs_path: &Path,
+    rules: &IgnoreRules,
+    suppress: &mut PullWriteSuppress,
+    now: Instant,
+) -> bool {
+    let Some(rel) = rel_under_content_root(content_root, abs_path) else {
+        return false;
+    };
+    if !rel.starts_with("knowledge/") && rel != "knowledge" {
+        return false;
+    }
+    // Hard-skip like the scanner — not via IgnoreRules (a team `!.conflicts/`
+    // must not re-open this tree for watch either).
+    if crate::sync::oss::conflict::is_under_conflicts_dir(&rel) {
+        return false;
+    }
+    if rules.is_ignored_with_ancestors(&rel) {
+        return false;
+    }
+    if suppress.is_suppressed(team_id, &rel, now) {
+        return false;
+    }
+    true
+}
+
+#[derive(Debug)]
+enum WatchMsg {
+    Path(PathBuf),
+    /// OS watcher runtime failure — stop this team's watch.
+    Error(String),
+}
+
+/// Spawn a knowledge-dir watcher for `team_id`. Failures warn once and exit the
+/// task; the 300s timer remains the fallback. Never panics the daemon.
+pub fn spawn(dispatcher: SyncDispatcher, team_id: String) {
+    let team_id = team_id.trim().to_string();
+    if team_id.is_empty() {
+        tracing::debug!("knowledge watch not started: daemon is not onboarded to a team");
+        return;
+    }
+    tokio::spawn(async move {
+        run_watch_loop(dispatcher, team_id).await;
+    });
+}
+
+async fn run_watch_loop(dispatcher: SyncDispatcher, team_id: String) {
+    let content_root = crate::config::global_team_store::sync_content_root(&team_id);
+    let knowledge_root = content_root.join("knowledge");
+
+    let (event_tx, mut event_rx) = tokio::sync::mpsc::unbounded_channel::<WatchMsg>();
+    let mut watcher = match RecommendedWatcher::new(
+        move |result: notify::Result<Event>| match result {
+            Ok(event) => {
+                if !is_relevant_event(&event.kind) {
+                    return;
+                }
+                for path in event.paths {
+                    let _ = event_tx.send(WatchMsg::Path(path));
+                }
+            }
+            Err(error) => {
+                let _ = event_tx.send(WatchMsg::Error(error.to_string()));
+            }
+        },
+        Config::default(),
+    ) {
+        Ok(w) => w,
+        Err(error) => {
+            warn!(
+                team_id = %team_id,
+                %error,
+                "failed to create knowledge filesystem watcher; relying on 300s timer"
+            );
+            return;
+        }
+    };
+
+    let mut watched = false;
+    let mut reconcile = tokio::time::interval(WATCH_RECONCILE_INTERVAL);
+    reconcile.set_missed_tick_behavior(MissedTickBehavior::Skip);
+    // Reload ignore rules periodically so a new `.amuxignore` takes effect
+    // without a daemon restart. Cheap: one file read every reconcile.
+    let mut rules = IgnoreRules::load(&content_root);
+
+    if reconcile_arm(
+        &mut watcher,
+        &mut watched,
+        &mut rules,
+        &content_root,
+        &knowledge_root,
+        &team_id,
+    ) == ArmOutcome::Stop
+    {
+        return;
+    }
+
+    loop {
+        tokio::select! {
+            _ = reconcile.tick() => {
+                if reconcile_arm(
+                    &mut watcher,
+                    &mut watched,
+                    &mut rules,
+                    &content_root,
+                    &knowledge_root,
+                    &team_id,
+                ) == ArmOutcome::Stop
+                {
+                    return;
+                }
+            }
+            msg = event_rx.recv() => {
+                match msg {
+                    None => return,
+                    Some(WatchMsg::Error(error)) => {
+                        warn!(
+                            team_id = %team_id,
+                            %error,
+                            "knowledge filesystem watcher error; stopping watch, relying on 300s timer"
+                        );
+                        return;
+                    }
+                    Some(WatchMsg::Path(path)) => {
+                        let should = {
+                            let mut suppress = pull_writes()
+                                .lock()
+                                .unwrap_or_else(|e| e.into_inner());
+                            should_schedule_local(
+                                &team_id,
+                                &content_root,
+                                &path,
+                                &rules,
+                                &mut suppress,
+                                Instant::now(),
+                            )
+                        };
+                        if should {
+                            dispatcher
+                                .trigger_sync(&team_id, Trigger::Local)
+                                .await;
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn reconcile_arm(
+    watcher: &mut RecommendedWatcher,
+    watched: &mut bool,
+    rules: &mut IgnoreRules,
+    content_root: &Path,
+    knowledge_root: &Path,
+    team_id: &str,
+) -> ArmOutcome {
+    *rules = IgnoreRules::load(content_root);
+    if knowledge_root.is_dir() {
+        if !*watched {
+            match watcher.watch(knowledge_root, RecursiveMode::Recursive) {
+                Ok(()) => {
+                    *watched = true;
+                    tracing::debug!(
+                        team_id = %team_id,
+                        path = %knowledge_root.display(),
+                        "armed knowledge filesystem watch"
+                    );
+                }
+                Err(error) => {
+                    warn!(
+                        team_id = %team_id,
+                        path = %knowledge_root.display(),
+                        %error,
+                        "failed to arm knowledge watch; relying on 300s timer"
+                    );
+                    // Permanent stop for this team — no retry loop.
+                    return ArmOutcome::Stop;
+                }
+            }
+        }
+    } else if *watched {
+        let _ = watcher.unwatch(knowledge_root);
+        *watched = false;
+    }
+    ArmOutcome::Continue
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ArmOutcome {
+    Continue,
+    Stop,
+}
+
+/// Pure helper for tests: apply a batch of paths and collect which would schedule.
+#[cfg(test)]
+fn scheduled_for_paths(
+    team_id: &str,
+    content_root: &Path,
+    paths: &[PathBuf],
+    rules: &IgnoreRules,
+    suppress: &mut PullWriteSuppress,
+    now: Instant,
+) -> Vec<PathBuf> {
+    paths
+        .iter()
+        .filter(|p| should_schedule_local(team_id, content_root, p, rules, suppress, now))
+        .cloned()
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::Arc;
+
+    #[test]
+    fn ignored_subtree_storm_schedules_nothing() {
+        let dir = tempfile::tempdir().unwrap();
+        let content_root = dir.path();
+        std::fs::create_dir_all(content_root.join("knowledge/node_modules/pkg")).unwrap();
+        let rules = IgnoreRules::load(content_root);
+        let mut suppress = PullWriteSuppress::new();
+        let now = Instant::now();
+
+        let storm: Vec<PathBuf> = (0..200)
+            .map(|i| {
+                content_root.join(format!(
+                    "knowledge/node_modules/pkg/file-{i}.js"
+                ))
+            })
+            .collect();
+
+        let scheduled = scheduled_for_paths(
+            "team-storm",
+            content_root,
+            &storm,
+            &rules,
+            &mut suppress,
+            now,
+        );
+        assert!(
+            scheduled.is_empty(),
+            "ignored subtree must not schedule Local triggers, got {}",
+            scheduled.len()
+        );
+
+        // A real note beside the ignored tree still schedules.
+        let note = content_root.join("knowledge/notes/hello.md");
+        assert!(should_schedule_local(
+            "team-storm",
+            content_root,
+            &note,
+            &rules,
+            &mut suppress,
+            now,
+        ));
+    }
+
+    #[test]
+    fn pull_written_paths_suppressed_but_foreign_path_schedules() {
+        let dir = tempfile::tempdir().unwrap();
+        let content_root = dir.path();
+        std::fs::create_dir_all(content_root.join("knowledge")).unwrap();
+        let rules = IgnoreRules::load(content_root);
+        let mut suppress = PullWriteSuppress::new();
+        let now = Instant::now();
+        let team = "team-pull";
+
+        // Pull wrote these two files.
+        suppress.record(team, "knowledge/from-remote-a.md", now);
+        suppress.record(team, "knowledge/from-remote-b.md", now);
+
+        let pulled_a = content_root.join("knowledge/from-remote-a.md");
+        let pulled_b = content_root.join("knowledge/from-remote-b.md");
+        let foreign = content_root.join("knowledge/user-edit.md");
+
+        assert!(
+            !should_schedule_local(team, content_root, &pulled_a, &rules, &mut suppress, now),
+            "pull-written path within 3s must not schedule"
+        );
+        assert!(
+            !should_schedule_local(
+                team,
+                content_root,
+                &pulled_b,
+                &rules,
+                &mut suppress,
+                now + Duration::from_secs(2),
+            ),
+            "pull-written path still within 3s must not schedule"
+        );
+        assert!(
+            should_schedule_local(team, content_root, &foreign, &rules, &mut suppress, now),
+            "a foreign path during the same pull must still schedule"
+        );
+
+        // After the window, pull-written paths schedule again.
+        assert!(should_schedule_local(
+            team,
+            content_root,
+            &pulled_a,
+            &rules,
+            &mut suppress,
+            now + Duration::from_secs(4),
+        ));
+    }
+
+    #[test]
+    fn watcher_error_stops_team_without_panic() {
+        // Mimic the production failure path: an Error message ends the watch
+        // loop cleanly. The AtomicBool stands in for "daemon still running".
+        let alive = Arc::new(AtomicBool::new(true));
+        let alive_flag = alive.clone();
+
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<WatchMsg>();
+        tx.send(WatchMsg::Error("inotify watch limit reached".into()))
+            .unwrap();
+        drop(tx);
+
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        runtime.block_on(async move {
+            // Same control flow as run_watch_loop's Error arm.
+            match rx.recv().await {
+                Some(WatchMsg::Error(error)) => {
+                    warn!(%error, "knowledge filesystem watcher error (test)");
+                    // stop watching — do not panic, do not retry
+                }
+                other => panic!("expected Error, got {other:?}"),
+            }
+            assert!(
+                alive_flag.load(Ordering::SeqCst),
+                "daemon liveness flag must remain set after watcher error"
+            );
+        });
+        assert!(alive.load(Ordering::SeqCst));
+    }
+
+    #[test]
+    fn access_events_are_not_relevant() {
+        assert!(!is_relevant_event(&EventKind::Access(
+            notify::event::AccessKind::Read
+        )));
+        assert!(is_relevant_event(&EventKind::Modify(
+            notify::event::ModifyKind::Data(notify::event::DataChange::Any)
+        )));
+        assert!(is_relevant_event(&EventKind::Create(
+            notify::event::CreateKind::File
+        )));
+    }
+
+    #[test]
+    fn global_record_pull_write_feeds_suppress_check() {
+        clear_pull_writes();
+        let dir = tempfile::tempdir().unwrap();
+        let content_root = dir.path();
+        std::fs::create_dir_all(content_root.join("knowledge")).unwrap();
+        let rules = IgnoreRules::load(content_root);
+        let team = "team-global";
+        record_pull_write(team, "knowledge/pulled.md");
+
+        let suppressed = {
+            let mut guard = pull_writes().lock().unwrap();
+            !should_schedule_local(
+                team,
+                content_root,
+                &content_root.join("knowledge/pulled.md"),
+                &rules,
+                &mut guard,
+                Instant::now(),
+            )
+        };
+        assert!(suppressed, "global record_pull_write must suppress the path");
+        clear_pull_writes();
+    }
+
+    #[test]
+    fn desired_knowledge_root_is_content_root_knowledge() {
+        let dir = tempfile::tempdir().unwrap();
+        let content = dir.path().join("shared");
+        let knowledge = content.join("knowledge");
+        std::fs::create_dir_all(&knowledge).unwrap();
+        assert!(knowledge.is_dir());
+        assert_eq!(
+            content.join("knowledge"),
+            knowledge,
+            "watch root must be <content root>/knowledge"
+        );
+    }
+}

--- a/apps/daemon/src/sync/watch.rs
+++ b/apps/daemon/src/sync/watch.rs
@@ -48,6 +48,10 @@ fn pull_writes() -> &'static Mutex<PullWriteSuppress> {
 /// Record that pull is about to write `rel_path` (content-root relative, e.g.
 /// `knowledge/notes/a.md`). Events on that path within 3s are dropped.
 ///
+/// Records the ancestor directories too: pull calls `create_dir_all` for the
+/// parent, and the Create events for freshly materialized directories would
+/// otherwise schedule a Local trigger and cost the receiver a no-op push tick.
+///
 /// **Ordering contract:** callers MUST invoke this *before* `create_dir_all` /
 /// `fs::write` for that path. Recording after the write races the OS watcher:
 /// inotify can deliver a Local trigger before the suppress entry exists.
@@ -55,7 +59,7 @@ pub fn record_pull_write(team_id: &str, rel_path: &str) {
     let mut guard = pull_writes()
         .lock()
         .unwrap_or_else(|e| e.into_inner());
-    guard.record(team_id, rel_path, Instant::now());
+    guard.record_with_parents(team_id, rel_path, Instant::now());
 }
 
 /// Test / internal: clear all recorded pull writes.
@@ -79,11 +83,35 @@ impl PullWriteSuppress {
         Self::default()
     }
 
+    /// Record one path. Expired entries for this team are dropped on the way in,
+    /// so the map stays bounded by "paths written in the last 3s" even when the
+    /// watch loop is not running to call [`Self::is_suppressed`] (watcher failed
+    /// to arm, inotify exhausted, `knowledge/` never created) while the 300s
+    /// timer keeps pulling.
     pub fn record(&mut self, team_id: &str, rel_path: &str, now: Instant) {
-        self.by_team
-            .entry(team_id.to_string())
-            .or_default()
-            .insert(normalize_rel(rel_path), now);
+        let paths = self.by_team.entry(team_id.to_string()).or_default();
+        paths.retain(|_, at| now.duration_since(*at) < PULL_WRITE_SUPPRESS);
+        paths.insert(normalize_rel(rel_path), now);
+    }
+
+    /// Record `rel_path` and every ancestor directory under the content root.
+    ///
+    /// `knowledge/projects/alpha/a.md` also records `knowledge/projects/alpha`,
+    /// `knowledge/projects` and `knowledge` — the directories `create_dir_all`
+    /// materializes during a pull. Suppressing the directory does not hide a
+    /// user's concurrent edit: inotify reports a new file at its own path, not
+    /// at its parent's.
+    pub fn record_with_parents(&mut self, team_id: &str, rel_path: &str, now: Instant) {
+        let rel = normalize_rel(rel_path);
+        self.record(team_id, &rel, now);
+        let mut cursor = rel.as_str();
+        while let Some((parent, _)) = cursor.rsplit_once('/') {
+            if parent.is_empty() {
+                break;
+            }
+            self.record(team_id, parent, now);
+            cursor = parent;
+        }
     }
 
     pub fn is_suppressed(&mut self, team_id: &str, rel_path: &str, now: Instant) -> bool {
@@ -149,13 +177,35 @@ pub fn should_schedule_local(
     if crate::sync::oss::conflict::is_under_conflicts_dir(&rel) {
         return false;
     }
-    if rules.is_ignored_with_ancestors(&rel) {
+    if is_ignored_for_event(rules, &rel, abs_path) {
         return false;
     }
     if suppress.is_suppressed(team_id, &rel, now) {
         return false;
     }
     true
+}
+
+/// Ignore test for a filesystem *event*, which may name a directory.
+///
+/// [`IgnoreRules::is_ignored_with_ancestors`] evaluates the leaf as a file
+/// (`is_dir = false`) — right for the tombstone and pull callers, which only
+/// ever hold file paths. A watch event can name the ignored directory itself,
+/// and `node_modules/` is directory-only under gitignore semantics, so the leaf
+/// check alone lets `Create(knowledge/repo/node_modules)` through.
+///
+/// A path that has already vanished (Remove) is treated as a directory: a
+/// removed *file* named exactly `node_modules` is not a thing, and dropping
+/// that event only defers the delete to the 300s timer.
+fn is_ignored_for_event(rules: &IgnoreRules, rel: &str, abs_path: &Path) -> bool {
+    if rules.is_ignored_with_ancestors(rel) {
+        return true;
+    }
+    let treat_as_dir = match std::fs::metadata(abs_path) {
+        Ok(meta) => meta.is_dir(),
+        Err(_) => true,
+    };
+    treat_as_dir && rules.is_ignored(rel, true)
 }
 
 #[derive(Debug)]
@@ -213,14 +263,18 @@ async fn run_watch_loop(dispatcher: SyncDispatcher, team_id: String) {
     let mut watched = false;
     let mut reconcile = tokio::time::interval(WATCH_RECONCILE_INTERVAL);
     reconcile.set_missed_tick_behavior(MissedTickBehavior::Skip);
-    // Reload ignore rules periodically so a new `.amuxignore` takes effect
-    // without a daemon restart. Cheap: one file read every reconcile.
+    // Reload ignore rules when they change, so a new `.amuxignore` takes effect
+    // without a daemon restart — gated on a stat fingerprint, not rebuilt every
+    // tick. Stamp first: a rule file edited between the stamp and the load leaves
+    // a stale stamp, which costs one extra reload rather than missing the edit.
+    let mut rules_stamp = rules_fingerprint(&content_root);
     let mut rules = IgnoreRules::load(&content_root);
 
     if reconcile_arm(
         &mut watcher,
         &mut watched,
         &mut rules,
+        &mut rules_stamp,
         &content_root,
         &knowledge_root,
         &team_id,
@@ -236,6 +290,7 @@ async fn run_watch_loop(dispatcher: SyncDispatcher, team_id: String) {
                     &mut watcher,
                     &mut watched,
                     &mut rules,
+                    &mut rules_stamp,
                     &content_root,
                     &knowledge_root,
                     &team_id,
@@ -281,15 +336,46 @@ async fn run_watch_loop(dispatcher: SyncDispatcher, team_id: String) {
     }
 }
 
+/// Cheap change-detector for the two on-disk rule files, so the 2s reconcile
+/// tick does not recompile the globset 30 times a minute forever.
+///
+/// `(len, mtime)` per file, `None` when absent. Missing → present, edited, and
+/// deleted all change the fingerprint.
+type RulesFingerprint = [Option<(u64, std::time::SystemTime)>; 2];
+
+fn rules_fingerprint(content_root: &Path) -> RulesFingerprint {
+    let stat = |p: PathBuf| {
+        std::fs::metadata(p)
+            .ok()
+            .and_then(|m| m.modified().ok().map(|t| (m.len(), t)))
+    };
+    [
+        stat(
+            content_root
+                .join("knowledge")
+                .join(crate::sync::oss::ignore_rules::TEAM_IGNORE_FILE),
+        ),
+        stat(content_root.join(crate::sync::oss::ignore_rules::LOCAL_IGNORE_FILE)),
+    ]
+}
+
 fn reconcile_arm(
     watcher: &mut RecommendedWatcher,
     watched: &mut bool,
     rules: &mut IgnoreRules,
+    rules_stamp: &mut RulesFingerprint,
     content_root: &Path,
     knowledge_root: &Path,
     team_id: &str,
 ) -> ArmOutcome {
-    *rules = IgnoreRules::load(content_root);
+    // Reload only when `.amuxignore` / `.syncignore.local` actually changed: a
+    // rebuild re-adds every builtin rule and recompiles the globset, and this
+    // runs on the same task that must stay responsive to fs events.
+    let stamp = rules_fingerprint(content_root);
+    if stamp != *rules_stamp {
+        *rules = IgnoreRules::load(content_root);
+        *rules_stamp = stamp;
+    }
     if knowledge_root.is_dir() {
         if !*watched {
             match watcher.watch(knowledge_root, RecursiveMode::Recursive) {
@@ -538,6 +624,119 @@ mod tests {
             !should_schedule_local(team, content_root, &abs, &rules, &mut suppress, now),
             "event arriving immediately after write must already be suppressed"
         );
+    }
+
+    /// Pull materializes `knowledge/projects/alpha/` — the Create events for the
+    /// two new directories must not schedule a Local tick (plan acceptance #9).
+    #[test]
+    fn pull_created_directories_are_suppressed() {
+        let dir = tempfile::tempdir().unwrap();
+        let content_root = dir.path();
+        std::fs::create_dir_all(content_root.join("knowledge/projects/alpha")).unwrap();
+        let rules = IgnoreRules::load(content_root);
+        let mut suppress = PullWriteSuppress::new();
+        let now = Instant::now();
+        let team = "team-dirs";
+
+        suppress.record_with_parents(team, "knowledge/projects/alpha/a.md", now);
+
+        for rel in [
+            "knowledge/projects/alpha/a.md",
+            "knowledge/projects/alpha",
+            "knowledge/projects",
+            "knowledge",
+        ] {
+            assert!(
+                !should_schedule_local(
+                    team,
+                    content_root,
+                    &content_root.join(rel),
+                    &rules,
+                    &mut suppress,
+                    now,
+                ),
+                "{rel} was written by pull and must not schedule"
+            );
+        }
+
+        // A note the user creates in the same tree during the pull still does.
+        assert!(should_schedule_local(
+            team,
+            content_root,
+            &content_root.join("knowledge/projects/alpha/mine.md"),
+            &rules,
+            &mut suppress,
+            now,
+        ));
+    }
+
+    /// The map must stay bounded even when the watch loop never runs, because
+    /// `is_suppressed` (the only other reaper) is then never called.
+    #[test]
+    fn record_prunes_expired_entries_without_the_watch_loop() {
+        let mut suppress = PullWriteSuppress::new();
+        let team = "team-leak";
+        let t0 = Instant::now();
+
+        for i in 0..500 {
+            suppress.record(team, &format!("knowledge/old-{i}.md"), t0);
+        }
+        // A later pull, after the suppress window: recording must drop the lot.
+        suppress.record(team, "knowledge/new.md", t0 + Duration::from_secs(10));
+
+        let held = suppress.by_team.get(team).map(|m| m.len()).unwrap_or(0);
+        assert_eq!(
+            held, 1,
+            "expired pull-write entries must be reaped on record, got {held}"
+        );
+    }
+
+    /// `node_modules/` is directory-only under gitignore semantics, so the
+    /// Create event for the directory itself needs the is_dir form.
+    #[test]
+    fn ignored_directory_event_itself_is_filtered() {
+        let dir = tempfile::tempdir().unwrap();
+        let content_root = dir.path();
+        let ignored_dir = content_root.join("knowledge/repo/node_modules");
+        std::fs::create_dir_all(&ignored_dir).unwrap();
+        let rules = IgnoreRules::load(content_root);
+        let mut suppress = PullWriteSuppress::new();
+        let now = Instant::now();
+
+        assert!(
+            !should_schedule_local(
+                "team-dir-ignore",
+                content_root,
+                &ignored_dir,
+                &rules,
+                &mut suppress,
+                now,
+            ),
+            "Create on the ignored directory itself must not schedule"
+        );
+
+        // Removed (already gone) ignored directory: same answer.
+        let gone = content_root.join("knowledge/repo/target");
+        assert!(!should_schedule_local(
+            "team-dir-ignore",
+            content_root,
+            &gone,
+            &rules,
+            &mut suppress,
+            now,
+        ));
+
+        // An ordinary directory still schedules.
+        let real = content_root.join("knowledge/repo/notes");
+        std::fs::create_dir_all(&real).unwrap();
+        assert!(should_schedule_local(
+            "team-dir-ignore",
+            content_root,
+            &real,
+            &rules,
+            &mut suppress,
+            now,
+        ));
     }
 
     #[test]

--- a/apps/daemon/src/sync/watch.rs
+++ b/apps/daemon/src/sync/watch.rs
@@ -15,6 +15,9 @@
 //! registration. Events under ignored subtrees are dropped; if the OS watcher
 //! errors (e.g. Linux inotify exhaustion), we `warn!` once, stop watching that
 //! team, and rely on the 300s timer — the daemon keeps running.
+//!
+//! Pull self-writes: [`record_pull_write`] must run *before* `create_dir_all` /
+//! `fs::write`, or inotify can schedule Local before the path is suppressed.
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
@@ -42,8 +45,12 @@ fn pull_writes() -> &'static Mutex<PullWriteSuppress> {
     PULL_WRITES.get_or_init(|| Mutex::new(PullWriteSuppress::new()))
 }
 
-/// Record that pull just wrote `rel_path` (content-root relative, e.g.
+/// Record that pull is about to write `rel_path` (content-root relative, e.g.
 /// `knowledge/notes/a.md`). Events on that path within 3s are dropped.
+///
+/// **Ordering contract:** callers MUST invoke this *before* `create_dir_all` /
+/// `fs::write` for that path. Recording after the write races the OS watcher:
+/// inotify can deliver a Local trigger before the suppress entry exists.
 pub fn record_pull_write(team_id: &str, rel_path: &str) {
     let mut guard = pull_writes()
         .lock()
@@ -503,6 +510,34 @@ mod tests {
         };
         assert!(suppressed, "global record_pull_write must suppress the path");
         clear_pull_writes();
+    }
+
+    /// Ordering contract: suppress must be registered *before* the write
+    /// returns, so an inotify event that races the write await is already
+    /// covered. Simulates: record → (write returns / event arrives) → filter.
+    ///
+    /// Uses a local suppress map (not the process-global) so parallel test
+    /// binaries cannot clear the entry mid-assert.
+    #[test]
+    fn record_before_write_covers_immediate_post_write_event() {
+        let dir = tempfile::tempdir().unwrap();
+        let content_root = dir.path();
+        let rel = "knowledge/race.md";
+        let abs = content_root.join(rel);
+        std::fs::create_dir_all(content_root.join("knowledge")).unwrap();
+        let rules = IgnoreRules::load(content_root);
+        let team = "team-race";
+        let mut suppress = PullWriteSuppress::new();
+        let now = Instant::now();
+
+        // Production order in engine.rs: record, then create_dir_all / write.
+        suppress.record(team, rel, now);
+        std::fs::write(&abs, b"from-pull").unwrap();
+
+        assert!(
+            !should_schedule_local(team, content_root, &abs, &rules, &mut suppress, now),
+            "event arriving immediately after write must already be suppressed"
+        );
     }
 
     #[test]

--- a/crates/teamclu-transport/src/publisher.rs
+++ b/crates/teamclu-transport/src/publisher.rs
@@ -37,6 +37,17 @@ pub trait MessagePublisher: Send + Sync {
         delivery: DeliveryGuarantee,
     ) -> Result<(), PublisherError>;
 
+    /// Best-effort subscribe. Default: same as [`Self::subscribe`].
+    /// MQTT supervisor overrides this so broker ACL rejection does not rebuild
+    /// the worker (used for `amux/<team>/sync/+` before ACL migration lands).
+    async fn subscribe_optional(
+        &self,
+        topic: &str,
+        delivery: DeliveryGuarantee,
+    ) -> Result<(), PublisherError> {
+        self.subscribe(topic, delivery).await
+    }
+
     async fn unsubscribe(&self, topic: &str) -> Result<(), PublisherError>;
 }
 

--- a/crates/teamclu-types/src/mqtt.rs
+++ b/crates/teamclu-types/src/mqtt.rs
@@ -75,6 +75,11 @@ impl Topics {
     pub fn sync(&self, resource: &str) -> String {
         sync_topic(&self.team_id, resource)
     }
+
+    /// Wildcard covering every sync resource: `amux/<team>/sync/+`.
+    pub fn sync_wildcard(&self) -> String {
+        sync_wildcard(&self.team_id)
+    }
 }
 
 pub fn session_live(team_id: &str, session_id: &str) -> String {
@@ -93,6 +98,11 @@ pub fn sync_topic(team_id: &str, resource: &str) -> String {
     format!("amux/{team_id}/sync/{resource}")
 }
 
+/// Subscribe filter for all sync resources under a team.
+pub fn sync_wildcard(team_id: &str) -> String {
+    format!("amux/{team_id}/sync/+")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -103,6 +113,7 @@ mod tests {
         assert_eq!(actor_state("t1", "d1"), "amux/t1/d1/state");
         // Resource segment last so ACL `amux/%s/sync/+` covers future resources.
         assert_eq!(sync_topic("TEAM", "knowledge"), "amux/TEAM/sync/knowledge");
+        assert_eq!(sync_wildcard("TEAM"), "amux/TEAM/sync/+");
     }
 
     #[test]
@@ -131,5 +142,6 @@ mod tests {
             "amux/team1/user/actor-xyz/notify"
         );
         assert_eq!(t.sync("knowledge"), "amux/team1/sync/knowledge");
+        assert_eq!(t.sync_wildcard(), "amux/team1/sync/+");
     }
 }

--- a/crates/teamclu-types/src/mqtt.rs
+++ b/crates/teamclu-types/src/mqtt.rs
@@ -70,6 +70,11 @@ impl Topics {
     pub fn user_notify(&self, actor_id: &str) -> String {
         format!("amux/{}/user/{}/notify", self.team_id, actor_id)
     }
+
+    /// Team-scoped sync hint topic for a resource (resource segment last).
+    pub fn sync(&self, resource: &str) -> String {
+        sync_topic(&self.team_id, resource)
+    }
 }
 
 pub fn session_live(team_id: &str, session_id: &str) -> String {
@@ -80,6 +85,14 @@ pub fn actor_state(team_id: &str, actor_id: &str) -> String {
     format!("amux/{team_id}/{actor_id}/state")
 }
 
+/// Sync hint topic: `amux/<team_id>/sync/<resource>`.
+///
+/// Resource is the last segment so a single ACL `amux/%s/sync/+` covers every
+/// future resource without migration. Mirrored in FC (`mqtt-topics.ts`).
+pub fn sync_topic(team_id: &str, resource: &str) -> String {
+    format!("amux/{team_id}/sync/{resource}")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -88,6 +101,8 @@ mod tests {
     fn shared_topic_functions_match_wire_paths() {
         assert_eq!(session_live("t1", "s1"), "amux/t1/session/s1/live");
         assert_eq!(actor_state("t1", "d1"), "amux/t1/d1/state");
+        // Resource segment last so ACL `amux/%s/sync/+` covers future resources.
+        assert_eq!(sync_topic("TEAM", "knowledge"), "amux/TEAM/sync/knowledge");
     }
 
     #[test]
@@ -115,5 +130,6 @@ mod tests {
             t.user_notify("actor-xyz"),
             "amux/team1/user/actor-xyz/notify"
         );
+        assert_eq!(t.sync("knowledge"), "amux/team1/sync/knowledge");
     }
 }

--- a/deploy/self-host/.env.example
+++ b/deploy/self-host/.env.example
@@ -32,6 +32,9 @@ CADDY_SITE_SCHEME=
 # the built-in 50000, which a knowledge base nobody has dropped a repo into does
 # not approach — a single node_modules passes it on its own.
 #SYNC_MAX_FILES_PER_TEAM=50000
+# Same backstop for total live-file bytes (sum of amuxc_files.size). Unset uses
+# 2 GiB. Counts current pointers only — not historical version blobs on disk.
+#SYNC_MAX_BYTES_PER_TEAM=2147483648
 #SKILLS_STORAGE_BUCKET=team-skills
 
 # ── system / docker integration ────────────────────────────────────────

--- a/deploy/self-host/docker-compose.yml
+++ b/deploy/self-host/docker-compose.yml
@@ -298,6 +298,9 @@ services:
       # team may hold. Unset uses the built-in 50000. Raise it for a team that
       # legitimately grows into it — see services/fc/src/lib/sync-guards.ts.
       SYNC_MAX_FILES_PER_TEAM: "${SYNC_MAX_FILES_PER_TEAM:-}"
+      # Same backstop for total live-file bytes (amuxc_files.size sum). Unset
+      # uses 2 GiB. Not disk protection — historical version blobs are separate.
+      SYNC_MAX_BYTES_PER_TEAM: "${SYNC_MAX_BYTES_PER_TEAM:-}"
       # MinIO addresses buckets by path; virtual-host style would need per-bucket
       # DNS. Alibaba OSS works either way, so this stays blank there.
       S3_FORCE_PATH_STYLE: "${S3_FORCE_PATH_STYLE:-}"

--- a/docs/adr/0008-knowledge-sync-p0-p1-scope.md
+++ b/docs/adr/0008-knowledge-sync-p0-p1-scope.md
@@ -106,6 +106,16 @@ Knowledge 同步是**团队 Markdown vault 的云副本**，不是通用网盘�
    的 10s 缓存（一个 200 条 batch 最坏超出 200 × 25 MiB = 5 GiB，比配额还大）；
    不做跨请求 in-flight 计数。写入 compose / `s.yaml` / `.env.example` 三处
    （`deploy-env-parity.test.ts` 守着，且要求源码里真的读了它）。
+
+   **运行累加只对新增路径计费，且只在该 item 成功之后计。** 这条是本 ADR 第一版漏
+   写、代码照做之后被 review 抓出来的：一次编辑的旧字节**本来就在 sum 里**，再按全量
+   size 计一遍等于把同一个文件数了两次——一个 50/100 的团队改三篇 30 字节的笔记就会
+   在第 2 条上撞 422，而这三条全部写完总量根本没变；被拒的 item（`IgnoredPath`、CAS
+   失败）更是从来不会变成字节，却把额度花掉、连累同一 batch 里后面所有合法笔记。
+   判据用请求体里现成的 `parentVersion`：`0` = 新路径，计费；`> 0` = 编辑，计 0。
+   代价是一个**有界的少算**——编辑让文件变大的那部分要等下一次调用重读 sum 才算得上，
+   所以超收上限就是一个 batch（≤200 条）。对一道专防病态批量新增的闸门，这是正确的
+   方向：**配额可以让一个 batch 冲过头，但绝不能误挡**（§4.7「配额不会误挡」）。
    **配额 ≠ 磁盘保护**：物理占用还含历史版本 blob，依赖 `oss_sync_gc_orphan_blobs`
    的 FC cron，而 cron 是 compose 独立 profile，self-host 未开。GC 启用单开 ops
    ticket，不进本路线图；ticket 关闭前对外不说「磁盘安全」。

--- a/docs/adr/0008-knowledge-sync-p0-p1-scope.md
+++ b/docs/adr/0008-knowledge-sync-p0-p1-scope.md
@@ -36,18 +36,17 @@ Knowledge 同步是**团队 Markdown vault 的云副本**，不是通用网盘�
 
 ## 安全叙事（与实现对齐）
 
-现行引擎对 knowledge **明文上传**：`apps/daemon/src/sync/oss/engine.rs:552-575`
+现行引擎对 knowledge **明文上传**：`apps/daemon/src/sync/oss/engine.rs`
 `prepare_upload` 里 `cipher_hash == plain_hash`，字节原样上去。`crypto.rs` 只剩两个
 用途：读切换前写入的 AES-GCM 旧 blob，和本地 `state/secrets.enc`。团队 secret 已不是
-同步的前置条件（`dispatch.rs:198-205`：fetched, not required）。
+同步的前置条件（`dispatch.rs` `run_once`：fetched, not required）。
 
 对内对外统一表述为：**服务端与对象存储可读的团队共享盘**；TLS 保护传输，不是端
 到端加密。因此：
 
-1. 修正残留的「加密 / E2E」表述。本 PR：`obsidian-compatible-knowledge.md` §2.1
-   「加密只发生在上传」一行、根 `CLAUDE.md`「无 secret → 没东西加解密 → skipped」
-   一段。实现 PR：前端 `cloudVersion.unreadable` 文案里「或用本设备没有的团队密钥
-   加密」半句、`engine.rs` 里 `Stage 0: encrypt + hash` 的日志标签。
+1. 残留的「加密 / E2E」表述已清掉：`obsidian-compatible-knowledge.md` §2.1、
+   根 `CLAUDE.md`、前端 `cloudVersion.unreadable`、daemon `Stage 0` /
+   `[oss_sync] prepare` 日志标签（见 `fix(sync): drop leftover knowledge-encryption wording`）。
 2. MQTT sync hint **仍然禁止**携带路径、文件名、内容、内容哈希——路径本身敏感，
    broker 内可见。这是元数据最小化，不是假 E2E 洁癖。
 3. 真 E2E（含密钥分发）单独立项，不与本路线图绑定。

--- a/docs/adr/0008-knowledge-sync-p0-p1-scope.md
+++ b/docs/adr/0008-knowledge-sync-p0-p1-scope.md
@@ -1,0 +1,146 @@
+---
+status: accepted
+date: 2026-08-26
+---
+
+# Knowledge 同步：P0/P1 范围与产品锁
+
+本 ADR 冻结 2026-08-26 两轮 grill 的结论；第二轮逐条对照代码查证后修订了
+第一轮的几处事实错误（延迟数字、`.md` 已落地、重连「风暴」已退避、prepare 已批
+量）。实施细节见
+[`docs/plans/2026-08-26-knowledge-sync-p0-p1.md`](../plans/2026-08-26-knowledge-sync-p0-p1.md)。
+设计原文：
+
+- [`docs/architecture/knowledge-sync-push-notify.md`](../architecture/knowledge-sync-push-notify.md)
+- [`docs/architecture/obsidian-compatible-knowledge.md`](../architecture/obsidian-compatible-knowledge.md)
+
+## 产品定位
+
+Knowledge 同步是**团队 Markdown vault 的云副本**，不是通用网盘，也不是 Notion
+式协作文档。
+
+- 主写入面（战略）：**Obsidian** 直接打开
+  `~/.amuxd[-<brand>]/teams/<id>/shared/knowledge`
+- TeamClu：同步引擎 + Agent / RAG 消费同一棵树
+- 成功标准围绕「笔记秒级到齐、Obsidian 不当垃圾场」，不围绕大文件块级或行级 merge
+
+## 主痛点
+
+跨成员延迟。今日只有两个触发源：app 里的手动 Sync Now，和 daemon 的 **300s**
+定时器（`sync/timer.rs:21`）；app 内的本地编辑**不**触发 push
+（`use-team-cloud-sync.ts` 只是手动按钮）。A 的定时器与 B 的定时器相互独立，
+所以别人改完**最长约 10 分钟、平均约 5 分钟**才可见。
+
+**两条腿缺一不可。** 只做 fs 监听（我的出去）或只做 MQTT（别人的进来），各自
+只砍掉一半，平均降到 ~2.5 分钟，都到不了秒级。顺序只影响风险，不影响体感。
+
+## 安全叙事（与实现对齐）
+
+现行引擎对 knowledge **明文上传**：`apps/daemon/src/sync/oss/engine.rs:552-575`
+`prepare_upload` 里 `cipher_hash == plain_hash`，字节原样上去。`crypto.rs` 只剩两个
+用途：读切换前写入的 AES-GCM 旧 blob，和本地 `state/secrets.enc`。团队 secret 已不是
+同步的前置条件（`dispatch.rs:198-205`：fetched, not required）。
+
+对内对外统一表述为：**服务端与对象存储可读的团队共享盘**；TLS 保护传输，不是端
+到端加密。因此：
+
+1. 修正残留的「加密 / E2E」表述。本 PR：`obsidian-compatible-knowledge.md` §2.1
+   「加密只发生在上传」一行、根 `CLAUDE.md`「无 secret → 没东西加解密 → skipped」
+   一段。实现 PR：前端 `cloudVersion.unreadable` 文案里「或用本设备没有的团队密钥
+   加密」半句、`engine.rs` 里 `Stage 0: encrypt + hash` 的日志标签。
+2. MQTT sync hint **仍然禁止**携带路径、文件名、内容、内容哈希——路径本身敏感，
+   broker 内可见。这是元数据最小化，不是假 E2E 洁癖。
+3. 真 E2E（含密钥分发）单独立项，不与本路线图绑定。
+
+## 本路线图范围
+
+### 做（P0 — 协作体感）
+
+顺序按**风险从低到高**，每一项可独立对外：
+
+1. **`.conflicts/`**：冲突 sidecar 迁入 `knowledge/.conflicts/<镜像相对路径>`，
+   文件名格式不变。扫描器与 pull 侧**硬排除**该目录——不走 ignore 规则，不可被团队
+   `.amuxignore` 的 `!.conflicts/` 反向覆盖，与「`.amuxignore` 自身永不被忽略」同级。
+   旧 sidecar 扫描时本地搬入（它们从未上云，扫描器一直硬跳过，所以无广播、无迁移
+   风险）。前端剪掉该目录，并删除 `isConflictSidecarName` 的 `.includes('.conflict.')`
+   判定——它与 daemon 的数字时间戳判定不一致，`merge.conflict.md` 被树隐藏却照常同步。
+2. **Per-team 同步调度器 + knowledge 根 fs 监听**（daemon 内容根）。调度器两路
+   输入：`Local`（fs 事件）与 `Remote { seq }`（MQTT hint）；固定 2s 窗口**不重置**
+   （coalescing，不是 debounce）+ 从上一次 tick **结束**起算的地板：本地 5s、远端
+   15s，硬编码，不设「先采一周数据」门槛。300s 定时器与手动 Sync Now **不走**调度器
+   （定时器已有 in-flight 跳过；手动是用户意图，直接 force）。watcher 是 `sync/` 下
+   独立模块，不复用 `refresh_watch` 的 classifier；2s reconcile 处理晚出现的根目录；
+   创建失败或运行报错 warn 一次退回定时器，不重试；ignore 规则只过滤事件（管不了
+   `notify` 的递归注册）；pull 写过的路径 3s 内的事件丢弃（按路径集合，不按时间窗
+   全量压制，否则 pull 期间的真实编辑会被吞掉）。
+3. **FC 广播**：每次成功的 `complete-batch` / `delete-batch` 各发一条 hint 到
+   `amux/<team_id>/sync/knowledge`。**不做 500ms 合批定时器**——daemon 已按 200 一批
+   调用，每 tick 最多 10 条（2000 闸门），已经是「个位数不是 200」；去掉定时器顺带
+   解决 belayo（阿里云 FC 冻结实例 `setTimeout` 不触发）与多 origin 时 `originNodeId`
+   的歧义。`await` publish，500ms 超时只 warn，响应照常 200。先只发不收。
+4. **ACL**：`agent` 与 `member` 增加 `sub amux/<team>/sync/+`。**容错订阅是唯一
+   硬要求**：现状订阅被拒会一路 `Err` 到 `request_rebuild_for_generation`、CONNACK
+   后 restore 被拒会 `forced_rebuild`（#1073 之后是 5→30s 退避的 worker 重建循环，
+   不再是 100 次/秒，但会拖着 RPC / session-live 一起断）。所以订阅要带 `optional`
+   标记贯穿首次订阅与 restore：被拒只 warn 一次、不重建 worker、不影响其它订阅、
+   下次重连再试。token 3600s 轮换、daemon 到期前 5 min 主动重建，≤1h 自愈——
+   「先迁移、再发订阅端」降为**建议**，同批发布也可。注：Postgres/Better-Auth 后端
+   不产 `acl` claim、all-in-one（NanoMQ）无 ACL，这条迁移只对 Supabase 后端有意义，
+   别拿 all-in-one 验它。FC 自己的 service token 无 `acl` claim，发布端零改动。
+5. **Daemon 收端**：上传填 `node_id = daemon_device_id()`（现在四处都传 `None`，
+   字段连 wire 都不出现）；订阅 → 回声过滤（`originNodeId == self`）→ seq 比较 →
+   调度器 `Remote`。
+6. App **不**订阅 sync 主题；它已靠 Tauri `watch_directory` 的 `file-change` 事件
+   刷新树与角标（`FileBrowser.tsx` / `TeamShareListColumn.tsx`），daemon 落盘即可见。
+7. **不**改 300s 定时器间隔；它降级为兜底。
+
+延迟目标：**安静 ≤10s 端到端**（Obsidian A 保存 → Obsidian B 可见，含 A 侧 2s
+窗口 + push tick + hint + B 侧 2s 窗口 + pull tick + 两端 watcher）；繁忙 ≤ 地板
++ 一次 tick。
+
+### 做（P1 — 防炸与成本）
+
+1. 每 team **字节配额**：`SYNC_MAX_BYTES_PER_TEAM`，默认 **2 GiB**——self-host
+   MinIO 在根盘、余量个位数 GB，8 GiB 比整盘余量还大等于没保护。按 live 逻辑字节
+   算（CAS 去重后物理更小，偏严是安全方向）；422 `QuotaExceeded` + `kind: 'bytes'`，
+   与文件数配额同一错误形状；**batch 内一次 sum + 逐 item 运行累加**，不能照抄文件数
+   的 10s 缓存（一个 200 条 batch 最坏超出 200 × 25 MiB = 5 GiB，比配额还大）；
+   不做跨请求 in-flight 计数。写入 compose / `s.yaml` / `.env.example` 三处
+   （`deploy-env-parity.test.ts` 守着，且要求源码里真的读了它）。
+   **配额 ≠ 磁盘保护**：物理占用还含历史版本 blob，依赖 `oss_sync_gc_orphan_blobs`
+   的 FC cron，而 cron 是 compose 独立 profile，self-host 未开。GC 启用单开 ops
+   ticket，不进本路线图；ticket 关闭前对外不说「磁盘安全」。
+2. ~~Prepare 按 team 限速~~ **砍掉**。prepare 已按 200 批，合法 tick 只有 1 次调用；
+   旧客户端灌 `node_modules` 被文件数配额挡、字节被上一条挡，剩余动机只有 Postgres
+   行插入风暴。而 429 在 daemon 侧是 tick 内指数退避 5 次（~24s 持 per-team 锁）后
+   deferred 并**报红到 UI**，代价大于收益。
+
+### 明确不做（freeze）
+
+直到有用量或独立 RFC 之前：
+
+- 块级 / CDC 同步
+- 按需下载（Smart Sync）
+- Markdown 行级 merge / OT / CRDT
+- 「谁改了什么」活动流 UI（P0 只填 `nodeId` 供协议用）
+- 移动端 knowledge 同步
+- 文本压缩上传（明文路径需要新 wire；有流量证据再开）
+- Prepare 限速（见 P1 #2）
+- 重命名补 `.md`、无后缀旧文件的树上提示（单开 issue）
+- 拉长 300s 定时器（另 PR，且仅在推送稳定后）
+
+## 与既有实现的关系
+
+已落地、本 ADR 不重做：ignore 三层规则、25 MiB 单文件闸、每 tick 2000 新文件闸、
+服务端路径拒绝、每 team 文件数配额（默认 5 万）、**新建笔记默认 `.md`**
+（`3d6e8fd3`，`withDefaultExtension` 覆盖根与树内两处入口）、app 侧 fs watcher
+刷新、MQTT 认证被拒后的退避重建（#1073）。
+
+## 后果
+
+- 下个 session 不得把 P2/P3 悄悄拉回「同一波」。
+- `.conflicts/` 必须在 fs 监听**之前或同批**对外：Obsidian 用户先看到干净的库，
+  再看到快的库。
+- optional 订阅未过验收（订阅被拒不重建 worker、RPC 不断）前，禁止拉长定时器。
+- 字节配额上线不等于磁盘安全，GC ticket 关闭前不这么说。
+- 地板 5s / 15s、窗口 2s 是起点；调整走独立 PR 并附 tick 频率数据。

--- a/docs/architecture/knowledge-sync-push-notify.md
+++ b/docs/architecture/knowledge-sync-push-notify.md
@@ -1,6 +1,9 @@
 # 知识同步的推送通知（MQTT）
 
-> 状态：**设计，未实现**。
+> 状态：**设计，未实现**。范围与分期已由
+> [`docs/adr/0008-knowledge-sync-p0-p1-scope.md`](../adr/0008-knowledge-sync-p0-p1-scope.md)
+> 冻结；任务拆解见
+> [`docs/plans/2026-08-26-knowledge-sync-p0-p1.md`](../plans/2026-08-26-knowledge-sync-p0-p1.md)。
 >
 > 相关：`docs/architecture/obsidian-compatible-knowledge.md`（同一条同步链路上
 > 的另一批改动，其中「刀 4 文件监听」与本文互补，见 §2）。
@@ -8,16 +11,20 @@
 ## 1. 要解决的问题
 
 `knowledge/` 的同步目前有两个触发源：app 里的手动按钮，和 daemon 的 300 秒定时
-器（`apps/daemon/src/sync/timer.rs:21`）。也就是说：
+器（`apps/daemon/src/sync/timer.rs:21`）。app 内的本地编辑**不**触发 push
+（`use-team-cloud-sync.ts` 只是一个手动按钮）。A 的定时器和 B 的定时器互相独立，
+也就是说：
 
-> A 在自己机器上写完一篇笔记，B 最长要等 5 分钟才看得见。
+> A 在自己机器上写完一篇笔记，B 最长要等约 10 分钟、平均约 5 分钟才看得见。
 
 对一个「团队知识库」来说，这个延迟决定了它是不是一个能一起工作的东西。
 
-**文件监听只解决一半。** Obsidian 那份设计里的刀 4（给 knowledge 根挂 fs 监听）
-解决的是「我改的东西快点发出去」；本文解决的是「别人改的东西快点到我这」。后者
-才是协作体感的大头 —— 一个人改、其他所有人等，等的人数总是更多。两件事互补，
-都要做。
+**文件监听只解决一半，本文也只解决一半。** Obsidian 那份设计里的刀 4（给
+knowledge 根挂 fs 监听）解决的是「我改的东西快点发出去」；本文解决的是「别人改的
+东西快点到我这」。两条腿各占一个 300 秒定时器：只做任何一条，平均延迟从 ~5 分钟
+降到 ~2.5 分钟，都到不了秒级。两件事互补，都要做；**顺序按风险排**——fs 监听是
+纯 daemon 内代码、零 ACL 零 token 依赖，先上；本文这条要迁移 + 容错订阅，后上
+（ADR-0008）。
 
 ## 2. 为什么是 MQTT
 
@@ -59,7 +66,7 @@ amux/<team_id>/sync/<resource>
 
 **资源段放最后，不是放中间。** 直觉上会写成 `amux/<team>/knowledge/sync`，但那样
 每加一种资源（skills 注册表、团队 MCP 配置）都要改一次 ACL 规则 —— 而按 §7，改
-ACL 意味着一次迁移、等所有设备 token 刷新、并承担订阅被拒触发重连死循环的风险。
+ACL 意味着一次迁移、等设备 token 轮换、并承担订阅被拒触发 worker 重建循环的风险。
 资源段放最后，ACL 一条 `amux/%s/sync/+` 就永久覆盖，以后加资源**零迁移**。
 
 这条理由值得写下来，因为两种写法读起来一样自然，代价却差一个数量级。
@@ -101,16 +108,17 @@ ACL 意味着一次迁移、等所有设备 token 刷新、并承担订阅被拒
 | 字段 | 类型 | 必填 | 含义 |
 |---|---|---|---|
 | `v` | int | 是 | 报文版本。收到不认识的 `v` **整条丢弃**，不要尝试解析 |
-| `changeSeq` | int64 | 是 | 服务端此刻该 team 的最大 `change_seq`。收端拿它和本地 high-water 比 |
-| `originNodeId` | string \| null | 否 | 触发这次变更的设备。收端用它丢掉自己的回声（§6） |
+| `changeSeq` | int64 | 是 | 触发这条 hint 的那次 batch 调用推进到的最大 `change_seq`。收端拿它和本地 high-water 比 |
+| `originNodeId` | string \| null | 否 | 触发这次变更的设备（该次调用 body 里的 `nodeId`；一次调用只有一个来源，没有歧义）。收端用它丢掉自己的回声（§6） |
 | `at` | ISO-8601 string | 否 | 服务端时间。**仅用于日志**，不参与任何判断 |
 
 **报文里没有、且永远不能有的东西：文件路径、文件名、内容、内容哈希。**
 
-知识库是端到端加密的 —— 明文不出设备，FC 和对象存储都只见密文。但**路径本身就是
-内容**：`knowledge/2026-裁员名单.md` 这一个字符串泄露的东西不比正文少。而 MQTT 到
-broker 是 TLS 传输、broker 内部是明文，运维能看见，日志会记下来。这条约束不是洁癖，
-它决定了整个 E2E 设计成不成立。
+Knowledge 现行上传是**明文**（FC 与对象存储可见正文；见 ADR-0008）。即便如此，
+**路径本身就是敏感元数据**：`knowledge/2026-裁员名单.md` 泄露的东西不比正文少。
+MQTT 到 broker 是 TLS 传输、broker 内部是明文，运维能看见，日志会记下来。所以
+hint 里仍然禁止路径——这不是「假 E2E 洁癖」，是元数据最小化；将来若做真端到端
+加密，这条约束只会更硬，不会更松。
 
 **也没有 `count`（本次变了几个文件）。** 它诱使收端做增量假设，而经过 §7 的合批之后
 这个数字的语义本就模糊（是窗口内的总数还是最后一次的？）。收端唯一该做的事是「拉一次
@@ -120,11 +128,15 @@ manifest」，不需要知道要拉几个。
 会失精。自增序列实际到不了那个量级，但 FC 侧序列化时不要走任何会做数值转换的中间层，
 Rust 侧用 `i64` 解析。
 
-**`originNodeId` 有个前置条件：daemon 现在根本不传 nodeId。** `upload_prepare` 的签名
-里有这个参数（`fc_client.rs:227`），但 `engine.rs:747` 和 `engine.rs:1096` 两处调用都传
-`node_id: None`。所以要先让 daemon 填上 —— 现成的稳定标识是
-`daemon_device_id()`（`apps/daemon/src/device_id.rs:47`）。这一步可以独立先做，与推送
-无关，做完 `amuxc_files` 的 `created_by_node_id` 也终于有值了。
+**`originNodeId` 有个前置条件：daemon 现在根本不传 nodeId。** `fc_client.rs` 的
+prepare / delete 请求体都有 `node_id`，但 `engine.rs` 四处调用（`:837` 批量 prepare、
+`:1186` 批量 delete、`:1316` 单条 prepare、`:1409` 单条 delete）全传 `None`，而且字段
+是 `skip_serializing_if = "Option::is_none"`，wire 上根本不出现。所以要先让 daemon
+填上 —— 现成的稳定标识是 `daemon_device_id()`（`apps/daemon/src/device_id.rs:47`）。
+这一步可以独立先做，与推送无关，做完 `amuxc_files` 的 `created_by_node_id` 也终于
+有值了。实现时顺手确认 daemon 是否会用自己 `complete-batch` 响应里的 seq 更新
+high-water：如果只在 manifest 拉取时更新，那这层回声过滤就不只是省一次空转，而是
+每次自己 push 之后必然多跑一次 tick 的唯一防线。
 
 **报文的定位：hint，不是命令，不是数据。**
 
@@ -159,9 +171,11 @@ Rust 侧用 `i64` 解析。
    nodeId**，见 §5 —— 现在两处上传都传的 `None`。在那之前这一层过滤是空的，
    只能靠下面的 seq 比较兜底（够用，只是会多一次空转）。
 2. **丢掉不新的 seq。** 与本地 high-water 比较，不高于就丢弃。
-3. **合并窗口 + 最小间隔地板**，再落到已有的 `dispatch.sync_team`。它自带 per-team
-   互斥锁，不会和定时器打架 —— 正在跑就跳过，这条已有逻辑不用改。第 3 条比前两条
-   复杂，单独展开在 §7。
+3. **进 per-team 同步调度器**（合并窗口 + 最小间隔地板），再落到已有的
+   `dispatch.sync_team`。这个调度器与刀 4 的 fs 监听**共用**：两路输入 `Local`（fs
+   事件）与 `Remote { seq }`（本文的 hint）。`sync_team` 自带 per-team 互斥锁，不会
+   和定时器打架 —— 正在跑就跳过，这条已有逻辑不用改。第 3 条比前两条复杂，单独
+   展开在 §7。
 
 ## 7. 收端限流：活跃团队不能把自己拉垮
 
@@ -190,6 +204,12 @@ Rust 侧用 `i64` 解析。
 要的是 **coalescing window**：第一条到达就起一个固定窗口（2 秒），期间来的全部合并，
 到点执行一次，**不重置**。
 
+同一个陷阱在发端也存在：Obsidian 自动保存约 2 秒一次，只给 fs 监听配 debounce 的
+话，一个人连续打字 = 每 2 秒一个完整 tick（全树 scan + prepare + complete + 一条
+hint），10 人团队就是 300 tick/分钟，把每个队友的收端地板顶满。所以窗口和地板是
+**一个 per-team 调度器**，两路输入共用（§6 第 3 条）。300 秒定时器和手动 Sync Now
+**不走**调度器：定时器已有 in-flight 跳过，手动是用户意图，直接 `force`。
+
 ### 7.3 为什么可以这么简单：合并是无损的
 
 关键性质：**拉取的语义是「拉到最新」，不是「拉某个文件」**。manifest 按 `afterSeq`
@@ -207,13 +227,19 @@ Rust 侧用 `i64` 解析。
 N 秒，就排到点上执行一次（而不是丢弃 —— 丢弃会让最后一次变更传不到）。
 
 ```
-安静时：一条广播 → 窗口 2 秒 → 拉一次        延迟 ≈ 2 秒
+安静时：一条广播 → 窗口 2 秒 → 拉一次        这一段延迟 ≈ 2 秒
 繁忙时：无论几条广播 → 每 N 秒最多拉一次
 ```
 
-N 暂定 **15 秒**（待验证，§12）：最差延迟从 300 秒降到 15 秒（快 20 倍），tick 频率
-从 0.2 次/分钟涨到最多 4 次/分钟（20 倍）。20 倍资源换 20 倍实时性，比例是线性的。
-朴素实现那 90 倍里的大部分是白花的 —— 合并掉之后结果一模一样。
+N 取 **15 秒**（远端 hint）/ **5 秒**（本地 fs 事件），硬编码，**不设「先采一周数据
+再定」的门槛**——两个值是起点，调整走独立 PR 并附 §12 第 7、8 条的 tick 频率数据。
+两路都 pending 时取小的那个。远端 15 秒意味着：最差延迟从 300 秒降到 15 秒（快 20
+倍），tick 频率从 0.2 次/分钟涨到最多 4 次/分钟（20 倍）。20 倍资源换 20 倍实时性，
+比例是线性的。朴素实现那 90 倍里的大部分是白花的 —— 合并掉之后结果一模一样。
+
+「延迟 ≈ 2 秒」只是 hint 这一段。端到端（Obsidian A 保存 → Obsidian B 可见）还要加
+A 侧 2 秒窗口 + push tick + B 侧 pull tick + 两端 watcher，安静时在 6–10 秒量级；
+ADR-0008 定的目标是**安静 ≤10 秒、繁忙 ≤ 地板 + 一次 tick**。
 
 **地板从上一次 tick 结束算，不是开始。** 否则一个慢 tick 会让下一次紧接着排上，在
 大知识库上叠成连续跑。
@@ -226,20 +252,34 @@ manifest 查询加全树扫描。所以限流**加在订阅端**。加在 FC 的
 
 ## 8. 合批：一次 tick 不能变成 200 条广播
 
-`push_phase` 一次最多推 200 个文件（`MAX_SYNC_BATCH`），每个文件一次 CAS 写入。
-逐次写入逐次广播 = 一次同步 200 条消息。
+担心的是：`push_phase` 一次最多推 200 个文件（`MAX_SYNC_BATCH`），逐文件广播 =
+一次同步 200 条消息。
 
-做法：FC 侧按 team 开一个 500ms 的时间窗，窗口内只发最后一条（seq 最大的那条）。
-因为 payload 只有一个 seq，**合并是无损的** —— 后一条完全覆盖前一条的信息量。
+**但 daemon 已经按 200 一批调 HTTP**：`engine.rs:816` 按 `MAX_BATCH = 200` 切块，
+每块一次 `upload_complete_batch`（`/v1/sync/upload/complete-batch`），删除同理走
+`delete-batch`。逐文件的 `upload_complete` 只在 FC 返回 404 `BatchUnsupported` 时
+才走，现役 FC 不会。
 
-self-host 是单 FC 容器，进程内合并就够。将来多实例的话重复广播也无害：收端有 §5
-的 seq 去重。
+所以做法是：**每次成功的 `complete-batch` / `delete-batch` 调用发一条**，seq 取该次
+调用里成功项的最大 `changeSeq`。一次 tick 最多 2000 个新文件（客户端闸门）= 最多
+10 条 hint，已经是「个位数不是 200」。**不做 500ms 合批定时器**，两个理由：
+
+1. belayo 跑在阿里云 FC 上，响应返回后实例可能被冻结，`setTimeout` 不保证触发。
+2. 定时器窗口里落进多个来源时 `originNodeId` 填谁没有好答案；按调用发，一次调用
+   一个来源。
+
+发送 `await` publish，**500ms 超时**：超时只 `warn!`，HTTP 响应照常 200——hint 是
+best-effort，定时器兜底。self-host 上 broker 在本机，亚毫秒，不感知。
+
+多实例重复广播无害：收端有 §5 的 seq 去重。
 
 ## 9. ⚠️ ACL：这一步最容易把线上打挂
 
 EMQX 的授权规则由 `amux_acl_rules_for(team, actor, type)` 生成
-（`services/supabase/migrations/20260706120000_member_sub_own_rpc_req.sql`），**烘进
-access token**。
+（`services/supabase/migrations/20260706120000_member_sub_own_rpc_req.sql`），由
+GoTrue 的 `amux_access_token_hook` 在签发时展开成 `acl` claim **烘进 access token**。
+EMQX 侧只配了 JWT 认证（`deploy/self-host/emqx/emqx.conf`），没有 authorization
+块，也没有 Postgres authz 源——ACL 完全跟着 token 走。
 
 看当前规则表：`member` 有一条通配的 `('sub', 'amux/<team>/+/state')`，但
 **`agent` 没有任何可复用的通配 sub** —— 而 daemon 就是 agent 类型。所以没有「零迁移
@@ -252,22 +292,34 @@ access token**。
 用通配 `sync/+` 而不是逐个资源列出，是 §4 那个「资源段放最后」的兑现点：这条规则
 上一次之后，将来加 skills、mcp 的推送就不用再动 ACL 了。
 
-**上线顺序**：
+三个顺带的事实：
 
-1. **先**上 ACL 迁移，等设备的 token 自然刷新（daemon 的 cloud token 会自动续）。
-2. **再**发带订阅的新 daemon。
+- FC 自己的 publisher 用的是 `MQTT_SERVICE_TOKEN`，手工签的 JWT，**没有** `acl`
+  claim；没有 authz 源时 EMQX 走 `no_match` 默认放行。所以**发布端零 ACL 改动**，
+  只有订阅端（daemon / app）需要这条迁移。
+- Postgres / Better-Auth 后端签的 token **不产 `acl` claim**，all-in-one 镜像跑的是
+  NanoMQ、无 ACL。这条迁移只对 Supabase 后端有意义；**别拿 all-in-one 验它**。
+- token 只活 3600s（`JWT_EXPIRY`），daemon 到期前 60s 续、到期前 **5 分钟主动重建
+  MQTT 连接**（`backend/mod.rs` `PROACTIVE_CREDENTIAL_BUFFER`）并逐条重订阅。所以
+  迁移之后**最长 1 小时**，每台 daemon 都拿到了带新规则的 token。
 
-顺序反了会怎样：新 daemon 拿着老 token 去订阅，EMQX 拒绝，而
-`mqtt_resubscribe_after_connack`（`apps/daemon/src/daemon/server.rs:868`）对订阅
-失败的处理是 `return Err` → 外层重连循环。这正是那个已知故障：**被拒后约 100 次
-/秒重连、不退避、generation 永不前进，broker 那头修好之后也必须重启 daemon 才能
-恢复。**
+**上线顺序是建议，不是门槛**：先上迁移、后发 daemon 最省事；但只要订阅容错（下
+面），同一发布里带上两者也没事——最长 1 小时内自愈。
+
+**为什么容错是硬要求。** 现状订阅被拒的路径：`mqtt_resubscribe_after_connack`
+（`apps/daemon/src/daemon/server.rs:886-915`）`return Err` → 调用方
+`request_rebuild_for_generation` → `schedule_restart`；CONNACK 后的 restore 路径
+（`supervisor.rs:1717-1746`）被拒直接 `forced_rebuild`。#1073 之后这已经不是「100 次
+/秒不退避」的风暴——重建按 5→30s 指数退避、generation 会前进——但仍然是一个
+**worker 重建循环**：每 5–30 秒断一次连接，RPC、session live、presence 全跟着断，
+直到 token 轮换、订阅成功为止，最长 1 小时。
 
 所以：
 
-> **这条新订阅失败必须容错。** 它不是核心功能，拿不到就退回定时器同步。实现上单独
-> 一次 `subscribe`，失败只 `warn!`，**不** `return Err`，不影响 CONNACK 之后的其它
-> 订阅。
+> **这条新订阅必须是「可选订阅」。** `MqttCommand::Subscribe` 带 `optional` 标记，
+> tracked subscriptions 也带；首次订阅和 CONNACK 后的 restore 都适用：被拒只 `warn!`
+> 一次，**不** `forced_rebuild`，**不** `return Err`，不影响其它订阅，下次重连再试
+> （token 轮换保证 1 小时内有一次）。拿不到就退回定时器同步。
 
 这一条比迁移顺序更重要 —— 顺序会被人搞错，容错不会。
 
@@ -282,39 +334,51 @@ MQTT 会丢：设备离线期间的广播不补发（不 retain，QoS 1 只保�
 
 ## 11. 分阶段
 
+按 ADR-0008 的全局顺序（风险从低到高），本文覆盖的是其中的 C / D / E：
+
 | 阶段 | 内容 | 可独立验证 |
 |---|---|---|
-| 1 | FC 侧广播 + 合批 | 没人订阅，先让消息流起来，用 EMQX dashboard 或一个 mosquitto_sub 看 |
-| 2 | ACL 迁移 | token 刷新后用一个测试客户端订阅得上 |
-| 3 | daemon 订阅 + 三个过滤（订阅失败容错） | 端到端 |
-| 4 | 观察后再考虑拉长定时器 | — |
+| A | `.conflicts/`（obsidian 文档刀 7） | Obsidian 里副本消失 |
+| B | per-team 调度器 + fs 监听（刀 4） | Obsidian 保存后 2 秒窗口内 push |
+| C | FC 侧按调用广播（§8） | 没人订阅，先让消息流起来，用 `mosquitto_sub amux/+/sync/knowledge` 看 |
+| D | ACL 迁移（§9） | 1 小时后用一个测试客户端订阅得上 |
+| E | daemon nodeId + 可选订阅 + 三个过滤 → 调度器 `Remote` | 联调验收 §12 |
+| — | 观察后再考虑拉长定时器 | 另 PR |
 
-阶段 1 完全无风险（发到一个没人听的主题），可以先上 —— 而且它一举两得：既验证合批
-窗口够不够，又采到了 §7.4 定地板所需的真实写入分布。**先上阶段 1，用它的数据定 N，
-再做阶段 3。**
+C 完全无风险（发到一个没人听的主题），可以任何时候先上；它顺带采到真实写入分布，
+但**不作为定地板的门槛**——15s / 5s 硬编码上线，调整走独立 PR。D 与 E 可以同一发布
+（§9）。
 
 ## 12. 验收
 
-1. A 保存一篇笔记 → B 在 5 秒内看到（不是 5 分钟）。
-2. A 一次推 200 个文件 → 广播条数是个位数，不是 200。
+1. A 在 Obsidian 保存一篇笔记 → B 在 Obsidian 里 **≤10 秒**看到（端到端，A/B 都
+   跑着 B + C + D + E；不是 5 分钟，也不是 hint 那一段的 2 秒）。
+2. A 一次推 2000 个文件 → 广播条数 ≤10，不是 2000。
 3. A 自己不会因为自己的推送而多跑一次同步（`originNodeId` 过滤生效）。
-4. 掐掉 EMQX → 同步仍然工作，只是退回 300 秒节奏；日志有 warn，没有重连风暴。
-5. 用一个**故意不刷新 token** 的 daemon 连上去 → 订阅被拒，daemon 正常工作，**没有**
-   每秒上百次的重连。这条是 §7 的回归测试，必须真的做。
+4. 掐掉 EMQX → 同步仍然工作，只是退回 300 秒节奏；日志有 warn；worker 重建只按
+   既有的 5→30s 退避，EMQX 回来后 RPC 自行恢复。
+5. 用一个**拿着迁移前 token** 的 daemon 连上去 → `sync/+` 被拒，只 warn 一次，
+   **worker 不重建**，RPC / session live 不断；token 轮换后（≤1h）订阅成功。这条是
+   §9 的回归测试，必须真的做，而且要有单测：可选订阅被拒不 `schedule_restart`，
+   必选订阅被拒仍然会。
 6. 抓包/看 broker：消息里没有任何文件路径。
-7. **活跃团队不把自己拉垮**：10 个人同时密集编辑一小时，每台设备的 tick 次数不超过
-   `3600 / N`（N = §7.4 的地板）。这是 §7 存在的理由，不验就等于没做。
-8. **持续高频不会饿死**：连续写入 10 分钟不停，期间同步照常发生 —— 这条专门盯 §7.2
-   那个陷阱，用 debounce 写会在这里挂掉（计时器被无限刷新，一次都不触发）。
+7. **活跃团队不把自己拉垮**：10 个人同时密集编辑一小时，每台设备由远端 hint 触发的
+   tick 次数不超过 `3600 / 15`。这是 §7 存在的理由，不验就等于没做。
+8. **持续高频不会饿死**：A 在 Obsidian 里连续打字 10 分钟不停，A 的 tick ≤ `600 / 5`，
+   期间 B 持续收到更新 —— 这条专门盯 §7.2 那个陷阱，用 debounce 写会在这里挂掉
+   （计时器被无限刷新，一次都不触发）。
+9. **pull 不自触发**：B 收 hint 拉下 50 个文件，落盘产生的 fs 事件不会让 B 再排一次
+   本地 tick（路径集合压制生效）；但 pull 期间 B 自己改的另一篇笔记照常排。
 
 ## 13. 未决
 
-- app（member 身份）要不要也订阅、直接刷新 UI？现在它靠 window focus 事件刷新
-  （`KnowledgeSyncFooter`）。daemon 收到后本来就会同步并触发文件变更事件，app 可能
-  不需要自己订阅 —— 先做 daemon，再看 UI 有没有缺口。
+- ~~app（member 身份）要不要也订阅、直接刷新 UI？~~ **已定：不订阅。** daemon 拉完
+  不会通知 app（`sync/` 下没有任何 emit，app 只能轮询 `/v1/team/sync/status`），但
+  app 打开 knowledge 列时对内容根挂了 Tauri `watch_directory`（`workspace.ts`
+  `openExternalRoot` → `filewatcher.rs` → `file-change` 事件），`FileBrowser.tsx` 与
+  `TeamShareListColumn.tsx` 都在听它刷新树、角标与冲突列表。daemon 落盘即可见。
 - iOS 将来如果有知识库（目前完全没有），同一条主题可以直接复用。
-- §7.4 地板取值 15 秒是估的，没有数据支撑。要看真实团队的写入分布才好定 —— 而阶段 1
-  （FC 广播，没人订阅）正好能采到这个数据：广播频率就是写入频率。定 N 之前先跑一周
-  阶段 1。
+- ~~§7.4 地板取值 15 秒是估的~~ **已定：15s / 5s 硬编码上线，不设采数门槛**；调整走
+  独立 PR 并附 §12 第 7、8 条的 tick 频率数据（阶段 C 的广播频率就是写入频率）。
 - 要不要把 skills 注册表的更新也走 `amux/<team>/sync/skills`？同样的问题、同样的
   解法，而且按 §4 的主题形状它**不需要再改 ACL**。但不要在本次一起做。

--- a/docs/architecture/obsidian-compatible-knowledge.md
+++ b/docs/architecture/obsidian-compatible-knowledge.md
@@ -409,6 +409,16 @@ drizzle）。定下来的形状：`SYNC_MAX_BYTES_PER_TEAM` 默认 **2 GiB**—�
 不能照抄文件数的 10 秒缓存——一个 200 条的 batch 在缓存过期前全部放行，最坏超出
 200 × 25 MiB = 5 GiB，比配额本身还大。
 
+**累加只对新增路径（`parentVersion === 0`）计费，且只在该 item 成功之后计。** 编辑
+的旧字节本来就在 sum 里，再按全量 size 计一遍就是把文件数了两次，会让一个远未触顶的
+团队吃 422——这正是本节开头那条「配额不会误挡」不能破的地方。代价是一个有界的少算
+（编辑变大的部分等下次重读 sum 才算得上，超收上限一个 batch），方向是对的。
+
+sum 走 `amuxc_team_live_bytes` / drizzle `sumLiveBytes`，并有一条
+`(team_id) INCLUDE (size) WHERE deleted = false` 的偏索引兜着——`amuxc_files` 原有
+三条索引都不带 `deleted`/`size`，不加索引的话这个聚合会在写路径上把全团队 live 行
+都捞一遍（上限 5 万行），一次 tick 最多 10 次。
+
 **配额 ≠ 磁盘保护。** 物理占用还含历史版本 blob，回收靠 FC cron 的
 `amux.oss_sync_gc_orphan_blobs()`，而 cron 是 compose 的独立 profile，self-host 没开。
 启用 GC 单开 ops ticket（注意记忆里 FC cron 曾因 drizzle 裸表名 vs `amux` schema 的

--- a/docs/architecture/obsidian-compatible-knowledge.md
+++ b/docs/architecture/obsidian-compatible-knowledge.md
@@ -39,7 +39,7 @@
 | 同步前缀只剩 `knowledge/` | `apps/daemon/src/sync/oss/path_validator.rs:8`、`services/fc/src/lib/sync-path.ts:11` |
 | 内容根是 `~/.amuxd[-<brand>]/teams/<id>/shared/`，vault 候选是其下的 `knowledge/` | `apps/daemon/src/config/global_team_store.rs` |
 | 也可从 `<workspace>/team-knowledge` 软链进入 | `apps/daemon/src/config/workspace_link.rs:200` |
-| **磁盘上是明文，上传也是明文**（`cipher_hash == plain_hash`）；`crypto.rs` 只剩读切换前的旧 blob 与本地 `secrets.enc` 两个用途；团队 secret 不再是同步前置条件 | `apps/daemon/src/sync/oss/engine.rs:552-575`、`dispatch.rs:198-205`，见 ADR-0008 |
+| **磁盘上是明文，上传也是明文**（`cipher_hash == plain_hash`）；`crypto.rs` 只剩读切换前的旧 blob 与本地 `secrets.enc` 两个用途；团队 secret 不再是同步前置条件 | `apps/daemon/src/sync/oss/engine.rs` `prepare_upload`、`dispatch.rs` `run_once`，见 ADR-0008 |
 | 扫描器全量 walk，**只跳过 `*.conflict.*`**，点开头的目录照收 | `apps/daemon/src/sync/oss/scanner.rs:33` |
 | 任意文件类型都同步（字节走 blob） | `apps/daemon/src/sync/oss/engine.rs` |
 | 触发：app 内手动 + 300 秒定时器 | `apps/daemon/src/sync/timer.rs:21` |

--- a/docs/architecture/obsidian-compatible-knowledge.md
+++ b/docs/architecture/obsidian-compatible-knowledge.md
@@ -1,6 +1,11 @@
 # knowledge 目录兼容 Obsidian + 同步忽略规则
 
-> 状态：**设计，未实现**。本文描述目标态。
+> 状态：**部分已落地**（ignore、护栏、服务端拒绝与文件数配额、Obsidian 打开入口、
+> 附件目录预置、刀 3 `.md` 后缀）。未落地且纳入 ADR-0008 的：刀 7（`.conflicts/`）、
+> 刀 4（fs 监听 + per-team 调度器），**刀 7 必须在刀 4 之前或同批**对外。MQTT 推送
+> 见 `knowledge-sync-push-notify.md`。范围锁：
+> [`docs/adr/0008-knowledge-sync-p0-p1-scope.md`](../adr/0008-knowledge-sync-p0-p1-scope.md)；
+> 实施：[`docs/plans/2026-08-26-knowledge-sync-p0-p1.md`](../plans/2026-08-26-knowledge-sync-p0-p1.md)。
 >
 > 相关：`docs/architecture/team-mcp-and-env-cloud.md`（同步为什么只剩
 > `knowledge/`）、`docs/architecture/amuxd-home-layout-v2.md`（家目录布局）。
@@ -17,7 +22,7 @@
 **非目标**（本轮不做，见 §8）
 
 - Obsidian 移动端。那需要插件方案（vault 可在任意位置 + 我们的同步协议用 TS
-  重写 + 团队 E2E 密钥交给第三方 app），代价与收益不成比例。
+  重写 + 把团队同步密钥交给第三方 app），代价与收益不成比例。
 - 把 `knowledge/` 软链进用户已有的个人 vault。Obsidian 官方不支持 vault 内部的
   软链，其 watcher 可能收不到软链子树的外部写入，队友同步来的新笔记要重启才可
   见。可以作为文档里的逃生通道，不作为支持的形态。
@@ -34,7 +39,7 @@
 | 同步前缀只剩 `knowledge/` | `apps/daemon/src/sync/oss/path_validator.rs:8`、`services/fc/src/lib/sync-path.ts:11` |
 | 内容根是 `~/.amuxd[-<brand>]/teams/<id>/shared/`，vault 候选是其下的 `knowledge/` | `apps/daemon/src/config/global_team_store.rs` |
 | 也可从 `<workspace>/team-knowledge` 软链进入 | `apps/daemon/src/config/workspace_link.rs:200` |
-| **磁盘上是明文**，加密只发生在上传 | `apps/daemon/src/sync/oss/crypto.rs`，扫描器算的是 `local_plain_hash` |
+| **磁盘上是明文，上传也是明文**（`cipher_hash == plain_hash`）；`crypto.rs` 只剩读切换前的旧 blob 与本地 `secrets.enc` 两个用途；团队 secret 不再是同步前置条件 | `apps/daemon/src/sync/oss/engine.rs:552-575`、`dispatch.rs:198-205`，见 ADR-0008 |
 | 扫描器全量 walk，**只跳过 `*.conflict.*`**，点开头的目录照收 | `apps/daemon/src/sync/oss/scanner.rs:33` |
 | 任意文件类型都同步（字节走 blob） | `apps/daemon/src/sync/oss/engine.rs` |
 | 触发：app 内手动 + 300 秒定时器 | `apps/daemon/src/sync/timer.rs:21` |
@@ -72,10 +77,10 @@
 
 | # | 缺口 | 后果 |
 |---|---|---|
-| 1 | 新建笔记默认名是 `untitled`，无 `.md` 后缀（`packages/app/src/components/workspace/FileTree.tsx:1121`） | Obsidian 打不开、默认不显示。真实团队的同步状态里已经有 `knowledge/untitled` |
+| 1 | ~~新建笔记默认名是 `untitled`，无 `.md` 后缀~~ **已修**（`3d6e8fd3`，`knowledge-file-names.ts` `withDefaultExtension`，根与树内两处入口） | 历史遗留的 `knowledge/untitled` 仍在，不自动改名（见 §5.1） |
 | 2 | 没有忽略机制，点开头目录照收 | `.obsidian/`、`.trash/`、`.DS_Store` 全同步；`node_modules/` 一旦被放进来就是灾难 |
 | 3 | 冲突副本是 `.md`，就躺在原文件旁边（`apps/daemon/src/sync/oss/conflict.rs:38`，形如 `foo.conflict.1748332800.abc123de.md`） | 在 Obsidian 里是正经笔记：出现在文件树、关系图、搜索、链接补全 |
-| 4 | 外部改动最多 5 分钟才发出去 | 在 Obsidian 里改完关掉，队友要等一个定时器周期 |
+| 4 | 外部改动最多 5 分钟才发出去；队友那头还要再等自己的定时器，端到端最坏约 10 分钟 | 在 Obsidian 里改完关掉，队友要等两个定时器周期 |
 | 5 | 编辑器不渲染 `![[附件]]` 嵌入，附件目录无约定 | 两边对附件放哪没有共识 |
 
 ## 3. 决策：vault 就是 knowledge 目录
@@ -397,44 +402,83 @@ env 变量在 `docker-compose.yml`、`s.yaml`、`.env.example` **三处**都声�
 
 限流本身维持现状：配额是按 team 而不是按 IP 的，不会有 NAT 后互相饿死的问题。
 
-**未做：字节配额。** PostgREST 的聚合支持取决于版本，做 `sum(size)` 需要一次迁移加
-一个 rpc。单文件 25 MiB 的闸门（§4.4）已经挡住了最坏的单个文件，文件数配额挡住了数
-量，两者之外的空隙（一万个 20MB 文件）留待有数据支撑阈值时再补。
+**字节配额：ADR-0008 P1，未落地。** `sum(size)` 需要一次迁移加一个 rpc（pg 后端走
+drizzle）。定下来的形状：`SYNC_MAX_BYTES_PER_TEAM` 默认 **2 GiB**——self-host MinIO
+在根盘、余量个位数 GB，8 GiB 比整盘余量还大等于没保护；按 live 逻辑字节算；错误
+沿用 422 `QuotaExceeded` 加 `kind: 'bytes'`；**batch 内一次 sum + 逐 item 运行累加**，
+不能照抄文件数的 10 秒缓存——一个 200 条的 batch 在缓存过期前全部放行，最坏超出
+200 × 25 MiB = 5 GiB，比配额本身还大。
+
+**配额 ≠ 磁盘保护。** 物理占用还含历史版本 blob，回收靠 FC cron 的
+`amux.oss_sync_gc_orphan_blobs()`，而 cron 是 compose 的独立 profile，self-host 没开。
+启用 GC 单开 ops ticket（注意记忆里 FC cron 曾因 drizzle 裸表名 vs `amux` schema 的
+search_path 问题全挂），ticket 关闭前对外不说「磁盘安全」。
+
+**不做 prepare 限速。** prepare 已按 200 一批、合法 tick 只 1 次调用，剩余动机只有
+Postgres 行插入风暴；而 429 在 daemon 侧是 tick 内指数退避 5 次（~24s 持锁）后
+deferred 并报红到 UI，代价大于收益。
 
 ## 5. 其余四个缺口
 
 ### 5.1 `.md` 后缀（缺口 1）
 
-- 新建文件默认名改为 `untitled.md`。
-- knowledge 树下新建 / 重命名时，若用户没写扩展名则补 `.md`；若写了别的扩展名，
-  尊重用户（附件、图片是合法内容）。
-- 已存在的无后缀文件：不自动改名（会打断队友的链接），但在文件树上给一个提示。
+- ~~新建文件默认名改为 `untitled.md`。~~ **已完成**（`3d6e8fd3`）：占位名是
+  `untitled.md`；knowledge 树下新建时若用户没写扩展名则补 `.md`
+  （`packages/app/src/lib/knowledge-file-names.ts` `withDefaultExtension`，点开头的
+  文件与已有扩展名的不碰）；若写了别的扩展名，尊重用户（附件、图片是合法内容）。
+  规则只挂在 knowledge 的两处入口，skills 树刻意不用。
+- **未做，且不进 ADR-0008**（单开 issue）：重命名时补 `.md`；已存在的无后缀文件不
+  自动改名（会打断队友的链接），但在文件树上给一个提示。
 
-§3.3 预置的 `showUnsupportedFiles: true` 让这些文件在 Obsidian 里至少**可见**，
-但它们仍然打不开、也不是笔记 —— 那只是止血，这一刀还是要做。
+§3.3 预置的 `showUnsupportedFiles: true` 让历史遗留的无后缀文件在 Obsidian 里至少
+**可见**，但它们仍然打不开、也不是笔记。
 
 ### 5.2 冲突副本（缺口 3）
 
-两个选项：
+**已决策：A**（ADR-0008 P0 #1）。
 
-- **A（倾向）**：保持文件名格式不变，但落到 `.conflicts/` 这个点目录下的镜像路
-  径。Obsidian 默认忽略点目录，副本对它完全隐形；我们自己的冲突 UI 改成从这个
-  目录读。需要同步改 `original_from_conflict` / `conflict_timestamp` 的路径推导
-  （`conflict.rs:70-110`）。
-- B：维持现状，文档里告诉用户在 Obsidian 的 Excluded files 里加 `*.conflict.*`。
-  成本为零，但 Obsidian 的排除只降权、不隐藏，关系图里还是看得见。
+- **A**：保持文件名格式不变，但落到 `.conflicts/` 这个点目录下的镜像路径
+  （`knowledge/a/foo.md` → `knowledge/.conflicts/a/foo.conflict.<ts>.<hash>.md`）。
+  Obsidian 默认忽略点目录，副本对它完全隐形；我们自己的冲突 UI 改成从这个目录读。
+  需要同步改 `original_from_conflict` / `conflict_timestamp` 的路径推导
+  （`conflict.rs:56-110`）。
+- ~~B：维持现状，文档里告诉用户在 Obsidian 的 Excluded files 里加 `*.conflict.*`。~~
+  Obsidian 的排除只降权、不隐藏，关系图里还是看得见。
+
+三条实现约束：
+
+1. **`.conflicts/` 在扫描器与 pull 侧硬排除，不走 ignore 规则。** §4.1 后层覆盖前层，
+   放进内置清单的话团队 `.amuxignore` 一条 `!.conflicts/` 就能把副本推上云。它和
+   「`.amuxignore` 自身永不被忽略」是同一个级别的硬规则。pull 侧遇到该前缀
+   `continue`，不 `return Err`（§4.5 的教训）。
+2. **旧 sidecar move-on-scan。** 现在的 sidecar 是扫描器硬跳过、从未上传过的，所以
+   搬进 `.conflicts/` 是纯本地 rename：无 tombstone、无广播、无 §4.6 那类迁移风险。
+3. **前端判定改掉。** `team-conflicts.ts` 的 `isConflictSidecarName` 用
+   `.includes('.conflict.')`，与 daemon `has_conflict_infix` 的数字时间戳判定不一致：
+   `merge.conflict.md` 被树隐藏却照常同步、也不在冲突列表里。改成剪 `.conflicts/`
+   目录，删掉 infix 判定。
 
 ### 5.3 即时同步（缺口 4）
 
-给 knowledge 根挂一个带 debounce 的文件监听，事件落地后触发一次 sync tick。
+给 knowledge 根挂文件监听，事件进 per-team 同步调度器，到点触发一次 sync tick。
+形状已由 ADR-0008 P0 #2 定死：
 
 - 桌面端已有现成的 `watch_directory`（`apps/desktop/src/commands/filewatcher.rs:46`，
-  基于 `notify-debouncer-mini`），但它只在 app 开着时有效。
-- daemon 侧已有 `notify` 依赖与 `refresh_watch.rs` 的模式，headless 场景应该走
-  这条。
-- debounce 建议 2 秒；Obsidian 保存频繁，太短会把一次编辑打成多次 tick。
-- 监听必须复用同一套 ignore 规则，否则一个 `node_modules/` 的写入风暴会把 tick
-  触发到爆。
+  基于 `notify-debouncer-mini`），但它只在 app 开着时有效，而且它是 app 刷新树用的，
+  不是同步用的。daemon 侧走 `notify`，headless 也生效。
+- **独立模块 `sync/watch.rs`**，不复用 `runtime/refresh_watch.rs` 的 classifier——
+  那是 runtime refresh 的输入，塞一个 Knowledge kind 进去会把两个消费者搅在一起。
+  抄它的模式：监听父目录以扛住原子保存、丢 `Access` 事件、2 秒 reconcile 处理晚出现
+  的根目录（加入团队、重新 onboard）。
+- **不是 debounce，是 coalescing window + 地板**（`knowledge-sync-push-notify.md`
+  §7.2 的同一个陷阱）：固定 2 秒窗口不重置，地板本地 5 秒、远端 hint 15 秒，从上次
+  tick **结束**起算。Obsidian 自动保存约 2 秒一次，只有 debounce 的话一个人连续打字
+  = 每 2 秒一个完整 tick。定时器与手动 Sync Now 不走调度器。
+- 监听必须复用同一套 ignore 规则**过滤事件**；它管不了 `notify` 的递归注册，Linux
+  上一个 `node_modules/` 仍会吃 inotify watch 数。所以 watcher 创建失败或运行报错
+  → `warn!` 一次、退回定时器，不重试。
+- **pull 自写压制按路径集合**：pull 阶段记录写过的路径，这些路径 3 秒内的事件丢弃。
+  不做时间窗全量压制——pull 期间用户的真实编辑会被吞到下一个定时器。
 
 ### 5.4 附件（缺口 5）
 
@@ -450,11 +494,11 @@ env 变量在 `docker-compose.yml`、`s.yaml`、`.env.example` **三处**都声�
 |---|---|---|
 | 1 | ~~ignore 机制：三层规则来源 + 内置清单 + **tombstone 排除**（§4.6）~~ **已完成** | 无 |
 | 2 | ~~兜底护栏：单文件大小 + 单 tick 文件数上限，含 UI 呈现~~ **已完成** | 刀 1 |
-| 3 | `.md` 后缀默认值与补全 | 无 |
-| 4 | 文件监听触发即时同步 | 刀 1（必须复用 ignore） |
+| 3 | ~~`.md` 后缀默认值与补全~~ **已完成**（`3d6e8fd3`；重命名补全与树上提示单开 issue） | 无 |
+| 4 | 文件监听 + per-team 调度器触发即时同步（§5.3） | 刀 1（必须复用 ignore）；**刀 7 之后或同批** |
 | 5 | ~~「在 Obsidian 中打开」入口~~ **已完成** + 用户文档 | 刀 3 |
-| 6 | ~~服务端写入口拒绝 + 每 team 配额~~ **已完成**（清单**不**共用，见 §4.7） | 刀 1 |
-| 7 | 冲突副本迁 `.conflicts/` | 独立 |
+| 6 | ~~服务端写入口拒绝 + 每 team 文件数配额~~ **已完成**（清单**不**共用，见 §4.7）；字节配额是 ADR-0008 P1 | 刀 1 |
+| 7 | 冲突副本迁 `.conflicts/`（§5.2 A，硬排除 + move-on-scan + 前端判定） | 独立；ADR-0008 里排第一 |
 | 8 | ~~附件目录约定~~ **已完成**（§3.3 预置 `attachmentFolderPath`）+ 编辑器渲染 `![[...]]` | 独立 |
 
 刀 1 与刀 2 是「防止服务器被冲垮」的实质内容，优先级最高。刀 1 里的 §4.6 是**上
@@ -465,7 +509,14 @@ env 变量在 `docker-compose.yml`、`s.yaml`、`.env.example` **三处**都声�
 
 1. 在 `knowledge/` 里 `git clone` 一个带 `node_modules/` 的仓库，等一个 tick：
    同步状态显示被忽略/被闸门拦截，`amuxc_files` 表没有新增行，MinIO 没有新对象。
-2. 用 Obsidian 打开 vault，改一篇笔记 → 2 秒内 tick 发出 → 另一台设备收到。
+2. 用 Obsidian 打开 vault，改一篇笔记 → 2 秒窗口到点 tick 发出 → 另一台设备收到
+   （端到端 ≤10 秒要等 MQTT 那条链路也上线；只有刀 4 时对方仍靠自己的定时器）。
+2b. 在 Obsidian 里连续打字 10 分钟 → 本机 tick ≤ `600 / 5`，期间每次 tick 都有
+   内容发出（coalesce 不是 debounce）。
+2c. `knowledge/` 下放一个 `node_modules/`（被 ignore）→ daemon 不崩，其余笔记照常
+   同步；Linux 上 inotify 超限时日志一条 warn，退回定时器。
+2d. 冲突副本只出现在 `.conflicts/`，Obsidian 文件树与关系图里看不见；
+   `merge.conflict.md` 在 app 的树里可见、照常同步。
 3. Obsidian 产生的 `.obsidian/workspace.json` 在任何设备上都不产生同步流量。
 4. 在 app 里新建笔记 → Obsidian 里立刻可见可编辑（`.md` 后缀生效）。
 4b. 一台从没打开过这个目录的机器：Obsidian 没在运行时点按钮 → 直接进 vault，无需
@@ -476,8 +527,11 @@ env 变量在 `docker-compose.yml`、`s.yaml`、`.env.example` **三处**都声�
 
 ## 8. 未决问题
 
-- 每 team 配额的具体阈值（文件数 / 总字节）。需要先看现有团队的分布。
-- 冲突副本走 §5.2 的 A 还是 B。
-- 附件目录叫 `attachments/` 还是别的；是否需要在 onboarding 时替用户写一次
-  Obsidian 配置（等于承认我们在写 `.obsidian/`，与 §3.2 的立场有张力）。
-- ~~被忽略的文件在 app 的文件树里如何呈现~~ **已定**，见 §5.5。
+- ~~每 team 配额的具体阈值（文件数 / 总字节）。~~ **已定**：文件数 5 万（已落地），
+  字节 2 GiB（ADR-0008 P1，见 §4.7）；GC ticket 关闭后再看真实分布调整。
+- ~~冲突副本走 §5.2 的 A 还是 B。~~ **已定：A**，见 §5.2。
+- ~~附件目录叫 `attachments/` 还是别的；是否需要在 onboarding 时替用户写一次
+  Obsidian 配置。~~ **已定**：§3.3 首次注册时 seed `.obsidian/app.json`，本地创建、
+  不上传，与 §3.2 不矛盾。
+- ~~被忽略的文件在 app 的文件树里如何呈现~~ **已定并落地**（`3d6e8fd3`：被忽略的
+  文件在树上灰显）。

--- a/docs/plans/2026-08-26-knowledge-sync-p0-p1.md
+++ b/docs/plans/2026-08-26-knowledge-sync-p0-p1.md
@@ -372,9 +372,18 @@ token rotation guarantees one within 1h. No dedicated timer.
   `SYNC_MAX_BYTES_PER_TEAM`, default `2 * 1024 ** 3`), `liveByteSum(teamId, sumBytes)`
   with the same "cannot establish → `null` → allow" policy as the file count
 - Modify: `services/fc/src/lib/sync-handlers.ts` — `handleSyncUploadPrepareBatch`
-  fetches the live sum **once per batch call** and keeps a running total of item
-  `size` across the batch; the item that crosses the line and every item after it
-  get 422 `{ code: 'QuotaExceeded', kind: 'bytes' }`. Single prepare: `sum + size`.
+  fetches the live sum **once per batch call** and keeps a running total across
+  the batch; the item that crosses the line and every item after it get 422
+  `{ code: 'QuotaExceeded', kind: 'bytes' }`. Single prepare: `sum + size`.
+  **Charge only new paths (`parentVersion === 0`), and only after the item
+  succeeded.** An edit's old bytes are already inside the sum, so charging its
+  full size double-counts the file and refuses writes a team is nowhere near its
+  limit; a rejected item never becomes bytes at all. The bounded under-count
+  (growth on an edit goes uncharged until the next call re-reads the sum) is the
+  right direction for this guard — see ADR-0008 P1 #1.
+- Migration: partial covering index for the sum —
+  `(team_id) INCLUDE (size) WHERE deleted = false`. Without it the aggregate
+  heap-fetches every live row on the write path, up to 10× per tick per device.
 - Repository: `sum(size)` over live files on both backends — pg-repo via drizzle,
   Supabase via a new RPC `amux.amuxc_team_live_bytes(team_id)` (migration)
 - Env: declare in `deploy/self-host/docker-compose.yml` (fc `environment:`, indent 6),

--- a/docs/plans/2026-08-26-knowledge-sync-p0-p1.md
+++ b/docs/plans/2026-08-26-knowledge-sync-p0-p1.md
@@ -1,0 +1,434 @@
+# Knowledge sync P0/P1 Implementation Plan
+
+> **For Claude:** implement task-by-task in the order below; each task ends in its
+> own commit. Do not open PRs or push unless explicitly asked (CLAUDE.md).
+
+**Goal:** Cut cross-member knowledge latency from ~10 minutes worst case (two
+independent 300s timers) to ≤10s end-to-end quiet (fs watch → MQTT hint → pull),
+keep Obsidian vaults clean (`.conflicts/`), and close the remaining abuse gap
+(per-team byte quota)—without block-level sync, compression, prepare rate
+limiting, or activity-stream UI.
+
+**Architecture:** Keep the existing whole-file CAS engine (`amuxd` tick → FC
+`/sync/*` → presigned blob store). Add a per-team **sync scheduler** in the daemon
+with two inputs (local fs events, remote MQTT hints), a **hint-only** MQTT topic
+published by FC once per successful batch call, and a server-side byte guard.
+Content stays **server-readable plaintext**; MQTT payloads never carry paths.
+
+**Tech Stack:** amuxd (Rust, rumqttc, notify), FC (`services/fc/src`), EMQX ACL
+baked into JWT via `amux_access_token_hook` → `amux_acl_rules_for`,
+`crates/teamclu-types` MQTT topic helpers, React Knowledge UI only where the
+conflict path changes.
+
+**Scope lock:** [`docs/adr/0008-knowledge-sync-p0-p1-scope.md`](../adr/0008-knowledge-sync-p0-p1-scope.md)
+
+**Design sources (do not re-litigate):**
+
+- [`docs/architecture/knowledge-sync-push-notify.md`](../architecture/knowledge-sync-push-notify.md)
+- [`docs/architecture/obsidian-compatible-knowledge.md`](../architecture/obsidian-compatible-knowledge.md)
+
+**Out of scope (freeze):** block/CDC sync, on-demand download, line merge,
+activity-stream UI, mobile knowledge, upload compression, prepare rate limit,
+rename-time `.md` completion, lengthening the 300s timer.
+
+**Already landed (do not redo):** default `.md` on new notes (`3d6e8fd3`,
+`packages/app/src/lib/knowledge-file-names.ts` `withDefaultExtension`), ignore
+rules, 25 MiB / 2000-new-files gates, server path rejection, file-count quota,
+app-side `watch_directory` refresh, MQTT auth-reject backoff (#1073).
+
+---
+
+## Phase map
+
+Ordered by **risk, low → high**. Each phase is independently shippable.
+
+| Phase | What | User-visible? |
+|---|---|---|
+| 0 | Narrative fix (plaintext, not E2E) — docs + `CLAUDE.md` | Docs only |
+| A | `.conflicts/` sidecar directory | Yes (Obsidian hygiene) — **before or with B** |
+| B | Daemon sync scheduler + knowledge fs watch | Yes (my edits go out in seconds) |
+| C | Topic helper + FC per-call hint publish | No (nobody subscribed) |
+| D | ACL migration `sync/+` | No (self-heals ≤1h after daemon ships) |
+| E | Daemon `node_id` + optional subscribe + hint → scheduler | Yes (others' edits arrive in seconds) |
+| F | Byte quota | Yes only when over limit |
+
+C may go out any time after 0. D and E may ship in the same release **only
+because** E's subscribe is tolerant (Task 8). F parallelizes with anything.
+
+---
+
+### Task 0: Correct security narrative in docs
+
+> **Done on branch `docs/knowledge-sync-p0-p1-roadmap`:** ADR-0008, this plan,
+> push-notify §5/§7/§8/§9/§11/§12/§13 rewrite, obsidian doc header + §2.1 + §5.2 +
+> §5.3 + §6 + §8, root `CLAUDE.md` team-secret paragraph. Commit when asked.
+
+**Files:**
+
+- Create: `docs/adr/0008-knowledge-sync-p0-p1-scope.md`
+- Create: `docs/plans/2026-08-26-knowledge-sync-p0-p1.md`
+- Modify: `docs/architecture/knowledge-sync-push-notify.md`
+- Modify: `docs/architecture/obsidian-compatible-knowledge.md`
+- Modify: `CLAUDE.md` (the "team secret decides whether a team can sync" paragraph
+  — `dispatch.rs:198-205` no longer requires a secret)
+
+**Residue for the implementation PRs (grep already done, these are the only hits):**
+
+- `packages/app/src/locales/{en,zh-CN}.json` `cloudVersion.unreadable` — drop the
+  "…or encrypted with a team secret this device does not have" half (knowledge
+  blobs are no longer encrypted on upload; `KnowledgeCloudVersion.tsx:201-206`).
+- `apps/daemon/src/sync/oss/engine.rs:817-822` — `Stage 0: encrypt + hash` label
+  and the `[oss_sync] encrypt {p}` warn are stale names; rename to hash/prepare.
+
+**Commit** (when explicitly requested):
+
+```bash
+git add docs/adr/0008-knowledge-sync-p0-p1-scope.md \
+  docs/plans/2026-08-26-knowledge-sync-p0-p1.md \
+  docs/architecture/knowledge-sync-push-notify.md \
+  docs/architecture/obsidian-compatible-knowledge.md \
+  CLAUDE.md
+git commit -m "$(cat <<'MSG'
+docs: lock knowledge sync P0/P1 scope and fix E2E narrative
+
+ADR-0008 freezes product scope after a code-verified grill; architecture
+docs and CLAUDE.md stop claiming end-to-end encryption or a secret
+precondition for knowledge sync (uploads are plaintext).
+MSG
+)"
+```
+
+---
+
+### Task 1: Move conflict sidecars under `.conflicts/` (Phase A)
+
+**Files:**
+
+- Modify: `apps/daemon/src/sync/oss/conflict.rs` (`conflict_filename`,
+  `original_from_conflict`, `conflict_timestamp` — path now mirrors the original's
+  relative dir under `.conflicts/`)
+- Modify: `apps/daemon/src/sync/oss/scanner.rs` — **hard-skip** the `.conflicts/`
+  directory next to the existing `is_conflict_file` skip (not via `IgnoreRules`,
+  so a team `.amuxignore` `!.conflicts/` cannot re-include it); `scan_conflict_files`
+  walks `.conflicts/` instead of the whole tree
+- Modify: pull path in `engine.rs` — skip any manifest entry under `.conflicts/`
+  with `continue`, never `return Err` (§4.5 lesson)
+- Modify: `apps/daemon/src/http/team_sync.rs` `conflict_entries` / resolve handler
+  (sidecar path is now under `.conflicts/`)
+- Modify: `packages/app/src/stores/team-conflicts.ts` — delete
+  `isConflictSidecarName` (`.includes('.conflict.')` disagrees with the daemon's
+  numeric-timestamp check and hides `merge.conflict.md`);
+  `packages/app/src/lib/knowledge-tree-pruning.ts` prunes the `.conflicts/`
+  directory instead; `KnowledgeConflictResolver.tsx` + tests still open both sides
+
+**Layout (chosen in ADR):**
+
+```text
+knowledge/a/foo.md
+knowledge/.conflicts/a/foo.conflict.<ts>.<hash>.md
+```
+
+**Step 1: Daemon unit tests** — new path ↔ original mapping (nested dirs, no
+extension, CJK names); scanner never yields anything under `.conflicts/`; a team
+rule `!.conflicts/` still does not re-include it.
+
+**Step 2: Implement writer + readers.**
+
+**Step 3: Legacy sidecars — move-on-scan.** Sidecars were never uploaded (scanner
+skips them), so this is a local rename with no tombstone side effect: when the
+scanner meets `<stem>.conflict.<ts>.<hash>[.<ext>]` beside a note, move it to the
+mirrored `.conflicts/` path and continue.
+
+**Step 4: Frontend tests** — tree hides `.conflicts/`, shows `merge.conflict.md`;
+conflict tabs still resolve.
+
+**Step 5: Commit** `fix(sync): store knowledge conflict sidecars under .conflicts/`
+
+---
+
+### Task 2: Per-team sync scheduler (Phase B, part 1)
+
+**Files:**
+
+- Create: `apps/daemon/src/sync/scheduler.rs` (pure logic, no I/O; driven by a
+  clock trait so tests are deterministic)
+- Modify: `apps/daemon/src/sync/dispatch.rs` — own one scheduler per team; the
+  scheduler's "fire" calls `sync_team(team_id, TickOptions { force: false, allow_bulk_add: false, .. })`
+- Do **not** touch `apps/daemon/src/sync/timer.rs` — the 300s timer and the
+  manual `POST /v1/team/sync` (force) bypass the scheduler
+
+**Semantics (ADR):**
+
+- Inputs: `Trigger::Local` (fs event) and `Trigger::Remote { seq: i64 }` (hint).
+- Coalescing window: first trigger opens a fixed **2s** window; further triggers
+  inside it are merged; the window **never resets** (this is the "continuous
+  writes still sync" property — a debounce fails it).
+- Floor: earliest next tick = `last_tick_end + floor(kind)`, `Local` = 5s,
+  `Remote` = 15s. When both kinds are pending, use the smaller floor. If the
+  window closes before the floor, schedule at the floor, never drop.
+- Floor is measured from the **end** of the previous tick (a slow tick must not
+  queue the next one back-to-back).
+
+**Step 1: Failing tests**
+
+- quiet: one `Local` → fires at +2s
+- burst: 50 triggers in 1.5s → exactly one fire
+- continuous: a trigger every 500ms for 60s → fires at ~2s, then every 5s (not zero)
+- floor: `Remote` right after a tick ends → fires at +15s, not +2s
+- mixed pending: `Local` + `Remote` pending → floor 5s
+- a tick that takes 20s → next fire ≥ 15s after it **ends**
+
+**Step 2: Implement.**
+
+**Step 3: Commit** `feat(sync): per-team coalescing scheduler for sync triggers`
+
+---
+
+### Task 3: Daemon fs watch on knowledge root (Phase B, part 2)
+
+**Files:**
+
+- Create: `apps/daemon/src/sync/watch.rs` — independent of
+  `runtime/refresh_watch.rs` (that classifier feeds runtime refresh; do not add a
+  Knowledge kind there). Copy its patterns: parent-dir watch for atomic saves,
+  drop `EventKind::Access`, 2s reconcile loop for roots that appear later
+  (team join / re-onboard).
+- Root: `<content root>/knowledge` per team from `global_team_store`
+- Reuse `IgnoreRules::is_ignored_with_ancestors` to **filter events** (it cannot
+  limit `notify`'s recursive registration)
+- Self-write suppression: the pull phase records the set of paths it wrote;
+  events on those paths within **3s** are dropped. Not a time-window blanket
+  suppression — a user's real edit during a pull must still schedule a tick.
+- Failure mode: watcher creation error or runtime error → `warn!` **once**, stop
+  watching that team, rely on the 300s timer. No retry loop.
+- Wire: surviving events → `scheduler.trigger(team, Trigger::Local)`
+
+**Step 1: Unit tests** — ignored subtree storm schedules nothing; pull-written
+paths within 3s schedule nothing but a foreign path during the same pull does;
+watcher error leaves the daemon running.
+
+**Step 2: Implement spawn next to the sync timer** (`sync/timer.rs` neighbor).
+
+**Step 3: Acceptance** — Obsidian save on A (TeamClu app closed) → push within
+~2s window + tick; a `node_modules/` inside `knowledge/` does not crash the daemon
+(Linux inotify limits) and the rest still syncs.
+
+**Step 4: Commit** `feat(daemon): watch knowledge dir to trigger sync`
+
+**Release gate:** Task 1 ships **before or with** Tasks 2–3 (ADR consequence).
+
+---
+
+### Task 4: Shared MQTT topic helper (Phase C, part 1)
+
+**Files:**
+
+- Modify: `crates/teamclu-types/src/mqtt.rs` — `Topics::sync(resource)` +
+  free `sync_topic(team_id, resource)`; extend `shared_topic_functions_match_wire_paths`
+- Mirror: `services/fc/src/lib/mqtt-topics.ts` (create) + unit test on the literal
+- Swift mirror (`apps/ios/.../MQTTTopics.swift`) is **not** required now — iOS has
+  no knowledge sync; parity is by convention (each side asserts its own literal)
+
+**Step 1: Failing test** — `sync_topic("TEAM", "knowledge") == "amux/TEAM/sync/knowledge"`.
+Resource segment **last** (`sync/+` ACL forever).
+
+**Step 2: Implement. Step 3: Commit** `feat(mqtt): add amux/<team>/sync/<resource> topic helper`
+
+---
+
+### Task 5: FC publishes one hint per successful batch call (Phase C, part 2)
+
+**Files:**
+
+- Modify: `services/fc/src/lib/sync-handlers.ts` — after `handleSyncUploadCompleteBatch`
+  and the delete-batch handler have processed their items, publish **once** with
+  the highest `changeSeq` among the successful items (single-item complete/delete
+  publish too — that path is only reached by old daemons)
+- Publish via the existing `createMqttPublisher` singleton
+  (`services/fc/src/lib/mqtt-client.ts`, wired in `push-deps.ts`)
+- Test: `services/fc/test/` — one batch of N completes → exactly one publish;
+  payload `{ v: 1, changeSeq, originNodeId, at }`; **no** `path`; publish failure or
+  missing `MQTT_BROKER_URL` does not change the HTTP result
+
+**Rules:**
+
+- **No coalescing timer.** The daemon already batches 200 per call, so a tick
+  produces ≤10 hints (2000-new-file gate). A timer would also be unreliable on the
+  Alibaba FC target (frozen instance after response).
+- `await` the publish with a **500ms** timeout; on timeout `warn!` and still
+  return 200 — the hint is best-effort, the 300s timer is the fallback.
+- `originNodeId` = the request body's `nodeId` (one caller per call, no ambiguity);
+  `null` when absent.
+- QoS 1, **not** retain.
+- FC's service token has no `acl` claim and EMQX has no authz source, so the
+  publish side needs **no** ACL change.
+
+**Step 1: Failing test. Step 2: Implement. Step 3: `cd services/fc && npm test`.**
+
+**Step 4: Commit** `feat(fc): broadcast knowledge sync hints per batch call`
+
+**Step 5: Deploy/observe (ops)** — `mosquitto_sub` on `amux/+/sync/knowledge`
+confirms messages and payload shape. No daemon subscribe yet → zero user risk.
+
+---
+
+### Task 6: ACL migration for `sync/+` (Phase D)
+
+**Files:**
+
+- Create: `services/supabase/migrations/YYYYMMDDHHMMSS_acl_sync_topic.sql`
+- Modify: `public.amux_acl_rules_for` (current definition:
+  `20260706120000_member_sub_own_rpc_req.sql`)
+- pgTAP test following the existing ACL pattern
+
+**Step 1: Write migration** — for **both** `member` and `agent`:
+
+```sql
+('sub', format('amux/%s/sync/+', p_team))
+```
+
+**Step 2: Migration comment states the facts:**
+
+- ACL is baked into the JWT by `amux_access_token_hook`; existing connections keep
+  their old claim until the token rotates (3600s) — the daemon rebuilds its MQTT
+  connection 5 min before expiry, so **≤1h** after this migration every daemon can
+  subscribe.
+- Because Task 8's subscribe is tolerant, shipping this migration and the daemon
+  in the same release is acceptable; "migrate first" is advice, not a gate.
+- The Postgres/Better-Auth backend mints no `acl` claim and the all-in-one image
+  runs NanoMQ without ACL — this migration only matters on the Supabase backend;
+  do not validate it against all-in-one.
+
+**Step 3: Commit** `fix(db): allow sub amux/<team>/sync/+ for member and agent`
+
+---
+
+### Task 7: Daemon passes `daemon_device_id` as upload `node_id` (Phase E, part 1)
+
+**Files:**
+
+- Modify: `apps/daemon/src/sync/oss/engine.rs` — `engine.rs:837` (`PrepareBatchItem`),
+  `:1186` (`DeleteBatchItem`), `:1316-1323` (`upload_prepare`), `:1409` (`delete_file`)
+  all pass `None` today
+- Read: `apps/daemon/src/device_id.rs:47` `daemon_device_id()`
+- Test: prepare/delete payload contains `nodeId == daemon_device_id()`
+
+**Verify at implement time:** whether the daemon updates its server high-water
+seq from its own `complete-batch` response or only from manifest pulls. If only
+from pulls, the echo filter in Task 8 is what prevents a wasted tick after every
+own push — not just an optimization.
+
+**Step 1: Failing test. Step 2: Plumb. Step 3: Commit**
+`fix(daemon): set created_by_node_id on knowledge uploads`
+
+---
+
+### Task 8: Optional subscribe + hint → scheduler (Phase E, part 2)
+
+**Files:**
+
+- Modify: `apps/daemon/src/mqtt/supervisor.rs` — `MqttCommand::Subscribe` gains
+  `optional: bool` (or a sibling `SubscribeOptional`); tracked subscriptions carry
+  the flag; on SUBACK failure for an optional topic: `warn!` once, **no**
+  `forced_rebuild`, **no** `PublisherError::Unavailable` escalation; the restore
+  loop after CONNACK (`supervisor.rs:1624-1634`, `:1717-1746`) applies the same rule
+- Modify: `apps/daemon/src/daemon/server.rs` `mqtt_resubscribe_after_connack`
+  (`:886-915`) — subscribe `amux/<team>/sync/+` as optional, never `return Err` for it
+- Modify: `apps/daemon/src/mqtt/subscriber.rs` `parse_frame` — new family:
+  4 segments, `parts[2] == "sync"`, `parts[3]` = resource; unknown resource → ignore
+- Modify: `apps/daemon/src/sync/dispatch.rs` — on accepted hint:
+  drop if `originNodeId == daemon_device_id()`; drop if `changeSeq <= high-water`;
+  drop unknown `v` (warn once); else `scheduler.trigger(team, Trigger::Remote { seq })`
+- Test: parse tests; filter tests; supervisor test that a rejected optional
+  subscribe does not schedule a rebuild while a rejected required one still does
+
+**Retry cadence:** optional subscribes are retried only on the next (re)connect —
+token rotation guarantees one within 1h. No dedicated timer.
+
+**Manual / integration checklist (ADR + push-notify §12):**
+
+1. A saves in Obsidian → B sees it in Obsidian within ≤10s (Tasks 2–3 + 5 + 8 all live)
+2. A pushes 2000 files in one tick → ≤10 hints, not 2000
+3. A does not re-tick on its own echo once `nodeId` is set
+4. Kill EMQX → sync continues on the 300s timer; daemon logs warn; **no worker
+   rebuild loop** beyond the existing 5→30s backoff; RPC recovers when EMQX returns
+5. Daemon with a **pre-migration token** → `sync/+` denied → one warn, worker not
+   rebuilt, RPC/session-live unaffected; subscribe succeeds after rotation (≤1h)
+6. Broker capture: payload has no paths
+7. 10 people editing for an hour → each device ticks ≤ `3600/15` from remote hints
+8. Continuous typing in Obsidian for 10 min on A → A ticks ≤ `600/5`, B keeps
+   receiving throughout (coalesce, not debounce)
+9. A pull that writes 50 files does not trigger a second local tick on the receiver
+
+**Commit** `feat(daemon): pull knowledge on MQTT sync hints`
+
+---
+
+### Task 9: Per-team byte quota (Phase F)
+
+**Files:**
+
+- Modify: `services/fc/src/lib/sync-guards.ts` — `maxBytesPerTeam()` (env
+  `SYNC_MAX_BYTES_PER_TEAM`, default `2 * 1024 ** 3`), `liveByteSum(teamId, sumBytes)`
+  with the same "cannot establish → `null` → allow" policy as the file count
+- Modify: `services/fc/src/lib/sync-handlers.ts` — `handleSyncUploadPrepareBatch`
+  fetches the live sum **once per batch call** and keeps a running total of item
+  `size` across the batch; the item that crosses the line and every item after it
+  get 422 `{ code: 'QuotaExceeded', kind: 'bytes' }`. Single prepare: `sum + size`.
+- Repository: `sum(size)` over live files on both backends — pg-repo via drizzle,
+  Supabase via a new RPC `amux.amuxc_team_live_bytes(team_id)` (migration)
+- Env: declare in `deploy/self-host/docker-compose.yml` (fc `environment:`, indent 6),
+  `services/fc/s.yaml` (`environmentVariables:`, indent 8), `.env.example` —
+  `deploy-env-parity.test.ts` also requires the source to actually read it
+- Test: `services/fc/test/sync-guards.test.ts` + handler test for the batch running total
+
+**Not disk protection:** physical usage also holds historical version blobs;
+reclaiming them is `amux.oss_sync_gc_orphan_blobs()` on the FC cron, which lives
+under the compose `cron` profile that self-host does not enable. Enabling it is an
+**ops ticket outside this plan** (watch for the drizzle `search_path` failure noted
+in memory). Until it is closed, do not describe the quota as disk protection.
+
+**Step 1: Failing tests** — over-quota single prepare → 422; batch that crosses at
+item k → items ≥ k rejected, < k accepted; sum failure → allow.
+
+**Step 2: RPC + guard + env parity.**
+
+**Step 3: Commit** `feat(fc): enforce per-team knowledge byte quota`
+
+---
+
+### Task 10: Final verification checklist
+
+Run (docs/daemon/FC as applicable in the executing worktree — **no cargo in
+parallel worktrees**; use the `rust:*` wrappers):
+
+- [ ] ADR-0008 matches shipped behavior
+- [ ] No docs or locale strings claim knowledge encryption / E2E
+- [ ] MQTT payload fixtures contain no paths
+- [ ] Optional-subscribe rejection does not rebuild the worker (regression test)
+- [ ] Obsidian: conflict files invisible under `.conflicts/`; `merge.conflict.md` visible
+- [ ] Timer still 300s; manual Sync Now still bypasses the scheduler
+- [ ] `SYNC_MAX_BYTES_PER_TEAM` on **both** compose and `s.yaml` and `.env.example`
+- [ ] Freeze items untouched (no block store, no compression writer, no activity UI,
+      no prepare rate limit, no rename `.md` completion)
+
+**Stop.** Do not lengthen the timer here. Do not start P2/P3.
+
+---
+
+## Suggested PR slicing
+
+1. Docs + ADR + `CLAUDE.md` (Task 0) — this branch ships alone
+2. `.conflicts/` (Task 1)
+3. Scheduler + fs watch (Tasks 2–3) — **after or with** PR 2
+4. Topic helper + FC per-call publish (Tasks 4–5)
+5. ACL migration (Task 6)
+6. Daemon nodeId + optional subscribe + hint wiring (Tasks 7–8)
+7. Byte quota (Task 9)
+
+## Open knobs (do not block implementation)
+
+- Floors 5s (local) / 15s (remote) and the 2s window are hardcoded starting
+  points; tune in a follow-up PR with tick-rate data from Task 8's checklist #7–8
+- `SYNC_MAX_BYTES_PER_TEAM` default 2 GiB — revisit once the GC ticket is closed
+  and real team sizes are known

--- a/packages/app/src/components/teamshare/KnowledgeCloudVersion.tsx
+++ b/packages/app/src/components/teamshare/KnowledgeCloudVersion.tsx
@@ -202,7 +202,7 @@ export function KnowledgeCloudVersion({ path }: { path: string }) {
           <div className="px-4 py-8 text-center text-[13px] text-muted-foreground">
             {t(
               'cloudVersion.unreadable',
-              'The cloud copy cannot be read here: it is either binary, or encrypted with a team secret this device does not have.',
+              'The cloud copy cannot be read here: it is binary.',
             )}
           </div>
         ) : (

--- a/packages/app/src/components/teamshare/__tests__/KnowledgeConflictResolver.test.tsx
+++ b/packages/app/src/components/teamshare/__tests__/KnowledgeConflictResolver.test.tsx
@@ -59,7 +59,7 @@ vi.mock('@/lib/team-skill-paths', () => ({
 }))
 
 const DOC = `${KNOWLEDGE_DIR}/note.md`
-const SIDECAR = 'knowledge/note.conflict.1000.aabbccdd.md'
+const SIDECAR = 'knowledge/.conflicts/note.conflict.1000.aabbccdd.md'
 
 const conflict = { path: 'knowledge/note.md', sidecar: SIDECAR, conflictedAt: 1000, kind: 'oss' }
 
@@ -101,7 +101,9 @@ describe('KnowledgeConflictResolver', () => {
 
     await waitFor(() => expect(screen.getByText(/my draft/)).toBeTruthy())
     expect(screen.getByText(/cloud text/)).toBeTruthy()
-    expect(readTextFile).toHaveBeenCalledWith(`${KNOWLEDGE_DIR}/note.conflict.1000.aabbccdd.md`)
+    expect(readTextFile).toHaveBeenCalledWith(
+      `${KNOWLEDGE_DIR}/.conflicts/note.conflict.1000.aabbccdd.md`,
+    )
     expect(readTextFile).toHaveBeenCalledWith(DOC)
   })
 

--- a/packages/app/src/components/teamshare/__tests__/KnowledgeSyncFooter.test.tsx
+++ b/packages/app/src/components/teamshare/__tests__/KnowledgeSyncFooter.test.tsx
@@ -170,7 +170,9 @@ describe('KnowledgeSyncFooter', () => {
   })
 
   it('leads with conflicts, and the list goes to the decision instead of syncing', async () => {
-    conflictState.entries = [{ path: 'knowledge/note.md', sidecar: 'knowledge/note.conflict.1.a.md' }]
+    conflictState.entries = [
+      { path: 'knowledge/note.md', sidecar: 'knowledge/.conflicts/note.conflict.1.a.md' },
+    ]
     render(<KnowledgeSyncFooter />)
 
     expect(screen.getByText('1 conflicts need a decision')).toBeTruthy()
@@ -216,7 +218,9 @@ describe('KnowledgeSyncFooter', () => {
     unmount()
 
     // A conflict is local, so it is decidable either way.
-    conflictState.entries = [{ path: 'knowledge/note.md', sidecar: 'knowledge/note.conflict.1.a.md' }]
+    conflictState.entries = [
+      { path: 'knowledge/note.md', sidecar: 'knowledge/.conflicts/note.conflict.1.a.md' },
+    ]
     render(<KnowledgeSyncFooter />)
     fireEvent.click(screen.getByTestId('knowledge-sync-footer'))
     fireEvent.click(await screen.findByText('note.md'))

--- a/packages/app/src/lib/__tests__/knowledge-tree-pruning.test.ts
+++ b/packages/app/src/lib/__tests__/knowledge-tree-pruning.test.ts
@@ -28,18 +28,27 @@ describe('pruneKnowledgeNoise', () => {
     expect(out[0].children!.map((n) => n.name)).toEqual(['a.md'])
   })
 
-  it('hides conflict sidecars but keeps the document itself', () => {
+  it('hides the .conflicts directory but keeps ordinary notes', () => {
     const tree = [
       file(`${KNOWLEDGE}/note.md`),
-      file(`${KNOWLEDGE}/note.conflict.1748332800.abc123de.md`),
+      dir(`${KNOWLEDGE}/.conflicts`, [
+        file(`${KNOWLEDGE}/.conflicts/note.conflict.1748332800.abc123de.md`),
+      ]),
     ]
     const out = pruneKnowledgeNoise(tree, opts)
     expect(out.map((n) => n.name)).toEqual(['note.md'])
   })
 
-  // The scoping test. A user's own vault, or a source file that happens to be
-  // called `foo.conflict.ts`, lives outside the knowledge tree and must be left
-  // alone — hiding it would be a bug of our own.
+  // A note somebody named after the word — must stay visible. The old
+  // `.includes('.conflict.')` check hid it while the daemon still synced it.
+  it('keeps merge.conflict.md visible', () => {
+    const tree = [file(`${KNOWLEDGE}/merge.conflict.md`), file(`${KNOWLEDGE}/note.md`)]
+    const out = pruneKnowledgeNoise(tree, opts)
+    expect(out.map((n) => n.name)).toEqual(['merge.conflict.md', 'note.md'])
+  })
+
+  // The scoping test. A user's own vault lives outside the knowledge tree and
+  // must be left alone — hiding it would be a bug of our own.
   it('leaves .obsidian alone outside the knowledge tree', () => {
     const tree = [dir('/work/my-vault/.obsidian'), file('/work/a.md')]
     const out = pruneKnowledgeNoise(tree, opts)

--- a/packages/app/src/lib/__tests__/knowledge-tree-pruning.test.ts
+++ b/packages/app/src/lib/__tests__/knowledge-tree-pruning.test.ts
@@ -67,4 +67,24 @@ describe('pruneKnowledgeNoise', () => {
     const tree = [file(`${KNOWLEDGE}/.obsidian`)]
     expect(pruneKnowledgeNoise(tree, opts).map((n) => n.name)).toEqual(['.obsidian'])
   })
+
+  // The daemon's `is_under_conflicts_dir` only hard-skips `<prefix>/.conflicts`,
+  // so a folder a user happens to name `.conflicts` deeper in the tree is their
+  // own: it syncs and is shared with the team. Matching by bare directory name
+  // hid files that really do sync — the `merge.conflict.md` bug inverted.
+  it('keeps a user directory named .conflicts below the knowledge root', () => {
+    const tree = [
+      dir(`${KNOWLEDGE}/.conflicts`, [
+        file(`${KNOWLEDGE}/.conflicts/note.conflict.1748332800.abc123de.md`),
+      ]),
+      dir(`${KNOWLEDGE}/projects`, [
+        dir(`${KNOWLEDGE}/projects/.conflicts`, [
+          file(`${KNOWLEDGE}/projects/.conflicts/notes.md`),
+        ]),
+      ]),
+    ]
+    const out = pruneKnowledgeNoise(tree, opts)
+    expect(out.map((n) => n.name)).toEqual(['projects'])
+    expect(out[0].children!.map((n) => n.name)).toEqual(['.conflicts'])
+  })
 })

--- a/packages/app/src/lib/knowledge-tree-pruning.ts
+++ b/packages/app/src/lib/knowledge-tree-pruning.ts
@@ -7,13 +7,25 @@ import { teamSyncKeyForPath } from '@/lib/team-skill-paths'
  * `.obsidian` is Obsidian's own per-vault config. We create it ourselves when
  * first registering the knowledge dir as a vault, so it is present on every
  * machine — and it is never synced, so listing it would put a folder nobody
- * asked for at the top of the team's documents.
- *
- * `.conflicts` holds the sync engine's local-only conflict copies (mirrored
- * under the note's relative path). Obsidian ignores dot-directories; we hide
- * the same folder so the tree badge on the document is the only signal.
+ * asked for at the top of the team's documents. Matched by NAME at any depth,
+ * which is what the daemon does too: `.obsidian/` in its builtin ignore list is
+ * a gitignore pattern without a leading slash, so it matches at every level.
  */
-const KNOWLEDGE_TOOLING_DIRS = new Set(['.obsidian', '.conflicts'])
+const KNOWLEDGE_TOOLING_DIRS = new Set(['.obsidian'])
+
+/**
+ * The sync engine's local-only conflict copies, mirrored under the note's
+ * relative path. Obsidian ignores dot-directories; we hide the same folder so
+ * the tree badge on the document is the only signal.
+ *
+ * Matched by SYNC KEY, not by name: the daemon's `is_under_conflicts_dir` only
+ * hard-skips `<prefix>/.conflicts`, so a folder a user happens to call
+ * `.conflicts` deeper in the tree (`knowledge/projects/.conflicts/`) is theirs —
+ * it syncs and is shared with the team. Hiding it by name would make files that
+ * really do sync invisible: the same daemon/UI disagreement that once hid
+ * `merge.conflict.md`, just inverted.
+ */
+const CONFLICTS_SYNC_KEY = 'knowledge/.conflicts'
 
 export interface KnowledgeScopeOpts {
   knowledgeDir?: string | null
@@ -41,9 +53,9 @@ export function pruneKnowledgeNoise(
   let changed = false
   const out: FileNode[] = []
   for (const node of nodes) {
-    const inKnowledge = teamSyncKeyForPath(node.path, opts) !== null
-    if (inKnowledge) {
-      if (node.type === 'directory' && KNOWLEDGE_TOOLING_DIRS.has(node.name)) {
+    const syncKey = teamSyncKeyForPath(node.path, opts)
+    if (syncKey !== null && node.type === 'directory') {
+      if (KNOWLEDGE_TOOLING_DIRS.has(node.name) || syncKey === CONFLICTS_SYNC_KEY) {
         changed = true
         continue
       }

--- a/packages/app/src/lib/knowledge-tree-pruning.ts
+++ b/packages/app/src/lib/knowledge-tree-pruning.ts
@@ -1,5 +1,4 @@
 import type { FileNode } from '@/stores/workspace'
-import { isConflictSidecarName } from '@/stores/team-conflicts'
 import { teamSyncKeyForPath } from '@/lib/team-skill-paths'
 
 /**
@@ -9,8 +8,12 @@ import { teamSyncKeyForPath } from '@/lib/team-skill-paths'
  * first registering the knowledge dir as a vault, so it is present on every
  * machine — and it is never synced, so listing it would put a folder nobody
  * asked for at the top of the team's documents.
+ *
+ * `.conflicts` holds the sync engine's local-only conflict copies (mirrored
+ * under the note's relative path). Obsidian ignores dot-directories; we hide
+ * the same folder so the tree badge on the document is the only signal.
  */
-const KNOWLEDGE_TOOLING_DIRS = new Set(['.obsidian'])
+const KNOWLEDGE_TOOLING_DIRS = new Set(['.obsidian', '.conflicts'])
 
 export interface KnowledgeScopeOpts {
   knowledgeDir?: string | null
@@ -18,17 +21,15 @@ export interface KnowledgeScopeOpts {
 }
 
 /**
- * Drop what a team-knowledge tree should not show: conflict sidecars, and the
- * tooling directories above.
+ * Drop what a team-knowledge tree should not show: tooling directories above.
  *
- * A sidecar is a local-only copy the sync engine parked next to a document it
- * had to overwrite. Listing it turns one conflict into two near-identical rows
- * with no explanation; the document's own row carries the badge instead, and
- * the sidecar is what the decision view reads.
+ * Conflict copies live under `.conflicts/` (not beside the note), so pruning
+ * that directory is enough — do not hide ordinary notes whose names happen to
+ * contain `.conflict.` (e.g. `merge.conflict.md`).
  *
  * Both rules are scoped to team knowledge by the same test, because a
- * workspace may legitimately hold a `foo.conflict.ts` or the user's own
- * Obsidian vault — hiding those would be a bug of our own.
+ * workspace may legitimately hold the user's own Obsidian vault — hiding those
+ * would be a bug of our own.
  *
  * Returns the SAME array when nothing was pruned, so the common case costs one
  * walk and no downstream re-render.
@@ -42,10 +43,6 @@ export function pruneKnowledgeNoise(
   for (const node of nodes) {
     const inKnowledge = teamSyncKeyForPath(node.path, opts) !== null
     if (inKnowledge) {
-      if (node.type !== 'directory' && isConflictSidecarName(node.name)) {
-        changed = true
-        continue
-      }
       if (node.type === 'directory' && KNOWLEDGE_TOOLING_DIRS.has(node.name)) {
         changed = true
         continue

--- a/packages/app/src/locales/en.json
+++ b/packages/app/src/locales/en.json
@@ -2784,7 +2784,7 @@
     "restored": "The cloud version was written to this document",
     "restoreFailed": "Could not restore: {{msg}}",
     "notPushed": "This document only exists here — the cloud has no copy of it yet.",
-    "unreadable": "The cloud copy cannot be read here: it is either binary, or encrypted with a team secret this device does not have.",
+    "unreadable": "The cloud copy cannot be read here: it is binary.",
     "notTeamContent": "This file is not part of the team knowledge base."
   },
   "knowledgeConflict": {

--- a/packages/app/src/locales/zh-CN.json
+++ b/packages/app/src/locales/zh-CN.json
@@ -2784,7 +2784,7 @@
     "restored": "已把云端版本写回这篇文档",
     "restoreFailed": "恢复失败：{{msg}}",
     "notPushed": "这篇文档只存在于本机 —— 云端还没有它。",
-    "unreadable": "这份云端内容在这台机器上读不出来：要么是二进制，要么是用本机没有的团队密钥加密的。",
+    "unreadable": "这份云端内容在这台机器上读不出来：是二进制。",
     "notTeamContent": "这个文件不属于团队知识库。"
   },
   "knowledgeConflict": {

--- a/packages/app/src/stores/__tests__/team-conflicts.test.ts
+++ b/packages/app/src/stores/__tests__/team-conflicts.test.ts
@@ -17,8 +17,8 @@ vi.mock('@/stores/oss-sync', () => ({
 
 const { useTeamConflictsStore } = await import('../team-conflicts')
 
-const SIDECAR = 'knowledge/note.conflict.1000.aabbccdd.md'
-const OLDER = 'knowledge/note.conflict.900.eeeeeeee.md'
+const SIDECAR = 'knowledge/.conflicts/note.conflict.1000.aabbccdd.md'
+const OLDER = 'knowledge/.conflicts/note.conflict.900.eeeeeeee.md'
 
 function entry(sidecar: string, conflictedAt: number) {
   return { path: 'knowledge/note.md', sidecar, conflictedAt, kind: 'oss-sidecar' }
@@ -49,7 +49,7 @@ describe('team-conflicts store', () => {
     await useTeamConflictsStore.getState().load()
 
     expect(useTeamConflictsStore.getState().absPathFor(SIDECAR)).toBe(
-      '/home/u/.amuxd/teams/team-1/shared/knowledge/note.conflict.1000.aabbccdd.md',
+      '/home/u/.amuxd/teams/team-1/shared/knowledge/.conflicts/note.conflict.1000.aabbccdd.md',
     )
     // Anything outside the knowledge prefix is not ours to place.
     expect(useTeamConflictsStore.getState().absPathFor('skills/x.md')).toBeNull()

--- a/packages/app/src/stores/team-conflicts.ts
+++ b/packages/app/src/stores/team-conflicts.ts
@@ -9,9 +9,10 @@ import { TEAM_SYNCED_EVENT } from '@/lib/build-config'
  * One conflict waiting for a human decision.
  *
  * A conflict happens when a document changed on both sides: the sync engine
- * parks the local bytes in a sidecar and lets the remote version overwrite the
- * document. So `path` is the document the user recognises (already holding the
- * REMOTE text), and `sidecar` is where their own text went.
+ * parks the local bytes in a sidecar under `.conflicts/` and lets the remote
+ * version overwrite the document. So `path` is the document the user recognises
+ * (already holding the REMOTE text), and `sidecar` is where their own text went
+ * (e.g. `knowledge/.conflicts/a/foo.conflict.<ts>.<hash>.md`).
  */
 export interface TeamConflict {
   /** Sync key of the document, e.g. `knowledge/onboarding.md`. */
@@ -48,17 +49,6 @@ interface TeamConflictsState {
 }
 
 const KNOWLEDGE_PREFIX = 'knowledge/'
-
-/**
- * Whether a filename is a conflict sidecar (`<stem>.conflict.<ts>.<hash>[.<ext>]`).
- *
- * Must agree with the daemon's `has_conflict_infix` — that is what decides which
- * files the sync engine refuses to upload, and the same files are the ones the
- * knowledge tree hides in favour of a badge on the document itself.
- */
-export function isConflictSidecarName(name: string): boolean {
-  return name.includes('.conflict.')
-}
 
 function groupBySyncKey(entries: TeamConflict[]): Record<string, TeamConflict[]> {
   const out: Record<string, TeamConflict[]> = {}

--- a/packages/app/src/stores/team-share-browser.ts
+++ b/packages/app/src/stores/team-share-browser.ts
@@ -17,7 +17,6 @@ import {
   type SkillLocalState,
 } from '@/lib/skills/auto-follow'
 import { useCurrentTeamStore } from '@/stores/current-team'
-import { isConflictSidecarName } from '@/stores/team-conflicts'
 import { effectiveWorkspacePath } from '@/lib/effective-workspace'
 import { useTabsStore } from '@/stores/tabs'
 import {
@@ -421,11 +420,11 @@ async function listTeamKnowledge(knowledgeDir: string): Promise<TeamKnowledgeIte
   // Dotfiles are deliberately not filtered: the tree renders them, so counting
   // them is what keeps the two numbers equal.
   //
-  // Conflict sidecars ARE filtered, for the same reason: the tree hides them
-  // and marks the document they belong to instead, so counting them here would
+  // `.conflicts/` IS filtered, for the same reason: the tree hides that folder
+  // and marks the document they belong to instead, so counting it here would
   // put a number next to the header that no visible row accounts for.
   return entries
-    .filter((entry) => !isConflictSidecarName(entry.name))
+    .filter((entry) => entry.name !== '.conflicts')
     .map((entry) => ({
       path: `${knowledgeDir}/${entry.name}`,
       relPath: entry.name,

--- a/services/fc/s.yaml
+++ b/services/fc/s.yaml
@@ -50,6 +50,7 @@ resources:
         # own MinIO — one code path, two backends, chosen per deployment.
         TEAM_BLOBS_BACKEND: ${env('TEAM_BLOBS_BACKEND', 's3')}
         SYNC_MAX_FILES_PER_TEAM: ${env('SYNC_MAX_FILES_PER_TEAM', '')}
+        SYNC_MAX_BYTES_PER_TEAM: ${env('SYNC_MAX_BYTES_PER_TEAM', '')}
         # OSS addresses buckets virtual-host style; only MinIO needs path style.
         S3_FORCE_PATH_STYLE: ${env('S3_FORCE_PATH_STYLE', '')}
         LITELLM_URL: ${env('LITELLM_URL', 'https://ai.ucar.cc')}

--- a/services/fc/src/lib/mqtt-topics.ts
+++ b/services/fc/src/lib/mqtt-topics.ts
@@ -1,0 +1,12 @@
+// MQTT topic path helpers.
+//
+// Wire-literal mirror of `crates/teamclu-types/src/mqtt.rs`. FC does not depend
+// on the Rust crate, so each side asserts its own literal. Resource is last so
+// ACL `amux/%s/sync/+` covers future resources without migration.
+
+/**
+ * Sync hint topic: `amux/<teamId>/sync/<resource>`.
+ */
+export function syncTopic(teamId: string, resource: string): string {
+  return `amux/${teamId}/sync/${resource}`;
+}

--- a/services/fc/src/lib/pg-repo/oss-sync.ts
+++ b/services/fc/src/lib/pg-repo/oss-sync.ts
@@ -431,6 +431,21 @@ export function makeOssSyncRepo(db: DbLike) {
     },
 
     /**
+     * Sum of `size` over live (non-deleted) files for a team.
+     * Empty team → 0. Used by the prepare byte-quota guard.
+     */
+    async sumLiveBytes(teamId: string): Promise<number> {
+      const [row] = await db
+        .select({
+          total: sql<number>`coalesce(sum(${amuxcFiles.size}), 0)`,
+        })
+        .from(amuxcFiles)
+        .where(and(eq(amuxcFiles.teamId, teamId), eq(amuxcFiles.deleted, false)));
+      const n = row?.total;
+      return typeof n === "number" && Number.isFinite(n) ? n : Number(n) || 0;
+    },
+
+    /**
      * Set team sync mode — only team owners may switch.
      * actorId must be a team owner (role='owner' in team_members).
      */

--- a/services/fc/src/lib/sync-guards.ts
+++ b/services/fc/src/lib/sync-guards.ts
@@ -81,10 +81,13 @@ export function maxFilesPerTeam(): number {
 // security boundary, so a team briefly running over it is not a failure.
 const COUNT_TTL_MS = 10_000;
 const countCache = new Map<string, { at: number; count: number }>();
+const BYTE_TTL_MS = 10_000;
+const byteCache = new Map<string, { at: number; sum: number }>();
 
-/** Drop cached counts. Tests only — production entries expire on their own. */
+/** Drop cached counts / sums. Tests only — production entries expire on their own. */
 export function resetQuotaCache(): void {
   countCache.clear();
+  byteCache.clear();
 }
 
 /**
@@ -114,4 +117,43 @@ export async function liveFileCount(
  */
 export function isOverFileQuota(count: number | null): boolean {
   return count !== null && count >= maxFilesPerTeam();
+}
+
+/**
+ * Largest total live-file byte size one team may hold.
+ *
+ * Counts current pointers in `amuxc_files` only — not historical version blobs
+ * on disk. Raising the env var does not reclaim space; that is a GC ops concern.
+ */
+export function maxBytesPerTeam(): number {
+  const raw = Number(process.env.SYNC_MAX_BYTES_PER_TEAM);
+  return Number.isFinite(raw) && raw > 0 ? raw : 2 * 1024 ** 3;
+}
+
+/**
+ * Sum of live file sizes for this team, cached for {@link BYTE_TTL_MS}.
+ *
+ * Returns `null` when the sum cannot be established — callers treat that as
+ * "allow", same policy as {@link liveFileCount}.
+ */
+export async function liveByteSum(
+  teamId: string,
+  sumBytes: (teamId: string) => Promise<number | null>,
+): Promise<number | null> {
+  const hit = byteCache.get(teamId);
+  if (hit && Date.now() - hit.at < BYTE_TTL_MS) return hit.sum;
+  const sum = await sumBytes(teamId).catch(() => null);
+  if (sum === null) return null;
+  byteCache.set(teamId, { at: Date.now(), sum });
+  return sum;
+}
+
+/**
+ * Whether a projected byte total (live sum + incoming size) exceeds the ceiling.
+ *
+ * Exactly at the ceiling is still allowed; one byte past is not. `null` → not
+ * over: see {@link liveByteSum}.
+ */
+export function isOverByteQuota(projectedTotal: number | null): boolean {
+  return projectedTotal !== null && projectedTotal > maxBytesPerTeam();
 }

--- a/services/fc/src/lib/sync-guards.ts
+++ b/services/fc/src/lib/sync-guards.ts
@@ -81,13 +81,10 @@ export function maxFilesPerTeam(): number {
 // security boundary, so a team briefly running over it is not a failure.
 const COUNT_TTL_MS = 10_000;
 const countCache = new Map<string, { at: number; count: number }>();
-const BYTE_TTL_MS = 10_000;
-const byteCache = new Map<string, { at: number; sum: number }>();
 
-/** Drop cached counts / sums. Tests only — production entries expire on their own. */
+/** Drop cached counts. Tests only — production entries expire on their own. */
 export function resetQuotaCache(): void {
   countCache.clear();
-  byteCache.clear();
 }
 
 /**
@@ -131,21 +128,21 @@ export function maxBytesPerTeam(): number {
 }
 
 /**
- * Sum of live file sizes for this team, cached for {@link BYTE_TTL_MS}.
+ * Sum of live file sizes for this team.
+ *
+ * Not TTL-cached across calls: prepare→complete updates live sizes, and the
+ * next prepare-batch must see the post-complete sum. Within a batch, the
+ * handler fetches once and keeps a running total across items.
  *
  * Returns `null` when the sum cannot be established — callers treat that as
- * "allow", same policy as {@link liveFileCount}.
+ * "allow", same policy as {@link liveFileCount}. That policy is about fetch
+ * failure, not about remembering a stale success.
  */
 export async function liveByteSum(
   teamId: string,
   sumBytes: (teamId: string) => Promise<number | null>,
 ): Promise<number | null> {
-  const hit = byteCache.get(teamId);
-  if (hit && Date.now() - hit.at < BYTE_TTL_MS) return hit.sum;
-  const sum = await sumBytes(teamId).catch(() => null);
-  if (sum === null) return null;
-  byteCache.set(teamId, { at: Date.now(), sum });
-  return sum;
+  return sumBytes(teamId).catch(() => null);
 }
 
 /**

--- a/services/fc/src/lib/sync-handlers.ts
+++ b/services/fc/src/lib/sync-handlers.ts
@@ -20,12 +20,26 @@ import { getDb, type Db } from '../db/client.js';
 import { ApiError } from './http-utils.js';
 import { teamWorkspaceConfig, amuxcUploadSessions } from '../db/schema/index.js';
 import { eq } from 'drizzle-orm';
+import { syncTopic } from './mqtt-topics.js';
+import { pgPushDeps, pushDeps } from './push-deps.js';
 
 const DOWNLOAD_TTL_SEC = 900;
+
+/** Best-effort MQTT publish budget for sync hints — never blocks the HTTP 200. */
+const SYNC_HINT_PUBLISH_TIMEOUT_MS = 500;
 
 // ---------------------------------------------------------------------------
 // Injectable deps — production callers omit these; tests inject stubs.
 // ---------------------------------------------------------------------------
+
+/** Minimal publisher surface (matches createMqttPublisher / push-deps). */
+export interface SyncMqttPublisher {
+  publish(
+    topic: string,
+    payload: string,
+    options?: { qos?: number; retain?: boolean },
+  ): Promise<void>;
+}
 
 export interface SyncHandlerDeps {
   db?: Db;
@@ -33,6 +47,18 @@ export interface SyncHandlerDeps {
   storage?: BlobStorage;
   /** Override the live-file count. Tests only — production reads the table. */
   countLiveFiles?: (teamId: string) => Promise<number | null>;
+  /**
+   * MQTT publisher for knowledge sync hints. `undefined` → resolve from
+   * push-deps (null when MQTT_BROKER_URL is unset). Explicit `null` skips.
+   */
+  mqtt?: SyncMqttPublisher | null;
+  /** Clock override for hint `at` (tests). */
+  now?: () => Date;
+  /**
+   * When true, skip the per-call hint — batch wrappers publish once after
+   * all items finish.
+   */
+  suppressSyncHint?: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -107,6 +133,127 @@ function resolveRepo(deps: SyncHandlerDeps): OssSyncRepo {
   if (deps.repo) return deps.repo;
   const db = deps.db ?? getDb();
   return makeOssSyncRepo(db);
+}
+
+function resolveMqtt(deps: SyncHandlerDeps): SyncMqttPublisher | null {
+  if (deps.mqtt !== undefined) return deps.mqtt;
+  try {
+    const bundle = resolveBackendKind() === 'postgres' ? pgPushDeps() : pushDeps();
+    return bundle.mqtt ?? null;
+  } catch (e: any) {
+    console.warn('[sync] mqtt resolve failed:', e?.message ?? e);
+    return null;
+  }
+}
+
+function originNodeIdFromBody(body: Record<string, unknown> | undefined): string | null {
+  const raw = body?.nodeId;
+  return typeof raw === 'string' && raw.length > 0 ? raw : null;
+}
+
+/**
+ * Best-effort knowledge sync hint: one MQTT message with the highest changeSeq
+ * among successful items. Never throws; 500ms timeout; missing broker is a no-op.
+ */
+async function publishKnowledgeSyncHint(opts: {
+  teamId: string;
+  changeSeq: number;
+  originNodeId: string | null;
+  deps: SyncHandlerDeps;
+}): Promise<void> {
+  const { teamId, changeSeq, originNodeId, deps } = opts;
+  if (deps.suppressSyncHint) return;
+  if (!Number.isFinite(changeSeq) || changeSeq <= 0) return;
+
+  const mqtt = resolveMqtt(deps);
+  if (!mqtt) return;
+
+  const now = deps.now ?? (() => new Date());
+  const topic = syncTopic(teamId, 'knowledge');
+  const payload = JSON.stringify({
+    v: 1,
+    changeSeq,
+    originNodeId,
+    at: now().toISOString(),
+  });
+
+  try {
+    await Promise.race([
+      mqtt.publish(topic, payload, { qos: 1, retain: false }),
+      new Promise<never>((_, reject) => {
+        setTimeout(
+          () => reject(new Error(`mqtt publish timeout after ${SYNC_HINT_PUBLISH_TIMEOUT_MS}ms`)),
+          SYNC_HINT_PUBLISH_TIMEOUT_MS,
+        );
+      }),
+    ]);
+  } catch (e: any) {
+    console.warn('[sync] knowledge hint publish failed:', e?.message ?? e);
+  }
+}
+
+/** Max changeSeq among successful batch results; null if none succeeded. */
+function maxSuccessfulChangeSeq(envelope: SyncEnvelope): number | null {
+  if (envelope.statusCode < 200 || envelope.statusCode >= 300) return null;
+  let parsed: { results?: unknown };
+  try {
+    parsed = envelope.body ? JSON.parse(envelope.body) : {};
+  } catch {
+    return null;
+  }
+  if (!Array.isArray(parsed.results)) return null;
+  let max: number | null = null;
+  for (const item of parsed.results) {
+    if (!item || typeof item !== 'object') continue;
+    const row = item as Record<string, unknown>;
+    if (row.ok !== true) continue;
+    const seq = row.changeSeq;
+    if (typeof seq === 'number' && Number.isFinite(seq)) {
+      max = max === null ? seq : Math.max(max, seq);
+    }
+  }
+  return max;
+}
+
+async function publishHintAfterBatch(
+  caller: { teamId: string },
+  body: Record<string, unknown> | undefined,
+  envelope: SyncEnvelope,
+  deps: SyncHandlerDeps,
+): Promise<void> {
+  const changeSeq = maxSuccessfulChangeSeq(envelope);
+  if (changeSeq === null) return;
+  await publishKnowledgeSyncHint({
+    teamId: caller.teamId,
+    changeSeq,
+    originNodeId: originNodeIdFromBody(body),
+    deps: { ...deps, suppressSyncHint: false },
+  });
+}
+
+async function publishHintAfterSingle(
+  caller: { teamId: string },
+  body: Record<string, unknown> | undefined,
+  envelope: SyncEnvelope,
+  deps: SyncHandlerDeps,
+): Promise<SyncEnvelope> {
+  if (deps.suppressSyncHint) return envelope;
+  if (envelope.statusCode < 200 || envelope.statusCode >= 300) return envelope;
+  let changeSeq: number | undefined;
+  try {
+    const parsed = envelope.body ? JSON.parse(envelope.body) : {};
+    if (typeof parsed.changeSeq === 'number') changeSeq = parsed.changeSeq;
+  } catch {
+    return envelope;
+  }
+  if (changeSeq === undefined) return envelope;
+  await publishKnowledgeSyncHint({
+    teamId: caller.teamId,
+    changeSeq,
+    originNodeId: originNodeIdFromBody(body),
+    deps,
+  });
+  return envelope;
 }
 
 // ---------------------------------------------------------------------------
@@ -515,11 +662,16 @@ export async function handleSyncUploadComplete(
 
     try {
       const result = await repo.completeUpload(uploadSessionId as string, actorId);
-      return json(200, {
-        version:     result.version,
-        contentHash: result.contentHash,
-        changeSeq:   result.changeSeq,
-      });
+      return publishHintAfterSingle(
+        caller,
+        body,
+        json(200, {
+          version:     result.version,
+          contentHash: result.contentHash,
+          changeSeq:   result.changeSeq,
+        }),
+        deps,
+      );
     } catch (e: any) {
       if (e instanceof ApiError) {
         if (e.statusCode === 409) return json(409, { reason: 'cas-mismatch', remoteVersion: undefined, remoteHash: undefined });
@@ -601,11 +753,16 @@ export async function handleSyncUploadComplete(
   }
 
   const result = (rpcResult as any[])[0];
-  return json(200, {
-    version:     result.version,
-    contentHash: result.content_hash,
-    changeSeq:   result.change_seq,
-  });
+  return publishHintAfterSingle(
+    caller,
+    body,
+    json(200, {
+      version:     result.version,
+      contentHash: result.content_hash,
+      changeSeq:   result.change_seq,
+    }),
+    deps,
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -701,7 +858,12 @@ export async function handleSyncDelete(
         actorId,
         nodeId: (nodeId as string | undefined) ?? null,
       });
-      return json(200, { version: result.version, changeSeq: result.changeSeq });
+      return publishHintAfterSingle(
+        caller,
+        body,
+        json(200, { version: result.version, changeSeq: result.changeSeq }),
+        deps,
+      );
     } catch (e: any) {
       if (e instanceof ApiError) {
         if (e.statusCode === 409) return json(409, { reason: 'cas-mismatch', remoteVersion: undefined, remoteHash: undefined });
@@ -746,10 +908,15 @@ export async function handleSyncDelete(
   }
 
   const result = (rpcResult as any[])[0];
-  return json(200, {
-    version:   result.version,
-    changeSeq: result.change_seq,
-  });
+  return publishHintAfterSingle(
+    caller,
+    body,
+    json(200, {
+      version:   result.version,
+      changeSeq: result.change_seq,
+    }),
+    deps,
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -988,7 +1155,11 @@ export async function handleSyncUploadCompleteBatch(
   body: Record<string, unknown> | undefined,
   deps: SyncHandlerDeps = {},
 ) {
-  return runSyncBatch(body?.items, (item) => handleSyncUploadComplete(caller, item, deps));
+  const envelope = await runSyncBatch(body?.items, (item) =>
+    handleSyncUploadComplete(caller, item, { ...deps, suppressSyncHint: true }),
+  );
+  await publishHintAfterBatch(caller, body, envelope, deps);
+  return envelope;
 }
 
 /** POST /sync/download-batch — N presigned GET URLs in one round-trip. */
@@ -1006,5 +1177,9 @@ export async function handleSyncDeleteBatch(
   body: Record<string, unknown> | undefined,
   deps: SyncHandlerDeps = {},
 ) {
-  return runSyncBatch(body?.items, (item) => handleSyncDelete(caller, item, deps));
+  const envelope = await runSyncBatch(body?.items, (item) =>
+    handleSyncDelete(caller, item, { ...deps, suppressSyncHint: true }),
+  );
+  await publishHintAfterBatch(caller, body, envelope, deps);
+  return envelope;
 }

--- a/services/fc/src/lib/sync-handlers.ts
+++ b/services/fc/src/lib/sync-handlers.ts
@@ -11,7 +11,7 @@
 import { createHash, randomUUID } from 'node:crypto';
 import { createServiceRoleClient } from './supabase.js';
 import { validateSyncPath } from './sync-path.js';
-import { isOverFileQuota, isRejectedSyncPath, liveFileCount, maxFilesPerTeam } from './sync-guards.js';
+import { isOverByteQuota, isOverFileQuota, isRejectedSyncPath, liveByteSum, liveFileCount, maxBytesPerTeam, maxFilesPerTeam } from './sync-guards.js';
 import { resolveBackendKind } from './backend-kind.js';
 import { getTeamBlobStorage, type BlobStorage } from './team-blob-storage.js';
 import { makeOssSyncRepo, type OssSyncRepo } from './pg-repo/oss-sync.js';
@@ -47,6 +47,8 @@ export interface SyncHandlerDeps {
   storage?: BlobStorage;
   /** Override the live-file count. Tests only — production reads the table. */
   countLiveFiles?: (teamId: string) => Promise<number | null>;
+  /** Override the live-file byte sum. Tests only — production reads the table. */
+  sumLiveBytes?: (teamId: string) => Promise<number | null>;
   /**
    * MQTT publisher for knowledge sync hints. `undefined` → resolve from
    * push-deps (null when MQTT_BROKER_URL is unset). Explicit `null` skips.
@@ -59,6 +61,11 @@ export interface SyncHandlerDeps {
    * all items finish.
    */
   suppressSyncHint?: boolean;
+  /**
+   * When true, skip the byte-quota check inside single prepare — batch
+   * already applied a running total across items.
+   */
+  skipByteQuota?: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -111,6 +118,36 @@ async function countLiveFiles(
     .eq('deleted', false);
   if (error) return null;
   return typeof count === 'number' ? count : null;
+}
+
+/**
+ * Sum of live (non-deleted) file sizes for a team, or `null` when unknown.
+ *
+ * Postgres: drizzle `sum(size)`. Supabase: RPC `amux.amuxc_team_live_bytes`.
+ */
+async function sumLiveBytes(
+  teamId: string,
+  deps: SyncHandlerDeps = {},
+): Promise<number | null> {
+  if (deps.sumLiveBytes) return deps.sumLiveBytes(teamId);
+  if (resolveBackendKind() === 'postgres') {
+    try {
+      return await resolveRepo(deps).sumLiveBytes(teamId);
+    } catch {
+      return null;
+    }
+  }
+  try {
+    const supabase = createServiceRoleClient();
+    const { data, error } = await supabase
+      .schema('amux')
+      .rpc('amuxc_team_live_bytes', { p_team_id: teamId });
+    if (error) return null;
+    const n = typeof data === 'number' ? data : Number(data);
+    return Number.isFinite(n) ? n : null;
+  } catch {
+    return null;
+  }
 }
 
 async function blobRequiresUpload(
@@ -512,6 +549,19 @@ export async function handleSyncUploadPrepare(
       error: `team is at its file limit (${count} of ${maxFilesPerTeam()}); remove files or raise SYNC_MAX_FILES_PER_TEAM`,
       code: 'QuotaExceeded',
     });
+  }
+
+  // Byte ceiling on live pointers only (not historical blobs). Batch prepare
+  // applies a running total itself and sets skipByteQuota.
+  if (!deps.skipByteQuota) {
+    const sum = await liveByteSum(teamId, (id) => sumLiveBytes(id, deps));
+    if (isOverByteQuota(sum === null ? null : sum + size)) {
+      return json(422, {
+        error: `team is at its byte limit (${sum} + ${size} of ${maxBytesPerTeam()}); remove files or raise SYNC_MAX_BYTES_PER_TEAM`,
+        code: 'QuotaExceeded',
+        kind: 'bytes',
+      });
+    }
   }
 
   const ossKey = ossKeyForHash(teamId, contentHash);
@@ -1146,7 +1196,30 @@ export async function handleSyncUploadPrepareBatch(
   body: Record<string, unknown> | undefined,
   deps: SyncHandlerDeps = {},
 ) {
-  return runSyncBatch(body?.items, (item) => handleSyncUploadPrepare(caller, item, deps));
+  // One live sum per batch; running total so later items see earlier sizes.
+  // Sum failure → null → allow (same policy as single prepare).
+  const sum = await liveByteSum(caller.teamId, (id) => sumLiveBytes(id, deps));
+  let running = sum ?? 0;
+  const sumKnown = sum !== null;
+  let crossed = false;
+
+  return runSyncBatch(body?.items, async (item) => {
+    if (sumKnown) {
+      const size = typeof item.size === 'number' ? item.size : NaN;
+      if (Number.isFinite(size) && size >= 0) {
+        if (crossed || isOverByteQuota(running + size)) {
+          crossed = true;
+          return json(422, {
+            error: `team is at its byte limit (${running} + ${size} of ${maxBytesPerTeam()}); remove files or raise SYNC_MAX_BYTES_PER_TEAM`,
+            code: 'QuotaExceeded',
+            kind: 'bytes',
+          });
+        }
+        running += size;
+      }
+    }
+    return handleSyncUploadPrepare(caller, item, { ...deps, skipByteQuota: true });
+  });
 }
 
 /** POST /sync/upload/complete-batch — N CAS completes; per-item ok/conflict/error. */

--- a/services/fc/src/lib/sync-handlers.ts
+++ b/services/fc/src/lib/sync-handlers.ts
@@ -172,15 +172,31 @@ function resolveRepo(deps: SyncHandlerDeps): OssSyncRepo {
   return makeOssSyncRepo(db);
 }
 
+/** Resolved once per process: `undefined` = not tried yet, `null` = unavailable. */
+let cachedSyncMqtt: SyncMqttPublisher | null | undefined;
+
 function resolveMqtt(deps: SyncHandlerDeps): SyncMqttPublisher | null {
   if (deps.mqtt !== undefined) return deps.mqtt;
+  if (cachedSyncMqtt !== undefined) return cachedSyncMqtt;
   try {
     const bundle = resolveBackendKind() === 'postgres' ? pgPushDeps() : pushDeps();
-    return bundle.mqtt ?? null;
+    cachedSyncMqtt = bundle.mqtt ?? null;
   } catch (e: any) {
-    console.warn('[sync] mqtt resolve failed:', e?.message ?? e);
-    return null;
+    // Memoize the failure too. The push bundle also builds a service-role
+    // Supabase client and an APNS client, neither of which sync needs; on a
+    // deployment that has no SUPABASE_SERVICE_ROLE_KEY it throws on EVERY
+    // complete/delete, so this used to repeat that construction and log a line
+    // per request, forever, without ever converging. Hints are best-effort —
+    // the 300s timer is the fallback — so one warning is the right volume.
+    console.warn('[sync] mqtt unavailable, knowledge hints disabled:', e?.message ?? e);
+    cachedSyncMqtt = null;
   }
+  return cachedSyncMqtt;
+}
+
+/** Test seam: forget the memoized publisher. */
+export function resetSyncMqttCacheForTests(): void {
+  cachedSyncMqtt = undefined;
 }
 
 function originNodeIdFromBody(body: Record<string, unknown> | undefined): string | null {
@@ -1196,7 +1212,7 @@ export async function handleSyncUploadPrepareBatch(
   body: Record<string, unknown> | undefined,
   deps: SyncHandlerDeps = {},
 ) {
-  // One live sum per batch; running total so later items see earlier sizes.
+  // One live sum per batch; running total so later items see earlier ones.
   // Sum failure → null → allow (same policy as single prepare).
   const sum = await liveByteSum(caller.teamId, (id) => sumLiveBytes(id, deps));
   let running = sum ?? 0;
@@ -1204,21 +1220,45 @@ export async function handleSyncUploadPrepareBatch(
   let crossed = false;
 
   return runSyncBatch(body?.items, async (item) => {
-    if (sumKnown) {
-      const size = typeof item.size === 'number' ? item.size : NaN;
-      if (Number.isFinite(size) && size >= 0) {
-        if (crossed || isOverByteQuota(running + size)) {
-          crossed = true;
-          return json(422, {
-            error: `team is at its byte limit (${running} + ${size} of ${maxBytesPerTeam()}); remove files or raise SYNC_MAX_BYTES_PER_TEAM`,
-            code: 'QuotaExceeded',
-            kind: 'bytes',
-          });
-        }
-        running += size;
-      }
+    // Only a NEW path adds bytes to the team. `parentVersion === 0` is the
+    // client saying "no row for this path yet"; anything higher is an edit
+    // whose old bytes are ALREADY inside `sum`, so charging its full size
+    // counted the file twice — 200 edits totalling 600 MB looked like 600 MB of
+    // growth and pushed a team at 1.5 GiB over a 2 GiB quota that completing
+    // them would have left untouched. A quota that fires on writes a team is
+    // nowhere near its limit is worse than one that lets a batch overshoot.
+    //
+    // The trade is a bounded under-count: an edit that GROWS a file is charged
+    // nothing until the next call re-reads the live sum, so the overshoot can
+    // never exceed one batch (≤200 items). That is the right direction for a
+    // guard whose job is stopping pathological bulk adds.
+    const size = typeof item.size === 'number' ? item.size : NaN;
+    const parentVersion =
+      typeof item.parentVersion === 'number' ? item.parentVersion : NaN;
+    const charge =
+      sumKnown && parentVersion === 0 && Number.isFinite(size) && size >= 0 ? size : 0;
+
+    if (crossed || (charge > 0 && isOverByteQuota(running + charge))) {
+      crossed = true;
+      return json(422, {
+        error: `team is at its byte limit (${running} + ${charge} of ${maxBytesPerTeam()}); remove files or raise SYNC_MAX_BYTES_PER_TEAM`,
+        code: 'QuotaExceeded',
+        kind: 'bytes',
+      });
     }
-    return handleSyncUploadPrepare(caller, item, { ...deps, skipByteQuota: true });
+
+    const result = await handleSyncUploadPrepare(caller, item, {
+      ...deps,
+      skipByteQuota: true,
+    });
+
+    // Charge only what actually got an upload slot. A rejected item
+    // (IgnoredPath, bad CAS, validation) never becomes bytes, and burning
+    // budget for it refused every later valid note in the same batch.
+    if (charge > 0 && result.statusCode >= 200 && result.statusCode < 300) {
+      running += charge;
+    }
+    return result;
   });
 }
 

--- a/services/fc/test/mqtt-topics.test.ts
+++ b/services/fc/test/mqtt-topics.test.ts
@@ -1,0 +1,8 @@
+// Unit tests for MQTT topic helpers — pin the wire literal.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { syncTopic } from '../src/lib/mqtt-topics.js';
+
+test('syncTopic puts resource last: amux/<team>/sync/<resource>', () => {
+  assert.equal(syncTopic('TEAM', 'knowledge'), 'amux/TEAM/sync/knowledge');
+});

--- a/services/fc/test/sync-guards.test.ts
+++ b/services/fc/test/sync-guards.test.ts
@@ -4,8 +4,11 @@ import assert from 'node:assert/strict';
 import {
   isRejectedSyncPath,
   isOverFileQuota,
+  isOverByteQuota,
   liveFileCount,
+  liveByteSum,
   maxFilesPerTeam,
+  maxBytesPerTeam,
   resetQuotaCache,
 } from '../src/lib/sync-guards.js';
 
@@ -80,5 +83,54 @@ test('sync-guards: a failing count returns null and is not cached', async () => 
   };
   assert.equal(await liveFileCount('team-b', counter), null);
   assert.equal(await liveFileCount('team-b', counter), null);
+  assert.equal(calls, 2, 'a failure must not be remembered as an answer');
+});
+
+// Byte quota — resource ceiling on live file sizes (not disk protection: historical
+// version blobs stay until GC). Default 2 GiB; projected total is sum + size.
+test('sync-guards: byte quota default is 2 GiB', () => {
+  const prev = process.env.SYNC_MAX_BYTES_PER_TEAM;
+  delete process.env.SYNC_MAX_BYTES_PER_TEAM;
+  try {
+    assert.equal(maxBytesPerTeam(), 2 * 1024 ** 3);
+  } finally {
+    if (prev === undefined) delete process.env.SYNC_MAX_BYTES_PER_TEAM;
+    else process.env.SYNC_MAX_BYTES_PER_TEAM = prev;
+  }
+});
+
+test('sync-guards: projected byte total crosses only past the ceiling', () => {
+  const max = maxBytesPerTeam();
+  assert.equal(isOverByteQuota(max - 1), false);
+  assert.equal(isOverByteQuota(max), false);
+  assert.equal(isOverByteQuota(max + 1), true);
+});
+
+test('sync-guards: an unknown byte sum is not over quota', () => {
+  assert.equal(isOverByteQuota(null), false);
+});
+
+test('sync-guards: the byte sum is cached so a batch pays for it once', async () => {
+  resetQuotaCache();
+  let calls = 0;
+  const summer = async () => {
+    calls += 1;
+    return 42;
+  };
+  for (let i = 0; i < 200; i++) {
+    assert.equal(await liveByteSum('team-bytes', summer), 42);
+  }
+  assert.equal(calls, 1);
+});
+
+test('sync-guards: a failing byte sum returns null and is not cached', async () => {
+  resetQuotaCache();
+  let calls = 0;
+  const summer = async () => {
+    calls += 1;
+    throw new Error('db down');
+  };
+  assert.equal(await liveByteSum('team-bytes-fail', summer), null);
+  assert.equal(await liveByteSum('team-bytes-fail', summer), null);
   assert.equal(calls, 2, 'a failure must not be remembered as an answer');
 });

--- a/services/fc/test/sync-guards.test.ts
+++ b/services/fc/test/sync-guards.test.ts
@@ -110,20 +110,19 @@ test('sync-guards: an unknown byte sum is not over quota', () => {
   assert.equal(isOverByteQuota(null), false);
 });
 
-test('sync-guards: the byte sum is cached so a batch pays for it once', async () => {
+// Unlike file count, byte sums must not TTL-cache across prepare-batch calls:
+// complete updates live sizes, and the next chunk must see the fresh total.
+test('sync-guards: each liveByteSum call re-fetches (no cross-batch TTL cache)', async () => {
   resetQuotaCache();
+  const sums = [10, 90];
   let calls = 0;
-  const summer = async () => {
-    calls += 1;
-    return 42;
-  };
-  for (let i = 0; i < 200; i++) {
-    assert.equal(await liveByteSum('team-bytes', summer), 42);
-  }
-  assert.equal(calls, 1);
+  const summer = async () => sums[calls++];
+  assert.equal(await liveByteSum('team-bytes', summer), 10);
+  assert.equal(await liveByteSum('team-bytes', summer), 90);
+  assert.equal(calls, 2);
 });
 
-test('sync-guards: a failing byte sum returns null and is not cached', async () => {
+test('sync-guards: a failing byte sum returns null (null→allow on failure only)', async () => {
   resetQuotaCache();
   let calls = 0;
   const summer = async () => {

--- a/services/fc/test/sync-handlers-pg.test.ts
+++ b/services/fc/test/sync-handlers-pg.test.ts
@@ -33,6 +33,7 @@ import {
   handleSyncDeleteBatch,
   MAX_SYNC_BATCH,
 } from "../src/lib/sync-handlers.js";
+import { resetQuotaCache } from "../src/lib/sync-guards.js";
 
 // ---------------------------------------------------------------------------
 // Force BACKEND_KIND=postgres
@@ -981,5 +982,112 @@ describe("sync knowledge MQTT hints", () => {
     assert.equal(hint.changeSeq, maxSeq);
     assert.equal(hint.originNodeId, "del-node");
     assert.equal(published[0].topic, `amux/${team.id}/sync/knowledge`);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Per-team byte quota (Phase F) — live sum of amuxc_files.size, not disk.
+// ---------------------------------------------------------------------------
+
+describe("sync upload prepare byte quota", () => {
+  const prevMax = process.env.SYNC_MAX_BYTES_PER_TEAM;
+
+  before(() => {
+    process.env.SYNC_MAX_BYTES_PER_TEAM = "100";
+  });
+
+  after(() => {
+    if (prevMax === undefined) delete process.env.SYNC_MAX_BYTES_PER_TEAM;
+    else process.env.SYNC_MAX_BYTES_PER_TEAM = prevMax;
+  });
+
+  test("single prepare: sum + size over ceiling → 422 QuotaExceeded kind bytes", async () => {
+    resetQuotaCache();
+    const { db } = await makeTestDb();
+    const repo = makeOssSyncRepo(db);
+    const team = await seedTeam(db);
+    const actor = await seedMember(db, team.id);
+    const storage = makeMockStorage({ objects: new Map() });
+
+    const res = await handleSyncUploadPrepare(
+      makeCaller(team.id, actor.id),
+      { path: "knowledge/big.md", parentVersion: 0, contentHash: h32("q"), size: 40 },
+      {
+        db,
+        repo,
+        storage,
+        sumLiveBytes: async () => 80,
+        countLiveFiles: async () => 0,
+      },
+    );
+
+    assert.equal(res.statusCode, 422);
+    const body = JSON.parse(res.body);
+    assert.equal(body.code, "QuotaExceeded");
+    assert.equal(body.kind, "bytes");
+  });
+
+  test("prepare-batch: item that crosses and every item after it are rejected", async () => {
+    resetQuotaCache();
+    const { db } = await makeTestDb();
+    const repo = makeOssSyncRepo(db);
+    const team = await seedTeam(db);
+    const actor = await seedMember(db, team.id);
+    const storage = makeMockStorage({ objects: new Map() });
+
+    // max=100, live sum=50 → sizes 30, 30, 30 cross at index 1 (50+30+30=110).
+    const res = await handleSyncUploadPrepareBatch(
+      makeCaller(team.id, actor.id),
+      {
+        items: [
+          { path: "knowledge/b0.md", parentVersion: 0, contentHash: h32("0"), size: 30 },
+          { path: "knowledge/b1.md", parentVersion: 0, contentHash: h32("1"), size: 30 },
+          { path: "knowledge/b2.md", parentVersion: 0, contentHash: h32("2"), size: 30 },
+        ],
+      },
+      {
+        db,
+        repo,
+        storage,
+        sumLiveBytes: async () => 50,
+        countLiveFiles: async () => 0,
+      },
+    );
+
+    assert.equal(res.statusCode, 200);
+    const { results } = JSON.parse(res.body);
+    assert.equal(results.length, 3);
+    assert.equal(results[0].ok, true, "item 0 stays under the ceiling");
+    assert.equal(results[1].ok, false);
+    assert.equal(results[1].status, 422);
+    assert.equal(results[1].code, "QuotaExceeded");
+    assert.equal(results[1].kind, "bytes");
+    assert.equal(results[2].ok, false);
+    assert.equal(results[2].status, 422);
+    assert.equal(results[2].kind, "bytes");
+  });
+
+  test("single prepare: sum failure → allow (null policy)", async () => {
+    resetQuotaCache();
+    const { db } = await makeTestDb();
+    const repo = makeOssSyncRepo(db);
+    const team = await seedTeam(db);
+    const actor = await seedMember(db, team.id);
+    const storage = makeMockStorage({ objects: new Map() });
+
+    const res = await handleSyncUploadPrepare(
+      makeCaller(team.id, actor.id),
+      { path: "knowledge/ok.md", parentVersion: 0, contentHash: h32("ok"), size: 90 },
+      {
+        db,
+        repo,
+        storage,
+        sumLiveBytes: async () => null,
+        countLiveFiles: async () => 0,
+      },
+    );
+
+    assert.equal(res.statusCode, 200);
+    assert.ok(JSON.parse(res.body).uploadSessionId);
   });
 });

--- a/services/fc/test/sync-handlers-pg.test.ts
+++ b/services/fc/test/sync-handlers-pg.test.ts
@@ -1090,4 +1090,57 @@ describe("sync upload prepare byte quota", () => {
     assert.equal(res.statusCode, 200);
     assert.ok(JSON.parse(res.body).uploadSessionId);
   });
+
+  // Daemon prepare→complete→next-chunk: the second batch must see the updated
+  // live sum, not a stale TTL from the first prepare-batch.
+  test("prepare-batch: sequential calls use a fresh sumLiveBytes each time", async () => {
+    resetQuotaCache();
+    const { db } = await makeTestDb();
+    const repo = makeOssSyncRepo(db);
+    const team = await seedTeam(db);
+    const actor = await seedMember(db, team.id);
+    const storage = makeMockStorage({ objects: new Map() });
+
+    const liveSums = [0, 80];
+    let sumCalls = 0;
+    const deps = {
+      db,
+      repo,
+      storage,
+      sumLiveBytes: async () => liveSums[sumCalls++] ?? 80,
+      countLiveFiles: async () => 0,
+    };
+
+    // max=100. First batch with live=0, size=40 → under ceiling.
+    const first = await handleSyncUploadPrepareBatch(
+      makeCaller(team.id, actor.id),
+      {
+        items: [
+          { path: "knowledge/c0.md", parentVersion: 0, contentHash: h32("c0"), size: 40 },
+        ],
+      },
+      deps,
+    );
+    assert.equal(first.statusCode, 200);
+    assert.equal(JSON.parse(first.body).results[0].ok, true);
+
+    // Second batch with live=80 (as after complete), size=40 → 80+40=120 over.
+    // A 10s TTL cache of the first sum (0) would wrongly accept this.
+    const second = await handleSyncUploadPrepareBatch(
+      makeCaller(team.id, actor.id),
+      {
+        items: [
+          { path: "knowledge/c1.md", parentVersion: 0, contentHash: h32("c1"), size: 40 },
+        ],
+      },
+      deps,
+    );
+    assert.equal(second.statusCode, 200);
+    const { results } = JSON.parse(second.body);
+    assert.equal(results[0].ok, false);
+    assert.equal(results[0].status, 422);
+    assert.equal(results[0].code, "QuotaExceeded");
+    assert.equal(results[0].kind, "bytes");
+    assert.equal(sumCalls, 2, "each prepare-batch must re-fetch the live sum");
+  });
 });

--- a/services/fc/test/sync-handlers-pg.test.ts
+++ b/services/fc/test/sync-handlers-pg.test.ts
@@ -738,3 +738,248 @@ describe("sync batch endpoints postgres path", () => {
     assert.deepEqual(JSON.parse(empty.body).results, []);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Knowledge sync MQTT hints — one publish per successful complete/delete call.
+// ---------------------------------------------------------------------------
+
+describe("sync knowledge MQTT hints", () => {
+  function makeMqttRecorder() {
+    const published: Array<{ topic: string; payload: string; options?: Record<string, unknown> }> = [];
+    return {
+      published,
+      mqtt: {
+        publish: async (topic: string, payload: string, options?: Record<string, unknown>) => {
+          published.push({ topic, payload, options });
+        },
+      },
+    };
+  }
+
+  test("complete-batch of N → exactly one publish with max changeSeq, no path", async () => {
+    const { db } = await makeTestDb();
+    const repo = makeOssSyncRepo(db);
+    const team = await seedTeam(db);
+    const actor = await seedMember(db, team.id);
+    const caller = makeCaller(team.id, actor.id);
+
+    const hA = h32("1");
+    const hB = h32("2");
+    const hC = h32("3");
+    const storeState: MockStorageState = {
+      objects: new Map([
+        [ossKeyFor(team.id, hA), 10],
+        [ossKeyFor(team.id, hB), 20],
+        [ossKeyFor(team.id, hC), 30],
+      ]),
+    };
+    const storage = makeMockStorage(storeState);
+    const { mqtt, published } = makeMqttRecorder();
+    const fixedNow = new Date("2026-08-26T07:12:00.000Z");
+    const deps = { db, repo, storage, mqtt, now: () => fixedNow };
+
+    const prep = async (path: string, hash: string, size: number) =>
+      JSON.parse(
+        (await handleSyncUploadPrepare(
+          caller,
+          { path, parentVersion: 0, contentHash: hash, size },
+          { db, repo, storage },
+        )).body,
+      ).uploadSessionId;
+
+    const sessA = await prep("knowledge/hint-a.md", hA, 10);
+    const sessB = await prep("knowledge/hint-b.md", hB, 20);
+    const sessC = await prep("knowledge/hint-c.md", hC, 30);
+
+    const res = await handleSyncUploadCompleteBatch(
+      caller,
+      {
+        nodeId: "mac-9f3c",
+        items: [
+          { uploadSessionId: sessA },
+          { uploadSessionId: sessB },
+          { uploadSessionId: sessC },
+        ],
+      },
+      deps,
+    );
+
+    assert.equal(res.statusCode, 200);
+    const { results } = JSON.parse(res.body);
+    assert.equal(results.length, 3);
+    assert.ok(results.every((r: any) => r.ok));
+    const maxSeq = Math.max(...results.map((r: any) => r.changeSeq));
+
+    assert.equal(published.length, 1, "exactly one MQTT publish for the batch");
+    assert.equal(published[0].topic, `amux/${team.id}/sync/knowledge`);
+    assert.equal(published[0].options?.retain, false);
+    assert.equal(published[0].options?.qos, 1);
+
+    const hint = JSON.parse(published[0].payload);
+    assert.equal(hint.v, 1);
+    assert.equal(hint.changeSeq, maxSeq);
+    assert.equal(hint.originNodeId, "mac-9f3c");
+    assert.equal(hint.at, "2026-08-26T07:12:00.000Z");
+    assert.equal("path" in hint, false, "hint must not carry path");
+  });
+
+  test("publish failure does not change the HTTP 200 result", async () => {
+    const { db } = await makeTestDb();
+    const repo = makeOssSyncRepo(db);
+    const team = await seedTeam(db);
+    const actor = await seedMember(db, team.id);
+    const caller = makeCaller(team.id, actor.id);
+
+    const hash = h32("f");
+    const size = 7;
+    const storeState: MockStorageState = {
+      objects: new Map([[ossKeyFor(team.id, hash), size]]),
+    };
+    const storage = makeMockStorage(storeState);
+    const mqtt = {
+      publish: async () => {
+        throw new Error("broker unreachable");
+      },
+    };
+
+    const prep = await handleSyncUploadPrepare(
+      caller,
+      { path: "knowledge/fail-hint.md", parentVersion: 0, contentHash: hash, size },
+      { db, repo, storage },
+    );
+    const sess = JSON.parse(prep.body).uploadSessionId;
+
+    const res = await handleSyncUploadCompleteBatch(
+      caller,
+      { items: [{ uploadSessionId: sess }] },
+      { db, repo, storage, mqtt },
+    );
+
+    assert.equal(res.statusCode, 200);
+    assert.equal(JSON.parse(res.body).results[0].ok, true);
+  });
+
+  test("mqtt: null (no MQTT_BROKER_URL) still returns 200", async () => {
+    const { db } = await makeTestDb();
+    const repo = makeOssSyncRepo(db);
+    const team = await seedTeam(db);
+    const actor = await seedMember(db, team.id);
+    const caller = makeCaller(team.id, actor.id);
+
+    const hash = h32("n");
+    const size = 5;
+    const storeState: MockStorageState = {
+      objects: new Map([[ossKeyFor(team.id, hash), size]]),
+    };
+    const storage = makeMockStorage(storeState);
+
+    const prep = await handleSyncUploadPrepare(
+      caller,
+      { path: "knowledge/no-mqtt.md", parentVersion: 0, contentHash: hash, size },
+      { db, repo, storage },
+    );
+    const sess = JSON.parse(prep.body).uploadSessionId;
+
+    const res = await handleSyncUploadCompleteBatch(
+      caller,
+      { items: [{ uploadSessionId: sess }] },
+      { db, repo, storage, mqtt: null },
+    );
+
+    assert.equal(res.statusCode, 200);
+    assert.equal(JSON.parse(res.body).results[0].ok, true);
+  });
+
+  test("single complete publishes one hint (legacy path)", async () => {
+    const { db } = await makeTestDb();
+    const repo = makeOssSyncRepo(db);
+    const team = await seedTeam(db);
+    const actor = await seedMember(db, team.id);
+    const caller = makeCaller(team.id, actor.id);
+
+    const hash = h32("s");
+    const size = 4;
+    const storeState: MockStorageState = {
+      objects: new Map([[ossKeyFor(team.id, hash), size]]),
+    };
+    const storage = makeMockStorage(storeState);
+    const { mqtt, published } = makeMqttRecorder();
+
+    const prep = await handleSyncUploadPrepare(
+      caller,
+      { path: "knowledge/single.md", parentVersion: 0, contentHash: hash, size },
+      { db, repo, storage },
+    );
+    const res = await handleSyncUploadComplete(
+      caller,
+      { uploadSessionId: JSON.parse(prep.body).uploadSessionId, nodeId: "node-legacy" },
+      { db, repo, storage, mqtt },
+    );
+
+    assert.equal(res.statusCode, 200);
+    const body = JSON.parse(res.body);
+    assert.equal(published.length, 1);
+    const hint = JSON.parse(published[0].payload);
+    assert.equal(hint.changeSeq, body.changeSeq);
+    assert.equal(hint.originNodeId, "node-legacy");
+  });
+
+  test("delete-batch publishes once with max successful changeSeq", async () => {
+    const { db } = await makeTestDb();
+    const repo = makeOssSyncRepo(db);
+    const team = await seedTeam(db);
+    const actor = await seedMember(db, team.id);
+    const caller = makeCaller(team.id, actor.id);
+
+    const hA = h32("d");
+    const hB = h32("e");
+    const storeState: MockStorageState = {
+      objects: new Map([
+        [ossKeyFor(team.id, hA), 8],
+        [ossKeyFor(team.id, hB), 9],
+      ]),
+    };
+    const storage = makeMockStorage(storeState);
+    const { mqtt, published } = makeMqttRecorder();
+    const deps = { db, repo, storage };
+
+    for (const [path, hash, size] of [
+      ["knowledge/del-a.md", hA, 8],
+      ["knowledge/del-b.md", hB, 9],
+    ] as const) {
+      const pr = await handleSyncUploadPrepare(
+        caller,
+        { path, parentVersion: 0, contentHash: hash, size },
+        deps,
+      );
+      await handleSyncUploadComplete(
+        caller,
+        { uploadSessionId: JSON.parse(pr.body).uploadSessionId },
+        { ...deps, mqtt: null },
+      );
+    }
+
+    published.length = 0;
+    const res = await handleSyncDeleteBatch(
+      caller,
+      {
+        nodeId: "del-node",
+        items: [
+          { path: "knowledge/del-a.md", parentVersion: 1 },
+          { path: "knowledge/del-b.md", parentVersion: 1 },
+        ],
+      },
+      { db, repo, mqtt },
+    );
+
+    assert.equal(res.statusCode, 200);
+    const { results } = JSON.parse(res.body);
+    assert.ok(results.every((r: any) => r.ok));
+    const maxSeq = Math.max(...results.map((r: any) => r.changeSeq));
+    assert.equal(published.length, 1);
+    const hint = JSON.parse(published[0].payload);
+    assert.equal(hint.changeSeq, maxSeq);
+    assert.equal(hint.originNodeId, "del-node");
+    assert.equal(published[0].topic, `amux/${team.id}/sync/knowledge`);
+  });
+});

--- a/services/fc/test/sync-handlers-pg.test.ts
+++ b/services/fc/test/sync-handlers-pg.test.ts
@@ -1027,6 +1027,91 @@ describe("sync upload prepare byte quota", () => {
     assert.equal(body.kind, "bytes");
   });
 
+  // An edit's old bytes are ALREADY inside the live sum, so charging its full
+  // size counted the file twice: a team at 50 of 100 editing three 30-byte
+  // notes looked like +90 and got refused at item 1, even though completing all
+  // three leaves the total exactly where it started. A quota that fires on
+  // writes a team is nowhere near its limit is worse than one that overshoots.
+  test("prepare-batch: edits do not consume quota (their bytes are already summed)", async () => {
+    resetQuotaCache();
+    const { db } = await makeTestDb();
+    const repo = makeOssSyncRepo(db);
+    const team = await seedTeam(db);
+    const actor = await seedMember(db, team.id);
+    const storage = makeMockStorage({ objects: new Map() });
+
+    const res = await handleSyncUploadPrepareBatch(
+      makeCaller(team.id, actor.id),
+      {
+        items: [
+          { path: "knowledge/e0.md", parentVersion: 3, contentHash: h32("a"), size: 30 },
+          { path: "knowledge/e1.md", parentVersion: 7, contentHash: h32("b"), size: 30 },
+          { path: "knowledge/e2.md", parentVersion: 1, contentHash: h32("c"), size: 30 },
+        ],
+      },
+      {
+        db,
+        repo,
+        storage,
+        sumLiveBytes: async () => 50,
+        countLiveFiles: async () => 0,
+      },
+    );
+
+    assert.equal(res.statusCode, 200);
+    const { results } = JSON.parse(res.body);
+    assert.deepEqual(
+      results.map((r: any) => r.ok),
+      [true, true, true],
+      "edits must not be charged against the byte quota",
+    );
+  });
+
+  // A rejected item never becomes bytes. Charging it burned budget that then
+  // refused every later valid note in the same batch.
+  test("prepare-batch: a rejected item does not consume quota", async () => {
+    resetQuotaCache();
+    const { db } = await makeTestDb();
+    const repo = makeOssSyncRepo(db);
+    const team = await seedTeam(db);
+    const actor = await seedMember(db, team.id);
+    const storage = makeMockStorage({ objects: new Map() });
+
+    // max=100, live sum=50. The first item is refused as an ignored path, so
+    // only the second one's 40 bytes count: 50 + 40 = 90, under the ceiling.
+    const res = await handleSyncUploadPrepareBatch(
+      makeCaller(team.id, actor.id),
+      {
+        items: [
+          {
+            path: "knowledge/node_modules/pkg/index.js",
+            parentVersion: 0,
+            contentHash: h32("d"),
+            size: 40,
+          },
+          { path: "knowledge/real.md", parentVersion: 0, contentHash: h32("e"), size: 40 },
+        ],
+      },
+      {
+        db,
+        repo,
+        storage,
+        sumLiveBytes: async () => 50,
+        countLiveFiles: async () => 0,
+      },
+    );
+
+    assert.equal(res.statusCode, 200);
+    const { results } = JSON.parse(res.body);
+    assert.equal(results[0].ok, false);
+    assert.equal(results[0].code, "IgnoredPath");
+    assert.equal(
+      results[1].ok,
+      true,
+      "the refused item must not have spent the quota the valid one needed",
+    );
+  });
+
   test("prepare-batch: item that crosses and every item after it are rejected", async () => {
     resetQuotaCache();
     const { db } = await makeTestDb();

--- a/services/supabase/migrations/20260827000000_acl_sync_topic.sql
+++ b/services/supabase/migrations/20260827000000_acl_sync_topic.sql
@@ -1,0 +1,74 @@
+-- Allow member and agent MQTT clients to SUBSCRIBE `amux/<team>/sync/+`.
+--
+-- Facts for operators:
+-- - ACL is baked into the JWT by amux_access_token_hook. Existing MQTT
+--   connections keep the old claim until the access token rotates (TTL 3600s).
+--   The daemon rebuilds its MQTT connection ~5 minutes before expiry, so
+--   within ≤1 hour after this migration every daemon can subscribe.
+-- - Task 8's subscribe path is tolerant of ACL deny / missing topic: shipping
+--   this migration and the daemon subscribe change in the same release is OK.
+--   Migrate-first is advice, not a hard gate.
+-- - Postgres / Better-Auth backends mint no `acl` claim; all-in-one NanoMQ has
+--   no ACL. This migration only matters on the Supabase backend — do not
+--   validate the rule against all-in-one.
+
+create or replace function public.amux_acl_rules_for(
+  p_team  uuid,
+  p_actor uuid,
+  p_type  text
+) returns table (action text, topic text)
+language sql
+immutable
+set search_path = public
+as $$
+  select action, topic
+    from (values
+      ('sub', format('amux/%s/user/%s/notify',              p_team, p_actor)),
+      ('sub', format('amux/%s/session/+/live',              p_team)),
+      ('sub', format('amux/%s/+/state',                     p_team)),
+      ('sub', format('amux/%s/+/runtime/+/state',           p_team)),
+      ('sub', format('amux/%s/+/runtime/+/events',          p_team)),
+      ('sub', format('amux/%s/+/rpc/res',                   p_team)),
+      ('sub', format('amux/%s/%s/rpc/req',                  p_team, p_actor)),
+      ('sub', format('amux/%s/sync/+',                      p_team)),
+      ('pub', format('amux/%s/+/rpc/req',                   p_team)),
+      ('pub', format('amux/%s/+/runtime/+/commands',        p_team))
+    ) as r(action, topic)
+   where p_type = 'member'
+
+  union all
+
+  select action, topic
+    from (values
+      ('pub', format('amux/%s/%s/state',                    p_team, p_actor)),
+      ('pub', format('amux/%s/%s/runtime/+/state',          p_team, p_actor)),
+      ('pub', format('amux/%s/%s/runtime/+/events',         p_team, p_actor)),
+      ('pub', format('amux/%s/%s/notify',                   p_team, p_actor)),
+      ('pub', format('amux/%s/+/rpc/res',                   p_team)),
+      ('pub', format('amux/%s/+/rpc/req',                   p_team)),
+      ('pub', format('amux/%s/session/+/live',              p_team)),
+      ('pub', format('amux/%s/user/+/notify',               p_team)),
+      ('sub', format('amux/%s/%s/runtime/+/commands',       p_team, p_actor)),
+      ('sub', format('amux/%s/%s/rpc/req',                  p_team, p_actor)),
+      ('sub', format('amux/%s/%s/notify',                   p_team, p_actor)),
+      ('sub', format('amux/%s/session/+/live',              p_team)),
+      ('sub', format('amux/%s/user/%s/notify',               p_team, p_actor)),
+      ('sub', format('amux/%s/sync/+',                      p_team))
+    ) as r(action, topic)
+   where p_type = 'agent';
+$$;
+
+revoke execute on function public.amux_acl_rules_for(uuid, uuid, text) from public, anon, authenticated;
+grant  execute on function public.amux_acl_rules_for(uuid, uuid, text) to supabase_auth_admin;
+
+create or replace function amux.amux_acl_rules_for(p_team uuid, p_actor uuid, p_type text)
+returns table (action text, topic text)
+language sql
+immutable
+set search_path = amux, public
+as $$
+  select action, topic from public.amux_acl_rules_for(p_team, p_actor, p_type)
+$$;
+
+revoke execute on function amux.amux_acl_rules_for(uuid, uuid, text) from public, anon, authenticated;
+grant  execute on function amux.amux_acl_rules_for(uuid, uuid, text) to supabase_auth_admin;

--- a/services/supabase/migrations/20260827120000_amuxc_team_live_bytes.sql
+++ b/services/supabase/migrations/20260827120000_amuxc_team_live_bytes.sql
@@ -1,0 +1,22 @@
+-- Sum of live (non-deleted) amuxc_files.size for a team.
+-- Used by FC /sync/upload/prepare byte-quota backstop (SYNC_MAX_BYTES_PER_TEAM).
+-- Counts current path pointers only — not historical version blobs.
+
+CREATE OR REPLACE FUNCTION amux.amuxc_team_live_bytes(p_team_id uuid)
+RETURNS bigint
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = amux, public
+AS $$
+  SELECT coalesce(sum(size), 0)::bigint
+    FROM amux.amuxc_files
+   WHERE team_id = p_team_id
+     AND deleted = false;
+$$;
+
+COMMENT ON FUNCTION amux.amuxc_team_live_bytes(uuid) IS
+  'Sum of live amuxc_files.size for the team. FC prepare quota; not disk usage.';
+
+REVOKE ALL ON FUNCTION amux.amuxc_team_live_bytes(uuid) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION amux.amuxc_team_live_bytes(uuid) TO service_role;

--- a/services/supabase/migrations/20260827130000_amuxc_files_live_bytes_index.sql
+++ b/services/supabase/migrations/20260827130000_amuxc_files_live_bytes_index.sql
@@ -1,0 +1,25 @@
+-- Index for the live-bytes sum behind the per-team knowledge byte quota.
+--
+-- `amuxc_team_live_bytes` (and the drizzle `sumLiveBytes` on the postgres
+-- backend) runs `sum(size) WHERE team_id = ? AND deleted = false` on the sync
+-- WRITE path: once per prepare and once per prepare-batch call, deliberately
+-- uncached so the guard cannot be fooled by a stale total.
+--
+-- The three existing indexes on amuxc_files are (team_id, change_seq),
+-- (team_id, updated_at) and unique (team_id, path). None of them carries
+-- `deleted` or `size`, so the sum heap-fetched every live row for the team —
+-- up to SYNC_MAX_FILES_PER_TEAM (50k) rows per call. A single daemon tick makes
+-- up to 10 prepare-batch calls, so an active team with ten devices produced
+-- ~100 full aggregates per tick window: the same shape as the statement-timeout
+-- cliff already hit on /v1/sessions.
+--
+-- Partial (live rows only) + INCLUDE (size) makes it an index-only scan, and
+-- the partial predicate keeps it off the tombstone rows the sum ignores.
+
+CREATE INDEX IF NOT EXISTS idx_amuxc_files_team_live_size
+    ON amux.amuxc_files USING btree (team_id)
+    INCLUDE (size)
+    WHERE deleted = false;
+
+COMMENT ON INDEX amux.idx_amuxc_files_team_live_size IS
+  'Index-only scan for amuxc_team_live_bytes / sumLiveBytes (byte quota on the sync write path).';

--- a/services/supabase/tests/006_access_token_hook.sql
+++ b/services/supabase/tests/006_access_token_hook.sql
@@ -2,7 +2,7 @@ begin;
 
 select plan(28);
 
--- Rule catalog for a member yields exactly 9 allow rules with the expected topic shapes.
+-- Rule catalog for a member yields exactly 10 allow rules with the expected topic shapes.
 select is(
   (select count(*)::int
      from amux.amux_acl_rules_for(
@@ -10,8 +10,8 @@ select is(
        '22222222-2222-2222-2222-222222222222'::uuid,
        'member'
      )),
-  9,
-  'member rule set has exactly 9 rules'
+  10,
+  'member rule set has exactly 10 rules'
 );
 
 select bag_eq(
@@ -27,6 +27,7 @@ select bag_eq(
       ('sub','amux/11111111-1111-1111-1111-111111111111/+/runtime/+/events'),
       ('sub','amux/11111111-1111-1111-1111-111111111111/+/rpc/res'),
       ('sub','amux/11111111-1111-1111-1111-111111111111/22222222-2222-2222-2222-222222222222/rpc/req'),
+      ('sub','amux/11111111-1111-1111-1111-111111111111/sync/+'),
       ('pub','amux/11111111-1111-1111-1111-111111111111/+/rpc/req'),
       ('pub','amux/11111111-1111-1111-1111-111111111111/+/runtime/+/commands')
   $$,
@@ -43,7 +44,7 @@ select is(
   'unknown actor_type yields zero rules'
 );
 
--- Rule catalog for an agent yields exactly 13 allow rules.
+-- Rule catalog for an agent yields exactly 14 allow rules.
 select is(
   (select count(*)::int
      from amux.amux_acl_rules_for(
@@ -51,8 +52,8 @@ select is(
        '44444444-4444-4444-4444-444444444444'::uuid,
        'agent'
      )),
-  13,
-  'agent rule set has exactly 13 rules'
+  14,
+  'agent rule set has exactly 14 rules'
 );
 
 select bag_eq(
@@ -73,7 +74,8 @@ select bag_eq(
       ('sub','amux/33333333-3333-3333-3333-333333333333/44444444-4444-4444-4444-444444444444/rpc/req'),
       ('sub','amux/33333333-3333-3333-3333-333333333333/44444444-4444-4444-4444-444444444444/notify'),
       ('sub','amux/33333333-3333-3333-3333-333333333333/session/+/live'),
-      ('sub','amux/33333333-3333-3333-3333-333333333333/user/44444444-4444-4444-4444-444444444444/notify')
+      ('sub','amux/33333333-3333-3333-3333-333333333333/user/44444444-4444-4444-4444-444444444444/notify'),
+      ('sub','amux/33333333-3333-3333-3333-333333333333/sync/+')
   $$,
   'agent rule topics match exactly'
 );
@@ -105,7 +107,7 @@ select is(
   'hook with null user_id returns event unchanged'
 );
 
--- Single-team member: memberships has 1 row, acl has 9 allow + 1 deny rules.
+-- Single-team member: memberships has 1 row, acl has 10 allow + 1 deny rules.
 do $$
 declare
   v_team  uuid := gen_random_uuid();
@@ -141,8 +143,8 @@ begin
   );
   perform is(
     jsonb_array_length(v_claims->'acl'),
-    10,
-    'single-team member: acl has 9 allow + 1 deny = 10 rules'
+    11,
+    'single-team member: acl has 10 allow + 1 deny = 11 rules'
   );
   perform is(
     jsonb_array_length(v_claims->'app_metadata'->'memberships'),
@@ -207,7 +209,7 @@ begin
 end;
 $$;
 
--- Multi-team member: 2 memberships, 2*9+1 = 19 acl rules.
+-- Multi-team member: 2 memberships, 2*10+1 = 21 acl rules.
 do $$
 declare
   v_user   uuid := gen_random_uuid();
@@ -247,8 +249,8 @@ begin
   );
   perform is(
     jsonb_array_length(v_claims->'acl'),
-    19,
-    'multi-team member: 18 allow + 1 deny = 19 rules'
+    21,
+    'multi-team member: 20 allow + 1 deny = 21 rules'
   );
   perform is(
     v_claims->'acl'->-1,
@@ -259,7 +261,7 @@ end;
 $$;
 
 -- Mixed actor types on one user: member in team A, agent in team B.
--- Expected: memberships has 2 entries, acl has 9 + 13 + 1 = 23 rules.
+-- Expected: memberships has 2 entries, acl has 10 + 14 + 1 = 25 rules.
 do $$
 declare
   v_user   uuid := gen_random_uuid();
@@ -299,8 +301,8 @@ begin
   );
   perform is(
     jsonb_array_length(v_claims->'acl'),
-    23,
-    'mixed: 9 (member) + 13 (agent) + 1 (deny) = 23 rules'
+    25,
+    'mixed: 10 (member) + 14 (agent) + 1 (deny) = 25 rules'
   );
 end;
 $$;

--- a/services/supabase/tests/020_oss_sync_schema.sql
+++ b/services/supabase/tests/020_oss_sync_schema.sql
@@ -152,9 +152,15 @@ select col_default_is('amux', 'amuxc_files', 'current_version', '0',
 
 -- Unique (team_id, path) — not partial. Tombstone + revive must update the
 -- existing row, never insert a second one.
+--
+-- `idx_amuxc_files_team_live_size` is the partial covering index behind the
+-- per-team byte quota: `sum(size) where deleted = false` runs on the sync WRITE
+-- path (once per prepare, once per prepare-batch, deliberately uncached), and
+-- none of the other four indexes carries `deleted` or `size`.
 select indexes_are('amux', 'amuxc_files',
   array['amuxc_files_pkey', 'uniq_amuxc_path',
-        'idx_amuxc_files_team_updated', 'idx_amuxc_files_team_seq'],
+        'idx_amuxc_files_team_updated', 'idx_amuxc_files_team_seq',
+        'idx_amuxc_files_team_live_size'],
   'amuxc_files has expected indexes');
 
 -- Same path can be inserted only once even when first row is deleted=true.


### PR DESCRIPTION
## What

Knowledge sync P0/P1 — the scope lock (ADR-0008 + plan), the implementation, and the fixes from a `/code-review` pass over it.

Cuts cross-member knowledge latency from ~10 min worst case (two independent 300s timers) to seconds, via a per-team coalescing scheduler fed by a knowledge-dir fs watch and an MQTT `amux/<team>/sync/knowledge` hint published by FC. Plus `.conflicts/` for Obsidian hygiene and a per-team byte quota.

## Scope decisions worth knowing

- **Knowledge uploads are plaintext.** `prepare_upload` sets `cipher_hash == plain_hash`; the team secret is fetched, not required. Docs and `CLAUDE.md` no longer claim E2E.
- **Ordered by risk, not by "who waits more"**: `.conflicts/` → scheduler + fs watch → FC publish → ACL migration → daemon subscribe → byte quota.
- **Optional MQTT subscriptions are the hard requirement**, not migration order. ACL is baked into the JWT and rotates hourly, so a pre-migration token self-heals — but only if a rejected `sync/+` subscribe warns instead of rebuilding the worker.
- Dropped from the original plan: prepare rate limiting (prepare is already batched 200/call), and `.md` default completion (already shipped in `3d6e8fd3`).

## Code-review fixes in this branch

14 findings, all applied. The ones that mattered:

| | |
|---|---|
| **Byte quota over-counted** | An edit's old bytes are already in the live sum, so charging its full size double-counted the file — a team at 1.5 GiB editing 600 MB of notes got 422s on writes it was nowhere near the limit for. Rejected items burned budget too. Now: new paths only (`parentVersion === 0`), and only on success. |
| **Sidecars could land outside the tree** | `insert_conflicts_component` anchored on the first `knowledge` component of the **absolute** path, so `AMUXD_HOME=/data/knowledge/…` wrote conflict copies where `scan_conflict_files` never looks. Now derived from the relative sync path, like every reader. |
| **Un-announced MQTT worker** | If every tracked subscription was optional and every queue attempt was rejected, no SUBACK ever arrived and the announce path — which now lives only in the SUBACK handler — was unreachable. |
| **Unindexed sum on the write path** | `sum(size) WHERE deleted = false` had no covering index; up to 50k rows per call, ~10 calls per tick per device. Partial covering index added. |
| **`.conflicts` hidden by name** | The daemon only hard-skips `<prefix>/.conflicts`, so a user folder named `.conflicts` deeper in the tree synced but was invisible — the `merge.conflict.md` bug inverted. |

Also: pull-write suppression map could grow unbounded when the watcher was not running; directories created during a pull triggered a no-op push tick; sync hints accepted any `team_id` from the topic segment; legacy sidecars were renamed out of a directory `WalkDir` was still reading.

## Testing

- `cargo test -p amuxd` — 1475 passed. One failure, `cursor_sdk::permission::…ask_policy_surfaces_a_request_and_honours_a_denial`, is the known parallel-load flake: 3/3 green run alone, and `permission.rs` is untouched since #899.
- `pnpm test:unit` — 3041 passed, 0 failed. `pnpm typecheck`, `pnpm lint` — clean.
- `services/fc` build (`tsconfig.json`, the one that gates the self-host image) — clean.
- FC test suite: sync suites all green, including two new byte-quota regression tests. **Pre-existing failures on this branch, not from these changes**: `deploy-env-parity` (`FC_SUPABASE_URL` / `TRUSTED_EXTERNAL_JWT_SECRET` are in compose but not `s.yaml` at HEAD — none of those three files is touched here), `pg-repo-contract`, `upsertSessionParticipant`, and the `sync-flow` tests that need a local Supabase.

## Follow-ups deliberately not in here

- **Enabling the blob GC cron** (`oss_sync_gc_orphan_blobs` sits under the compose `cron` profile self-host does not run). Until that lands the byte quota bounds *logical* live bytes, not disk — do not describe it as disk protection.
- Rename-time `.md` completion and the tree hint for extensionless files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)