### PR TITLE
feat(skills): turn-scoped native directory fallback guard (PR3)

### DIFF
--- a/apps/daemon/src/daemon/server/messaging.rs
+++ b/apps/daemon/src/daemon/server/messaging.rs
@@ -339,11 +339,20 @@ impl DaemonServer {
         if let Some(amux::acp_event::Event::StatusChange(ref sc)) = acp_event.event {
             let became_idle = sc.old_status == amux::AgentStatus::Active as i32
                 && sc.new_status == amux::AgentStatus::Idle as i32;
+            let turn_opened = sc.old_status == amux::AgentStatus::Idle as i32
+                && sc.new_status == amux::AgentStatus::Active as i32;
             {
                 let mut agents = self.agents.lock().await;
                 if let Some(handle) = agents.get_handle_mut(agent_id) {
                     handle.status = amux::AgentStatus::try_from(sc.new_status)
                         .unwrap_or(amux::AgentStatus::Unknown);
+                    if turn_opened && crate::runtime::guard_enabled() {
+                        handle.native_skill_baseline = Some(
+                            crate::runtime::snapshot_baseline(std::path::Path::new(
+                                &handle.worktree,
+                            )),
+                        );
+                    }
                 }
             }
             self.publish_runtime_state_by_id(agent_id).await;
@@ -384,7 +393,7 @@ impl DaemonServer {
         // emitted messages (cloud `messages.sequence`). The envelope
         // append below uses the same value, keeping a 1:1 link between an
         // ACP event boundary and the messages that flowed from it.
-        let (emitted, turn_id, seq, reply_to_message_id, clear_reply_to) = {
+        let (mut emitted, turn_id, seq, reply_to_message_id, clear_reply_to) = {
             let mut agents = self.agents.lock().await;
             let seq = agents
                 .get_handle_mut(agent_id)
@@ -400,30 +409,43 @@ impl DaemonServer {
                     if sc.old_status == amux::AgentStatus::Active as i32
                         && sc.new_status == amux::AgentStatus::Idle as i32
             );
-            match agents.aggregator_mut(agent_id) {
-                Some(agg) if !is_child_event => {
-                    let emitted = agg.ingest(&acp_event);
-                    let turn_id = agg.current_turn_id().unwrap_or("").to_string();
-                    (emitted, turn_id, seq, reply_to_message_id, clear_reply_to)
+            let turn_id_before = agents
+                .aggregator(agent_id)
+                .and_then(|a| a.current_turn_id())
+                .map(str::to_string);
+            let mut emitted = match agents.aggregator_mut(agent_id) {
+                Some(agg) if !is_child_event => agg.ingest(&acp_event),
+                _ => Vec::new(),
+            };
+            if clear_reply_to {
+                if let Some(handle) = agents.get_handle_mut(agent_id) {
+                    if let Some(baseline) = handle.native_skill_baseline.take() {
+                        let violations = crate::runtime::violations_after_turn(
+                            &baseline,
+                            std::path::Path::new(&handle.worktree),
+                        );
+                        if !violations.is_empty() {
+                            tracing::warn!(
+                                agent_id = %agent_id,
+                                workspace = %handle.worktree,
+                                count = violations.len(),
+                                slugs = ?violations.iter().map(|v| v.slug.as_str()).collect::<Vec<_>>(),
+                                "native skill written to unsupported directory during turn"
+                            );
+                            emitted.push(crate::runtime::turn_aggregator::EmittedMessage {
+                                kind: crate::proto::teamclu::MessageKind::AgentReply,
+                                content: crate::runtime::AGENT_REPLY_CONTENT.to_string(),
+                                metadata_json: crate::runtime::AGENT_REPLY_METADATA_JSON
+                                    .to_string(),
+                                turn_id: turn_id_before.clone().unwrap_or_default(),
+                                cloud_persist: true,
+                            });
+                        }
+                    }
                 }
-                Some(agg) => {
-                    let turn_id = agg.current_turn_id().unwrap_or("").to_string();
-                    (
-                        Vec::new(),
-                        turn_id,
-                        seq,
-                        reply_to_message_id,
-                        clear_reply_to,
-                    )
-                }
-                None => (
-                    Vec::new(),
-                    String::new(),
-                    seq,
-                    reply_to_message_id,
-                    clear_reply_to,
-                ),
             }
+            let turn_id = turn_id_before.unwrap_or_default();
+            (emitted, turn_id, seq, reply_to_message_id, clear_reply_to)
         };
         if !collab_sessions.is_empty() && !emitted.is_empty() {
             if let Some(tc) = self.teamclu.as_ref() {

--- a/apps/daemon/src/runtime/claude_skills.rs
+++ b/apps/daemon/src/runtime/claude_skills.rs
@@ -50,6 +50,11 @@ fn claude_bridge_points_to_canonical(
     symlink_points_to(&link, canonical_pack)
 }
 
+/// Whether `.claude/skills/<slug>` is a team-bridge symlink (daemon-managed).
+pub fn is_claude_team_bridge_symlink(link: &Path, workspace_path: &Path) -> bool {
+    is_team_managed_symlink(link, &team_skill_roots(workspace_path))
+}
+
 /// After a managed personal skill mutation, refresh Claude bridge links and report
 /// whether a workspace-local pack still wins for Claude Code.
 pub fn reconcile_after_managed_mutation(

--- a/apps/daemon/src/runtime/handle.rs
+++ b/apps/daemon/src/runtime/handle.rs
@@ -111,6 +111,8 @@ pub struct RuntimeHandle {
     /// Another session on the shared OpenCode host may have dropped MCP; refresh
     /// on the next Idle transition (never detach/resume while Active).
     pub remote_tools_mcp_refresh_pending: bool,
+    /// Forbidden native skill slugs present when the current turn opened.
+    pub native_skill_baseline: Option<crate::runtime::NativeSkillBaseline>,
 }
 
 impl RuntimeHandle {
@@ -165,6 +167,7 @@ impl RuntimeHandle {
             env_snapshot: None,
             env_team_id: None,
             remote_tools_mcp_refresh_pending: false,
+            native_skill_baseline: None,
         }
     }
 
@@ -445,6 +448,7 @@ impl RuntimeHandle {
             env_snapshot: None,
             env_team_id: None,
             remote_tools_mcp_refresh_pending: false,
+            native_skill_baseline: None,
         }
     }
 }

--- a/apps/daemon/src/runtime/mod.rs
+++ b/apps/daemon/src/runtime/mod.rs
@@ -19,6 +19,11 @@ mod handle;
 mod instruction_delivery;
 pub mod managed_llm;
 mod manager;
+mod native_skill_fallback_guard;
+pub(crate) use native_skill_fallback_guard::{
+    guard_enabled, snapshot_baseline, violations_after_turn, AGENT_REPLY_CONTENT,
+    AGENT_REPLY_METADATA_JSON, NativeSkillBaseline,
+};
 pub mod permission_policy;
 pub mod prompt_attachments;
 pub mod refresh;

--- a/apps/daemon/src/runtime/native_skill_fallback_guard.rs
+++ b/apps/daemon/src/runtime/native_skill_fallback_guard.rs
@@ -1,0 +1,280 @@
+//! Turn-scoped detection when agents write skill packs to native runtime dirs
+//! instead of `manage_skills` → `~/.agents/skills/<slug>/`.
+//!
+//! PR3 ships **fail-closed detect** only: violations surface on turn end and
+//! instruct the agent to recreate via `manage_skills`. Auto-adoption is gated
+//! behind `TEAMCLU_NATIVE_SKILL_AUTO_ADOPTION` (default off).
+
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+
+use crate::runtime::claude_skills;
+
+pub const ERROR_CODE: &str = "skill_created_in_unsupported_directory";
+
+pub const AGENT_REPLY_CONTENT: &str = "\
+[Skill created in unsupported directory] A skill pack was written under a native \
+agent directory (.opencode/skills, .pi/skills, or .claude/skills) instead of \
+through manage_skills. The native copy was not adopted. Remove it and recreate \
+the skill with manage_skills action=create so it lands in ~/.agents/skills/<slug>/.";
+
+pub const AGENT_REPLY_METADATA_JSON: &str =
+    r#"{"turn_status":"skill_created_in_unsupported_directory"}"#;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+enum NativeRootKind {
+    Opencode,
+    Pi,
+    Claude,
+}
+
+impl NativeRootKind {
+    fn rel_dir(self) -> &'static str {
+        match self {
+            Self::Opencode => ".opencode/skills",
+            Self::Pi => ".pi/skills",
+            Self::Claude => ".claude/skills",
+        }
+    }
+
+    fn label(self) -> &'static str {
+        match self {
+            Self::Opencode => ".opencode/skills",
+            Self::Pi => ".pi/skills",
+            Self::Claude => ".claude/skills",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct NativeSkillKey {
+    root: NativeRootKind,
+    slug: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NativeSkillViolation {
+    pub root_label: &'static str,
+    pub slug: String,
+    pub path: PathBuf,
+}
+
+/// Snapshot of valid native-root skill slugs at turn start.
+#[derive(Debug, Clone, Default)]
+pub struct NativeSkillBaseline {
+    entries: HashSet<NativeSkillKey>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GuardMode {
+    Off,
+    Detect,
+}
+
+pub fn guard_mode() -> GuardMode {
+    match std::env::var("TEAMCLU_NATIVE_SKILL_FALLBACK_GUARD")
+        .ok()
+        .map(|v| v.trim().to_ascii_lowercase())
+        .as_deref()
+    {
+        None | Some("") | Some("detect") | Some("1") | Some("true") | Some("on") => {
+            GuardMode::Detect
+        }
+        Some("off") | Some("0") | Some("false") => GuardMode::Off,
+        _ => GuardMode::Detect,
+    }
+}
+
+pub fn guard_enabled() -> bool {
+    matches!(guard_mode(), GuardMode::Detect)
+}
+
+pub fn auto_adoption_enabled() -> bool {
+    matches!(
+        std::env::var("TEAMCLU_NATIVE_SKILL_AUTO_ADOPTION")
+            .ok()
+            .map(|v| v.trim().to_ascii_lowercase())
+            .as_deref(),
+        Some("1") | Some("true") | Some("on")
+    )
+}
+
+pub fn snapshot_baseline(workspace: &Path) -> NativeSkillBaseline {
+    NativeSkillBaseline {
+        entries: scan_native_skills(workspace),
+    }
+}
+
+pub fn violations_after_turn(
+    baseline: &NativeSkillBaseline,
+    workspace: &Path,
+) -> Vec<NativeSkillViolation> {
+    if !guard_enabled() || auto_adoption_enabled() {
+        return Vec::new();
+    }
+    let current = scan_native_skills(workspace);
+    current
+        .difference(&baseline.entries)
+        .map(|key| NativeSkillViolation {
+            root_label: key.root.label(),
+            slug: key.slug.clone(),
+            path: workspace.join(key.root.rel_dir()).join(&key.slug),
+        })
+        .collect()
+}
+
+fn forbidden_roots(workspace: &Path) -> [(NativeRootKind, PathBuf); 3] {
+    [
+        (
+            NativeRootKind::Opencode,
+            workspace.join(NativeRootKind::Opencode.rel_dir()),
+        ),
+        (
+            NativeRootKind::Pi,
+            workspace.join(NativeRootKind::Pi.rel_dir()),
+        ),
+        (
+            NativeRootKind::Claude,
+            workspace.join(NativeRootKind::Claude.rel_dir()),
+        ),
+    ]
+}
+
+fn scan_native_skills(workspace: &Path) -> HashSet<NativeSkillKey> {
+    let mut out = HashSet::new();
+    for (root, dir) in forbidden_roots(workspace) {
+        let Ok(read_dir) = std::fs::read_dir(&dir) else {
+            continue;
+        };
+        for entry in read_dir.flatten() {
+            let path = entry.path();
+            let Some(slug) = entry.file_name().to_str().map(str::to_string) else {
+                continue;
+            };
+            if slug.starts_with('.') {
+                continue;
+            }
+            if is_valid_native_skill_pack(&path, workspace, root) {
+                out.insert(NativeSkillKey { root, slug });
+            }
+        }
+    }
+    out
+}
+
+fn is_valid_native_skill_pack(path: &Path, workspace: &Path, root: NativeRootKind) -> bool {
+    let skill_md = path.join("SKILL.md");
+    if !skill_md.is_file() {
+        return false;
+    }
+    match std::fs::symlink_metadata(path) {
+        Ok(meta) if meta.file_type().is_symlink() => match root {
+            NativeRootKind::Claude => {
+                !claude_skills::is_claude_team_bridge_symlink(path, workspace)
+            }
+            _ => false,
+        },
+        Ok(meta) if meta.is_dir() => true,
+        Ok(meta) if meta.is_file() => root == NativeRootKind::Claude,
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{create_pack, ClaimedTeamContext, CreatePackRequest};
+    use crate::runtime::claude_skills::reconcile_after_managed_mutation;
+
+    fn write_native_pack(root: &Path, slug: &str, body: &str) {
+        let dir = root.join(slug);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("SKILL.md"), body).unwrap();
+    }
+
+    #[test]
+    fn detects_new_opencode_native_skill_after_turn() {
+        let _guard = crate::test_brand_env::BrandEnvGuard::set("teamclu");
+        let ws = tempfile::tempdir().unwrap();
+        let baseline = snapshot_baseline(ws.path());
+        write_native_pack(
+            &ws.path().join(".opencode/skills"),
+            "native-demo",
+            "---\nname: native-demo\ndescription: Native.\n---\n",
+        );
+        let violations = violations_after_turn(&baseline, ws.path());
+        assert_eq!(violations.len(), 1);
+        assert_eq!(violations[0].slug, "native-demo");
+        assert_eq!(violations[0].root_label, ".opencode/skills");
+    }
+
+    #[test]
+    fn baseline_skips_preexisting_native_skill() {
+        let _guard = crate::test_brand_env::BrandEnvGuard::set("teamclu");
+        let ws = tempfile::tempdir().unwrap();
+        write_native_pack(
+            &ws.path().join(".pi/skills"),
+            "legacy",
+            "---\nname: legacy\ndescription: Old.\n---\n",
+        );
+        let baseline = snapshot_baseline(ws.path());
+        let violations = violations_after_turn(&baseline, ws.path());
+        assert!(violations.is_empty());
+    }
+
+    #[test]
+    fn claude_bridge_symlink_from_manage_skills_is_not_a_violation() {
+        let lock = crate::config::global_team_store::TEST_HOME_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let home = tempfile::tempdir().unwrap();
+        std::env::set_var("HOME", home.path());
+        let ws = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(home.path().join(".agents/skills")).unwrap();
+        std::fs::write(
+            ws.path().join("opencode.json"),
+            format!(
+                r#"{{"skills":{{"paths":["{}"]}}}}"#,
+                home.path().join(".agents/skills").display()
+            ),
+        )
+        .unwrap();
+
+        let baseline = snapshot_baseline(ws.path());
+        let resp = create_pack(
+            ws.path(),
+            home.path(),
+            &CreatePackRequest {
+                slug: "bridged".into(),
+                content: "---\nname: bridged\ndescription: Bridged.\n---\n".into(),
+                files: vec![],
+            },
+            &ClaimedTeamContext::NoTeam,
+        )
+        .unwrap();
+        reconcile_after_managed_mutation(ws.path(), "bridged", Path::new(&resp.path)).unwrap();
+
+        let violations = violations_after_turn(&baseline, ws.path());
+        assert!(
+            violations.is_empty(),
+            "bridge symlink should not count as unsupported native write: {violations:?}"
+        );
+        drop(lock);
+    }
+
+    #[test]
+    fn guard_respects_off_flag() {
+        let _guard = crate::test_brand_env::BrandEnvGuard::set("teamclu");
+        std::env::set_var("TEAMCLU_NATIVE_SKILL_FALLBACK_GUARD", "off");
+        let ws = tempfile::tempdir().unwrap();
+        let baseline = snapshot_baseline(ws.path());
+        write_native_pack(
+            &ws.path().join(".opencode/skills"),
+            "ignored",
+            "---\nname: ignored\ndescription: Ignored.\n---\n",
+        );
+        let violations = violations_after_turn(&baseline, ws.path());
+        assert!(violations.is_empty());
+        std::env::remove_var("TEAMCLU_NATIVE_SKILL_FALLBACK_GUARD");
+    }
+}

--- a/apps/daemon/src/runtime/refresh_watch.rs
+++ b/apps/daemon/src/runtime/refresh_watch.rs
@@ -186,6 +186,8 @@ pub fn classify_change_path(
         {
             Some(RefreshChangeKind::EnvVars)
         } else if path.starts_with(workspace.workspace_path.join(".claude/skills"))
+            || path.starts_with(workspace.workspace_path.join(".opencode/skills"))
+            || path.starts_with(workspace.workspace_path.join(".pi/skills"))
             || path.starts_with(workspace.workspace_path.join(".agents/skills"))
             || is_team_skills_path(path, &workspace.workspace_path)
             || is_global_skill_path
@@ -238,6 +240,14 @@ fn watch_roots(workspaces: &[WatchedWorkspace], home: Option<&Path>) -> Vec<Watc
         }
         roots.push(WatchRoot {
             path: workspace.workspace_path.join(".claude/skills"),
+            recursive: true,
+        });
+        roots.push(WatchRoot {
+            path: workspace.workspace_path.join(".opencode/skills"),
+            recursive: true,
+        });
+        roots.push(WatchRoot {
+            path: workspace.workspace_path.join(".pi/skills"),
             recursive: true,
         });
         roots.push(WatchRoot {


### PR DESCRIPTION
## Summary

- Implements design doc **PR3** fail-closed detection: when an agent writes a new skill pack under `.opencode/skills`, `.pi/skills`, or `.claude/skills` during an active turn, the daemon detects it at turn end instead of silently accepting the native write.
- Snapshots forbidden native-root skill slugs at turn open (`Idle → Active`) and compares at turn close (`Active → Idle`).
- Surfaces a durable agent reply with `turn_status: skill_created_in_unsupported_directory`, instructing the agent to recreate via `manage_skills`.
- Excludes daemon-managed Claude bridge symlinks from false positives; extends refresh watch to `.opencode/skills` and `.pi/skills`.

## Feature flags

- `TEAMCLU_NATIVE_SKILL_FALLBACK_GUARD=detect|off` (default: detect)
- `TEAMCLU_NATIVE_SKILL_AUTO_ADOPTION` reserved for a follow-up; auto-adoption is not implemented in this PR

## Test plan

- [x] `cargo test -p amuxd --bin amuxd native_skill_fallback_guard`
- [x] `cargo test -p amuxd --bin amuxd claude_skills`


Made with [Cursor](https://cursor.com)