### PR TITLE
fix(daemon): concurrent session deeplink follow-up (#1099)

### DIFF
--- a/apps/daemon/assets/pi-extension/session-context.test.mjs
+++ b/apps/daemon/assets/pi-extension/session-context.test.mjs
@@ -1,0 +1,94 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+/** Mirrors `backendSessionIdFromContext` in teamclu.ts */
+function backendSessionIdFromContext(ctx) {
+  return ctx?.ui?.sessionId?.trim() || undefined;
+}
+
+/** Mirrors PI MCP proxy injection gate in teamclu.ts */
+async function injectForPiTool(toolName, params, ctx, deps = {}) {
+  const SESSION_SCOPED = new Set([
+    "get_session_deeplink",
+    "manage_participants",
+    "archive_session",
+  ]);
+  const base = toolName.split("/").pop()?.trim() ?? toolName;
+  if (!SESSION_SCOPED.has(base)) {
+    return params;
+  }
+  const explicit = String(params?.session_id ?? params?.sessionId ?? "").trim();
+  if (explicit) return params;
+  const backendSessionId = backendSessionIdFromContext(ctx);
+  if (!backendSessionId) {
+    throw new Error("session_context_unavailable");
+  }
+  const resolve = deps.resolve ?? (async (id) => `teamclu-for-${id}`);
+  return { ...params, session_id: await resolve(backendSessionId) };
+}
+
+function makeUiContext(sessionId) {
+  return { sessionId, confirm: async () => true, select: async () => undefined };
+}
+
+test("PI ctx.ui.sessionId drives injection for session-scoped tools", async () => {
+  const ctxA = { ui: makeUiContext("pi:/tmp/a.json") };
+  const ctxB = { ui: makeUiContext("pi:/tmp/b.json") };
+  const a = await injectForPiTool("get_session_deeplink", {}, ctxA);
+  const b = await injectForPiTool("get_session_deeplink", {}, ctxB);
+  assert.equal(a.session_id, "teamclu-for-pi:/tmp/a.json");
+  assert.equal(b.session_id, "teamclu-for-pi:/tmp/b.json");
+});
+
+test("missing ctx.ui.sessionId fails closed without resolver call", async () => {
+  let called = false;
+  await assert.rejects(
+    () =>
+      injectForPiTool(
+        "get_session_deeplink",
+        {},
+        { ui: makeUiContext("") },
+        { resolve: async () => {
+          called = true;
+          return "x";
+        } },
+      ),
+    /session_context_unavailable/,
+  );
+  assert.equal(called, false);
+});
+
+test("explicit session_id skips resolver on PI path", async () => {
+  let called = false;
+  const next = await injectForPiTool(
+    "archive_session",
+    { session_id: "explicit" },
+    { ui: makeUiContext("pi:/tmp/a.json") },
+    {
+      resolve: async () => {
+        called = true;
+        return "ignored";
+      },
+    },
+  );
+  assert.equal(next.session_id, "explicit");
+  assert.equal(called, false);
+});
+
+test("non allowlist PI tools ignore session identity", async () => {
+  let called = false;
+  const params = { path: "/tmp/x" };
+  const next = await injectForPiTool(
+    "read",
+    params,
+    { ui: makeUiContext("pi:/tmp/a.json") },
+    {
+      resolve: async () => {
+        called = true;
+        return "ignored";
+      },
+    },
+  );
+  assert.deepEqual(next, params);
+  assert.equal(called, false);
+});

--- a/apps/daemon/assets/pi-extension/teamclu.ts
+++ b/apps/daemon/assets/pi-extension/teamclu.ts
@@ -67,16 +67,17 @@ type ToolCallEvent = {
   toolCallId: string;
   input: Record<string, unknown>;
 };
-type ExtensionContext = {
+type TeamcluExtensionUIContext = {
   sessionId?: string;
-  ui: {
-    confirm(title: string, message?: string, options?: { timeout?: number }): Promise<boolean>;
-    select(
-      title: string,
-      options: string[],
-      opts?: { timeout?: number; signal?: AbortSignal },
-    ): Promise<string | undefined>;
-  };
+  confirm(title: string, message?: string, options?: { timeout?: number }): Promise<boolean>;
+  select(
+    title: string,
+    options: string[],
+    opts?: { timeout?: number; signal?: AbortSignal },
+  ): Promise<string | undefined>;
+};
+type ExtensionContext = {
+  ui: TeamcluExtensionUIContext;
 };
 type ExtensionAPI = {
   on(
@@ -114,9 +115,23 @@ const SESSION_SCOPED_TOOLS = new Set([
   "archive_session",
 ]);
 
+function normalizeSessionScopedToolName(name: string): string {
+  const raw = name.trim();
+  if (!raw) return "";
+  if (raw.startsWith("mcp__")) {
+    const parts = raw.split("__");
+    const last = parts[parts.length - 1]?.trim();
+    if (last) return last;
+  }
+  return raw.split("/").pop()?.trim() ?? raw;
+}
+
 function isSessionScopedTool(name: string): boolean {
-  const base = name.split("/").pop()?.trim() ?? name;
-  return SESSION_SCOPED_TOOLS.has(base);
+  return SESSION_SCOPED_TOOLS.has(normalizeSessionScopedToolName(name));
+}
+
+function backendSessionIdFromContext(ctx?: ExtensionContext): string | undefined {
+  return ctx?.ui?.sessionId?.trim() || undefined;
 }
 
 async function resolveTeamcluSessionId(backendSessionId: string): Promise<string> {
@@ -968,7 +983,11 @@ function registerBridgeTools(
         }
         let callParams = params ?? {};
         try {
-          callParams = await injectSessionIdForTool(tool.name, callParams, ctx?.sessionId);
+          callParams = await injectSessionIdForTool(
+            tool.name,
+            callParams,
+            backendSessionIdFromContext(ctx),
+          );
         } catch {
           return sessionContextUnavailableResult();
         }

--- a/apps/daemon/shared/session-context-client.mjs
+++ b/apps/daemon/shared/session-context-client.mjs
@@ -10,12 +10,20 @@ const SESSION_SCOPED_TOOLS = new Set([
   "archive_session",
 ]);
 
+/** Extract the bare tool name from OpenCode / MCP namespaced identifiers. */
+export function normalizeSessionScopedToolName(name) {
+  const raw = String(name ?? "").trim();
+  if (!raw) return "";
+  if (raw.startsWith("mcp__")) {
+    const parts = raw.split("__");
+    const last = parts[parts.length - 1]?.trim();
+    if (last) return last;
+  }
+  return raw.split("/").pop()?.trim() ?? raw;
+}
+
 export function isSessionScopedTool(name) {
-  const base = String(name ?? "")
-    .split("/")
-    .pop()
-    .trim();
-  return SESSION_SCOPED_TOOLS.has(base);
+  return SESSION_SCOPED_TOOLS.has(normalizeSessionScopedToolName(name));
 }
 
 function runtimeContextUrl() {
@@ -24,16 +32,17 @@ function runtimeContextUrl() {
   return null;
 }
 
-export async function resolveTeamcluSessionId(backendSessionId) {
-  const baseUrl = runtimeContextUrl();
-  const token = process.env.TEAMCLU_RUNTIME_CONTEXT_TOKEN?.trim();
-  const generationId = process.env.TEAMCLU_HOST_GENERATION_ID?.trim();
-  const backendKind = process.env.TEAMCLU_AGENT_BACKEND?.trim();
+export async function resolveTeamcluSessionId(backendSessionId, deps = {}) {
+  const fetchFn = deps.fetch ?? globalThis.fetch;
+  const baseUrl = deps.baseUrl ?? runtimeContextUrl();
+  const token = deps.token ?? process.env.TEAMCLU_RUNTIME_CONTEXT_TOKEN?.trim();
+  const generationId = deps.generationId ?? process.env.TEAMCLU_HOST_GENERATION_ID?.trim();
+  const backendKind = deps.backendKind ?? process.env.TEAMCLU_AGENT_BACKEND?.trim();
   const sessionId = String(backendSessionId ?? "").trim();
   if (!baseUrl || !token || !generationId || !backendKind || !sessionId) {
     throw new Error("session_context_unavailable");
   }
-  const resp = await fetch(`${baseUrl}/internal/runtime-context/resolve`, {
+  const resp = await fetchFn(`${baseUrl}/internal/runtime-context/resolve`, {
     method: "POST",
     headers: {
       Authorization: `Bearer ${token}`,
@@ -56,7 +65,7 @@ export async function resolveTeamcluSessionId(backendSessionId) {
   return teamcluSessionId;
 }
 
-export async function injectSessionIdForTool(toolName, args, backendSessionId) {
+export async function injectSessionIdForTool(toolName, args, backendSessionId, deps = {}) {
   if (!isSessionScopedTool(toolName)) {
     return args ?? {};
   }
@@ -65,8 +74,30 @@ export async function injectSessionIdForTool(toolName, args, backendSessionId) {
   if (explicit) {
     return next;
   }
-  next.session_id = await resolveTeamcluSessionId(backendSessionId);
+  const resolve = deps.resolveTeamcluSessionId ?? resolveTeamcluSessionId;
+  next.session_id = await resolve(backendSessionId, deps);
   return next;
+}
+
+/**
+ * OpenCode 1.18.x `tool.execute.before` hook handler.
+ *
+ * Contract: input.tool (string), input.sessionID (string), output.args (mutable).
+ */
+export async function handleToolExecuteBefore(input, output, deps = {}) {
+  if (!input || typeof input !== "object" || !output || typeof output !== "object") {
+    throw new Error("session_context_unavailable");
+  }
+  const toolName = input.tool;
+  if (!isSessionScopedTool(toolName)) {
+    return;
+  }
+  const backendSessionId = input.sessionID;
+  if (!backendSessionId || !String(backendSessionId).trim()) {
+    throw new Error("session_context_unavailable");
+  }
+  const inject = deps.injectSessionIdForTool ?? injectSessionIdForTool;
+  output.args = await inject(toolName, output.args ?? {}, String(backendSessionId).trim(), deps);
 }
 
 export function sessionContextUnavailableResult() {

--- a/apps/daemon/shared/session-context-client.test.mjs
+++ b/apps/daemon/shared/session-context-client.test.mjs
@@ -1,0 +1,136 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  handleToolExecuteBefore,
+  injectSessionIdForTool,
+  isSessionScopedTool,
+  normalizeSessionScopedToolName,
+  resolveTeamcluSessionId,
+} from "./session-context-client.mjs";
+
+test("normalizeSessionScopedToolName handles slash and mcp__ forms", () => {
+  assert.equal(normalizeSessionScopedToolName("get_session_deeplink"), "get_session_deeplink");
+  assert.equal(
+    normalizeSessionScopedToolName("teamclu-introspect/get_session_deeplink"),
+    "get_session_deeplink",
+  );
+  assert.equal(
+    normalizeSessionScopedToolName("mcp__teamclu-introspect__get_session_deeplink"),
+    "get_session_deeplink",
+  );
+  assert.equal(
+    normalizeSessionScopedToolName("mcp__my_server-with_underscores__archive_session"),
+    "archive_session",
+  );
+});
+
+test("isSessionScopedTool recognizes namespaced MCP tool ids", () => {
+  assert.equal(isSessionScopedTool("mcp__teamclu-introspect__manage_participants"), true);
+  assert.equal(isSessionScopedTool("browser_click"), false);
+});
+
+test("handleToolExecuteBefore injects output.args.session_id using OpenCode hook shape", async () => {
+  const output = { args: {} };
+  await handleToolExecuteBefore(
+    { tool: "get_session_deeplink", sessionID: "backend-a", callID: "c1" },
+    output,
+    {
+      injectSessionIdForTool: async () => ({ session_id: "teamclu-a" }),
+    },
+  );
+  assert.equal(output.args.session_id, "teamclu-a");
+});
+
+test("concurrent A/B resolve injects distinct TeamClu sessions", async () => {
+  const resolver = async (backendSessionId) => {
+    if (backendSessionId === "backend-a") return "teamclu-a";
+    if (backendSessionId === "backend-b") return "teamclu-b";
+    throw new Error("session_context_unavailable");
+  };
+  const inject = (toolName, args, backendSessionId) =>
+    injectSessionIdForTool(toolName, args, backendSessionId, {
+      resolveTeamcluSessionId: resolver,
+    });
+
+  const results = await Promise.all([
+    inject("get_session_deeplink", {}, "backend-a"),
+    inject("get_session_deeplink", {}, "backend-b"),
+    inject("get_session_deeplink", {}, "backend-a"),
+  ]);
+  assert.deepEqual(results, [
+    { session_id: "teamclu-a" },
+    { session_id: "teamclu-b" },
+    { session_id: "teamclu-a" },
+  ]);
+});
+
+test("explicit session_id skips resolver fetch", async () => {
+  let called = false;
+  const next = await injectSessionIdForTool(
+    "get_session_deeplink",
+    { session_id: "explicit-id" },
+    "backend-a",
+    {
+      resolveTeamcluSessionId: async () => {
+        called = true;
+        return "ignored";
+      },
+    },
+  );
+  assert.equal(next.session_id, "explicit-id");
+  assert.equal(called, false);
+});
+
+test("non allowlist tools leave args unchanged and skip fetch", async () => {
+  let called = false;
+  const args = { foo: 1 };
+  const next = await injectSessionIdForTool("browser_click", args, "backend-a", {
+    resolveTeamcluSessionId: async () => {
+      called = true;
+      return "ignored";
+    },
+  });
+  assert.deepEqual(next, args);
+  assert.equal(called, false);
+});
+
+test("resolver HTTP failures fail closed", async () => {
+  for (const status of [401, 404, 409, 500]) {
+    await assert.rejects(
+      () =>
+        resolveTeamcluSessionId("backend-a", {
+          baseUrl: "http://127.0.0.1:1",
+          token: "tok",
+          generationId: "gen1",
+          backendKind: "opencode",
+          fetch: async () => ({ ok: false, status }),
+        }),
+      /session_context_unavailable/,
+    );
+  }
+});
+
+test("invalid JSON and empty teamclu session id fail closed", async () => {
+  await assert.rejects(
+    () =>
+      resolveTeamcluSessionId("backend-a", {
+        baseUrl: "http://127.0.0.1:1",
+        token: "tok",
+        generationId: "gen1",
+        backendKind: "opencode",
+        fetch: async () => ({
+          ok: true,
+          json: async () => ({ teamcluSessionId: "  " }),
+        }),
+      }),
+    /session_context_unavailable/,
+  );
+});
+
+test("missing sessionID on session-scoped tool fails closed", async () => {
+  await assert.rejects(
+    () => handleToolExecuteBefore({ tool: "get_session_deeplink", callID: "c1" }, { args: {} }),
+    /session_context_unavailable/,
+  );
+});

--- a/apps/daemon/src/http/server.rs
+++ b/apps/daemon/src/http/server.rs
@@ -54,6 +54,25 @@ impl Drop for HttpHandle {
     }
 }
 
+/// Loopback URL adapters use to reach `/internal/runtime-context/resolve`.
+/// The public listener may bind `0.0.0.0` or `[::]`; resolver clients must
+/// always target an explicit loopback address.
+pub(crate) fn loopback_runtime_context_url(requested_bind: SocketAddr, bound: SocketAddr) -> String {
+    let port = bound.port();
+    match requested_bind.ip() {
+        std::net::IpAddr::V4(v4) if v4.is_unspecified() => format!("http://127.0.0.1:{port}"),
+        std::net::IpAddr::V6(v6) if v6.is_unspecified() => format!("http://[::1]:{port}"),
+        ip if ip.is_loopback() => {
+            if ip.is_ipv6() {
+                format!("http://[::1]:{port}")
+            } else {
+                format!("http://127.0.0.1:{port}")
+            }
+        }
+        _ => format!("http://127.0.0.1:{port}"),
+    }
+}
+
 /// Spawn the HTTP listener. Errors surface as `anyhow::Result` because
 /// the daemon's startup path uses that as the lingua franca for early
 /// bring-up failures.
@@ -109,7 +128,7 @@ pub async fn spawn(
     let local_addr = listener.local_addr()?;
     tokens::write_port_file(&port_path, local_addr.port());
     if let Some(service) = runtime_context.as_ref() {
-        service.set_base_url(format!("http://{local_addr}"));
+        service.set_base_url(loopback_runtime_context_url(addr, local_addr));
     }
 
     tracing::info!(
@@ -1125,6 +1144,108 @@ mod tests {
             backend.state().team_skill_installs,
             vec![(team_id.to_string(), "managed-skill".to_string(), 2)]
         );
+
+        handle.shutdown().await;
+    }
+
+    #[test]
+    fn loopback_runtime_context_url_normalizes_bind_addresses() {
+        let bound_v4: SocketAddr = "127.0.0.1:8787".parse().unwrap();
+        assert_eq!(
+            loopback_runtime_context_url("127.0.0.1:0".parse().unwrap(), bound_v4),
+            "http://127.0.0.1:8787"
+        );
+        assert_eq!(
+            loopback_runtime_context_url("0.0.0.0:0".parse().unwrap(), bound_v4),
+            "http://127.0.0.1:8787"
+        );
+        let bound_v6: SocketAddr = "[::1]:8787".parse().unwrap();
+        assert_eq!(
+            loopback_runtime_context_url("[::1]:0".parse().unwrap(), bound_v6),
+            "http://[::1]:8787"
+        );
+        assert_eq!(
+            loopback_runtime_context_url("[::]:0".parse().unwrap(), bound_v6),
+            "http://[::1]:8787"
+        );
+    }
+
+    #[tokio::test]
+    async fn runtime_context_resolve_loopback_only() {
+        use crate::proto::amux;
+        use crate::runtime::context_registry::ResolveRuntimeContextRequest;
+        use crate::runtime::context_service::RuntimeContextService;
+
+        let dir = tempfile::tempdir().unwrap();
+        let cfg = HttpConfig {
+            bind: "127.0.0.1:0".into(),
+            token_file: Some(dir.path().join("token")),
+            port_file: Some(dir.path().join("port")),
+            ..HttpConfig::default()
+        };
+        let service = Arc::new(RuntimeContextService::new());
+        service.register_attached_session(
+            amux::AgentType::Opencode,
+            "gen-test",
+            "backend-a",
+            "teamclu-a",
+            "runtime-a",
+        );
+        let env = service.env_for_generation(amux::AgentType::Opencode, "gen-test");
+        let token = env
+            .get("TEAMCLU_RUNTIME_CONTEXT_TOKEN")
+            .cloned()
+            .expect("token");
+        let meta = metadata("actor-test".into(), "test");
+        let runtime = crate::http::runtime_adapter::StubRuntimeAdapter::new(256);
+        let handle = spawn(
+            cfg,
+            meta,
+            runtime,
+            None,
+            None,
+            None,
+            test_dispatcher(),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            Some(service),
+        )
+        .await
+        .unwrap();
+        let base = format!("http://{}", handle.local_addr);
+        let client = reqwest::Client::new();
+        let body = ResolveRuntimeContextRequest {
+            backend_session_id: "backend-a".into(),
+            host_generation_id: "gen-test".into(),
+            backend_kind: "opencode".into(),
+        };
+        let ok: serde_json::Value = client
+            .post(format!("{base}/internal/runtime-context/resolve"))
+            .bearer_auth(&token)
+            .json(&body)
+            .send()
+            .await
+            .unwrap()
+            .json()
+            .await
+            .unwrap();
+        assert_eq!(ok["teamcluSessionId"], "teamclu-a");
+
+        let bad_token = client
+            .post(format!("{base}/internal/runtime-context/resolve"))
+            .bearer_auth("rtctx_invalid")
+            .json(&body)
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(bad_token.status().as_u16(), 401);
 
         handle.shutdown().await;
     }

--- a/apps/daemon/src/runtime/manager.rs
+++ b/apps/daemon/src/runtime/manager.rs
@@ -6,7 +6,7 @@ use tracing::{info, warn};
 use uuid::Uuid;
 
 use super::agent_runtime_state::PerAgentRuntimeState;
-use super::backend::{agent_type_for_local_agent, create_backend, AgentBackend};
+use super::backend::{agent_type_for_local_agent, create_backend, AcpCommand, AcpStartupMetadata, AgentBackend};
 use super::builtin_commands::builtin_commands;
 use super::execution_context::{ExecutionContext, IsolationDomainKey, ProcessEnvRevision};
 use super::handle::RuntimeHandle;
@@ -535,6 +535,96 @@ impl RuntimeManager {
         self.aggregators.get(agent_id)
     }
 
+    fn uses_deferred_initial_prompt(agent_type: amux::AgentType) -> bool {
+        matches!(
+            agent_type,
+            amux::AgentType::Opencode | amux::AgentType::Pi
+        )
+    }
+
+    fn validate_managed_session_metadata(
+        agent_type: amux::AgentType,
+        startup: &AcpStartupMetadata,
+        teamclu_session_id: &str,
+    ) -> crate::error::Result<()> {
+        if !Self::uses_deferred_initial_prompt(agent_type) {
+            return Ok(());
+        }
+        if startup.host_generation_id.trim().is_empty()
+            || startup.acp_session_id.trim().is_empty()
+            || teamclu_session_id.trim().is_empty()
+        {
+            return Err(crate::error::AmuxError::Agent(
+                "session context metadata incomplete for managed runtime".into(),
+            ));
+        }
+        Ok(())
+    }
+
+    fn register_attached_session_context(
+        &self,
+        agent_type: amux::AgentType,
+        startup: &AcpStartupMetadata,
+        teamclu_session_id: &str,
+        runtime_id: &str,
+    ) {
+        if let Some(service) = self.context_service.as_ref() {
+            service.register_attached_session(
+                agent_type,
+                &startup.host_generation_id,
+                &startup.acp_session_id,
+                teamclu_session_id,
+                runtime_id,
+            );
+        }
+    }
+
+    async fn send_deferred_initial_prompt(
+        &self,
+        agent_type: amux::AgentType,
+        cmd_tx: &mpsc::Sender<AcpCommand>,
+        startup: &AcpStartupMetadata,
+        prompt: &str,
+    ) -> crate::error::Result<()> {
+        if !Self::uses_deferred_initial_prompt(agent_type) || prompt.is_empty() {
+            return Ok(());
+        }
+        cmd_tx
+            .send(AcpCommand::Prompt {
+                acp_session_id: startup.acp_session_id.clone(),
+                text: prompt.to_string(),
+                attachment_urls: Vec::new(),
+                requester_actor_id: None,
+                reply_to_message_id: None,
+            })
+            .await
+            .map_err(|_| {
+                if let Some(service) = self.context_service.as_ref() {
+                    service.unregister_backend_session(
+                        agent_type,
+                        &startup.host_generation_id,
+                        &startup.acp_session_id,
+                    );
+                }
+                crate::error::AmuxError::Agent("failed to enqueue initial prompt".into())
+            })
+    }
+
+    async fn finalize_attached_session(
+        &self,
+        agent_type: amux::AgentType,
+        startup: &AcpStartupMetadata,
+        teamclu_session_id: &str,
+        runtime_id: &str,
+        cmd_tx: &mpsc::Sender<AcpCommand>,
+        prompt: &str,
+    ) -> crate::error::Result<()> {
+        Self::validate_managed_session_metadata(agent_type, startup, teamclu_session_id)?;
+        self.register_attached_session_context(agent_type, startup, teamclu_session_id, runtime_id);
+        self.send_deferred_initial_prompt(agent_type, cmd_tx, startup, prompt)
+            .await
+    }
+
     #[allow(dead_code)]
     pub async fn start_runtime(
         &mut self,
@@ -640,6 +730,11 @@ impl RuntimeManager {
 
         let launch = self.launch_config_for(agent_type);
         let resume_requested = resume_acp_session_id.is_some();
+        let attach_prompt = if Self::uses_deferred_initial_prompt(agent_type) {
+            String::new()
+        } else {
+            prompt.to_string()
+        };
         let (cmd_tx, mut startup) = self
             .agent_backend
             .lock()
@@ -658,13 +753,23 @@ impl RuntimeManager {
                 // No device MRU: every entry point pins a model when it is
                 // created, so attach has nothing left to infer from (ADR-0007).
                 Vec::new(),
-                prompt.to_string(),
+                attach_prompt,
                 handle.event_tx.clone(),
                 permission,
                 forbid_new_session_fallback,
                 session_id.to_string(),
             )
             .await?;
+
+        self.finalize_attached_session(
+            agent_type,
+            &startup,
+            session_id,
+            &agent_id,
+            &cmd_tx,
+            prompt,
+        )
+        .await?;
 
         handle.cmd_tx = Some(cmd_tx);
         handle.host_generation_id = startup.host_generation_id.clone();
@@ -698,16 +803,6 @@ impl RuntimeManager {
         }
         if let Some(model_id) = startup.initial_model {
             self.set_current_model(&agent_id, &model_id);
-        }
-
-        if let Some(service) = self.context_service.as_ref() {
-            service.register_attached_session(
-                agent_type,
-                &startup.host_generation_id,
-                &startup.acp_session_id,
-                session_id,
-                &agent_id,
-            );
         }
 
         self.seed_cursor_from_prior_runtime(&agent_id, Some(session_id))
@@ -810,6 +905,11 @@ impl RuntimeManager {
         handle.is_gateway = is_gateway;
 
         let launch = self.launch_config_for(agent_type);
+        let attach_prompt = if Self::uses_deferred_initial_prompt(agent_type) {
+            String::new()
+        } else {
+            prompt.to_string()
+        };
         let (cmd_tx, mut startup) = self
             .agent_backend
             .lock()
@@ -828,13 +928,23 @@ impl RuntimeManager {
                 // No device MRU: every entry point pins a model when it is
                 // created, so attach has nothing left to infer from (ADR-0007).
                 Vec::new(),
-                prompt.to_string(),
+                attach_prompt,
                 handle.event_tx.clone(),
                 permission,
                 forbid_new_session_fallback,
                 session_id.to_string(),
             )
             .await?;
+
+        self.finalize_attached_session(
+            agent_type,
+            &startup,
+            session_id,
+            session_id,
+            &cmd_tx,
+            prompt,
+        )
+        .await?;
 
         handle.cmd_tx = Some(cmd_tx);
         handle.host_generation_id = startup.host_generation_id.clone();
@@ -859,16 +969,6 @@ impl RuntimeManager {
         }
         if let Some(model_id) = startup.initial_model {
             self.set_current_model(session_id, &model_id);
-        }
-
-        if let Some(service) = self.context_service.as_ref() {
-            service.register_attached_session(
-                agent_type,
-                &startup.host_generation_id,
-                &new_acp_sid,
-                session_id,
-                session_id,
-            );
         }
 
         self.seed_cursor_from_prior_runtime(session_id, Some(session_id))

--- a/apps/daemon/src/runtime/opencode_http/mod.rs
+++ b/apps/daemon/src/runtime/opencode_http/mod.rs
@@ -519,7 +519,7 @@ impl OpencodeHost {
         mcp_config_path: Option<PathBuf>,
         initial_model_override: Option<String>,
         model_mru: Vec<String>,
-        initial_prompt: String,
+        _initial_prompt: String,
         event_tx: mpsc::Sender<AcpEventFrame>,
         permission: PermissionPolicy,
         forbid_new_session_fallback: bool,
@@ -575,17 +575,6 @@ impl OpencodeHost {
         .await
         .map_err(crate::error::AmuxError::Agent)?
         .with_route_lease(route_lease);
-        if !initial_prompt.is_empty() {
-            let _ = cmd_tx
-                .send(AcpCommand::Prompt {
-                    acp_session_id: startup.acp_session_id.clone(),
-                    text: initial_prompt,
-                    attachment_urls: Vec::new(),
-                    requester_actor_id: None,
-                    reply_to_message_id: None,
-                })
-                .await;
-        }
         Ok((cmd_tx, startup))
     }
 }

--- a/apps/daemon/src/runtime/pi_rpc/mod.rs
+++ b/apps/daemon/src/runtime/pi_rpc/mod.rs
@@ -1409,7 +1409,7 @@ impl AgentBackend for PiRpcBackend {
         mcp_config_path: Option<PathBuf>,
         initial_model_override: Option<String>,
         model_mru: Vec<String>,
-        initial_prompt: String,
+        _initial_prompt: String,
         event_tx: mpsc::Sender<AcpEventFrame>,
         permission: PermissionPolicy,
         forbid_new_session_fallback: bool,
@@ -1442,17 +1442,6 @@ impl AgentBackend for PiRpcBackend {
         )
         .await
         .map_err(crate::error::AmuxError::Agent)?;
-        if !initial_prompt.is_empty() {
-            let _ = cmd_tx
-                .send(AcpCommand::Prompt {
-                    acp_session_id: startup.acp_session_id.clone(),
-                    text: initial_prompt,
-                    attachment_urls: Vec::new(),
-                    requester_actor_id: None,
-                    reply_to_message_id: None,
-                })
-                .await;
-        }
         Ok((cmd_tx, startup))
     }
 

--- a/apps/daemon/src/runtime/sidecar/mcp.rs
+++ b/apps/daemon/src/runtime/sidecar/mcp.rs
@@ -348,4 +348,60 @@ mod tests {
             json!("https://example.invalid/mcp")
         );
     }
+
+    #[test]
+    fn stamp_managed_session_context_sets_teamclu_introspect_env() {
+        let mut servers = Map::new();
+        servers.insert(
+            "teamclu-introspect".into(),
+            json!({
+                "type": "stdio",
+                "command": "teamclu-introspect",
+                "args": []
+            }),
+        );
+        stamp_managed_session_context(&mut servers, "sess-abc");
+        let env = servers["teamclu-introspect"]["env"].as_object().unwrap();
+        assert_eq!(env["TEAMCLU_SESSION_ID"], "sess-abc");
+        assert_eq!(env["TEAMCLU_REQUIRE_EXPLICIT_SESSION_ID"], "1");
+    }
+
+    #[test]
+    fn stamp_managed_session_context_preserves_existing_env_and_legacy_name() {
+        let mut servers = Map::new();
+        servers.insert(
+            "teamclaw-introspect".into(),
+            json!({
+                "type": "stdio",
+                "command": "teamclu-introspect",
+                "env": { "FOO": "bar" }
+            }),
+        );
+        stamp_managed_session_context(&mut servers, "sess-legacy");
+        let env = servers["teamclaw-introspect"]["env"].as_object().unwrap();
+        assert_eq!(env["FOO"], "bar");
+        assert_eq!(env["TEAMCLU_SESSION_ID"], "sess-legacy");
+    }
+
+    #[test]
+    fn stamp_managed_session_context_creates_env_object_when_missing() {
+        let mut servers = Map::new();
+        servers.insert(
+            "teamclu-introspect".into(),
+            json!({
+                "type": "stdio",
+                "command": "teamclu-introspect"
+            }),
+        );
+        stamp_managed_session_context(&mut servers, "sess-new");
+        assert!(servers["teamclu-introspect"]["env"].is_object());
+    }
+
+    #[test]
+    fn stamp_managed_session_context_skips_non_object_server_entries() {
+        let mut servers = Map::new();
+        servers.insert("teamclu-introspect".into(), json!("not-an-object"));
+        stamp_managed_session_context(&mut servers, "sess-x");
+        assert_eq!(servers["teamclu-introspect"], "not-an-object");
+    }
 }

--- a/apps/daemon/src/runtime/supervisor.rs
+++ b/apps/daemon/src/runtime/supervisor.rs
@@ -34,6 +34,7 @@ const INSTRUCTION_PLUGIN_TEMPLATE: &str = include_str!(
 const SESSION_CONTEXT_PLUGIN_TEMPLATE: &str = include_str!(
     "../../../../packages/app/src/lib/opencode/templates/teamclu-session-context-plugin.mjs.txt"
 );
+const SESSION_CONTEXT_CLIENT_TEMPLATE: &str = include_str!("../../shared/session-context-client.mjs");
 
 use crate::config::workspace_control::{
     ApplyOutcome, EnvActivationBlocker, EnvActivationDiagnostics, RuntimeStatus,
@@ -749,21 +750,28 @@ fn install_instruction_plugin_file(workspace_path: &Path) -> Result<(), Workspac
 }
 
 fn install_session_context_plugin_file(workspace_path: &Path) -> Result<(), WorkspaceControlError> {
-    use crate::runtime::workspace_runtime::SESSION_CONTEXT_PLUGIN_REL;
+    use crate::runtime::workspace_runtime::{SESSION_CONTEXT_CLIENT_REL, SESSION_CONTEXT_PLUGIN_REL};
 
     let plugin_path = workspace_path.join(SESSION_CONTEXT_PLUGIN_REL);
+    let client_path = workspace_path.join(SESSION_CONTEXT_CLIENT_REL);
     if let Some(parent) = plugin_path.parent() {
         std::fs::create_dir_all(parent).map_err(|e| WorkspaceControlError::Io(e.to_string()))?;
     }
 
-    let should_write = match std::fs::read_to_string(&plugin_path) {
-        Ok(existing) => existing != SESSION_CONTEXT_PLUGIN_TEMPLATE,
-        Err(_) => true,
-    };
-    if should_write {
-        std::fs::write(&plugin_path, SESSION_CONTEXT_PLUGIN_TEMPLATE)
-            .map_err(|e| WorkspaceControlError::Io(e.to_string()))?;
-    }
+    let write_if_changed =
+        |path: &Path, template: &str| -> Result<(), WorkspaceControlError> {
+            let should_write = match std::fs::read_to_string(path) {
+                Ok(existing) => existing != template,
+                Err(_) => true,
+            };
+            if should_write {
+                std::fs::write(path, template).map_err(|e| WorkspaceControlError::Io(e.to_string()))?;
+            }
+            Ok(())
+        };
+
+    write_if_changed(&client_path, SESSION_CONTEXT_CLIENT_TEMPLATE)?;
+    write_if_changed(&plugin_path, SESSION_CONTEXT_PLUGIN_TEMPLATE)?;
     Ok(())
 }
 

--- a/apps/daemon/src/runtime/workspace_runtime.rs
+++ b/apps/daemon/src/runtime/workspace_runtime.rs
@@ -8,6 +8,7 @@ use crate::proto::amux;
 pub const INSTRUCTION_PLUGIN_REL: &str = ".opencode/plugins/teamclu-instruction.mjs";
 pub const INSTRUCTION_PLUGIN_CONFIG_ENTRY: &str = "./.opencode/plugins/teamclu-instruction.mjs";
 pub const SESSION_CONTEXT_PLUGIN_REL: &str = ".opencode/plugins/teamclu-session-context.mjs";
+pub const SESSION_CONTEXT_CLIENT_REL: &str = ".opencode/plugins/teamclu-session-context-client.mjs";
 pub const SESSION_CONTEXT_PLUGIN_CONFIG_ENTRY: &str =
     "./.opencode/plugins/teamclu-session-context.mjs";
 

--- a/packages/app/src/lib/opencode/templates/teamclu-session-context-plugin.mjs.txt
+++ b/packages/app/src/lib/opencode/templates/teamclu-session-context-plugin.mjs.txt
@@ -1,80 +1,10 @@
 // managed-plugin: teamclu-session-context
-// version: 1
+// version: 2
 
-const SESSION_SCOPED_TOOLS = new Set([
-  "get_session_deeplink",
-  "manage_participants",
-  "archive_session",
-])
+import { handleToolExecuteBefore } from "./teamclu-session-context-client.mjs";
 
-function isSessionScopedTool(name) {
-  const base = String(name ?? "")
-    .split("/")
-    .pop()
-    .trim()
-  return SESSION_SCOPED_TOOLS.has(base)
-}
+export const TeamcluSessionContextPlugin = async () => ({
+  "tool.execute.before": handleToolExecuteBefore,
+});
 
-async function resolveTeamcluSessionId(backendSessionId) {
-  const baseUrl = process.env.TEAMCLU_RUNTIME_CONTEXT_URL?.trim()?.replace(/\/$/, "")
-  const token = process.env.TEAMCLU_RUNTIME_CONTEXT_TOKEN?.trim()
-  const generationId = process.env.TEAMCLU_HOST_GENERATION_ID?.trim()
-  const backendKind = process.env.TEAMCLU_AGENT_BACKEND?.trim()
-  const sessionId = String(backendSessionId ?? "").trim()
-  if (!baseUrl || !token || !generationId || !backendKind || !sessionId) {
-    throw new Error("session_context_unavailable")
-  }
-  const resp = await fetch(`${baseUrl}/internal/runtime-context/resolve`, {
-    method: "POST",
-    headers: {
-      Authorization: `Bearer ${token}`,
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify({
-      backendSessionId: sessionId,
-      hostGenerationId: generationId,
-      backendKind,
-    }),
-  })
-  if (!resp.ok) {
-    throw new Error("session_context_unavailable")
-  }
-  const body = await resp.json()
-  const teamcluSessionId = String(body?.teamcluSessionId ?? "").trim()
-  if (!teamcluSessionId) {
-    throw new Error("session_context_unavailable")
-  }
-  return teamcluSessionId
-}
-
-async function injectSessionIdForTool(toolName, args, backendSessionId) {
-  if (!isSessionScopedTool(toolName)) {
-    return args ?? {}
-  }
-  const next = { ...(args ?? {}) }
-  const explicit = String(next.session_id ?? next.sessionId ?? "").trim()
-  if (explicit) {
-    return next
-  }
-  next.session_id = await resolveTeamcluSessionId(backendSessionId)
-  return next
-}
-
-export const TeamcluSessionContextPlugin = async () => {
-  return {
-    "tool.execute.before": async (input, output) => {
-      const toolName = output?.tool?.name ?? input?.tool?.name ?? input?.name
-      if (!isSessionScopedTool(toolName)) {
-        return
-      }
-      const sessionId = input?.sessionID ?? input?.sessionId ?? output?.session?.id
-      if (!sessionId) {
-        throw new Error("session_context_unavailable")
-      }
-      const args = output?.arguments ?? input?.arguments ?? {}
-      output.arguments = await injectSessionIdForTool(toolName, args, sessionId)
-    },
-  }
-}
-
-export default TeamcluSessionContextPlugin
+export default TeamcluSessionContextPlugin;


### PR DESCRIPTION
## Summary

- Fix OpenCode `tool.execute.before` to use the real 1.18.x hook contract (`input.tool`, `input.sessionID`, `output.args`) via shared `session-context-client.mjs`
- Fix PI session injection to read backend session ID from `ctx.ui.sessionId` (host `makeUiContext` contract)
- Ensure OpenCode/PI registry binding happens before the initial prompt is enqueued
- Normalize internal resolver base URL to explicit loopback for `0.0.0.0` / `[::]` HTTP binds
- Add adapter/resolver/stamping unit tests

## Test plan

- [x] `node --test apps/daemon/shared/session-context-client.test.mjs apps/daemon/assets/pi-extension/session-context.test.mjs`
- [x] `pnpm daemon:test -- context_registry context_service loopback_runtime_context runtime_context_resolve stamp_managed_session_context`

Made with [Cursor](https://cursor.com)