### PR TITLE
docs(fc): document dual supabase/postgres backend paths

### DIFF
--- a/services/fc/README.md
+++ b/services/fc/README.md
@@ -26,6 +26,40 @@ curl http://127.0.0.1:9000/healthz   # {"ok":true}
 
 All other vars (DB, Supabase, OSS, LiteLLM, APNs, MQTT, CodeUp) match `s.yaml`.
 
+## Dual backend paths (read before changing FC data access)
+
+Production self-host uses **`BACKEND_KIND=supabase`** (default). The codebase
+also carries a parallel **`postgres`** path (Drizzle + Better-Auth) for the same
+`/v1` repository contract. Treat them as **two implementations of one API**,
+not as “main vs dead code”, until the postgres path is removed.
+
+| Path | Switch | Business `/v1/*` | Auth |
+|------|--------|------------------|------|
+| **A — Supabase** | default / `supabase` | `lib/supabase-repo.ts` → PostgREST + RLS | GoTrue via `createSupabaseAuthRepository` |
+| **B — Postgres** | `BACKEND_KIND=postgres` | `lib/pg-repo/*` → Drizzle + `authz.ts` | Better-Auth via `createPgAuthRepository` |
+
+**Not Path B** (Drizzle exists on supabase deployments too): `lib/cron.ts`,
+`lib/litellm-usage.ts`, `lib/provisioning/app-postgres.ts` — tokenless or
+separate DB; always wired regardless of `BACKEND_KIND`.
+
+### Developer checklist (new Cloud API work)
+
+1. **Contract first** — `lib/repository-contract.ts`, then OpenAPI.
+2. **Implement both** — `supabase-repo.ts` (or `supabase-repo/*`) **and**
+   `pg-repo/<domain>.ts`, unless the feature is explicitly supabase-only.
+3. **Branching modules** — if you touch `sync-handlers.ts`, `sync-auth.ts`,
+   `push-deps.ts`, or `apps-vanity.ts`, update **both** the `postgres` and
+   `supabase` blocks (grep `resolveBackendKind()`).
+4. **Shared validation** — pure helpers imported from `pg-repo/` into
+   supabase-repo (e.g. `app-status`, `team-mcp`, `team-env-secrets`) must stay
+   backend-neutral; do not put PostgREST calls there.
+5. **Tests** — `test/repository-contract.test.ts` (supabase stub gate) and
+   `test/pg-repo-contract.test.ts` (pglite gate); domain tests often have
+   `pg-repo-*.test.ts` twins.
+
+Entry wiring: `src/index.ts` (`makeBusinessRepoFactory` / `makeAuthRepoFactory`).
+Switch: `src/lib/backend-kind.ts`.
+
 ### Cron (HTTP-triggered)
 
 Alibaba FC drives cron via timer triggers. In Docker, an external scheduler

--- a/services/fc/src/index.ts
+++ b/services/fc/src/index.ts
@@ -191,6 +191,13 @@ export function vanityLookup() {
   });
 }
 
+// ---------------------------------------------------------------------------
+// Repository factories — dual backend (see README.md § Dual backend paths).
+// make*RepoFactory(kind) must stay symmetric: new deps wired into BOTH
+// createSupabaseBusinessRepository and createPgBusinessRepository unless
+// documented supabase-only.
+// ---------------------------------------------------------------------------
+
 export function makeAuthRepoFactory(kind: "supabase" | "postgres") {
   if (kind === "postgres") {
     return () => createPgAuthRepository();

--- a/services/fc/src/lib/backend-kind.ts
+++ b/services/fc/src/lib/backend-kind.ts
@@ -1,7 +1,21 @@
 /**
- * Resolves the active backend kind from environment variables.
- * Centralised here so other modules can import without creating a cycle
- * through src/index.ts.
+ * FC database access switch — see README.md § "Dual backend paths".
+ *
+ * BACKEND_KIND selects between two parallel implementations of the same Cloud
+ * API repository contract:
+ *
+ *   supabase (default, production) — PostgREST + caller JWT + RLS
+ *     lib/supabase-repo.ts, lib/supabase-repo/*
+ *
+ *   postgres — Drizzle direct SQL + Better-Auth JWT + app-layer authz
+ *     lib/pg-repo/*
+ *
+ * New repository methods, sync handlers, push/vanity helpers, and shared
+ * validation rules must be implemented (or explicitly stubbed) on BOTH paths
+ * unless the change is supabase-only by design (e.g. phone auth).
+ *
+ * Side paths (cron, LiteLLM usage, per-app DB) use Drizzle regardless of
+ * BACKEND_KIND; they are not the postgres backend path.
  */
 export function resolveBackendKind(
   env: NodeJS.ProcessEnv = process.env,

--- a/services/fc/src/lib/pg-repo/index.ts
+++ b/services/fc/src/lib/pg-repo/index.ts
@@ -1,3 +1,9 @@
+/**
+ * Path B business repository — Drizzle + app-layer authz (BACKEND_KIND=postgres).
+ *
+ * Parity target: lib/supabase-repo.ts (Path A). Any new repository method needs
+ * a matching implementation here and in the contract tests above.
+ */
 import type { PgDatabase } from "drizzle-orm/pg-core";
 import { ApiError } from "../http-utils.js";
 import { makeTeamsRepo, type TeamsRepoDeps } from "./teams.js";

--- a/services/fc/src/lib/repository-contract.ts
+++ b/services/fc/src/lib/repository-contract.ts
@@ -1,3 +1,13 @@
+/**
+ * Shared behavioral contract for BOTH repository backends.
+ *
+ * Every method added here must be implemented in:
+ *   - lib/supabase-repo.ts (Path A — production default)
+ *   - lib/pg-repo/*       (Path B — BACKEND_KIND=postgres)
+ *
+ * Gates: test/repository-contract.test.ts (supabase stub),
+ *        test/pg-repo-contract.test.ts (pglite).
+ */
 export function runBusinessRepositoryContract({ test, assert, createRepository }) {
   test("repository contract: sessions keep canonical fields and ordering", async () => {
     const repo = createRepository();

--- a/services/fc/src/lib/supabase-repo.ts
+++ b/services/fc/src/lib/supabase-repo.ts
@@ -1,3 +1,9 @@
+/**
+ * Path A business repository — PostgREST + caller JWT + RLS (default production).
+ *
+ * Parity target: lib/pg-repo/* (Path B). New methods belong here AND in pg-repo
+ * unless explicitly supabase-only. See README.md § Dual backend paths.
+ */
 import { randomUUID } from "node:crypto";
 import { createClient as defaultCreateClient } from "@supabase/supabase-js";
 import { verifyTrustedExternalJwt } from "./trusted-external-jwt.js";
@@ -28,8 +34,8 @@ function assertNewOrgAllowed(): void {
 
 import { makeSupabaseMarketplaceMethods } from "./supabase-repo/marketplace.js";
 import { isLegalStatusTransition } from "./pg-repo/app-status.js";
-// Shared with the pg-repo twin on purpose — see the "Team MCP / env helpers"
-// note below. These are validation rules, not backend-specific plumbing.
+// Shared with the pg-repo twin on purpose — validation only; keep free of
+// PostgREST/Drizzle calls so both backends can import these helpers.
 import {
   assertTransportShape as assertTeamMcpTransportShape,
   readServerFields as readTeamMcpServerFields,

--- a/services/fc/src/lib/sync-auth.ts
+++ b/services/fc/src/lib/sync-auth.ts
@@ -3,6 +3,10 @@
 // JWT verification + actor resolution for /sync/* endpoints.
 // Spec §3 auth middleware.
 //
+// DUAL PATH: JWT + actor resolution for /sync/* — postgres uses verifyAccessToken
+// + pg-repo/authz; supabase uses auth.getUser + actor_id_for_user_in_team RPC.
+// Update BOTH branches when changing sync auth (README § Dual backend paths).
+//
 // Under BACKEND_KIND=postgres the token is verified locally (verifyAccessToken)
 // and actor membership is resolved via pg-repo/authz — no Supabase calls.
 // Under the default "supabase" backend the original supabase.auth.getUser +

--- a/services/fc/src/lib/sync-handlers.ts
+++ b/services/fc/src/lib/sync-handlers.ts
@@ -4,8 +4,10 @@
 // Each export is a standalone async function; the router in index.mjs
 // dispatches here after JWT/actor auth.
 //
-// Under BACKEND_KIND=postgres: metadata ops go through makeOssSyncRepo(getDb()).
-// Under BACKEND_KIND=supabase (default): original Supabase path is unchanged.
+// DUAL PATH: each handler branches on resolveBackendKind() — keep postgres AND
+// supabase blocks in sync when changing OSS sync metadata (README § Dual backend).
+//   postgres → makeOssSyncRepo(getDb())
+//   supabase → createServiceRoleClient() + .from() / .rpc()  (production default)
 // Blob bytes live in Supabase Storage under both (see team-blob-storage.ts).
 
 import { createHash, randomUUID } from 'node:crypto';

--- a/services/fc/test/pg-repo-contract.test.ts
+++ b/services/fc/test/pg-repo-contract.test.ts
@@ -1,5 +1,6 @@
 /**
- * pg-repo-contract.test.ts — GREEN GATE for pg-repo against the repository contract.
+ * pg-repo-contract.test.ts — GREEN GATE for Path B (pg-repo) against the contract.
+ * Path A gate: repository-contract.test.ts. Both must pass when changing the API.
  *
  * HARNESS STATE MODEL (derived from repository-contract.ts):
  *   - createRepository() is called fresh per test; the in-memory stub builds fresh

--- a/services/fc/test/repository-contract.test.ts
+++ b/services/fc/test/repository-contract.test.ts
@@ -1,3 +1,4 @@
+/** Path A contract gate — supabase-repo behavior (production default). Path B: pg-repo-contract.test.ts */
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";


### PR DESCRIPTION
## Summary

- Add **Dual backend paths** section to `services/fc/README.md` with Path A (supabase/PostgREST) vs Path B (postgres/Drizzle) table and a developer checklist.
- Add inline comments at the wiring and contract entry points so new Cloud API work is not missed on either side:
  - `backend-kind.ts`, `index.ts` (repo factories)
  - `repository-contract.ts`, `supabase-repo.ts`, `pg-repo/index.ts`
  - `sync-handlers.ts`, `sync-auth.ts`
  - contract test file headers

No behavior changes — comments and README only.

## Test plan

- [x] Documentation-only diff; no runtime code paths modified
- [ ] Reviewer confirms checklist matches current FC layout


Made with [Cursor](https://cursor.com)