### PR TITLE
fix(daemon): recognize OpenCode server_tool ids for session context injection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,9 @@ jobs:
           apps/daemon/claude-bridge/src/transcript-repair.test.mjs
           apps/daemon/claude-bridge/src/mcp-schema-sanitize.test.mjs
           apps/daemon/cursor-bridge/src/auth-retry.test.mjs
+          apps/daemon/shared/session-context-client.test.mjs
+          apps/daemon/shared/session-context-plugin-install.test.mjs
+          apps/daemon/assets/pi-extension/session-context.test.mjs
 
       # The scripts above are scoped to @teamclu/app, so the Expo app was
       # outside every gate until now. See apps/expo/CI.md for what is and is

--- a/apps/daemon/shared/session-context-client.mjs
+++ b/apps/daemon/shared/session-context-client.mjs
@@ -4,22 +4,33 @@
  * MCP tools without an explicit session_id argument.
  */
 
-const SESSION_SCOPED_TOOLS = new Set([
+const SESSION_SCOPED_TOOL_LIST = [
   "get_session_deeplink",
   "manage_participants",
   "archive_session",
-]);
+];
+
+const SESSION_SCOPED_TOOLS = new Set(SESSION_SCOPED_TOOL_LIST);
+
+/** Managed introspect MCP servers whose OpenCode tool IDs we recognize. */
+const MANAGED_INTROSPECT_SERVERS = ["teamclu-introspect", "teamclaw-introspect"];
 
 /** Extract the bare tool name from OpenCode / MCP namespaced identifiers. */
 export function normalizeSessionScopedToolName(name) {
   const raw = String(name ?? "").trim();
   if (!raw) return "";
-  if (raw.startsWith("mcp__")) {
-    const parts = raw.split("__");
-    const last = parts[parts.length - 1]?.trim();
-    if (last) return last;
+
+  for (const tool of SESSION_SCOPED_TOOL_LIST) {
+    if (raw === tool) return tool;
+    if (raw.endsWith(`/${tool}`)) return tool;
+    if (raw.startsWith("mcp__") && raw.endsWith(`__${tool}`)) return tool;
+
+    for (const server of MANAGED_INTROSPECT_SERVERS) {
+      if (raw === `${server}_${tool}`) return tool;
+    }
   }
-  return raw.split("/").pop()?.trim() ?? raw;
+
+  return raw;
 }
 
 export function isSessionScopedTool(name) {

--- a/apps/daemon/shared/session-context-client.test.mjs
+++ b/apps/daemon/shared/session-context-client.test.mjs
@@ -25,8 +25,39 @@ test("normalizeSessionScopedToolName handles slash and mcp__ forms", () => {
   );
 });
 
+test("normalizeSessionScopedToolName handles OpenCode server_tool ids", () => {
+  assert.equal(
+    normalizeSessionScopedToolName("teamclu-introspect_get_session_deeplink"),
+    "get_session_deeplink",
+  );
+  assert.equal(
+    normalizeSessionScopedToolName("teamclu-introspect_manage_participants"),
+    "manage_participants",
+  );
+  assert.equal(
+    normalizeSessionScopedToolName("teamclu-introspect_archive_session"),
+    "archive_session",
+  );
+  assert.equal(
+    normalizeSessionScopedToolName("teamclaw-introspect_get_session_deeplink"),
+    "get_session_deeplink",
+  );
+});
+
+test("normalizeSessionScopedToolName rejects similar but non-managed OpenCode ids", () => {
+  for (const name of [
+    "other-server_get_session_deeplink",
+    "teamclu-introspect_get_session_deeplink_extra",
+    "browser_manage_participants",
+  ]) {
+    assert.equal(normalizeSessionScopedToolName(name), name);
+    assert.equal(isSessionScopedTool(name), false);
+  }
+});
+
 test("isSessionScopedTool recognizes namespaced MCP tool ids", () => {
   assert.equal(isSessionScopedTool("mcp__teamclu-introspect__manage_participants"), true);
+  assert.equal(isSessionScopedTool("teamclu-introspect_get_session_deeplink"), true);
   assert.equal(isSessionScopedTool("browser_click"), false);
 });
 
@@ -37,6 +68,25 @@ test("handleToolExecuteBefore injects output.args.session_id using OpenCode hook
     output,
     {
       injectSessionIdForTool: async () => ({ session_id: "teamclu-a" }),
+    },
+  );
+  assert.equal(output.args.session_id, "teamclu-a");
+});
+
+test("handleToolExecuteBefore injects for real OpenCode production tool id", async () => {
+  const output = { args: { scheme: "copilot361" } };
+  await handleToolExecuteBefore(
+    {
+      tool: "teamclu-introspect_get_session_deeplink",
+      sessionID: "backend-a",
+      callID: "call-a",
+    },
+    output,
+    {
+      injectSessionIdForTool: async () => ({
+        scheme: "copilot361",
+        session_id: "teamclu-a",
+      }),
     },
   );
   assert.equal(output.args.session_id, "teamclu-a");
@@ -54,9 +104,9 @@ test("concurrent A/B resolve injects distinct TeamClu sessions", async () => {
     });
 
   const results = await Promise.all([
-    inject("get_session_deeplink", {}, "backend-a"),
-    inject("get_session_deeplink", {}, "backend-b"),
-    inject("get_session_deeplink", {}, "backend-a"),
+    inject("teamclu-introspect_get_session_deeplink", {}, "backend-a"),
+    inject("teamclu-introspect_get_session_deeplink", {}, "backend-b"),
+    inject("teamclu-introspect_get_session_deeplink", {}, "backend-a"),
   ]);
   assert.deepEqual(results, [
     { session_id: "teamclu-a" },

--- a/apps/daemon/shared/session-context-plugin-install.test.mjs
+++ b/apps/daemon/shared/session-context-plugin-install.test.mjs
@@ -1,0 +1,81 @@
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, "../../..");
+
+async function writeInstalledPlugin(dir) {
+  const pluginDir = path.join(dir, ".opencode", "plugins");
+  await fs.mkdir(pluginDir, { recursive: true });
+
+  const clientSrc = path.join(repoRoot, "apps/daemon/shared/session-context-client.mjs");
+  const pluginSrc = path.join(
+    repoRoot,
+    "packages/app/src/lib/opencode/templates/teamclu-session-context-plugin.mjs.txt",
+  );
+
+  const clientDest = path.join(pluginDir, "teamclu-session-context-client.mjs");
+  const pluginDest = path.join(pluginDir, "teamclu-session-context.mjs");
+
+  await fs.copyFile(clientSrc, clientDest);
+  await fs.copyFile(pluginSrc, pluginDest);
+
+  return { clientDest, pluginDest };
+}
+
+test("installed OpenCode plugin loads shared client and injects OpenCode tool ids", async () => {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "teamclu-session-context-"));
+  try {
+    const { pluginDest } = await writeInstalledPlugin(dir);
+
+    const pluginText = await fs.readFile(pluginDest, "utf8");
+    assert.match(pluginText, /teamclu-session-context-client\.mjs/);
+
+    const mod = await import(pathToFileURL(pluginDest).href);
+    const factory = mod.TeamcluSessionContextPlugin ?? mod.default;
+    assert.equal(typeof factory, "function");
+
+    const hooks = await factory();
+    assert.equal(typeof hooks["tool.execute.before"], "function");
+
+    const output = { args: { scheme: "copilot361" } };
+    await hooks["tool.execute.before"](
+      {
+        tool: "teamclu-introspect_get_session_deeplink",
+        sessionID: "backend-a",
+        callID: "call-a",
+      },
+      output,
+      {
+        injectSessionIdForTool: async () => ({
+          scheme: "copilot361",
+          session_id: "teamclu-a",
+        }),
+      },
+    );
+    assert.equal(output.args.session_id, "teamclu-a");
+  } finally {
+    await fs.rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("plugin install overwrites stale shared client on upgrade", async () => {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "teamclu-session-context-"));
+  try {
+    const { clientDest } = await writeInstalledPlugin(dir);
+    await fs.writeFile(clientDest, "// stale client\nexport function handleToolExecuteBefore() {}\n");
+
+    const clientSrc = path.join(repoRoot, "apps/daemon/shared/session-context-client.mjs");
+    await fs.copyFile(clientSrc, clientDest);
+
+    const upgraded = await fs.readFile(clientDest, "utf8");
+    assert.match(upgraded, /normalizeSessionScopedToolName/);
+    assert.doesNotMatch(upgraded, /stale client/);
+  } finally {
+    await fs.rm(dir, { recursive: true, force: true });
+  }
+});

--- a/apps/daemon/src/runtime/supervisor.rs
+++ b/apps/daemon/src/runtime/supervisor.rs
@@ -2665,6 +2665,39 @@ mod tests {
     }
 
     #[test]
+    fn ensure_session_context_plugin_creates_file_and_registers() {
+        let dir = tempfile::tempdir().unwrap();
+        ensure_session_context_plugin(dir.path()).unwrap();
+
+        let plugin_path = dir
+            .path()
+            .join(crate::runtime::workspace_runtime::SESSION_CONTEXT_PLUGIN_REL);
+        let client_path = dir
+            .path()
+            .join(crate::runtime::workspace_runtime::SESSION_CONTEXT_CLIENT_REL);
+        assert!(plugin_path.is_file());
+        assert!(client_path.is_file());
+        assert!(std::fs::read_to_string(plugin_path)
+            .unwrap()
+            .contains("teamclu-session-context-client.mjs"));
+        assert!(std::fs::read_to_string(client_path)
+            .unwrap()
+            .contains("normalizeSessionScopedToolName"));
+
+        let cfg: serde_json::Value = serde_json::from_str(
+            &std::fs::read_to_string(dir.path().join("opencode.json")).unwrap(),
+        )
+        .unwrap();
+        let plugins = cfg["plugin"].as_array().unwrap();
+        assert!(plugins.iter().any(|entry| {
+            entry
+                .as_str()
+                .map(|value| value.contains("teamclu-session-context"))
+                .unwrap_or(false)
+        }));
+    }
+
+    #[test]
     fn prepare_workspace_drops_renamed_inherent_mcp_entry() {
         // A workspace written before the 2026-08-09 teamclaw→teamclu rename
         // carries `teamclaw-introspect` with an absolute path into an app


### PR DESCRIPTION
## Summary

- Fix `normalizeSessionScopedToolName` to recognize OpenCode 1.18.x production tool IDs (`teamclu-introspect_get_session_deeplink`, etc.) so `handleToolExecuteBefore` injects `session_id` before `get_session_deeplink` runs.
- Restrict OpenCode matching to managed introspect servers (`teamclu-introspect`, legacy `teamclaw-introspect`) to avoid false positives on unrelated MCP tools.
- Add plugin install coverage, a Rust `ensure_session_context_plugin` test, and wire session-context JS tests into CI.

## Test plan

- [x] `node --test apps/daemon/shared/session-context-client.test.mjs apps/daemon/shared/session-context-plugin-install.test.mjs apps/daemon/assets/pi-extension/session-context.test.mjs`
- [x] `cargo test -p amuxd ensure_session_context_plugin_creates_file_and_registers --manifest-path apps/daemon/Cargo.toml`
- [ ] OpenCode managed runtime: call `get_session_deeplink({ scheme })` with empty `TEAMCLU_SESSION_ID` and empty `.copilot361/active-session-id`; expect a real deeplink, not `unavailable`


Made with [Cursor](https://cursor.com)