### PR TITLE
fix(ui): hide team skill delete button in sidebar list

### DIFF
--- a/packages/app/src/components/sidebar/TeamShareListColumn.tsx
+++ b/packages/app/src/components/sidebar/TeamShareListColumn.tsx
@@ -626,7 +626,7 @@ export function TeamShareListColumn({ section }: { section: TeamShareSection }) 
             </span>
           ),
           dimmed: s.status === 'deprecated',
-          deletableSlug: s.kind === 'personal' ? undefined : s.slug,
+          deletableSlug: undefined,
           // Three states, and only one of them is asking for anything.
           //
           // Behind on version is a transitional state that resolves itself


### PR DESCRIPTION
## Summary
- Hides the hover trash icon on team skills in the Team Share sidebar list (`deletableSlug` is no longer set for registry rows).
- Avoids accidental team-wide skill deletion from the registry until a safer, permission-gated flow exists.

## Test plan
- [ ] Open Team Share → Skills and confirm team skills no longer show the red trash icon on hover.
- [ ] Confirm personal skills and other row actions (select, expand, install indicators) still work.
- [ ] Confirm no delete confirmation dialog can be opened from the list.


Made with [Cursor](https://cursor.com)