### PR TITLE
feat(skills): managed skill refresh and Claude bridge reconcile (PR 2)

### DIFF
--- a/apps/daemon/src/config/managed_skill_writer.rs
+++ b/apps/daemon/src/config/managed_skill_writer.rs
@@ -325,6 +325,53 @@ fn verify_tree_confined(root: &Path) -> Result<(), ManagedSkillError> {
     Ok(())
 }
 
+/// Validates size and file-count limits on the final on-disk pack tree.
+fn validate_pack_tree_limits(root: &Path) -> Result<(), ManagedSkillError> {
+    verify_tree_confined(root)?;
+    let mut file_count = 0usize;
+    let mut total_bytes = 0usize;
+    for entry in walkdir::WalkDir::new(root)
+        .follow_links(false)
+        .into_iter()
+    {
+        let entry = entry.map_err(|e| io_managed(std::io::Error::other(e.to_string())))?;
+        if !entry.file_type().is_file() {
+            continue;
+        }
+        file_count += 1;
+        if file_count > MAX_PACK_FILES {
+            return Err(ManagedSkillError::new(
+                ManagedSkillErrorCode::SkillPackTooLarge,
+                "skill pack exceeds file count limit",
+            ));
+        }
+        let rel = entry
+            .path()
+            .strip_prefix(root)
+            .map_err(|_| io_managed(std::io::Error::other("strip pack prefix")))?;
+        let len = entry
+            .metadata()
+            .map_err(|e| io_managed(std::io::Error::other(e.to_string())))?
+            .len()
+            .try_into()
+            .unwrap_or(usize::MAX);
+        if len > MAX_SINGLE_FILE_BYTES {
+            return Err(ManagedSkillError::new(
+                ManagedSkillErrorCode::SkillPackTooLarge,
+                format!("file {} exceeds size limit", rel.display()),
+            ));
+        }
+        total_bytes = total_bytes.saturating_add(len);
+        if total_bytes > MAX_PACK_TOTAL_BYTES {
+            return Err(ManagedSkillError::new(
+                ManagedSkillErrorCode::SkillPackTooLarge,
+                "skill pack exceeds total size limit",
+            ));
+        }
+    }
+    Ok(())
+}
+
 struct PackBuild {
     skill_md: String,
     files: Vec<(PathBuf, Vec<u8>)>,
@@ -396,7 +443,6 @@ fn write_temp_pack(root: &Path, build: &PackBuild) -> Result<(), ManagedSkillErr
         }
         fs::write(&dest, bytes).map_err(io_managed)?;
     }
-    verify_tree_confined(root)?;
     Ok(())
 }
 
@@ -552,6 +598,7 @@ pub fn create_pack(
     let temp = TempPackGuard::new(skills_root.join(format!(".teamclu-create-{}", Uuid::new_v4())));
     write_temp_pack(temp.path(), &build)?;
     verify_final_skill_md(temp.path(), &req.slug)?;
+    validate_pack_tree_limits(temp.path())?;
     let digest = pack_digest(temp.path())?;
     publish_temp_dir(temp.path(), &target)?;
     temp.disarm();
@@ -584,6 +631,12 @@ pub fn update_pack(
         ));
     }
     validate_strict_frontmatter(&req.content, &req.slug)?;
+    if req.content.len() > MAX_SINGLE_FILE_BYTES {
+        return Err(ManagedSkillError::new(
+            ManagedSkillErrorCode::SkillPackTooLarge,
+            "SKILL.md exceeds size limit",
+        ));
+    }
 
     let mut patch_files = Vec::new();
     let mut total_bytes = req.content.len();
@@ -644,7 +697,7 @@ pub fn update_pack(
     apply_patch_files(temp.path(), &patch_files)?;
     apply_delete_files(temp.path(), &req.delete_files)?;
     verify_final_skill_md(temp.path(), &req.slug)?;
-    verify_tree_confined(temp.path())?;
+    validate_pack_tree_limits(temp.path())?;
     let digest = pack_digest(temp.path())?;
     let backup = skills_root.join(format!(".teamclu-backup-{}", Uuid::new_v4()));
     fs::rename(&target, &backup).map_err(io_managed)?;
@@ -1090,5 +1143,258 @@ mod tests {
         )
         .unwrap_err();
         assert_eq!(err.code, ManagedSkillErrorCode::SkillOwnershipUnavailable);
+    }
+
+    fn test_skill_md(slug: &str) -> String {
+        format!("---\nname: {slug}\ndescription: Demo.\n---\n")
+    }
+
+    fn blob(size: usize) -> String {
+        "x".repeat(size)
+    }
+
+    fn pack_files(prefix: &str, count: usize, size: usize) -> Vec<PackFileInput> {
+        (0..count)
+            .map(|i| PackFileInput {
+                path: format!("assets/{prefix}-{i}.bin"),
+                content: blob(size),
+                encoding: None,
+            })
+            .collect()
+    }
+
+    fn assert_no_update_temp_dirs(skills_root: &Path) {
+        let entries = fs::read_dir(skills_root).unwrap();
+        for entry in entries.flatten() {
+            let name = entry.file_name();
+            let name = name.to_string_lossy();
+            assert!(
+                !name.starts_with(".teamclu-update-"),
+                "unexpected temp dir: {name}"
+            );
+        }
+    }
+
+    #[test]
+    fn update_rejects_oversized_skill_md() {
+        let home = tempfile::tempdir().unwrap();
+        let _guard = crate::test_brand_env::BrandEnvGuard::set_with_home("teamclu", home.path());
+        let ws = tempfile::tempdir().unwrap();
+        create_pack(
+            ws.path(),
+            home.path(),
+            &CreatePackRequest {
+                slug: "big-md".into(),
+                content: test_skill_md("big-md"),
+                files: vec![],
+            },
+            &ClaimedTeamContext::NoTeam,
+        )
+        .unwrap();
+
+        let before = get_pack(home.path(), "big-md").unwrap();
+        let oversized = format!(
+            "{}\n{}",
+            test_skill_md("big-md"),
+            blob(MAX_SINGLE_FILE_BYTES)
+        );
+        let err = update_pack(
+            ws.path(),
+            home.path(),
+            &UpdatePackRequest {
+                slug: "big-md".into(),
+                content: oversized,
+                files: vec![],
+                expected_digest: None,
+                delete_files: vec![],
+            },
+            &ClaimedTeamContext::NoTeam,
+        )
+        .unwrap_err();
+        assert_eq!(err.code, ManagedSkillErrorCode::SkillPackTooLarge);
+        assert_eq!(get_pack(home.path(), "big-md").unwrap().digest, before.digest);
+        assert_no_update_temp_dirs(&home.path().join(".agents/skills"));
+    }
+
+    #[test]
+    fn update_rejects_when_final_file_count_exceeds_limit() {
+        let home = tempfile::tempdir().unwrap();
+        let _guard = crate::test_brand_env::BrandEnvGuard::set_with_home("teamclu", home.path());
+        let ws = tempfile::tempdir().unwrap();
+        create_pack(
+            ws.path(),
+            home.path(),
+            &CreatePackRequest {
+                slug: "many-files".into(),
+                content: test_skill_md("many-files"),
+                files: vec![PackFileInput {
+                    path: "assets/seed.bin".into(),
+                    content: "seed".into(),
+                    encoding: None,
+                }],
+            },
+            &ClaimedTeamContext::NoTeam,
+        )
+        .unwrap();
+
+        let before = get_pack(home.path(), "many-files").unwrap();
+        let err = update_pack(
+            ws.path(),
+            home.path(),
+            &UpdatePackRequest {
+                slug: "many-files".into(),
+                content: test_skill_md("many-files"),
+                files: pack_files("bulk", MAX_PACK_FILES - 1, 1),
+                expected_digest: None,
+                delete_files: vec![],
+            },
+            &ClaimedTeamContext::NoTeam,
+        )
+        .unwrap_err();
+        assert_eq!(err.code, ManagedSkillErrorCode::SkillPackTooLarge);
+        assert_eq!(get_pack(home.path(), "many-files").unwrap().digest, before.digest);
+        assert_no_update_temp_dirs(&home.path().join(".agents/skills"));
+    }
+
+    #[test]
+    fn update_rejects_when_retained_plus_new_exceeds_total_size() {
+        let home = tempfile::tempdir().unwrap();
+        let _guard = crate::test_brand_env::BrandEnvGuard::set_with_home("teamclu", home.path());
+        let ws = tempfile::tempdir().unwrap();
+        let chunk = MAX_SINGLE_FILE_BYTES - 512;
+        create_pack(
+            ws.path(),
+            home.path(),
+            &CreatePackRequest {
+                slug: "heavy".into(),
+                content: test_skill_md("heavy"),
+                files: pack_files("base", 3, chunk),
+            },
+            &ClaimedTeamContext::NoTeam,
+        )
+        .unwrap();
+
+        let before = get_pack(home.path(), "heavy").unwrap();
+        let err = update_pack(
+            ws.path(),
+            home.path(),
+            &UpdatePackRequest {
+                slug: "heavy".into(),
+                content: test_skill_md("heavy"),
+                files: pack_files("extra", 3, chunk),
+                expected_digest: None,
+                delete_files: vec![],
+            },
+            &ClaimedTeamContext::NoTeam,
+        )
+        .unwrap_err();
+        assert_eq!(err.code, ManagedSkillErrorCode::SkillPackTooLarge);
+        assert_eq!(get_pack(home.path(), "heavy").unwrap().digest, before.digest);
+        assert_no_update_temp_dirs(&home.path().join(".agents/skills"));
+    }
+
+    #[test]
+    fn cumulative_updates_reject_when_final_pack_exceeds_limit() {
+        let home = tempfile::tempdir().unwrap();
+        let _guard = crate::test_brand_env::BrandEnvGuard::set_with_home("teamclu", home.path());
+        let ws = tempfile::tempdir().unwrap();
+        let chunk = MAX_SINGLE_FILE_BYTES - 512;
+        create_pack(
+            ws.path(),
+            home.path(),
+            &CreatePackRequest {
+                slug: "grow".into(),
+                content: test_skill_md("grow"),
+                files: pack_files("seed", 3, chunk),
+            },
+            &ClaimedTeamContext::NoTeam,
+        )
+        .unwrap();
+
+        update_pack(
+            ws.path(),
+            home.path(),
+            &UpdatePackRequest {
+                slug: "grow".into(),
+                content: test_skill_md("grow"),
+                files: pack_files("step", 2, chunk),
+                expected_digest: None,
+                delete_files: vec![],
+            },
+            &ClaimedTeamContext::NoTeam,
+        )
+        .unwrap();
+
+        let before = get_pack(home.path(), "grow").unwrap();
+        let err = update_pack(
+            ws.path(),
+            home.path(),
+            &UpdatePackRequest {
+                slug: "grow".into(),
+                content: test_skill_md("grow"),
+                files: pack_files("final", 1, chunk),
+                expected_digest: None,
+                delete_files: vec![],
+            },
+            &ClaimedTeamContext::NoTeam,
+        )
+        .unwrap_err();
+        assert_eq!(err.code, ManagedSkillErrorCode::SkillPackTooLarge);
+        assert_eq!(get_pack(home.path(), "grow").unwrap().digest, before.digest);
+    }
+
+    #[test]
+    fn delete_files_frees_capacity_for_legal_update() {
+        let home = tempfile::tempdir().unwrap();
+        let _guard = crate::test_brand_env::BrandEnvGuard::set_with_home("teamclu", home.path());
+        let ws = tempfile::tempdir().unwrap();
+        let chunk = MAX_SINGLE_FILE_BYTES - 512;
+        create_pack(
+            ws.path(),
+            home.path(),
+            &CreatePackRequest {
+                slug: "trim".into(),
+                content: test_skill_md("trim"),
+                files: pack_files("base", 4, chunk),
+            },
+            &ClaimedTeamContext::NoTeam,
+        )
+        .unwrap();
+
+        update_pack(
+            ws.path(),
+            home.path(),
+            &UpdatePackRequest {
+                slug: "trim".into(),
+                content: test_skill_md("trim"),
+                files: vec![],
+                expected_digest: None,
+                delete_files: vec![
+                    "assets/base-0.bin".into(),
+                    "assets/base-1.bin".into(),
+                    "assets/base-2.bin".into(),
+                ],
+            },
+            &ClaimedTeamContext::NoTeam,
+        )
+        .unwrap();
+
+        update_pack(
+            ws.path(),
+            home.path(),
+            &UpdatePackRequest {
+                slug: "trim".into(),
+                content: test_skill_md("trim"),
+                files: pack_files("extra", 3, chunk),
+                expected_digest: None,
+                delete_files: vec![],
+            },
+            &ClaimedTeamContext::NoTeam,
+        )
+        .unwrap();
+
+        let root = home.path().join(".agents/skills/trim");
+        assert!(!root.join("assets/base-0.bin").exists());
+        assert!(root.join("assets/extra-0.bin").exists());
     }
 }

--- a/apps/daemon/src/daemon/server/skills_manage.rs
+++ b/apps/daemon/src/daemon/server/skills_manage.rs
@@ -26,6 +26,20 @@ fn sock_ok(result: Value) -> String {
     json!({ "ok": true, "result": result }).to_string()
 }
 
+fn merge_claude_bridge_warnings(workspace: &Path, slug: &str, warnings: &mut Vec<String>) {
+    match crate::runtime::claude_skills::reconcile_after_managed_mutation(workspace, slug) {
+        Ok(extra) => warnings.extend(extra),
+        Err(error) => {
+            tracing::warn!(
+                workspace_path = %workspace.display(),
+                slug = %slug,
+                error = %error,
+                "claude skill bridge reconcile failed after manage_skills"
+            );
+        }
+    }
+}
+
 async fn load_team_ownership(server: &DaemonServer) -> ClaimedTeamContext {
     let team_id = server.backend.team_id();
     if team_id.trim().is_empty() {
@@ -131,7 +145,8 @@ impl DaemonServer {
                     }
                 };
                 match create_pack(workspace, &home, &req, &ownership) {
-                    Ok(resp) => {
+                    Ok(mut resp) => {
+                        merge_claude_bridge_warnings(workspace, &req.slug, &mut resp.warnings);
                         record_skills_refresh(self, workspace).await;
                         sock_ok(serde_json::to_value(resp).unwrap_or(json!({})))
                     }
@@ -149,7 +164,8 @@ impl DaemonServer {
                     }
                 };
                 match update_pack(workspace, &home, &req, &ownership) {
-                    Ok(resp) => {
+                    Ok(mut resp) => {
+                        merge_claude_bridge_warnings(workspace, &req.slug, &mut resp.warnings);
                         record_skills_refresh(self, workspace).await;
                         sock_ok(serde_json::to_value(resp).unwrap_or(json!({})))
                     }

--- a/apps/daemon/src/runtime/claude_skills.rs
+++ b/apps/daemon/src/runtime/claude_skills.rs
@@ -12,6 +12,32 @@ use crate::config::team_skill_roots;
 use crate::config::workspace_control::WorkspaceControlError;
 
 const CLAUDE_SKILLS_DIR: &str = ".claude/skills";
+pub const WARNING_CLAUDE_LOCAL_OVERRIDE: &str = "claude_local_override";
+
+/// Whether a real workspace-local Claude skill directory blocks the bridge for `slug`.
+pub fn has_claude_local_skill_override(workspace_path: &Path, slug: &str) -> bool {
+    let local = workspace_path.join(CLAUDE_SKILLS_DIR).join(slug);
+    match std::fs::symlink_metadata(&local) {
+        Ok(meta) if meta.is_dir() && !meta.file_type().is_symlink() => true,
+        Ok(meta) if meta.is_file() && !meta.file_type().is_symlink() => true,
+        _ => false,
+    }
+}
+
+/// After a managed personal skill mutation, refresh Claude bridge links and report
+/// whether a workspace-local pack still wins for Claude Code.
+pub fn reconcile_after_managed_mutation(
+    workspace_path: &Path,
+    slug: &str,
+) -> Result<Vec<String>, WorkspaceControlError> {
+    let local_override = has_claude_local_skill_override(workspace_path, slug);
+    ensure_claude_team_skills(workspace_path)?;
+    Ok(if local_override {
+        vec![WARNING_CLAUDE_LOCAL_OVERRIDE.into()]
+    } else {
+        Vec::new()
+    })
+}
 
 /// Ensure team skills are symlinked into `.claude/skills/`, without overwriting
 /// workspace-local entries. Idempotent; safe to call on every `prepare_workspace`.
@@ -361,5 +387,34 @@ mod tests {
             assert!(link.join("SKILL.md").is_file());
             assert!(symlink_points_to(&link, &team_skills.join("broken-link")));
         }
+    }
+
+    #[test]
+    fn reconcile_after_managed_mutation_bridges_global_agent_skill() {
+        let (_lock, home, ws, _team_skills) = workspace_with_team_root();
+        let pack_root = home.path().join(".agents/skills");
+        write_skill(&pack_root, "managed-skill");
+
+        let warnings = reconcile_after_managed_mutation(ws.path(), "managed-skill").unwrap();
+        assert!(warnings.is_empty());
+
+        let link = ws.path().join(".claude/skills/managed-skill");
+        assert!(is_symlink(&link));
+        assert!(symlink_points_to(&link, &pack_root.join("managed-skill")));
+    }
+
+    #[test]
+    fn reconcile_after_managed_mutation_reports_local_override() {
+        let (_lock, home, ws, _team_skills) = workspace_with_team_root();
+        let pack_root = home.path().join(".agents/skills");
+        write_skill(&pack_root, "shared-name");
+
+        let local = ws.path().join(".claude/skills/shared-name");
+        std::fs::create_dir_all(&local).unwrap();
+        std::fs::write(local.join("SKILL.md"), "local wins").unwrap();
+
+        let warnings = reconcile_after_managed_mutation(ws.path(), "shared-name").unwrap();
+        assert_eq!(warnings, vec![WARNING_CLAUDE_LOCAL_OVERRIDE.to_string()]);
+        assert!(!is_symlink(&local));
     }
 }

--- a/apps/daemon/src/runtime/mod.rs
+++ b/apps/daemon/src/runtime/mod.rs
@@ -1,7 +1,7 @@
 pub mod acp_event_frame;
 pub mod backend;
 pub mod claude_agent;
-mod claude_skills;
+pub(crate) mod claude_skills;
 pub mod cursor_sdk;
 pub mod execution_context;
 pub mod opencode_http;

--- a/packages/app/src/components/chat/CommandPopover.tsx
+++ b/packages/app/src/components/chat/CommandPopover.tsx
@@ -11,6 +11,7 @@ export type Command = {
   _type?: 'role' | 'skill' | 'command';
 }
 import { SKILLS_CHANGED_EVENT } from '@/hooks/useAppInit'
+import { useWorkspaceRuntimeRefreshStore } from '@/stores/workspace-runtime-refresh'
 import { useWorkspaceStore } from '@/stores/workspace'
 import { attachmentsForSession, useRuntimeStateStore } from '@/stores/runtime-state-store'
 import { isTauri } from '@/lib/utils'
@@ -210,6 +211,7 @@ export function CommandPopover({
   const [isLoading, setIsLoading] = React.useState(false)
   const [highlightedIndex, setHighlightedIndex] = React.useState(0)
   const [skillsRevision, setSkillsRevision] = React.useState(0)
+  const runtimeRefresh = useWorkspaceRuntimeRefreshStore((s) => s.refresh)
   const listRef = React.useRef<HTMLDivElement>(null)
 
   React.useEffect(() => {
@@ -217,6 +219,12 @@ export function CommandPopover({
     window.addEventListener(SKILLS_CHANGED_EVENT, bump)
     return () => window.removeEventListener(SKILLS_CHANGED_EVENT, bump)
   }, [])
+
+  React.useEffect(() => {
+    if (!runtimeRefresh?.change_kinds.includes('skills')) return
+    setSkillsRevision((value) => value + 1)
+    window.dispatchEvent(new CustomEvent(SKILLS_CHANGED_EVENT))
+  }, [runtimeRefresh?.last_detected_at, runtimeRefresh?.change_kinds])
   
   // Load commands and skills when popover opens
   React.useEffect(() => {

--- a/packages/app/src/components/chat/ToolCallCard.tsx
+++ b/packages/app/src/components/chat/ToolCallCard.tsx
@@ -26,7 +26,7 @@ import { ReadToolCard } from "./tool-calls/ReadToolCard";
 import { RoleLoadToolCard } from "./tool-calls/RoleLoadToolCard";
 import { PageNavLinksToolCard } from "./tool-calls/PageNavLinksToolCard";
 import { QuestionCard } from "./QuestionCard";
-import { RoleSkillToolCard, SkillToolCard, TaskToolCard } from "./tool-calls/TaskToolCard";
+import { RoleSkillToolCard, ManageSkillsToolCard, SkillToolCard, TaskToolCard } from "./tool-calls/TaskToolCard";
 import {
   getStatusConfig,
   getToolIconByKind,
@@ -36,6 +36,7 @@ import {
   matchesReadTool,
   matchesTaskTool,
   matchesSkillTool,
+  matchesManageSkillsTool,
   matchesRoleSkillTool,
   matchesRoleLoadTool,
   matchesShowPageNavLinksTool,
@@ -282,6 +283,11 @@ export const ToolCallCard = React.memo(function ToolCallCard({ toolCall, onOpenD
 
   if (matchesShowPageNavLinksTool(toolCall)) {
     return <PageNavLinksToolCard toolCall={toolCall} />;
+  }
+
+  // If this is a manage_skills tool, render ManageSkillsToolCard
+  if (matchesManageSkillsTool(toolCall)) {
+    return <ManageSkillsToolCard toolCall={toolCall} />;
   }
 
   // If this is a Skill tool, render SkillToolCard

--- a/packages/app/src/components/chat/tool-calls/TaskToolCard.tsx
+++ b/packages/app/src/components/chat/tool-calls/TaskToolCard.tsx
@@ -8,6 +8,54 @@ import { ToolCall, useSessionStore } from "@/stores/session";
 import { useV2StreamingStore } from "@/stores/v2-streaming-store";
 import { ToolCallStatusGlyph } from "./ToolCallStatusGlyph";
 import { ToolCallDisclosure } from "./ToolCallDisclosure";
+import { parseManageSkillsToolResult } from "./tool-call-utils";
+
+export function ManageSkillsToolCard({ toolCall }: { toolCall: ToolCall }) {
+  const { t } = useTranslation();
+  const args = toolCall.arguments as {
+    action?: string;
+    slug?: string;
+  };
+  const parsed = parseManageSkillsToolResult(toolCall.result);
+  const slug = parsed?.slug || args?.slug || t("chat.toolCall.manageSkills.unknown", "unknown-skill");
+  const action = args?.action?.trim() || t("chat.toolCall.manageSkills.defaultAction", "update");
+  const target = `${action} · ${slug}`;
+  const footnotes: string[] = [];
+
+  if (parsed?.runtimeActivation === "next_start") {
+    footnotes.push(
+      t(
+        "chat.toolCall.manageSkills.nextStart",
+        "Saved to ~/.agents/skills. New OpenCode, Pi, and Claude Code runtimes will pick it up on their next start.",
+      ),
+    );
+  }
+  if (parsed?.warnings?.includes("claude_local_override")) {
+    footnotes.push(
+      t(
+        "chat.toolCall.manageSkills.claudeLocalOverride",
+        "Claude Code will keep using the workspace-local .claude/skills copy for this slug.",
+      ),
+    );
+  }
+
+  return (
+    <div className="w-full" data-testid="tool-card-manage-skills-wrap">
+      <ToolCallDisclosure
+        testId="tool-card-manage-skills"
+        icon={<Zap className="h-3.5 w-3.5" />}
+        title={t("chat.toolCall.manageSkills.title", "Manage skill")}
+        target={target}
+        status={<ToolCallStatusGlyph status={toolCall.status} />}
+      />
+      {footnotes.length > 0 ? (
+        <p className="mt-1 px-[9px] text-[11.5px] leading-relaxed text-muted-foreground">
+          {footnotes.join(" ")}
+        </p>
+      ) : null}
+    </div>
+  );
+}
 
 export function SkillToolCard({ toolCall }: { toolCall: ToolCall }) {
   const { t } = useTranslation();

--- a/packages/app/src/components/chat/tool-calls/__tests__/tool-call-utils.test.ts
+++ b/packages/app/src/components/chat/tool-calls/__tests__/tool-call-utils.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "vitest";
 import {
+  matchesManageSkillsTool,
   matchesSkillTool,
   matchesWriteTool,
+  parseManageSkillsToolResult,
   resolveWireToolName,
   routeToolPresentation,
 } from "../tool-call-utils";
@@ -55,6 +57,41 @@ describe("routeToolPresentation", () => {
         arguments: { name: "brainstorming", description: "skill" },
       }),
     ).toBe("skill");
+  });
+
+  it("routes manage_skills MCP tool to dedicated presentation", () => {
+    expect(
+      routeToolPresentation({
+        name: "manage_skills",
+        toolKind: "other",
+        arguments: { action: "create", slug: "demo" },
+      }),
+    ).toBe("manage_skills");
+    expect(
+      matchesManageSkillsTool({
+        name: "manage_skills",
+        toolKind: "other",
+        arguments: { action: "create", slug: "demo" },
+      }),
+    ).toBe(true);
+  });
+});
+
+describe("parseManageSkillsToolResult", () => {
+  it("parses JSON tool results with activation and warnings", () => {
+    expect(
+      parseManageSkillsToolResult({
+        slug: "demo",
+        path: "/Users/me/.agents/skills/demo",
+        runtimeActivation: "next_start",
+        warnings: ["claude_local_override"],
+      }),
+    ).toEqual({
+      slug: "demo",
+      path: "/Users/me/.agents/skills/demo",
+      runtimeActivation: "next_start",
+      warnings: ["claude_local_override"],
+    });
   });
 });
 

--- a/packages/app/src/components/chat/tool-calls/tool-call-utils.ts
+++ b/packages/app/src/components/chat/tool-calls/tool-call-utils.ts
@@ -97,6 +97,7 @@ export function routeToolPresentation(toolCall: ToolCallLike): string {
   if (hasArgument(args, "questions") || titleLower === "question") return "question";
 
   if (descHint === "skill" || titleLower === "skill") return "skill";
+  if (titleLower === "manage_skills") return "manage_skills";
   if (descHint === "role_skill" || titleLower === "role_skill") return "role_skill";
   if (descHint.includes("role_load") || titleLower.includes("role_load")) return "role_load";
 
@@ -263,6 +264,10 @@ export function matchesTaskTool(toolCall: ToolCallLike): boolean {
 
 export function matchesSkillTool(toolCall: ToolCallLike): boolean {
   return routeToolPresentation(toolCall) === "skill";
+}
+
+export function matchesManageSkillsTool(toolCall: ToolCallLike): boolean {
+  return routeToolPresentation(toolCall) === "manage_skills";
 }
 
 export function matchesRoleSkillTool(toolCall: ToolCallLike): boolean {
@@ -495,6 +500,9 @@ export function formatToolName(t: TranslateFn, name: string): string {
   if (name.toLowerCase() === "role_skill") {
     return t("chat.toolCall.roleSkill.title", "Role skill");
   }
+  if (name.toLowerCase() === "manage_skills") {
+    return t("chat.toolCall.manageSkills.title", "Manage skill");
+  }
   if (name.toLowerCase() === "role_load") {
     return t("chat.toolCall.roleLoad.title", "Role Load");
   }
@@ -548,6 +556,37 @@ export function parseDeleteOnlyPatch(patchText: string): string[] | null {
   }
 
   return deleteFiles.length > 0 ? deleteFiles : null;
+}
+
+export type ManageSkillsToolResult = {
+  slug?: string;
+  path?: string;
+  runtimeActivation?: string;
+  warnings?: string[];
+};
+
+export function parseManageSkillsToolResult(result: unknown): ManageSkillsToolResult | null {
+  let payload: unknown = result;
+  if (typeof payload === "string") {
+    const trimmed = payload.trim();
+    if (!trimmed.startsWith("{")) return null;
+    try {
+      payload = JSON.parse(trimmed) as unknown;
+    } catch {
+      return null;
+    }
+  }
+  if (!payload || typeof payload !== "object") return null;
+  const record = payload as Record<string, unknown>;
+  return {
+    slug: typeof record.slug === "string" ? record.slug : undefined,
+    path: typeof record.path === "string" ? record.path : undefined,
+    runtimeActivation:
+      typeof record.runtimeActivation === "string" ? record.runtimeActivation : undefined,
+    warnings: Array.isArray(record.warnings)
+      ? record.warnings.filter((value): value is string => typeof value === "string")
+      : undefined,
+  };
 }
 
 /**

--- a/packages/app/src/locales/en.json
+++ b/packages/app/src/locales/en.json
@@ -639,6 +639,13 @@
         "title": "Skill",
         "unknown": "unknown-skill"
       },
+      "manageSkills": {
+        "title": "Manage skill",
+        "unknown": "unknown-skill",
+        "defaultAction": "update",
+        "nextStart": "Saved to ~/.agents/skills. New OpenCode, Pi, and Claude Code runtimes will pick it up on their next start.",
+        "claudeLocalOverride": "Claude Code will keep using the workspace-local .claude/skills copy for this slug."
+      },
       "roleSkill": {
         "title": "Role skill",
         "unknown": "unknown-role-skill"

--- a/packages/app/src/locales/zh-CN.json
+++ b/packages/app/src/locales/zh-CN.json
@@ -639,6 +639,13 @@
         "title": "技能",
         "unknown": "未知技能"
       },
+      "manageSkills": {
+        "title": "管理技能",
+        "unknown": "未知技能",
+        "defaultAction": "更新",
+        "nextStart": "已保存至 ~/.agents/skills。新的 OpenCode、Pi 与 Claude Code 运行时将在下次启动时生效。",
+        "claudeLocalOverride": "Claude Code 将继续使用工作区内 .claude/skills 下的同名本地副本。"
+      },
       "roleSkill": {
         "title": "角色技能",
         "unknown": "未知角色技能"


### PR DESCRIPTION
## Summary

Implements design doc **PR 2** for unified managed skill creation:

- After `manage_skills` create/update, daemon runs Claude bridge reconcile (`ensure_claude_team_skills`) so `~/.agents/skills/<slug>` is symlinked into `<workspace>/.claude/skills/<slug>` when allowed.
- When a real workspace-local `.claude/skills/<slug>` directory already exists, the mutation still succeeds but returns a `claude_local_override` warning (Claude Code keeps the local copy).
- Slash picker reloads when daemon records a Skills refresh (in addition to the existing file-watcher event).
- Chat UI adds a dedicated `manage_skills` tool card with `next_start` activation hint and Claude override warning.

Depends on PR #1117 (final pack limit validation) when that lands; this branch currently stacks on top of it.

## Test plan

- [x] `cargo test -p amuxd --bin amuxd --locked reconcile_after_managed` (2 passed)
- [x] `pnpm exec vitest run src/components/chat/tool-calls/__tests__/tool-call-utils.test.ts` (12 passed)
- [ ] Manual: create skill via agent → verify `.claude/skills/<slug>` symlink + Skills list refresh + tool card footnote

## Out of scope (PR 3)

- Turn-scoped native directory fallback guard / auto-adoption


Made with [Cursor](https://cursor.com)