### PR TITLE
fc(supabase): inline dispatchPush for inbox MQTT fan-out

### DIFF
--- a/packages/app/src/components/sidebar/TeamShareListColumn.tsx
+++ b/packages/app/src/components/sidebar/TeamShareListColumn.tsx
@@ -23,7 +23,6 @@ import {
   ChevronDown,
   Trash2,
 } from 'lucide-react'
-import { toast } from 'sonner'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import {

--- a/services/fc/src/index.ts
+++ b/services/fc/src/index.ts
@@ -194,6 +194,7 @@ export function makeBusinessRepoFactory(
       supabasePublicUrl: SUPABASE_PUBLIC_URL_FN(),
       publishableKey: SUPABASE_PUBLISHABLE_KEY(),
       accessToken,
+      dispatchPush: async (record) => { await dispatchPush(record, pushDeps()); },
       ...makeDeployDeps(),
     });
 }

--- a/services/fc/src/lib/supabase-repo.ts
+++ b/services/fc/src/lib/supabase-repo.ts
@@ -289,6 +289,9 @@ export function createSupabaseBusinessRepository(options) {
     // Injectable for tests; defaults to the shared LiteLLM HTTP client.
     litellmFetch: litellmFetchOpt,
     trustedExternalJwtSecret = process.env.TRUSTED_EXTERNAL_JWT_SECRET,
+    // Optional push hook — called after every successful message INSERT. Best-effort:
+    // errors are logged and swallowed so insert outcome is never affected.
+    dispatchPush,
   } = options;
 
   if (!supabaseUrl) throw new Error("SUPABASE_URL is required");
@@ -1199,6 +1202,20 @@ export function createSupabaseBusinessRepository(options) {
         .select(MESSAGE_COLUMNS)
         .single();
       if (error) throw error;
+
+      if (dispatchPush) {
+        dispatchPush({
+          id: data.id,
+          session_id: data.session_id,
+          team_id: data.team_id,
+          sender_actor_id: data.sender_actor_id ?? null,
+          kind: data.kind ?? "text",
+          content: data.content ?? "",
+        }).catch((err: unknown) => {
+          console.error("[push] dispatchPush failed (swallowed):", err);
+        });
+      }
+
       return mapMessage(data);
     },
 


### PR DESCRIPTION
## Summary

- Wire `dispatchPush` into the **Supabase** business repository factory (`services/fc/src/index.ts`) — the Postgres path already had this; self-host defaults to `BACKEND_KIND=supabase`.
- After a successful `insertMessage`, FC now best-effort calls the existing `push-dispatch.ts` path (APNs + `inbox/{userId}` MQTT ping). Errors are logged and swallowed; message INSERT is unchanged.

## Why now / safe to ship alone

- `push-dispatch.ts` inbox fan-out already exists on `main`; this PR only ensures Supabase inserts actually invoke it.
- **No client changes required.** Old clients that do not SUB `inbox/{userId}` are unaffected; clients that already SUB (main Desktop) benefit immediately once broker ACL allows it.
- Can coexist with the DB webhook trigger: `push_idempotency_claim` dedupes duplicate dispatches. **Do not** drop the trigger until inline dispatch is verified in production.

## Out of scope (follow-up PRs)

- `20260826100000_inbox_mqtt_acl.sql` — JWT SUB permission for clients
- `20260826110000_drop_messages_push_dispatch.sql` — remove DB webhook after verification
- Desktop Phase A (remove wildcard / inbox-triggered session/live SUB)
- `services/fc/test/supabase-repo.test.ts` dispatchPush tests (on sibling branch)

## Test plan

- [ ] FC container has `MQTT_BROKER_URL` / `MQTT_USERNAME` / `MQTT_PASSWORD` configured
- [ ] Deploy FC only → send a message in a multi-member session
- [ ] EMQX / FC logs show publish to `inbox/{recipientUserId}` with `{ session_id, ts }`
- [ ] Message API still returns 200 when MQTT is down (dispatch failure swallowed)
- [ ] Optional: if DB webhook still active, confirm no double APNs (idempotency skip on second call)
- [ ] Optional: connected Desktop (main) shows unread dot / debounced list refresh


Made with [Cursor](https://cursor.com)