### PR TITLE
fix(skills): address PR2 re-review on symlinks, refresh UI, and tests

### DIFF
--- a/apps/daemon/src/daemon/server/skills_manage.rs
+++ b/apps/daemon/src/daemon/server/skills_manage.rs
@@ -12,7 +12,6 @@ use crate::config::{
 };
 use crate::runtime::claude_skills::{
     reconcile_after_managed_mutation, WARNING_CLAUDE_BRIDGE_RECONCILE_FAILED,
-    WARNING_CLAUDE_LOCAL_OVERRIDE,
 };
 use crate::runtime::refresh::{RefreshChangeKind, RefreshSource};
 
@@ -22,7 +21,7 @@ pub(crate) const WARNING_SKILL_REFRESH_FAILED: &str = "skill_refresh_failed";
 
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
-struct PartialFailure {
+pub(crate) struct PartialFailure {
     error_code: String,
     message: String,
 }

--- a/apps/daemon/src/runtime/claude_skills.rs
+++ b/apps/daemon/src/runtime/claude_skills.rs
@@ -105,11 +105,11 @@ pub fn ensure_claude_team_skills(workspace_path: &Path) -> Result<(), WorkspaceC
             }
             Ok(meta) if meta.is_file() && !meta.file_type().is_symlink() => continue,
             Ok(meta) if meta.file_type().is_symlink() => {
-                let broken = !link.exists();
-                if is_team_managed_symlink(&link, &team_roots) || (broken && desired_slugs.contains(slug)) {
+                if is_team_managed_symlink(&link, &team_roots) {
                     std::fs::remove_file(&link).map_err(io_err)?;
                 } else {
-                    // User-owned symlink — do not overwrite.
+                    // User-owned symlink — preserve even when broken; ownership
+                    // cannot be inferred from `desired_slugs` alone.
                     continue;
                 }
             }
@@ -215,6 +215,9 @@ fn resolve_symlink_target(link: &Path) -> Option<PathBuf> {
     } else {
         link.parent()?.join(dest)
     };
+    if !resolved.exists() {
+        return None;
+    }
     Some(std::fs::canonicalize(&resolved).unwrap_or(resolved))
 }
 
@@ -476,6 +479,109 @@ mod tests {
             assert_eq!(warnings, vec![WARNING_CLAUDE_LOCAL_OVERRIDE.to_string()]);
             assert!(is_symlink(&local));
         }
+    }
+
+    #[test]
+    fn reconcile_preserves_broken_user_owned_symlink() {
+        let (_lock, home, ws, _team_skills) = workspace_with_team_root();
+        let pack_root = home.path().join(".agents/skills");
+        write_skill(&pack_root, "demo");
+
+        let canonical = pack_root.join("demo");
+        let local = ws.path().join(".claude/skills/demo");
+        std::fs::create_dir_all(local.parent().unwrap()).unwrap();
+        #[cfg(unix)]
+        {
+            let external = ws.path().join("temporarily-unmounted/demo");
+            std::os::unix::fs::symlink(&external, &local).unwrap();
+            assert!(!local.exists());
+            let link_target_before = std::fs::read_link(&local).unwrap();
+
+            let warnings =
+                reconcile_after_managed_mutation(ws.path(), "demo", &canonical).unwrap();
+            assert_eq!(warnings, vec![WARNING_CLAUDE_LOCAL_OVERRIDE.to_string()]);
+            assert!(is_symlink(&local));
+            assert_eq!(std::fs::read_link(&local).unwrap(), link_target_before);
+            assert!(!symlink_points_to(&local, &canonical));
+        }
+    }
+
+    #[test]
+    fn managed_create_resolves_identical_pack_across_opencode_pi_claude() {
+        use crate::config::{
+            create_pack, team_skill_roots, ClaimedTeamContext, CreatePackRequest,
+        };
+        use crate::runtime::supervisor::prepare_workspace;
+
+        let (_lock, home, ws, _team_skills) = workspace_with_team_root();
+        let agents_root = home.path().join(".agents/skills");
+        std::fs::create_dir_all(&agents_root).unwrap();
+        std::fs::write(
+            ws.path().join("opencode.json"),
+            format!(
+                r#"{{"skills":{{"paths":["{}"]}}}}"#,
+                agents_root.to_string_lossy()
+            ),
+        )
+        .unwrap();
+
+        let body = "---\nname: cross-runtime\ndescription: Shared.\n---\n\n# Shared body\n";
+        let req = CreatePackRequest {
+            slug: "cross-runtime".into(),
+            content: body.into(),
+            files: vec![],
+        };
+        let resp = create_pack(
+            ws.path(),
+            home.path(),
+            &req,
+            &ClaimedTeamContext::NoTeam,
+        )
+        .unwrap();
+        let canonical = std::path::PathBuf::from(&resp.path);
+        let expected_digest = resp.digest.clone();
+
+        reconcile_after_managed_mutation(ws.path(), "cross-runtime", &canonical).unwrap();
+        prepare_workspace(ws.path()).unwrap();
+
+        let pi_pack = agents_root.join("cross-runtime");
+        assert_eq!(
+            std::fs::canonicalize(&pi_pack).unwrap(),
+            std::fs::canonicalize(&canonical).unwrap()
+        );
+
+        let mut opencode_found = false;
+        for root in team_skill_roots(ws.path()) {
+            let candidate = root.join("cross-runtime");
+            if candidate.join("SKILL.md").is_file() {
+                assert_eq!(
+                    std::fs::canonicalize(&candidate).unwrap(),
+                    std::fs::canonicalize(&canonical).unwrap()
+                );
+                opencode_found = true;
+            }
+        }
+        assert!(opencode_found, "OpenCode skills.paths should resolve the pack");
+
+        let claude_link = ws.path().join(".claude/skills/cross-runtime");
+        assert!(symlink_points_to(&claude_link, &canonical));
+        let claude_resolved = resolve_symlink_target(&claude_link).unwrap();
+        assert_eq!(
+            std::fs::canonicalize(&claude_resolved).unwrap(),
+            std::fs::canonicalize(&canonical).unwrap()
+        );
+
+        let canonical_body = std::fs::read_to_string(canonical.join("SKILL.md")).unwrap();
+        assert!(canonical_body.contains("# Shared body"));
+        assert_eq!(
+            std::fs::read_to_string(pi_pack.join("SKILL.md")).unwrap(),
+            canonical_body
+        );
+        assert_eq!(
+            std::fs::read_to_string(claude_resolved.join("SKILL.md")).unwrap(),
+            canonical_body
+        );
+        assert!(!expected_digest.is_empty());
     }
 
     #[test]

--- a/packages/app/src/components/chat/__tests__/CommandPopover.test.tsx
+++ b/packages/app/src/components/chat/__tests__/CommandPopover.test.tsx
@@ -1,6 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { CommandPopover } from '../CommandPopover'
+import { SKILLS_CHANGED_EVENT } from '@/hooks/useAppInit'
+import { useWorkspaceRuntimeRefreshStore } from '@/stores/workspace-runtime-refresh'
 
 const mocks = vi.hoisted(() => ({
   runtimeRows: [] as Array<{ runtime_id: string | null; backend_type: string | null; current_model: string | null }>,
@@ -66,6 +68,11 @@ vi.mock('@/lib/teamclu-config', () => ({
 describe('CommandPopover', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    useWorkspaceRuntimeRefreshStore.setState({
+      workspacePath: null,
+      refresh: null,
+      dismissedAt: null,
+    })
     mocks.runtimeRows = []
     mocks.runtimeStates = {}
     mocks.loadRolesSkillsWorkspaceState.mockResolvedValue({
@@ -259,5 +266,63 @@ describe('CommandPopover', () => {
       expect(screen.getByText('chat.commandPopover.skills:1')).toBeInTheDocument()
     })
     expect(screen.getAllByText('accounting-error-investigator')).toHaveLength(1)
+  })
+
+  it('reloads skills once when daemon refresh timestamp changes without noteLocalRefresh', async () => {
+    const noteLocalRefresh = vi.spyOn(
+      useWorkspaceRuntimeRefreshStore.getState(),
+      'noteLocalRefresh',
+    )
+
+    render(
+      <CommandPopover
+        open={true}
+        activeSessionId={null}
+        onOpenChange={vi.fn()}
+        searchQuery=""
+        onSelect={vi.fn()}
+      />,
+    )
+
+    await waitFor(() => {
+      expect(mocks.loadRolesSkillsWorkspaceState).toHaveBeenCalledTimes(1)
+    })
+
+    useWorkspaceRuntimeRefreshStore.setState({
+      refresh: {
+        status: 'pending',
+        change_kinds: ['skills'],
+        recommended_action: 'none',
+        auto_apply_blocked_by_active_runtime: false,
+        last_detected_at: '2026-08-28T07:00:00Z',
+        last_error: null,
+      },
+    })
+
+    await waitFor(() => {
+      expect(mocks.loadRolesSkillsWorkspaceState).toHaveBeenCalledTimes(2)
+    })
+    expect(noteLocalRefresh).not.toHaveBeenCalled()
+  })
+
+  it('reloads skills when SKILLS_CHANGED_EVENT fires from the filesystem path', async () => {
+    render(
+      <CommandPopover
+        open={true}
+        activeSessionId={null}
+        onOpenChange={vi.fn()}
+        searchQuery=""
+        onSelect={vi.fn()}
+      />,
+    )
+
+    await waitFor(() => {
+      expect(mocks.loadRolesSkillsWorkspaceState).toHaveBeenCalledTimes(1)
+    })
+
+    window.dispatchEvent(new CustomEvent(SKILLS_CHANGED_EVENT))
+    await waitFor(() => {
+      expect(mocks.loadRolesSkillsWorkspaceState).toHaveBeenCalledTimes(2)
+    })
   })
 })

--- a/packages/app/src/components/chat/__tests__/command-popover-skills-refresh.test.ts
+++ b/packages/app/src/components/chat/__tests__/command-popover-skills-refresh.test.ts
@@ -1,7 +1,4 @@
-import { describe, expect, it, vi } from 'vitest'
-
-import { SKILLS_CHANGED_EVENT } from '@/hooks/useAppInit'
-import { useWorkspaceRuntimeRefreshStore } from '@/stores/workspace-runtime-refresh'
+import { describe, expect, it } from 'vitest'
 
 import { shouldReloadPickerFromDaemonRefresh } from '../command-popover-skills-refresh'
 
@@ -48,38 +45,5 @@ describe('shouldReloadPickerFromDaemonRefresh', () => {
       null,
     )
     expect(result.reload).toBe(false)
-  })
-})
-
-describe('CommandPopover daemon refresh loop guard', () => {
-  it('does not call noteLocalRefresh when only bumping picker revision from daemon state', () => {
-    const noteLocalRefresh = vi.fn()
-    useWorkspaceRuntimeRefreshStore.setState({
-      refresh: {
-        status: 'pending',
-        change_kinds: ['skills'],
-        recommended_action: 'none',
-        auto_apply_blocked_by_active_runtime: false,
-        last_detected_at: '2026-08-28T06:01:00Z',
-        last_error: null,
-      },
-    })
-
-    const bump = () => {
-      const refresh = useWorkspaceRuntimeRefreshStore.getState().refresh
-      const handledAt = shouldReloadPickerFromDaemonRefresh(refresh, null)
-      expect(handledAt.reload).toBe(true)
-    }
-
-    bump()
-    expect(noteLocalRefresh).not.toHaveBeenCalled()
-  })
-
-  it('still allows filesystem-origin events to request noteLocalRefresh', () => {
-    const noteLocalRefresh = vi.fn()
-    const onFilesystemChange = () => noteLocalRefresh(['skills'])
-    window.dispatchEvent(new CustomEvent(SKILLS_CHANGED_EVENT))
-    onFilesystemChange()
-    expect(noteLocalRefresh).toHaveBeenCalledWith(['skills'])
   })
 })

--- a/packages/app/src/components/chat/tool-calls/TaskToolCard.tsx
+++ b/packages/app/src/components/chat/tool-calls/TaskToolCard.tsx
@@ -32,7 +32,8 @@ export function ManageSkillsToolCard({ toolCall }: { toolCall: ToolCall }) {
     const claudeBlocked =
       parsed?.warnings?.includes("claude_local_override") ||
       parsed?.warnings?.includes("claude_bridge_reconcile_failed");
-    if (!claudeBlocked) {
+    const refreshFailed = parsed?.warnings?.includes("skill_refresh_failed");
+    if (!claudeBlocked && !refreshFailed) {
       footnotes.push(
         t(
           "chat.toolCall.manageSkills.nextStartClaude",
@@ -40,6 +41,14 @@ export function ManageSkillsToolCard({ toolCall }: { toolCall: ToolCall }) {
         ),
       );
     }
+  }
+  if (parsed?.warnings?.includes("skill_refresh_failed")) {
+    footnotes.push(
+      t(
+        "chat.toolCall.manageSkills.skillRefreshFailed",
+        "The skill was saved, but TeamClu inventory refresh did not complete. Retry discovery or refresh the picker — do not create it again.",
+      ),
+    );
   }
   if (parsed?.warnings?.includes("claude_local_override")) {
     footnotes.push(

--- a/packages/app/src/components/chat/tool-calls/__tests__/ManageSkillsToolCard.test.tsx
+++ b/packages/app/src/components/chat/tool-calls/__tests__/ManageSkillsToolCard.test.tsx
@@ -1,0 +1,66 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { ManageSkillsToolCard } from "../TaskToolCard";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (_key: string, fallback?: string) => fallback ?? _key,
+  }),
+}));
+
+describe("ManageSkillsToolCard", () => {
+  it("shows refresh failure footnote without encouraging a second create", () => {
+    render(
+      <ManageSkillsToolCard
+        toolCall={{
+          id: "manage-1",
+          name: "manage_skills",
+          toolKind: "other",
+          status: "completed",
+          arguments: { action: "create", slug: "demo" },
+          result: {
+            slug: "demo",
+            path: "/Users/me/.agents/skills/demo",
+            runtimeActivation: "next_start",
+            warnings: ["skill_refresh_failed"],
+          },
+          startTime: new Date(),
+        }}
+      />,
+    );
+
+    expect(
+      screen.getByText(/inventory refresh did not complete/i),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/Claude Code will also load/i)).not.toBeInTheDocument();
+  });
+
+  it("shows refresh and Claude bridge failures together", () => {
+    render(
+      <ManageSkillsToolCard
+        toolCall={{
+          id: "manage-2",
+          name: "manage_skills",
+          toolKind: "other",
+          status: "completed",
+          arguments: { action: "update", slug: "demo" },
+          result: {
+            slug: "demo",
+            path: "/Users/me/.agents/skills/demo",
+            runtimeActivation: "next_start",
+            warnings: ["skill_refresh_failed", "claude_bridge_reconcile_failed"],
+          },
+          startTime: new Date(),
+        }}
+      />,
+    );
+
+    expect(
+      screen.getByText(/inventory refresh did not complete/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/Claude Code bridge setup did not complete/i),
+    ).toBeInTheDocument();
+  });
+});

--- a/packages/app/src/locales/en.json
+++ b/packages/app/src/locales/en.json
@@ -646,7 +646,8 @@
         "nextStartStorage": "Saved to ~/.agents/skills. New OpenCode and Pi runtimes will pick it up on their next start.",
         "nextStartClaude": "Claude Code will also load this skill on its next start.",
         "claudeLocalOverride": "Claude Code will keep using the workspace-local .claude/skills copy for this slug.",
-        "claudeBridgeReconcileFailed": "Claude Code bridge setup did not complete; Claude may not discover this skill on the next start."
+        "claudeBridgeReconcileFailed": "Claude Code bridge setup did not complete; Claude may not discover this skill on the next start.",
+        "skillRefreshFailed": "The skill was saved, but TeamClu inventory refresh did not complete. Retry discovery or refresh the picker — do not create it again."
       },
       "roleSkill": {
         "title": "Role skill",

--- a/packages/app/src/locales/zh-CN.json
+++ b/packages/app/src/locales/zh-CN.json
@@ -646,7 +646,8 @@
         "nextStartStorage": "已保存至 ~/.agents/skills。新的 OpenCode 与 Pi 运行时将在下次启动时生效。",
         "nextStartClaude": "Claude Code 也将在下次启动时加载此技能。",
         "claudeLocalOverride": "Claude Code 将继续使用工作区内 .claude/skills 下的同名本地副本。",
-        "claudeBridgeReconcileFailed": "Claude Code 桥接未完成；Claude 可能在下次启动时无法发现此技能。"
+        "claudeBridgeReconcileFailed": "Claude Code 桥接未完成；Claude 可能在下次启动时无法发现此技能。",
+        "skillRefreshFailed": "技能已保存，但 TeamClu 清单刷新未完成。请重试发现或刷新选择器，请勿重复创建。"
       },
       "roleSkill": {
         "title": "角色技能",


### PR DESCRIPTION
## Summary

Follow-up to #1119. Addresses re-review findings R1–R4:

- **R1:** Preserve broken user-owned `.claude/skills/<slug>` symlinks; only remove/repair links positively identified as TeamClu-managed.
- **R2:** Surface `skill_refresh_failed` in the manage-skill tool card with guidance to retry discovery instead of re-creating.
- **R3:** Add cross-runtime resolution test (OpenCode `skills.paths`, Pi native `~/.agents/skills`, Claude bridge symlink) after managed create + `prepare_workspace`.
- **R4:** Replace synthetic picker loop tests with real `CommandPopover` wiring tests for daemon refresh and `SKILLS_CHANGED_EVENT`.

Also fixes `resolve_symlink_target` to treat missing symlink targets as broken so team-managed link repair still works.

## Test plan

- [x] `cargo test -p amuxd runtime::claude_skills::tests` (12 passed)
- [x] Vitest: `CommandPopover.test.tsx`, `command-popover-skills-refresh.test.ts`, `ManageSkillsToolCard.test.tsx`


Made with [Cursor](https://cursor.com)