### PR TITLE
fix(app): open team skill folders right after install

### DIFF
--- a/packages/app/src/components/teamshare/SkillDetail.tsx
+++ b/packages/app/src/components/teamshare/SkillDetail.tsx
@@ -1625,15 +1625,21 @@ export function SkillDetail({ slug }: { slug: string }) {
                 Telling that user to install it is a dead end: installing again
                 changes nothing, and the pane stays read-only either way.
               */}
-              {item.installed || isPersonal
+              {item.kind === 'team-installed' && item.hasUpdate && !item.dirPath
                 ? t(
-                    'teamShare.skillOnRemoteAgentBody',
-                    '这个 Skill 装在所选 Agent 的机器上，远程暂不支持查看和编辑内容。',
+                    'teamShare.skillSyncingBody',
+                    '正在同步到 v{{v}}，完成后即可查看和编辑文件。',
+                    { v: item.latestVersion ?? item.installedVersion ?? '?' },
                   )
-                : t(
-                    'teamShare.skillNotInstalledBody',
-                    'Install this skill to read and edit its package contents on disk.',
-                  )}
+                : item.installed || isPersonal
+                  ? t(
+                      'teamShare.skillOnRemoteAgentBody',
+                      '这个 Skill 装在所选 Agent 的机器上，远程暂不支持查看和编辑内容。',
+                    )
+                  : t(
+                      'teamShare.skillNotInstalledBody',
+                      'Install this skill to read and edit its package contents on disk.',
+                    )}
             </p>
             {latestChangelog && (
               <p className="max-w-md text-[12px] leading-relaxed text-faint">

--- a/packages/app/src/stores/__tests__/team-share-skill-dir.test.ts
+++ b/packages/app/src/stores/__tests__/team-share-skill-dir.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+import { teamPackOnDisk } from '../team-share-browser'
+
+describe('teamPackOnDisk', () => {
+  it('is true when the local scan found a team pack', () => {
+    const onDisk = new Map([
+      [
+        'seatalk-webhook',
+        {
+          content: '# skill',
+          dirPath: '/Users/me/.agents/skills',
+          invocationName: 'seatalk-webhook',
+          source: 'global-agent' as const,
+        },
+      ],
+    ])
+    expect(teamPackOnDisk('seatalk-webhook', onDisk)).toBe(true)
+  })
+
+  it('is false when sync health is drift but nothing is on disk yet', () => {
+    expect(teamPackOnDisk('seatalk-webhook', new Map())).toBe(false)
+  })
+})

--- a/packages/app/src/stores/team-share-browser.ts
+++ b/packages/app/src/stores/team-share-browser.ts
@@ -435,6 +435,11 @@ async function listTeamKnowledge(knowledgeDir: string): Promise<TeamKnowledgeIte
 
 type OnDisk = { content: string; dirPath: string; invocationName: string; source: SkillSource }
 
+/** Whether a team pack row should borrow on-disk paths from the local scan. */
+export function teamPackOnDisk(slug: string, onDisk: Map<string, OnDisk>): boolean {
+  return onDisk.has(slug)
+}
+
 function registryItem(
   skill: TeamSkill,
   onDisk: Map<string, OnDisk>,
@@ -585,9 +590,15 @@ async function listTeamSkills(
     const items = result.skills.map((inventory): TeamSkillItem => {
       const skill = bySlug.get(inventory.id)
       if (inventory.teamItem && skill) {
+        // Sync health (`installed` vs `drift`) is about version parity, not
+        // whether a pack exists locally. While v1→v2 is in flight the Agent
+        // inventory reports `drift`, but the member should still browse and edit
+        // what is already on disk — withholding `dirPath` until health goes
+        // green made the folder tree appear only after a restart.
+        const packOnDisk = teamPackOnDisk(skill.slug, onDisk)
         return {
-          ...registryItem(skill, onDisk, 'team-installed', inventory.health === 'installed'),
-          installed: inventory.health === 'installed',
+          ...registryItem(skill, onDisk, 'team-installed', packOnDisk),
+          installed: true,
           installedVersion: Number(inventory.version) || null,
           hasUpdate: inventory.health !== 'installed',
         }
@@ -1133,6 +1144,11 @@ export const useTeamShareBrowserStore = create<TeamShareBrowserState>((set, get)
       version,
       timeoutMs: AGENT_MUTATION_TIMEOUT_MS,
     })
+    // The RPC reconciles into the daemon's cloud root; the skills pane reads
+    // paths from `~/.agents/skills` via auto-follow. Materialize here so the
+    // folder tree is populated in the same action instead of on the next tick
+    // (or only after restart).
+    await get().reconcileSkills().catch(() => {})
     await get().loadSection('skills', { force: true })
   },
 
@@ -1630,6 +1646,7 @@ export const useTeamShareBrowserStore = create<TeamShareBrowserState>((set, get)
     // never able to see.
     const onDisk = await listInstalledPacks().catch(() => listed)
     const plan = planReconcile(desired, onDisk, blocked, teamId, stillWantedByMember)
+    let diskChanged = false
 
     for (const { slug, version } of plan.install) {
       try {
@@ -1639,6 +1656,7 @@ export const useTeamShareBrowserStore = create<TeamShareBrowserState>((set, get)
         if (archivedPath) archived[slug] = archivedPath
         states[slug] = await inspectSkill(slug, version, teamId)
         delete errors[slug]
+        diskChanged = true
       } catch (e) {
         // A pack that turned dirty between the inspect and the install; the
         // backstop in the installer caught it.
@@ -1668,6 +1686,7 @@ export const useTeamShareBrowserStore = create<TeamShareBrowserState>((set, get)
         uninstalled.add(slug)
         delete states[slug]
         delete errors[slug]
+        diskChanged = true
       } catch {
         // Retried next tick.
       }
@@ -1715,6 +1734,10 @@ export const useTeamShareBrowserStore = create<TeamShareBrowserState>((set, get)
     set({ skillSyncErrors: errors, skillArchived: archived, skillRetired: retired })
 
     set({ skillLocalState: states })
+
+    if (diskChanged) {
+      await get().loadSection('skills', { force: true }).catch(() => {})
+    }
   },
 
   discardLocalSkill: async (slug) => {

--- a/services/supabase/migrations/20260827140000_team_skill_installs_owner_agent_rls.sql
+++ b/services/supabase/migrations/20260827140000_team_skill_installs_owner_agent_rls.sql
@@ -1,0 +1,60 @@
+-- team_skill_installs: allow a member to record installs onto their own agent.
+--
+-- The FC application gate (assertCanInstallTeamSkillFor in
+-- services/fc/src/lib/supabase-repo.ts and pg-repo/team-skills.ts) has three
+-- allowed targets:
+--   1. the caller's own member actor
+--   2. an agent the caller owns (owner_member_id = caller) — any visibility
+--   3. a visibility='team' agent, team admin only
+--
+-- The RLS policy only knew (1) and (3). Publishing or installing from the
+-- desktop with the local device agent selected as the subject hits (2): FC
+-- forwards the member's JWT to PostgREST with actor_id = <their own agent>,
+-- and Postgres answered
+--   new row violates row-level security policy for table "team_skill_installs"
+-- while the version itself had already published.
+--
+-- This adds branch (2) to both USING and WITH CHECK (the policy is FOR ALL,
+-- so both halves need it). Nothing loosens for other members' actors or
+-- other people's private agents.
+--
+-- Idempotent: safe for the self-host apply-migrations loop to re-run.
+
+drop policy if exists team_skill_installs_write_self_or_team_agent on amux.team_skill_installs;
+create policy team_skill_installs_write_self_or_team_agent on amux.team_skill_installs
+  for all using (
+    amux.is_team_member(team_id)
+    and (
+      actor_id = amux.current_actor_id_for_team(team_id)
+      or exists (
+        select 1 from amux.agents ag
+        where ag.id = actor_id
+          and ag.owner_member_id = amux.current_actor_id_for_team(team_id)
+      )
+      or (
+        amux.is_team_admin_or_owner(team_id)
+        and exists (
+          select 1 from amux.agents ag
+          where ag.id = actor_id and ag.visibility = 'team'
+        )
+      )
+    )
+  ) with check (
+    amux.is_team_member(team_id)
+    and (
+      actor_id = amux.current_actor_id_for_team(team_id)
+      or exists (
+        select 1 from amux.agents ag
+        where ag.id = actor_id
+          and ag.owner_member_id = amux.current_actor_id_for_team(team_id)
+      )
+      or (
+        amux.is_team_admin_or_owner(team_id)
+        and exists (
+          select 1 from amux.agents ag
+          where ag.id = actor_id and ag.visibility = 'team'
+        )
+      )
+    )
+  );
+


### PR DESCRIPTION
## Summary

- Fix team skill rows withholding `dirPath` while Agent inventory reports `drift`, which left the file tree empty until restart even when packs were already on disk.
- Reconcile to `~/.agents/skills` immediately after install and refresh the skills list when auto-follow changes disk contents.
- Add Supabase RLS migration so members can record `team_skill_installs` onto agents they own (not only self or team-visible agents).

## Test plan

- [ ] Install a team skill (e.g. `seatalk-webhook`) on the local Agent — folder tree and SKILL.md editor should open without restarting the app.
- [ ] While a skill is updating (v1 → v2), confirm the existing on-disk files remain browsable/editable.
- [ ] Publish or install a skill with the local device agent selected — `team_skill_installs` write should succeed (no RLS violation).
- [ ] `pnpm test:unit src/stores/__tests__/team-share-skill-dir.test.ts`


Made with [Cursor](https://cursor.com)