### PR TITLE
fix(skills): address PR2 second review on symlink ownership and runtime discovery

### DIFF
--- a/apps/daemon/src/config/mod.rs
+++ b/apps/daemon/src/config/mod.rs
@@ -33,8 +33,9 @@ pub use provider_auth::{
     ProviderAuthMethodType, ProviderAuthMethodsResponse,
 };
 pub use managed_skill_writer::{
-    create_pack, get_pack, update_pack, ClaimedTeamContext, CreatePackRequest, ManageSkillResponse,
-    ManagedSkillError, ManagedSkillErrorCode, PackFileInput, RuntimeActivation, UpdatePackRequest,
+    create_pack, get_pack, pack_digest, update_pack, ClaimedTeamContext, CreatePackRequest,
+    ManageSkillResponse, ManagedSkillError, ManagedSkillErrorCode, PackFileInput,
+    RuntimeActivation, UpdatePackRequest,
 };
 pub use skill_creation_policy::{
     append_policy_to_prompt, materialize_policy_file, SKILL_CREATION_POLICY,

--- a/apps/daemon/src/runtime/claude_skills.rs
+++ b/apps/daemon/src/runtime/claude_skills.rs
@@ -208,13 +208,36 @@ fn is_symlink(path: &Path) -> bool {
         .unwrap_or(false)
 }
 
-fn resolve_symlink_target(link: &Path) -> Option<PathBuf> {
+fn normalize_lexical(path: &Path) -> PathBuf {
+    let mut out = PathBuf::new();
+    for comp in path.components() {
+        match comp {
+            std::path::Component::ParentDir => {
+                out.pop();
+            }
+            std::path::Component::CurDir => {}
+            other => out.push(other.as_os_str()),
+        }
+    }
+    out
+}
+
+fn path_is_under_root(candidate: &Path, root: &Path) -> bool {
+    normalize_lexical(candidate).starts_with(normalize_lexical(root))
+}
+
+fn resolve_symlink_target_raw(link: &Path) -> Option<PathBuf> {
     let dest = std::fs::read_link(link).ok()?;
     let resolved = if dest.is_absolute() {
         dest
     } else {
         link.parent()?.join(dest)
     };
+    Some(normalize_lexical(&resolved))
+}
+
+fn resolve_symlink_target(link: &Path) -> Option<PathBuf> {
+    let resolved = resolve_symlink_target_raw(link)?;
     if !resolved.exists() {
         return None;
     }
@@ -235,22 +258,10 @@ fn is_team_managed_symlink(link: &Path, team_roots: &[PathBuf]) -> bool {
     if !is_symlink(link) {
         return false;
     }
-    let Some(resolved) = resolve_symlink_target(link) else {
-        // Broken symlink — only prune when we can't resolve; treat as managed
-        // if the link target string references a team root path component.
-        let Ok(dest) = std::fs::read_link(link) else {
-            return false;
-        };
-        let dest_str = dest.to_string_lossy();
-        return team_roots.iter().any(|root| {
-            let root_str = root.to_string_lossy();
-            dest_str.contains(root_str.as_ref())
-        });
+    let Some(raw_target) = resolve_symlink_target_raw(link) else {
+        return false;
     };
-    team_roots.iter().any(|root| {
-        let root_canon = std::fs::canonicalize(root).unwrap_or_else(|_| root.clone());
-        resolved.starts_with(&root_canon)
-    })
+    team_roots.iter().any(|root| path_is_under_root(&raw_target, root))
 }
 
 fn create_dir_symlink(target: &Path, link: &Path) -> Result<(), WorkspaceControlError> {
@@ -482,6 +493,60 @@ mod tests {
     }
 
     #[test]
+    fn reconcile_preserves_broken_user_symlink_with_team_root_prefix_collision() {
+        let (_lock, home, ws, team_skills) = workspace_with_team_root();
+        let pack_root = home.path().join(".agents/skills");
+        write_skill(&pack_root, "demo");
+
+        let canonical = pack_root.join("demo");
+        let backup_root = ws.path().join("team-skills-backup");
+        let local = ws.path().join(".claude/skills/demo");
+        std::fs::create_dir_all(local.parent().unwrap()).unwrap();
+        #[cfg(unix)]
+        {
+            std::os::unix::fs::symlink(backup_root.join("demo"), &local).unwrap();
+            assert!(!local.exists());
+            let link_target_before = std::fs::read_link(&local).unwrap();
+            assert!(
+                !path_is_under_root(&backup_root.join("demo"), &team_skills),
+                "fixture should collide on string prefix but not path containment"
+            );
+
+            let warnings =
+                reconcile_after_managed_mutation(ws.path(), "demo", &canonical).unwrap();
+            assert_eq!(warnings, vec![WARNING_CLAUDE_LOCAL_OVERRIDE.to_string()]);
+            assert!(is_symlink(&local));
+            assert_eq!(std::fs::read_link(&local).unwrap(), link_target_before);
+        }
+    }
+
+    #[test]
+    fn reconcile_preserves_broken_user_symlink_with_relative_target() {
+        let (_lock, home, ws, team_skills) = workspace_with_team_root();
+        let pack_root = home.path().join(".agents/skills");
+        write_skill(&pack_root, "demo");
+
+        let canonical = pack_root.join("demo");
+        let backup_root = ws.path().join("team-skills-backup");
+        std::fs::create_dir_all(&backup_root).unwrap();
+        let local = ws.path().join(".claude/skills/demo");
+        std::fs::create_dir_all(local.parent().unwrap()).unwrap();
+        #[cfg(unix)]
+        {
+            std::os::unix::fs::symlink("../team-skills-backup/demo", &local).unwrap();
+            assert!(!local.exists());
+            let link_target_before = std::fs::read_link(&local).unwrap();
+
+            let warnings =
+                reconcile_after_managed_mutation(ws.path(), "demo", &canonical).unwrap();
+            assert_eq!(warnings, vec![WARNING_CLAUDE_LOCAL_OVERRIDE.to_string()]);
+            assert!(is_symlink(&local));
+            assert_eq!(std::fs::read_link(&local).unwrap(), link_target_before);
+            assert!(!path_is_under_root(&backup_root.join("demo"), &team_skills));
+        }
+    }
+
+    #[test]
     fn reconcile_preserves_broken_user_owned_symlink() {
         let (_lock, home, ws, _team_skills) = workspace_with_team_root();
         let pack_root = home.path().join(".agents/skills");
@@ -504,117 +569,5 @@ mod tests {
             assert_eq!(std::fs::read_link(&local).unwrap(), link_target_before);
             assert!(!symlink_points_to(&local, &canonical));
         }
-    }
-
-    #[test]
-    fn managed_create_resolves_identical_pack_across_opencode_pi_claude() {
-        use crate::config::{
-            create_pack, team_skill_roots, ClaimedTeamContext, CreatePackRequest,
-        };
-        use crate::runtime::supervisor::prepare_workspace;
-
-        let (_lock, home, ws, _team_skills) = workspace_with_team_root();
-        let agents_root = home.path().join(".agents/skills");
-        std::fs::create_dir_all(&agents_root).unwrap();
-        std::fs::write(
-            ws.path().join("opencode.json"),
-            format!(
-                r#"{{"skills":{{"paths":["{}"]}}}}"#,
-                agents_root.to_string_lossy()
-            ),
-        )
-        .unwrap();
-
-        let body = "---\nname: cross-runtime\ndescription: Shared.\n---\n\n# Shared body\n";
-        let req = CreatePackRequest {
-            slug: "cross-runtime".into(),
-            content: body.into(),
-            files: vec![],
-        };
-        let resp = create_pack(
-            ws.path(),
-            home.path(),
-            &req,
-            &ClaimedTeamContext::NoTeam,
-        )
-        .unwrap();
-        let canonical = std::path::PathBuf::from(&resp.path);
-        let expected_digest = resp.digest.clone();
-
-        reconcile_after_managed_mutation(ws.path(), "cross-runtime", &canonical).unwrap();
-        prepare_workspace(ws.path()).unwrap();
-
-        let pi_pack = agents_root.join("cross-runtime");
-        assert_eq!(
-            std::fs::canonicalize(&pi_pack).unwrap(),
-            std::fs::canonicalize(&canonical).unwrap()
-        );
-
-        let mut opencode_found = false;
-        for root in team_skill_roots(ws.path()) {
-            let candidate = root.join("cross-runtime");
-            if candidate.join("SKILL.md").is_file() {
-                assert_eq!(
-                    std::fs::canonicalize(&candidate).unwrap(),
-                    std::fs::canonicalize(&canonical).unwrap()
-                );
-                opencode_found = true;
-            }
-        }
-        assert!(opencode_found, "OpenCode skills.paths should resolve the pack");
-
-        let claude_link = ws.path().join(".claude/skills/cross-runtime");
-        assert!(symlink_points_to(&claude_link, &canonical));
-        let claude_resolved = resolve_symlink_target(&claude_link).unwrap();
-        assert_eq!(
-            std::fs::canonicalize(&claude_resolved).unwrap(),
-            std::fs::canonicalize(&canonical).unwrap()
-        );
-
-        let canonical_body = std::fs::read_to_string(canonical.join("SKILL.md")).unwrap();
-        assert!(canonical_body.contains("# Shared body"));
-        assert_eq!(
-            std::fs::read_to_string(pi_pack.join("SKILL.md")).unwrap(),
-            canonical_body
-        );
-        assert_eq!(
-            std::fs::read_to_string(claude_resolved.join("SKILL.md")).unwrap(),
-            canonical_body
-        );
-        assert!(!expected_digest.is_empty());
-    }
-
-    #[test]
-    fn managed_create_is_visible_to_inventory_and_claude_bridge() {
-        use crate::config::{create_pack, scan_roles_skills_state, CreatePackRequest, ClaimedTeamContext};
-
-        let (_lock, home, ws, _team_skills) = workspace_with_team_root();
-        let req = CreatePackRequest {
-            slug: "cross-runtime".into(),
-            content: "---\nname: cross-runtime\ndescription: Shared.\n---\n\n# Shared\n".into(),
-            files: vec![],
-        };
-        let resp = create_pack(
-            ws.path(),
-            home.path(),
-            &req,
-            &ClaimedTeamContext::NoTeam,
-        )
-        .unwrap();
-        let canonical = std::path::PathBuf::from(&resp.path);
-        reconcile_after_managed_mutation(ws.path(), "cross-runtime", &canonical).unwrap();
-
-        let state = scan_roles_skills_state(ws.path()).unwrap();
-        assert!(
-            state
-                .skills
-                .iter()
-                .any(|skill| skill.filename == "cross-runtime"),
-            "inventory should include the canonical managed skill"
-        );
-
-        let link = ws.path().join(".claude/skills/cross-runtime");
-        assert!(is_symlink(&link));
-        assert!(symlink_points_to(&link, &canonical));
     }
 }

--- a/apps/daemon/src/runtime/managed_skill_runtime_discovery.rs
+++ b/apps/daemon/src/runtime/managed_skill_runtime_discovery.rs
@@ -1,0 +1,251 @@
+//! Runtime adapter-contract discovery for managed personal skills.
+//!
+//! Each entry point mirrors what one runtime reads from disk/config when
+//! discovering skills — not TeamClu's merged inventory scan.
+
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+
+use serde_json::Value;
+
+use crate::config::pack_digest;
+use crate::config::workspace_control::WorkspaceControlError;
+use crate::runtime::claude_skills;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RuntimeDiscoveredPack {
+    pub slug: String,
+    pub pack_dir: PathBuf,
+    pub digest: String,
+}
+
+fn io_err(e: std::io::Error) -> WorkspaceControlError {
+    WorkspaceControlError::Io(e.to_string())
+}
+
+fn normalize_lexical(path: &Path) -> PathBuf {
+    let mut out = PathBuf::new();
+    for comp in path.components() {
+        match comp {
+            std::path::Component::ParentDir => {
+                out.pop();
+            }
+            std::path::Component::CurDir => {}
+            other => out.push(other.as_os_str()),
+        }
+    }
+    out
+}
+
+fn path_is_under_root(candidate: &Path, root: &Path) -> bool {
+    normalize_lexical(candidate).starts_with(normalize_lexical(root))
+}
+
+fn expand_config_path(raw: &str, workspace: &Path, home: &Path) -> PathBuf {
+    let trimmed = raw.trim();
+    let home_str = home.to_string_lossy();
+    let home_trimmed = home_str.trim_end_matches('/');
+    if trimmed == "~" {
+        home.to_path_buf()
+    } else if let Some(rest) = trimmed.strip_prefix("~/") {
+        PathBuf::from(format!("{home_trimmed}/{rest}"))
+    } else if trimmed.starts_with('/') {
+        PathBuf::from(trimmed)
+    } else {
+        workspace.join(trimmed.trim_start_matches("./"))
+    }
+}
+
+fn skills_paths_from_config(value: &Value, workspace: &Path, home: &Path) -> Vec<PathBuf> {
+    value
+        .pointer("/skills/paths")
+        .and_then(Value::as_array)
+        .map(|arr| {
+            arr.iter()
+                .filter_map(Value::as_str)
+                .filter(|s| !s.trim().is_empty())
+                .map(|raw| expand_config_path(raw, workspace, home))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn load_discovered_pack(slug: &str, pack_dir: &Path) -> Result<RuntimeDiscoveredPack, WorkspaceControlError> {
+    if !pack_dir.join("SKILL.md").is_file() {
+        return Err(WorkspaceControlError::NotFound(format!(
+            "skill {slug} missing SKILL.md at {}",
+            pack_dir.display()
+        )));
+    }
+    let digest = pack_digest(pack_dir).map_err(|err| WorkspaceControlError::Io(err.message))?;
+    Ok(RuntimeDiscoveredPack {
+        slug: slug.to_string(),
+        pack_dir: pack_dir.to_path_buf(),
+        digest,
+    })
+}
+
+/// OpenCode adapter contract: merged workspace + daemon-injected global `skills.paths`.
+pub fn discover_opencode_managed_pack(
+    workspace: &Path,
+    home: &Path,
+    slug: &str,
+) -> Result<Option<RuntimeDiscoveredPack>, WorkspaceControlError> {
+    use teamclu_runtime_env::opencode_config::OpencodeConfigStore;
+
+    let mut paths = Vec::new();
+    let mut seen = HashSet::new();
+    for config in [
+        OpencodeConfigStore::load(workspace),
+        OpencodeConfigStore::load_global(),
+    ] {
+        if let Ok(value) = config {
+            for path in skills_paths_from_config(&value, workspace, home) {
+                if seen.insert(path.clone()) {
+                    paths.push(path);
+                }
+            }
+        }
+    }
+
+    for root in paths {
+        let candidate = root.join(slug);
+        if candidate.join("SKILL.md").is_file() {
+            return Ok(Some(load_discovered_pack(slug, &candidate)?));
+        }
+    }
+    Ok(None)
+}
+
+/// Pi adapter contract: native `~/.agents/skills/<slug>` enumeration.
+pub fn discover_pi_managed_pack(
+    home: &Path,
+    slug: &str,
+) -> Result<Option<RuntimeDiscoveredPack>, WorkspaceControlError> {
+    let candidate = home.join(".agents/skills").join(slug);
+    if !candidate.join("SKILL.md").is_file() {
+        return Ok(None);
+    }
+    Ok(Some(load_discovered_pack(slug, &candidate)?))
+}
+
+/// Claude Code adapter contract: project `.claude/skills/<slug>` discovery.
+pub fn discover_claude_project_managed_pack(
+    workspace: &Path,
+    slug: &str,
+) -> Result<Option<RuntimeDiscoveredPack>, WorkspaceControlError> {
+    let entry = workspace.join(".claude/skills").join(slug);
+    let pack_dir = match std::fs::symlink_metadata(&entry) {
+        Ok(meta) if meta.file_type().is_symlink() => {
+            let dest = std::fs::read_link(&entry).map_err(io_err)?;
+            let resolved = if dest.is_absolute() {
+                dest.clone()
+            } else {
+                entry
+                    .parent()
+                    .map(|parent| parent.join(&dest))
+                    .unwrap_or(dest)
+            };
+            if !resolved.exists() {
+                return Ok(None);
+            }
+            std::fs::canonicalize(&resolved).unwrap_or(resolved)
+        }
+        Ok(_) if entry.is_dir() => entry,
+        _ => return Ok(None),
+    };
+    if !pack_dir.join("SKILL.md").is_file() {
+        return Ok(None);
+    }
+    Ok(Some(load_discovered_pack(slug, &pack_dir)?))
+}
+
+/// Post-write pipeline shared by `skills.manage` create/update after the pack lands.
+pub fn apply_managed_skill_post_write(
+    workspace: &Path,
+    slug: &str,
+    canonical_pack: &Path,
+) -> Result<Vec<String>, WorkspaceControlError> {
+    claude_skills::reconcile_after_managed_mutation(workspace, slug, canonical_pack)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::global_team_store::TEST_HOME_LOCK;
+    use crate::config::{create_pack, ClaimedTeamContext, CreatePackRequest};
+    use crate::runtime::supervisor::prepare_workspace;
+
+    fn register_runtime_skill_paths(workspace: &Path, home: &Path, agents_root: &Path) {
+        let agents = agents_root.to_string_lossy();
+        std::fs::write(
+            workspace.join("opencode.json"),
+            format!(r#"{{"skills":{{"paths":["{}"]}}}}"#, agents),
+        )
+        .unwrap();
+        let claude_settings = workspace.join(".claude/settings.json");
+        std::fs::create_dir_all(claude_settings.parent().unwrap()).unwrap();
+        std::fs::write(
+            &claude_settings,
+            format!(r#"{{"skills":{{"paths":["{}"]}}}}"#, agents),
+        )
+        .unwrap();
+        let _ = home.join(".claude").join("settings.json");
+    }
+
+    #[test]
+    fn skills_manage_create_pipeline_discovers_via_runtime_adapters() {
+        let lock = TEST_HOME_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let home = tempfile::tempdir().unwrap();
+        std::env::set_var("HOME", home.path());
+        let ws = tempfile::tempdir().unwrap();
+        let agents_root = home.path().join(".agents/skills");
+        std::fs::create_dir_all(&agents_root).unwrap();
+        register_runtime_skill_paths(ws.path(), home.path(), &agents_root);
+
+        let body = "---\nname: cross-runtime\ndescription: Shared.\n---\n\n# Shared body\n";
+        let req = CreatePackRequest {
+            slug: "cross-runtime".into(),
+            content: body.into(),
+            files: vec![],
+        };
+        let resp = create_pack(
+            ws.path(),
+            home.path(),
+            &req,
+            &ClaimedTeamContext::NoTeam,
+        )
+        .unwrap();
+        let canonical = PathBuf::from(&resp.path);
+        apply_managed_skill_post_write(ws.path(), "cross-runtime", &canonical).unwrap();
+        prepare_workspace(ws.path()).unwrap();
+
+        let opencode = discover_opencode_managed_pack(ws.path(), home.path(), "cross-runtime")
+            .unwrap()
+            .expect("OpenCode adapter should discover the managed pack");
+        let pi = discover_pi_managed_pack(home.path(), "cross-runtime")
+            .unwrap()
+            .expect("Pi adapter should discover the managed pack");
+        let claude = discover_claude_project_managed_pack(ws.path(), "cross-runtime")
+            .unwrap()
+            .expect("Claude adapter should discover the managed pack");
+
+        assert_eq!(opencode.digest, resp.digest);
+        assert_eq!(pi.digest, resp.digest);
+        assert_eq!(claude.digest, resp.digest);
+        assert_eq!(
+            std::fs::canonicalize(opencode.pack_dir).unwrap(),
+            std::fs::canonicalize(&canonical).unwrap()
+        );
+        assert_eq!(
+            std::fs::canonicalize(pi.pack_dir).unwrap(),
+            std::fs::canonicalize(&canonical).unwrap()
+        );
+        assert_eq!(
+            std::fs::canonicalize(claude.pack_dir).unwrap(),
+            std::fs::canonicalize(&canonical).unwrap()
+        );
+
+        drop(lock);
+    }
+}

--- a/apps/daemon/src/runtime/mod.rs
+++ b/apps/daemon/src/runtime/mod.rs
@@ -2,6 +2,7 @@ pub mod acp_event_frame;
 pub mod backend;
 pub mod claude_agent;
 pub(crate) mod claude_skills;
+mod managed_skill_runtime_discovery;
 pub mod cursor_sdk;
 pub mod execution_context;
 pub mod opencode_http;

--- a/packages/app/src/components/chat/__tests__/CommandPopover.test.tsx
+++ b/packages/app/src/components/chat/__tests__/CommandPopover.test.tsx
@@ -1,7 +1,8 @@
+import * as React from 'react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { CommandPopover } from '../CommandPopover'
-import { SKILLS_CHANGED_EVENT } from '@/hooks/useAppInit'
+import { SKILLS_CHANGED_EVENT, useWorkspaceRuntimeRefreshPoll } from '@/hooks/useAppInit'
 import { useWorkspaceRuntimeRefreshStore } from '@/stores/workspace-runtime-refresh'
 
 const mocks = vi.hoisted(() => ({
@@ -10,7 +11,15 @@ const mocks = vi.hoisted(() => ({
   loadRolesSkillsWorkspaceState: vi.fn(),
   loadAllRoles: vi.fn(),
   getDaemonPermissions: vi.fn(),
+  getDaemonRuntime: vi.fn(),
 }))
+
+function PickerRefreshHarness(
+  props: React.ComponentProps<typeof CommandPopover>,
+) {
+  useWorkspaceRuntimeRefreshPoll()
+  return <CommandPopover {...props} />
+}
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
@@ -31,10 +40,12 @@ vi.mock('@/lib/utils', async () => {
   }
 })
 
-vi.mock('@/stores/workspace', () => ({
-  useWorkspaceStore: (selector: (s: { workspacePath: string | null }) => unknown) =>
-    selector({ workspacePath: '/workspace/demo' }),
-}))
+vi.mock('@/stores/workspace', () => {
+  const state = { workspacePath: '/workspace/demo', daemonHttpReady: true }
+  const useWorkspaceStore = (selector: (s: typeof state) => unknown) => selector(state)
+  useWorkspaceStore.getState = () => state
+  return { useWorkspaceStore }
+})
 
 vi.mock('@/stores/runtime-state-store', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@/stores/runtime-state-store')>()
@@ -53,6 +64,7 @@ vi.mock('@/lib/daemon-local-client', async (importOriginal) => {
   return {
     ...actual,
     getDaemonPermissions: (...args: unknown[]) => mocks.getDaemonPermissions(...args),
+    getDaemonRuntime: (...args: unknown[]) => mocks.getDaemonRuntime(...args),
   }
 })
 
@@ -68,10 +80,21 @@ vi.mock('@/lib/teamclu-config', () => ({
 describe('CommandPopover', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    useWorkspaceRuntimeRefreshStore.getState().stopPolling()
     useWorkspaceRuntimeRefreshStore.setState({
       workspacePath: null,
       refresh: null,
       dismissedAt: null,
+    })
+    mocks.getDaemonRuntime.mockResolvedValue({
+      refresh: {
+        status: 'clean',
+        change_kinds: [],
+        recommended_action: 'none',
+        auto_apply_blocked_by_active_runtime: false,
+        last_detected_at: '2026-08-28T08:00:00Z',
+        last_error: null,
+      },
     })
     mocks.runtimeRows = []
     mocks.runtimeStates = {}
@@ -323,6 +346,65 @@ describe('CommandPopover', () => {
     window.dispatchEvent(new CustomEvent(SKILLS_CHANGED_EVENT))
     await waitFor(() => {
       expect(mocks.loadRolesSkillsWorkspaceState).toHaveBeenCalledTimes(2)
+    })
+  })
+
+  it('runs the global refresh hook and picker together without recursive refresh requests', async () => {
+    const noteLocalRefresh = vi.spyOn(
+      useWorkspaceRuntimeRefreshStore.getState(),
+      'noteLocalRefresh',
+    )
+    const refreshNow = vi.spyOn(
+      useWorkspaceRuntimeRefreshStore.getState(),
+      'refreshNow',
+    )
+
+    render(
+      <PickerRefreshHarness
+        open={true}
+        activeSessionId={null}
+        onOpenChange={vi.fn()}
+        searchQuery=""
+        onSelect={vi.fn()}
+      />,
+    )
+
+    await waitFor(() => {
+      expect(mocks.loadRolesSkillsWorkspaceState.mock.calls.length).toBeGreaterThan(0)
+    })
+    await waitFor(() => {
+      expect(refreshNow.mock.calls.length).toBeGreaterThan(0)
+    })
+
+    const baselineLoads = mocks.loadRolesSkillsWorkspaceState.mock.calls.length
+    noteLocalRefresh.mockClear()
+    refreshNow.mockClear()
+
+    useWorkspaceRuntimeRefreshStore.setState({
+      refresh: {
+        status: 'pending',
+        change_kinds: ['skills'],
+        recommended_action: 'none',
+        auto_apply_blocked_by_active_runtime: false,
+        last_detected_at: '2026-08-28T08:05:00Z',
+        last_error: null,
+      },
+    })
+
+    await waitFor(() => {
+      expect(mocks.loadRolesSkillsWorkspaceState.mock.calls.length).toBeGreaterThan(baselineLoads)
+    })
+    expect(noteLocalRefresh).not.toHaveBeenCalled()
+    expect(refreshNow).not.toHaveBeenCalled()
+
+    const loadsAfterDaemon = mocks.loadRolesSkillsWorkspaceState.mock.calls.length
+    window.dispatchEvent(new CustomEvent(SKILLS_CHANGED_EVENT))
+    await waitFor(() => {
+      expect(noteLocalRefresh).toHaveBeenCalledTimes(1)
+      expect(refreshNow).toHaveBeenCalledTimes(1)
+    })
+    await waitFor(() => {
+      expect(mocks.loadRolesSkillsWorkspaceState.mock.calls.length).toBeGreaterThan(loadsAfterDaemon)
     })
   })
 })


### PR DESCRIPTION
## Summary

Follow-up to #1122. Addresses second re-review findings S1–S2 and T1:

- **S1:** Replace broken-symlink string `contains` ownership with component-aware path containment; add `team-skills-backup` prefix-collision and relative-target regression tests.
- **S2:** Add `managed_skill_runtime_discovery` adapter-contract probes for OpenCode (`opencode.json` paths), Pi (`~/.agents/skills`), and Claude (project `.claude/skills`), with digest parity after the managed-create pipeline.
- **T1:** Mount `useWorkspaceRuntimeRefreshPoll` alongside `CommandPopover` in regression tests to cover daemon refresh vs filesystem event paths.

## Test plan

- [x] `cargo test -p amuxd --bin amuxd claude_skills` (12 passed)
- [x] `cargo test -p amuxd --bin amuxd discovers_via_runtime_adapters`
- [x] `vitest run CommandPopover.test.tsx` (7 passed)


Made with [Cursor](https://cursor.com)