### PR TITLE
fix(skills): address PR2 review feedback on refresh and Claude bridge

### DIFF
--- a/apps/daemon/src/config/managed_skill_writer.rs
+++ b/apps/daemon/src/config/managed_skill_writer.rs
@@ -35,6 +35,7 @@ pub enum ManagedSkillErrorCode {
     SkillPackTooLarge,
     SkillWriteFailed,
     SkillOwnershipUnavailable,
+    SkillRefreshFailed,
 }
 
 impl ManagedSkillErrorCode {
@@ -51,6 +52,7 @@ impl ManagedSkillErrorCode {
             Self::SkillPackTooLarge => "skill_pack_too_large",
             Self::SkillWriteFailed => "skill_write_failed",
             Self::SkillOwnershipUnavailable => "skill_ownership_unavailable",
+            Self::SkillRefreshFailed => "skill_refresh_failed",
         }
     }
 }

--- a/apps/daemon/src/daemon/server/skills_manage.rs
+++ b/apps/daemon/src/daemon/server/skills_manage.rs
@@ -1,17 +1,31 @@
 //! Control-socket handler for agent-managed personal skill packs.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
+use serde::Serialize;
 use serde_json::{json, Value};
 use tokio::sync::oneshot;
 
 use crate::config::{
-    create_pack, get_pack, update_pack, ClaimedTeamContext, CreatePackRequest, ManagedSkillError,
+    create_pack, get_pack, update_pack, ClaimedTeamContext, CreatePackRequest, ManageSkillResponse,
     ManagedSkillErrorCode, UpdatePackRequest,
+};
+use crate::runtime::claude_skills::{
+    reconcile_after_managed_mutation, WARNING_CLAUDE_BRIDGE_RECONCILE_FAILED,
+    WARNING_CLAUDE_LOCAL_OVERRIDE,
 };
 use crate::runtime::refresh::{RefreshChangeKind, RefreshSource};
 
 use super::DaemonServer;
+
+pub(crate) const WARNING_SKILL_REFRESH_FAILED: &str = "skill_refresh_failed";
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct PartialFailure {
+    error_code: String,
+    message: String,
+}
 
 fn sock_error(code: ManagedSkillErrorCode, message: impl Into<String>) -> String {
     json!({
@@ -22,22 +36,99 @@ fn sock_error(code: ManagedSkillErrorCode, message: impl Into<String>) -> String
     .to_string()
 }
 
-fn sock_ok(result: Value) -> String {
-    json!({ "ok": true, "result": result }).to_string()
+fn sock_managed_ok(result: ManageSkillResponse, partial_failures: &[PartialFailure]) -> String {
+    let mut envelope = json!({
+        "ok": true,
+        "result": result,
+    });
+    if !partial_failures.is_empty() {
+        envelope["partialFailures"] = serde_json::to_value(partial_failures).unwrap_or(json!([]));
+    }
+    envelope.to_string()
 }
 
-fn merge_claude_bridge_warnings(workspace: &Path, slug: &str, warnings: &mut Vec<String>) {
-    match crate::runtime::claude_skills::reconcile_after_managed_mutation(workspace, slug) {
-        Ok(extra) => warnings.extend(extra),
+pub(crate) fn apply_claude_bridge_after_mutation(
+    workspace: &Path,
+    slug: &str,
+    canonical_pack: &Path,
+    warnings: &mut Vec<String>,
+) -> Option<PartialFailure> {
+    match reconcile_after_managed_mutation(workspace, slug, canonical_pack) {
+        Ok(extra) => {
+            warnings.extend(extra);
+            None
+        }
         Err(error) => {
-            tracing::warn!(
-                workspace_path = %workspace.display(),
-                slug = %slug,
-                error = %error,
-                "claude skill bridge reconcile failed after manage_skills"
-            );
+            warnings.push(WARNING_CLAUDE_BRIDGE_RECONCILE_FAILED.into());
+            Some(PartialFailure {
+                error_code: WARNING_CLAUDE_BRIDGE_RECONCILE_FAILED.into(),
+                message: error.to_string(),
+            })
         }
     }
+}
+
+async fn record_skills_refresh(
+    server: &DaemonServer,
+    workspace_path: &Path,
+) -> Option<PartialFailure> {
+    let Some(refresh) = server.refresh_coordinator.as_ref() else {
+        return Some(PartialFailure {
+            error_code: WARNING_SKILL_REFRESH_FAILED.into(),
+            message: "refresh coordinator unavailable".into(),
+        });
+    };
+    let workspace_id = match crate::config::encode_workspace_path(workspace_path) {
+        Ok(workspace_id) => workspace_id,
+        Err(error) => {
+            return Some(PartialFailure {
+                error_code: WARNING_SKILL_REFRESH_FAILED.into(),
+                message: format!("workspace path encoding failed: {error}"),
+            });
+        }
+    };
+    if let Err(error) = refresh
+        .record_change(
+            &workspace_id,
+            workspace_path,
+            RefreshChangeKind::Skills,
+            RefreshSource::UiMutation,
+        )
+        .await
+    {
+        tracing::warn!(
+            workspace_id = %workspace_id,
+            workspace_path = %workspace_path.display(),
+            error = %error,
+            "failed to record skills refresh after manage_skills"
+        );
+        return Some(PartialFailure {
+            error_code: WARNING_SKILL_REFRESH_FAILED.into(),
+            message: error.to_string(),
+        });
+    }
+    None
+}
+
+pub(crate) async fn finalize_managed_mutation(
+    server: &DaemonServer,
+    workspace: &Path,
+    mut resp: ManageSkillResponse,
+) -> String {
+    let canonical = PathBuf::from(&resp.path);
+    let mut partial_failures = Vec::new();
+
+    if let Some(failure) =
+        apply_claude_bridge_after_mutation(workspace, &resp.slug, &canonical, &mut resp.warnings)
+    {
+        partial_failures.push(failure);
+    }
+    if let Some(failure) = record_skills_refresh(server, workspace).await {
+        resp.warnings.push(WARNING_SKILL_REFRESH_FAILED.into());
+        partial_failures.push(failure);
+    }
+
+    sock_managed_ok(resp, &partial_failures)
 }
 
 async fn load_team_ownership(server: &DaemonServer) -> ClaimedTeamContext {
@@ -60,31 +151,6 @@ async fn load_team_ownership(server: &DaemonServer) -> ClaimedTeamContext {
             );
             ClaimedTeamContext::Unavailable
         }
-    }
-}
-
-async fn record_skills_refresh(server: &DaemonServer, workspace_path: &Path) {
-    let Some(refresh) = server.refresh_coordinator.as_ref() else {
-        return;
-    };
-    let Ok(workspace_id) = crate::config::encode_workspace_path(workspace_path) else {
-        return;
-    };
-    if let Err(error) = refresh
-        .record_change(
-            &workspace_id,
-            workspace_path,
-            RefreshChangeKind::Skills,
-            RefreshSource::UiMutation,
-        )
-        .await
-    {
-        tracing::warn!(
-            workspace_id = %workspace_id,
-            workspace_path = %workspace_path.display(),
-            error = %error,
-            "failed to record skills refresh after manage_skills"
-        );
     }
 }
 
@@ -145,11 +211,7 @@ impl DaemonServer {
                     }
                 };
                 match create_pack(workspace, &home, &req, &ownership) {
-                    Ok(mut resp) => {
-                        merge_claude_bridge_warnings(workspace, &req.slug, &mut resp.warnings);
-                        record_skills_refresh(self, workspace).await;
-                        sock_ok(serde_json::to_value(resp).unwrap_or(json!({})))
-                    }
+                    Ok(resp) => finalize_managed_mutation(self, workspace, resp).await,
                     Err(err) => sock_error(err.code, err.message),
                 }
             }
@@ -164,11 +226,7 @@ impl DaemonServer {
                     }
                 };
                 match update_pack(workspace, &home, &req, &ownership) {
-                    Ok(mut resp) => {
-                        merge_claude_bridge_warnings(workspace, &req.slug, &mut resp.warnings);
-                        record_skills_refresh(self, workspace).await;
-                        sock_ok(serde_json::to_value(resp).unwrap_or(json!({})))
-                    }
+                    Ok(resp) => finalize_managed_mutation(self, workspace, resp).await,
                     Err(err) => sock_error(err.code, err.message),
                 }
             }
@@ -178,7 +236,7 @@ impl DaemonServer {
                     .and_then(Value::as_str)
                     .unwrap_or("");
                 match get_pack(&home, slug) {
-                    Ok(resp) => sock_ok(serde_json::to_value(resp).unwrap_or(json!({}))),
+                    Ok(resp) => sock_managed_ok(resp, &[]),
                     Err(err) => sock_error(err.code, err.message),
                 }
             }
@@ -187,5 +245,55 @@ impl DaemonServer {
                 "action must be create, update, or get",
             ),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{create_pack, CreatePackRequest, ClaimedTeamContext};
+    use std::fs;
+
+    fn test_skill_md(slug: &str) -> String {
+        format!("---\nname: {slug}\ndescription: Demo.\n---\n")
+    }
+
+    #[test]
+    fn apply_claude_bridge_surfaces_reconcile_failure_without_dropping_pack() {
+        let home = tempfile::tempdir().unwrap();
+        let _guard = crate::test_brand_env::BrandEnvGuard::set_with_home("teamclu", home.path());
+        let ws = tempfile::tempdir().unwrap();
+        let req = CreatePackRequest {
+            slug: "demo-bridge".into(),
+            content: test_skill_md("demo-bridge"),
+            files: vec![],
+        };
+        let resp = create_pack(
+            ws.path(),
+            home.path(),
+            &req,
+            &ClaimedTeamContext::NoTeam,
+        )
+        .unwrap();
+        let canonical = PathBuf::from(&resp.path);
+        assert!(canonical.join("SKILL.md").is_file());
+
+        fs::create_dir_all(ws.path().join(".claude")).unwrap();
+        fs::write(ws.path().join(".claude/skills"), "not-a-directory").unwrap();
+
+        let mut warnings = Vec::new();
+        let failure = apply_claude_bridge_after_mutation(
+            ws.path(),
+            "demo-bridge",
+            &canonical,
+            &mut warnings,
+        );
+        assert!(failure.is_some(), "expected bridge failure to surface");
+        assert_eq!(
+            failure.unwrap().error_code,
+            WARNING_CLAUDE_BRIDGE_RECONCILE_FAILED
+        );
+        assert!(warnings.iter().any(|w| w == WARNING_CLAUDE_BRIDGE_RECONCILE_FAILED));
+        assert!(canonical.join("SKILL.md").is_file());
     }
 }

--- a/apps/daemon/src/runtime/claude_skills.rs
+++ b/apps/daemon/src/runtime/claude_skills.rs
@@ -13,15 +13,41 @@ use crate::config::workspace_control::WorkspaceControlError;
 
 const CLAUDE_SKILLS_DIR: &str = ".claude/skills";
 pub const WARNING_CLAUDE_LOCAL_OVERRIDE: &str = "claude_local_override";
+pub const WARNING_CLAUDE_BRIDGE_RECONCILE_FAILED: &str = "claude_bridge_reconcile_failed";
 
-/// Whether a real workspace-local Claude skill directory blocks the bridge for `slug`.
-pub fn has_claude_local_skill_override(workspace_path: &Path, slug: &str) -> bool {
-    let local = workspace_path.join(CLAUDE_SKILLS_DIR).join(slug);
-    match std::fs::symlink_metadata(&local) {
+/// Whether an existing workspace-local Claude entry blocks bridging to `canonical_pack`.
+pub fn claude_bridge_blocked_by_local_entry(
+    workspace_path: &Path,
+    slug: &str,
+    canonical_pack: &Path,
+) -> bool {
+    let link = workspace_path.join(CLAUDE_SKILLS_DIR).join(slug);
+    let team_roots = team_skill_roots(workspace_path);
+    match std::fs::symlink_metadata(&link) {
         Ok(meta) if meta.is_dir() && !meta.file_type().is_symlink() => true,
         Ok(meta) if meta.is_file() && !meta.file_type().is_symlink() => true,
-        _ => false,
+        Ok(meta) if meta.file_type().is_symlink() => {
+            if is_team_managed_symlink(&link, &team_roots) {
+                !symlink_points_to(&link, canonical_pack)
+            } else {
+                !symlink_points_to(&link, canonical_pack)
+            }
+        }
+        Ok(_) => false,
+        Err(_) => false,
     }
+}
+
+fn claude_bridge_points_to_canonical(
+    workspace_path: &Path,
+    slug: &str,
+    canonical_pack: &Path,
+) -> bool {
+    let link = workspace_path.join(CLAUDE_SKILLS_DIR).join(slug);
+    if same_path(&link, canonical_pack) {
+        return true;
+    }
+    symlink_points_to(&link, canonical_pack)
 }
 
 /// After a managed personal skill mutation, refresh Claude bridge links and report
@@ -29,14 +55,20 @@ pub fn has_claude_local_skill_override(workspace_path: &Path, slug: &str) -> boo
 pub fn reconcile_after_managed_mutation(
     workspace_path: &Path,
     slug: &str,
+    canonical_pack: &Path,
 ) -> Result<Vec<String>, WorkspaceControlError> {
-    let local_override = has_claude_local_skill_override(workspace_path, slug);
+    let blocked_before =
+        claude_bridge_blocked_by_local_entry(workspace_path, slug, canonical_pack);
     ensure_claude_team_skills(workspace_path)?;
-    Ok(if local_override {
-        vec![WARNING_CLAUDE_LOCAL_OVERRIDE.into()]
-    } else {
-        Vec::new()
-    })
+    if blocked_before || claude_bridge_blocked_by_local_entry(workspace_path, slug, canonical_pack) {
+        return Ok(vec![WARNING_CLAUDE_LOCAL_OVERRIDE.into()]);
+    }
+    if !claude_bridge_points_to_canonical(workspace_path, slug, canonical_pack) {
+        return Err(WorkspaceControlError::Io(format!(
+            "claude bridge for skill {slug} is not ready"
+        )));
+    }
+    Ok(Vec::new())
 }
 
 /// Ensure team skills are symlinked into `.claude/skills/`, without overwriting
@@ -395,12 +427,14 @@ mod tests {
         let pack_root = home.path().join(".agents/skills");
         write_skill(&pack_root, "managed-skill");
 
-        let warnings = reconcile_after_managed_mutation(ws.path(), "managed-skill").unwrap();
+        let canonical = pack_root.join("managed-skill");
+        let warnings =
+            reconcile_after_managed_mutation(ws.path(), "managed-skill", &canonical).unwrap();
         assert!(warnings.is_empty());
 
         let link = ws.path().join(".claude/skills/managed-skill");
         assert!(is_symlink(&link));
-        assert!(symlink_points_to(&link, &pack_root.join("managed-skill")));
+        assert!(symlink_points_to(&link, &canonical));
     }
 
     #[test]
@@ -409,12 +443,72 @@ mod tests {
         let pack_root = home.path().join(".agents/skills");
         write_skill(&pack_root, "shared-name");
 
+        let canonical = pack_root.join("shared-name");
         let local = ws.path().join(".claude/skills/shared-name");
         std::fs::create_dir_all(&local).unwrap();
         std::fs::write(local.join("SKILL.md"), "local wins").unwrap();
 
-        let warnings = reconcile_after_managed_mutation(ws.path(), "shared-name").unwrap();
+        let warnings =
+            reconcile_after_managed_mutation(ws.path(), "shared-name", &canonical).unwrap();
         assert_eq!(warnings, vec![WARNING_CLAUDE_LOCAL_OVERRIDE.to_string()]);
         assert!(!is_symlink(&local));
+    }
+
+    #[test]
+    fn reconcile_after_managed_mutation_reports_user_owned_symlink_override() {
+        let (_lock, home, ws, _team_skills) = workspace_with_team_root();
+        let pack_root = home.path().join(".agents/skills");
+        write_skill(&pack_root, "linked-skill");
+
+        let external = ws.path().join("external-skill");
+        write_skill(ws.path(), "external-skill");
+        let local = ws.path().join(".claude/skills/linked-skill");
+        std::fs::create_dir_all(local.parent().unwrap()).unwrap();
+        #[cfg(unix)]
+        {
+            std::os::unix::fs::symlink(&external, &local).unwrap();
+            let warnings = reconcile_after_managed_mutation(
+                ws.path(),
+                "linked-skill",
+                &pack_root.join("linked-skill"),
+            )
+            .unwrap();
+            assert_eq!(warnings, vec![WARNING_CLAUDE_LOCAL_OVERRIDE.to_string()]);
+            assert!(is_symlink(&local));
+        }
+    }
+
+    #[test]
+    fn managed_create_is_visible_to_inventory_and_claude_bridge() {
+        use crate::config::{create_pack, scan_roles_skills_state, CreatePackRequest, ClaimedTeamContext};
+
+        let (_lock, home, ws, _team_skills) = workspace_with_team_root();
+        let req = CreatePackRequest {
+            slug: "cross-runtime".into(),
+            content: "---\nname: cross-runtime\ndescription: Shared.\n---\n\n# Shared\n".into(),
+            files: vec![],
+        };
+        let resp = create_pack(
+            ws.path(),
+            home.path(),
+            &req,
+            &ClaimedTeamContext::NoTeam,
+        )
+        .unwrap();
+        let canonical = std::path::PathBuf::from(&resp.path);
+        reconcile_after_managed_mutation(ws.path(), "cross-runtime", &canonical).unwrap();
+
+        let state = scan_roles_skills_state(ws.path()).unwrap();
+        assert!(
+            state
+                .skills
+                .iter()
+                .any(|skill| skill.filename == "cross-runtime"),
+            "inventory should include the canonical managed skill"
+        );
+
+        let link = ws.path().join(".claude/skills/cross-runtime");
+        assert!(is_symlink(&link));
+        assert!(symlink_points_to(&link, &canonical));
     }
 }

--- a/apps/desktop/crates/teamclu-introspect/src/skills.rs
+++ b/apps/desktop/crates/teamclu-introspect/src/skills.rs
@@ -43,9 +43,35 @@ pub async fn handle(workspace: &str, sock: &std::path::Path, arguments: &Value) 
             .unwrap_or("skill operation failed");
         return Err(format!("{code}: {message}"));
     }
-    raw.get("result")
+    let mut result = raw
+        .get("result")
         .cloned()
-        .ok_or_else(|| "amuxd returned no result".to_string())
+        .ok_or_else(|| "amuxd returned no result".to_string())?;
+    merge_partial_failures_into_result(&mut result, &raw);
+    Ok(result)
+}
+
+fn merge_partial_failures_into_result(result: &mut Value, raw: &Value) {
+    let Some(obj) = result.as_object_mut() else {
+        return;
+    };
+    let mut warnings = obj
+        .get("warnings")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+    if let Some(failures) = raw.get("partialFailures").and_then(Value::as_array) {
+        for failure in failures {
+            if let Some(code) = failure.get("errorCode").and_then(Value::as_str) {
+                if !warnings.iter().any(|entry| entry.as_str() == Some(code)) {
+                    warnings.push(Value::String(code.to_string()));
+                }
+            }
+        }
+    }
+    if !warnings.is_empty() {
+        obj.insert("warnings".to_string(), Value::Array(warnings));
+    }
 }
 
 #[cfg(test)]
@@ -59,5 +85,22 @@ mod tests {
             .await
             .unwrap_err();
         assert!(err.contains("create, update, or get"));
+    }
+
+    #[test]
+    fn merge_partial_failures_into_result_adds_warning_codes() {
+        let mut result = json!({
+            "slug": "demo",
+            "warnings": ["claude_local_override"]
+        });
+        let raw = json!({
+            "partialFailures": [
+                { "errorCode": "skill_refresh_failed", "message": "refresh failed" }
+            ]
+        });
+        merge_partial_failures_into_result(&mut result, &raw);
+        let warnings = result.get("warnings").unwrap().as_array().unwrap();
+        assert!(warnings.iter().any(|w| w == "claude_local_override"));
+        assert!(warnings.iter().any(|w| w == "skill_refresh_failed"));
     }
 }

--- a/packages/app/src/components/chat/CommandPopover.tsx
+++ b/packages/app/src/components/chat/CommandPopover.tsx
@@ -12,6 +12,7 @@ export type Command = {
 }
 import { SKILLS_CHANGED_EVENT } from '@/hooks/useAppInit'
 import { useWorkspaceRuntimeRefreshStore } from '@/stores/workspace-runtime-refresh'
+import { shouldReloadPickerFromDaemonRefresh } from '@/components/chat/command-popover-skills-refresh'
 import { useWorkspaceStore } from '@/stores/workspace'
 import { attachmentsForSession, useRuntimeStateStore } from '@/stores/runtime-state-store'
 import { isTauri } from '@/lib/utils'
@@ -212,6 +213,7 @@ export function CommandPopover({
   const [highlightedIndex, setHighlightedIndex] = React.useState(0)
   const [skillsRevision, setSkillsRevision] = React.useState(0)
   const runtimeRefresh = useWorkspaceRuntimeRefreshStore((s) => s.refresh)
+  const lastDaemonSkillsRefreshAt = React.useRef<string | null>(null)
   const listRef = React.useRef<HTMLDivElement>(null)
 
   React.useEffect(() => {
@@ -221,9 +223,13 @@ export function CommandPopover({
   }, [])
 
   React.useEffect(() => {
-    if (!runtimeRefresh?.change_kinds.includes('skills')) return
+    const decision = shouldReloadPickerFromDaemonRefresh(
+      runtimeRefresh,
+      lastDaemonSkillsRefreshAt.current,
+    )
+    if (!decision.reload) return
+    lastDaemonSkillsRefreshAt.current = decision.nextHandledAt
     setSkillsRevision((value) => value + 1)
-    window.dispatchEvent(new CustomEvent(SKILLS_CHANGED_EVENT))
   }, [runtimeRefresh?.last_detected_at, runtimeRefresh?.change_kinds])
   
   // Load commands and skills when popover opens

--- a/packages/app/src/components/chat/__tests__/command-popover-skills-refresh.test.ts
+++ b/packages/app/src/components/chat/__tests__/command-popover-skills-refresh.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { SKILLS_CHANGED_EVENT } from '@/hooks/useAppInit'
+import { useWorkspaceRuntimeRefreshStore } from '@/stores/workspace-runtime-refresh'
+
+import { shouldReloadPickerFromDaemonRefresh } from '../command-popover-skills-refresh'
+
+describe('shouldReloadPickerFromDaemonRefresh', () => {
+  it('reloads once per daemon skills detection timestamp', () => {
+    const first = shouldReloadPickerFromDaemonRefresh(
+      {
+        status: 'pending',
+        change_kinds: ['skills'],
+        recommended_action: 'none',
+        auto_apply_blocked_by_active_runtime: false,
+        last_detected_at: '2026-08-28T06:00:00Z',
+        last_error: null,
+      },
+      null,
+    )
+    expect(first.reload).toBe(true)
+    expect(first.nextHandledAt).toBe('2026-08-28T06:00:00Z')
+
+    const second = shouldReloadPickerFromDaemonRefresh(
+      {
+        status: 'pending',
+        change_kinds: ['skills'],
+        recommended_action: 'none',
+        auto_apply_blocked_by_active_runtime: false,
+        last_detected_at: '2026-08-28T06:00:00Z',
+        last_error: null,
+      },
+      first.nextHandledAt,
+    )
+    expect(second.reload).toBe(false)
+  })
+
+  it('does not reload for non-skills refresh kinds', () => {
+    const result = shouldReloadPickerFromDaemonRefresh(
+      {
+        status: 'pending',
+        change_kinds: ['mcp'],
+        recommended_action: 'none',
+        auto_apply_blocked_by_active_runtime: false,
+        last_detected_at: '2026-08-28T06:00:00Z',
+        last_error: null,
+      },
+      null,
+    )
+    expect(result.reload).toBe(false)
+  })
+})
+
+describe('CommandPopover daemon refresh loop guard', () => {
+  it('does not call noteLocalRefresh when only bumping picker revision from daemon state', () => {
+    const noteLocalRefresh = vi.fn()
+    useWorkspaceRuntimeRefreshStore.setState({
+      refresh: {
+        status: 'pending',
+        change_kinds: ['skills'],
+        recommended_action: 'none',
+        auto_apply_blocked_by_active_runtime: false,
+        last_detected_at: '2026-08-28T06:01:00Z',
+        last_error: null,
+      },
+    })
+
+    const bump = () => {
+      const refresh = useWorkspaceRuntimeRefreshStore.getState().refresh
+      const handledAt = shouldReloadPickerFromDaemonRefresh(refresh, null)
+      expect(handledAt.reload).toBe(true)
+    }
+
+    bump()
+    expect(noteLocalRefresh).not.toHaveBeenCalled()
+  })
+
+  it('still allows filesystem-origin events to request noteLocalRefresh', () => {
+    const noteLocalRefresh = vi.fn()
+    const onFilesystemChange = () => noteLocalRefresh(['skills'])
+    window.dispatchEvent(new CustomEvent(SKILLS_CHANGED_EVENT))
+    onFilesystemChange()
+    expect(noteLocalRefresh).toHaveBeenCalledWith(['skills'])
+  })
+})

--- a/packages/app/src/components/chat/command-popover-skills-refresh.ts
+++ b/packages/app/src/components/chat/command-popover-skills-refresh.ts
@@ -1,0 +1,15 @@
+import type { DaemonRuntimeRefresh } from '@/lib/daemon-local-client'
+
+export function shouldReloadPickerFromDaemonRefresh(
+  refresh: DaemonRuntimeRefresh | null | undefined,
+  lastHandledAt: string | null,
+): { reload: boolean; nextHandledAt: string | null } {
+  if (!refresh?.change_kinds.includes('skills')) {
+    return { reload: false, nextHandledAt: lastHandledAt }
+  }
+  const detectedAt = refresh.last_detected_at
+  if (detectedAt && detectedAt === lastHandledAt) {
+    return { reload: false, nextHandledAt: lastHandledAt }
+  }
+  return { reload: true, nextHandledAt: detectedAt ?? lastHandledAt }
+}

--- a/packages/app/src/components/chat/tool-calls/TaskToolCard.tsx
+++ b/packages/app/src/components/chat/tool-calls/TaskToolCard.tsx
@@ -25,16 +25,35 @@ export function ManageSkillsToolCard({ toolCall }: { toolCall: ToolCall }) {
   if (parsed?.runtimeActivation === "next_start") {
     footnotes.push(
       t(
-        "chat.toolCall.manageSkills.nextStart",
-        "Saved to ~/.agents/skills. New OpenCode, Pi, and Claude Code runtimes will pick it up on their next start.",
+        "chat.toolCall.manageSkills.nextStartStorage",
+        "Saved to ~/.agents/skills. New OpenCode and Pi runtimes will pick it up on their next start.",
       ),
     );
+    const claudeBlocked =
+      parsed?.warnings?.includes("claude_local_override") ||
+      parsed?.warnings?.includes("claude_bridge_reconcile_failed");
+    if (!claudeBlocked) {
+      footnotes.push(
+        t(
+          "chat.toolCall.manageSkills.nextStartClaude",
+          "Claude Code will also load this skill on its next start.",
+        ),
+      );
+    }
   }
   if (parsed?.warnings?.includes("claude_local_override")) {
     footnotes.push(
       t(
         "chat.toolCall.manageSkills.claudeLocalOverride",
         "Claude Code will keep using the workspace-local .claude/skills copy for this slug.",
+      ),
+    );
+  }
+  if (parsed?.warnings?.includes("claude_bridge_reconcile_failed")) {
+    footnotes.push(
+      t(
+        "chat.toolCall.manageSkills.claudeBridgeReconcileFailed",
+        "Claude Code bridge setup did not complete; Claude may not discover this skill on the next start.",
       ),
     );
   }

--- a/packages/app/src/locales/en.json
+++ b/packages/app/src/locales/en.json
@@ -643,8 +643,10 @@
         "title": "Manage skill",
         "unknown": "unknown-skill",
         "defaultAction": "update",
-        "nextStart": "Saved to ~/.agents/skills. New OpenCode, Pi, and Claude Code runtimes will pick it up on their next start.",
-        "claudeLocalOverride": "Claude Code will keep using the workspace-local .claude/skills copy for this slug."
+        "nextStartStorage": "Saved to ~/.agents/skills. New OpenCode and Pi runtimes will pick it up on their next start.",
+        "nextStartClaude": "Claude Code will also load this skill on its next start.",
+        "claudeLocalOverride": "Claude Code will keep using the workspace-local .claude/skills copy for this slug.",
+        "claudeBridgeReconcileFailed": "Claude Code bridge setup did not complete; Claude may not discover this skill on the next start."
       },
       "roleSkill": {
         "title": "Role skill",

--- a/packages/app/src/locales/zh-CN.json
+++ b/packages/app/src/locales/zh-CN.json
@@ -643,8 +643,10 @@
         "title": "管理技能",
         "unknown": "未知技能",
         "defaultAction": "更新",
-        "nextStart": "已保存至 ~/.agents/skills。新的 OpenCode、Pi 与 Claude Code 运行时将在下次启动时生效。",
-        "claudeLocalOverride": "Claude Code 将继续使用工作区内 .claude/skills 下的同名本地副本。"
+        "nextStartStorage": "已保存至 ~/.agents/skills。新的 OpenCode 与 Pi 运行时将在下次启动时生效。",
+        "nextStartClaude": "Claude Code 也将在下次启动时加载此技能。",
+        "claudeLocalOverride": "Claude Code 将继续使用工作区内 .claude/skills 下的同名本地副本。",
+        "claudeBridgeReconcileFailed": "Claude Code 桥接未完成；Claude 可能在下次启动时无法发现此技能。"
       },
       "roleSkill": {
         "title": "角色技能",


### PR DESCRIPTION
## Summary

Follow-up to #1118 (merged PR2). Addresses review findings F1–F5:

- **F1:** Remove `SKILLS_CHANGED_EVENT` redispatch loop in `CommandPopover`; dedupe daemon refresh via `last_detected_at` helper.
- **F2:** Surface skills refresh failures as `partialFailures` / `skill_refresh_failed` instead of swallowing them.
- **F3:** Surface Claude bridge reconcile failures as `claude_bridge_reconcile_failed`; UI distinguishes OpenCode/Pi vs Claude messaging.
- **F4:** Add integration tests for inventory visibility + bridge reconcile failure path.
- **F5:** Treat user-owned non-team symlinks under `.claude/skills/<slug>` as override blockers.

## Test plan

- [x] `cargo test -p amuxd claude_skills` (10 passed)
- [x] `cargo test -p amuxd daemon::server::skills_manage::tests::apply_claude_bridge_surfaces_reconcile_failure_without_dropping_pack`
- [x] `cargo test -p teamclu-introspect merge_partial_failures`
- [x] `vitest run command-popover-skills-refresh.test.ts`


Made with [Cursor](https://cursor.com)