### PR TITLE
feat(ai-gateway): Team AI Gateway — design, plan, and Phase 0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,6 +204,34 @@ jobs:
           docker exec -e PGUSER=supabase_admin -e PGPASSWORD=postgres -e PGDATABASE=postgres \
             pgtap bash -c 'cd /work/services/supabase/tests && bash run.sh'
 
+      # The gateway suite runs HERE rather than in its own job because its most
+      # valuable tests need this database: "a valid token for a team you are not
+      # in is 403" is the regression test for the authorization hole, and it is
+      # only meaningful against the real actors table with its real RLS.
+      #
+      # The two tests that call a live upstream skip themselves without
+      # DEEPSEEK_API_KEY, so CI proves everything except the upstream round-trip.
+      - name: Expose Postgres to the runner
+        run: |
+          docker exec -e PGPASSWORD=postgres pgtap psql -U supabase_admin -d postgres \
+            -c "alter role ai_gateway login password 'ci';"
+          echo "PGHOST_IP=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' pgtap)" >> "$GITHUB_ENV"
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: AI gateway — typecheck, build, tests
+        working-directory: services/ai-gateway
+        env:
+          DATABASE_URL: postgres://ai_gateway:ci@${{ env.PGHOST_IP }}:5432/postgres
+          ADMIN_DATABASE_URL: postgres://supabase_admin:postgres@${{ env.PGHOST_IP }}:5432/postgres
+        run: |
+          npm ci
+          npm run typecheck   # tsconfig.test.json — covers test/ too
+          npm run build       # tsconfig.json — what the image actually compiles
+          npm test
+
   daemon-linux:
     name: Daemon Unit Tests (Linux)
     runs-on: ubuntu-latest

--- a/.github/workflows/self-host-deploy.yml
+++ b/.github/workflows/self-host-deploy.yml
@@ -7,6 +7,7 @@ on:
     paths:
       - 'deploy/self-host/**'
       - 'services/fc/**'
+      - 'services/ai-gateway/**'
       - 'services/supabase/migrations/**'
 
 # Shared with daemon-deploy.yml deploy job — both reset /opt/teamclaw on the
@@ -211,6 +212,9 @@ jobs:
             # Point FC at the bundled gateway explicitly. Left blank, FC's client
             # falls back to the hosted https://ai.ucar.cc.
             upsert_env LITELLM_URL "http://litellm:4000"
+            # New gateway, alongside litellm. Not a replacement yet: clients
+            # keep using litellm until their team's llm_base_url is flipped.
+            upsert_env AI_GATEWAY_INTERNAL_URL "http://ai-gateway:4001"
             # Admin credential for the gateway. Generated once on the server and then
             # preserved — rotating it would orphan every virtual key already issued
             # to a team in the _litellm database.
@@ -305,6 +309,10 @@ jobs:
             timeout 60 sh -c \
               'until docker compose ps kong | grep -q "Up\|running"; do sleep 3; done'
 
+            echo "=== wait for ai-gateway healthy ==="
+            timeout 180 sh -c \
+              'until docker compose ps ai-gateway | grep -q healthy; do sleep 5; done'
+
             echo "=== wait for litellm healthy (prisma migrate runs on first boot) ==="
             timeout 300 sh -c \
               'until docker compose ps litellm | grep -q healthy; do sleep 5; done'
@@ -320,6 +328,9 @@ jobs:
 
             echo "=== litellm smoke ==="
             sh /opt/teamclaw/deploy/self-host/smoke/litellm-smoke.sh
+
+            echo "=== ai-gateway smoke ==="
+            sh /opt/teamclaw/deploy/self-host/smoke/ai-gateway-smoke.sh
 
             echo "=== e2e verification ==="
             if [ -n "$FC_SUPABASE_URL" ]; then

--- a/deploy/self-host/.env.example
+++ b/deploy/self-host/.env.example
@@ -329,6 +329,30 @@ WEBSSO_STORAGE_KEY=
 # Postgres pool size for the apps admin connection (default: 1).
 PG_POOL_MAX=
 
+# ── Team AI gateway (services/ai-gateway) ─────────────────────────────
+# Replaces LiteLLM for clients, but runs ALONGSIDE it: every installed desktop
+# still points at the old gateway until its team's llm_base_url is flipped.
+# See docs/specs/2026-08-28-team-ai-gateway-design.md §11.
+#
+# Public, client-facing URL. Keeps the meaning it already had -- this is what
+# lands in a team's provider config, so it must be reachable from a laptop.
+# Caddy serves the gateway at /ai/*.
+AI_GATEWAY_ENDPOINT=https://api.example.com/ai/v1
+# FC -> gateway, inside the compose network. Never handed to a client.
+AI_GATEWAY_INTERNAL_URL=http://ai-gateway:4001
+# Shared secret for the gateway's /internal/* routes. Derived by
+# bootstrap/gen-secrets.sh; leave blank there.
+AI_GATEWAY_SERVICE_TOKEN=
+# Connection string for the gateway's own least-privilege role. The migration
+# 20260828120000_ai_gateway_credits.sql creates `ai_gateway` NOLOGIN so no
+# credential lives in the repo; grant it login once, then set this:
+#   alter role ai_gateway login password '<pick one>';
+#   AI_GATEWAY_DB_URL=postgres://ai_gateway:<that>@db:5432/postgres
+AI_GATEWAY_DB_URL=
+# Where the gateway asks GoTrue who a token belongs to (BACKEND_KIND=supabase).
+# In-network default; it never needs the public hostname.
+SUPABASE_URL=http://kong:8000
+
 # ── LiteLLM AI gateway (bundled; starts with `docker compose up`) ──────
 # Runs at http://litellm:4000 in-network and on the host at 127.0.0.1:4000.
 # Its state lives in the _litellm database inside the Supabase `db` container

--- a/deploy/self-host/ai/catalog.example.yaml
+++ b/deploy/self-host/ai/catalog.example.yaml
@@ -2,46 +2,42 @@
 # Mount read-only into ai-gateway container as /app/catalog.yaml
 #
 # Three layers:
-#   providers      — connection (api_base + api_key_env)
-#   backend_models — upstream model id + credits pricing
-#   public_models  — customer-facing id + 1:n routes
+#   providers      — how to reach an upstream (api_base + key + usage quirks)
+#   backend_models — which upstream model to call. NO PRICING.
+#   public_models  — the customer-facing tier: 1:n routes + THE PRICE
+#
+# Pricing is OURS, set on the three tiers, not derived from upstream cost.
+# See §4.4 of docs/specs/2026-08-28-team-ai-gateway-design.md for why that
+# collapses four layers of complexity (peak/off-peak spreads, prompt-cache
+# split billing, mixed-route price uncertainty, FX drift).
 #
 # This file is PER DEPLOYMENT, not a single source of truth in the repo: each
-# deploy target runs its own gateway against its own database (see §3.1 of
-# docs/specs/2026-08-28-team-ai-gateway-design.md).
-#
-# ⚠️ public_models must stay a SUPERSET of the ids LiteLLM exposes today
-# (default / pro / max / deepseek-v4-flash / deepseek-v4-pro). Those ids are
-# already stored in every team's team_workspace_config.llm_models — dropping one
-# silently invalidates the model those teams have selected. New ids (auto) may
-# be added; retiring an old id needs a separate UPDATE on llm_models.
+# deploy target runs its own gateway against its own database (§3.1).
 
 providers:
   deepseek:
     api_base: https://api.deepseek.com
     api_key_env: DEEPSEEK_API_KEY
+    # How this provider reports token usage on a STREAMING response.
+    #   always               — usage arrives unprompted, riding the last normal
+    #                          chunk (the one carrying finish_reason).
+    #   needs_stream_options — must inject stream_options.include_usage; the
+    #                          provider then emits an EXTRA usage-only frame
+    #                          with empty choices, which the gateway swallows
+    #                          when the client did not ask for it.
+    # Verified against the live API on 2026-08-28 (§4.4.0.1).
+    usage_mode: always
   openai:
     api_base: https://api.openai.com/v1
     api_key_env: OPENAI_API_KEY
+    usage_mode: needs_stream_options
 
-# ── credits pricing unit ─────────────────────────────────────────────
-# 1 credit = 0.000001 CNY of UPSTREAM COST, so a number here is simply
-#   <price in CNY per 1M tokens> * 1_000_000
-# The unit is deliberately this fine: at a coarser one, ceil() over-charges a
-# typical 5k-token agent request by ~10x, and agents are made of small requests.
-# See §4.4.1 of docs/specs/2026-08-28-team-ai-gateway-design.md.
+# Body keys forwarded upstream. Everything else is dropped with a debug log.
+# Replaces LiteLLM's `litellm_settings.drop_params: true`.
 #
-# Credits are anchored to COST, not to sale price — the markup lives in the one
-# CNY→credits conversion at top-up, so this file stays a straight transcription
-# of the provider's price list.
-#
-# ⚠️ Write plain digits. YAML 1.2 parsers read 1_000_000 as a STRING, not an int.
-# ⚠️ The numbers below are PLACEHOLDERS — replace with the real price list.
-
-# Body keys forwarded upstream. Everything else is dropped with a debug log —
-# this replaces LiteLLM's `litellm_settings.drop_params: true`, which existed
-# because agent runtimes (opencode / pi) send a SUPERSET of OpenAI params and
-# upstreams 400 on keys they don't know. Overridable per backend_model.
+# DeepSeek was measured to TOLERATE unknown params (a bogus key still returned
+# 200), so this is defensive rather than required — it earns its keep the day
+# we add a stricter provider. Not a Phase 0 blocker.
 default_supported_params:
   - model
   - messages
@@ -62,80 +58,101 @@ default_supported_params:
   - user
 
 backend_models:
+  # No pricing here — what a tier costs the customer is decided in
+  # public_models below. The optional `cost` block would feed margin reporting
+  # only and is never used to charge anyone; omitting it changes nothing.
   ds-v4-pro:
     provider: deepseek
     upstream_model: deepseek-v4-pro
-    # Used to size the pre-flight reservation when the request omits max_tokens,
-    # and as the conservative settle amount when the upstream returns no usage.
+    # Sizes the pre-flight reservation when the request omits max_tokens.
+    # Keep it generous: reasoning tokens count toward completion_tokens and can
+    # consume the entire output budget on their own (§4.4.0.1).
     default_max_output_tokens: 16000
-    pricing:
-      input_per_1m_credits: 2000000     # 2.00 CNY / 1M tokens
-      output_per_1m_credits: 4000000    # 4.00 CNY / 1M tokens
 
   ds-v4-flash:
     provider: deepseek
     upstream_model: deepseek-v4-flash
     default_max_output_tokens: 16000
-    pricing:
-      input_per_1m_credits: 500000      # 0.50 CNY / 1M tokens
-      output_per_1m_credits: 1000000    # 1.00 CNY / 1M tokens
 
   gpt-4o:
     provider: openai
     upstream_model: gpt-4o
     default_max_output_tokens: 16000
-    pricing:
-      input_per_1m_credits: 18000000    # 18.00 CNY / 1M tokens
-      output_per_1m_credits: 72000000   # 72.00 CNY / 1M tokens
 
 public_models:
-  # ── THE public contract: exactly three tiers ─────────────────────────
-  # The desktop hardcodes these three ids (design §4.3.1). They are STABLE
-  # NAMES — what changes is which backend they point at, and that mapping
-  # lives right here on the server. Re-point a tier, adjust weights, or swap
-  # vendors with no client release.
+  # ── THE public contract: exactly three tiers, and their prices ───────
+  # The desktop hardcodes these three ids (§4.3.1). They are STABLE NAMES —
+  # what changes is which backend they point at, and that mapping lives right
+  # here. Re-point a tier, adjust weights, or swap vendors with no client
+  # release and no price change.
   #
-  # Adding a FOURTH tier requires shipping a client. That is deliberate:
-  # adding a tier is a product decision, not a config tweak.
+  # Adding a FOURTH tier requires shipping a client. Deliberate: adding a tier
+  # is a product decision, not a config tweak.
+  #
+  # ⚠️ PRICES BELOW ARE PLACEHOLDERS — the real numbers are a pricing decision
+  # (design 附录 F). The one ENGINEERING constraint on whatever gets chosen:
+  # a typical request must cost at least a few thousand credits, or ceil()
+  # rounding swallows small requests — and agent traffic is all small requests
+  # (§4.4.1). These placeholders satisfy it by making 1 credit ≈ 1 input token
+  # on the `default` tier.
+  #
+  # ⚠️ Write plain digits. YAML 1.2 reads 1_000_000 as a STRING, not an int.
 
   default:
     name: 标准
     routing: priority
+    pricing:
+      input_per_1m_credits: 1000000
+      output_per_1m_credits: 4000000
     routes:
       - backend: ds-v4-flash
 
   pro:
     name: 高级
     routing: priority
+    pricing:
+      input_per_1m_credits: 4000000
+      output_per_1m_credits: 16000000
     routes:
       - backend: ds-v4-pro
 
-  # Mixed routing is exactly why pricing lives on backend_models: this tier
-  # bills gpt-4o on some calls and ds-v4-pro on others.
+  # Failover across two backends whose upstream costs differ by an order of
+  # magnitude — and the customer pays the same either way. That is the whole
+  # point of pricing the tier instead of the backend.
   max:
     name: 旗舰
     routing: failover
+    pricing:
+      input_per_1m_credits: 20000000
+      output_per_1m_credits: 80000000
     routes:
       - backend: gpt-4o
       - backend: ds-v4-pro
 
   # ── transition aliases — REMOVE IN PHASE 3 ───────────────────────────
   # Old clients still send these vendor ids, and they are still sitting in
-  # team_workspace_config.llm_models. Keep them serving until those clients
-  # are gone (same gate as deleting LiteLLM), then drop both these entries
-  # and the dead llm_models rows. See design §4.3.2.
+  # team_workspace_config.llm_models. Keep them serving until those clients are
+  # gone (same gate as deleting LiteLLM), then drop both these entries and the
+  # dead llm_models rows. See §4.3.2. Priced identically to the tier they
+  # shadow, so the migration never changes anyone's bill.
   #
   # Unknown model ids get 403 model_not_allowed — never a silent fallback to
-  # `default`, which would leave a mis-configured client on the wrong tier
-  # with no signal.
+  # `default`, which would leave a mis-configured client on the wrong tier with
+  # no signal.
   deepseek-v4-flash:
     name: DeepSeek V4 Flash
     routing: priority
+    pricing:
+      input_per_1m_credits: 1000000
+      output_per_1m_credits: 4000000
     routes:
       - backend: ds-v4-flash
 
   deepseek-v4-pro:
     name: DeepSeek V4 Pro
     routing: priority
+    pricing:
+      input_per_1m_credits: 4000000
+      output_per_1m_credits: 16000000
     routes:
       - backend: ds-v4-pro

--- a/deploy/self-host/ai/catalog.example.yaml
+++ b/deploy/self-host/ai/catalog.example.yaml
@@ -1,0 +1,141 @@
+# TeamClu AI Gateway — operator catalog (example)
+# Mount read-only into ai-gateway container as /app/catalog.yaml
+#
+# Three layers:
+#   providers      — connection (api_base + api_key_env)
+#   backend_models — upstream model id + credits pricing
+#   public_models  — customer-facing id + 1:n routes
+#
+# This file is PER DEPLOYMENT, not a single source of truth in the repo: each
+# deploy target runs its own gateway against its own database (see §3.1 of
+# docs/specs/2026-08-28-team-ai-gateway-design.md).
+#
+# ⚠️ public_models must stay a SUPERSET of the ids LiteLLM exposes today
+# (default / pro / max / deepseek-v4-flash / deepseek-v4-pro). Those ids are
+# already stored in every team's team_workspace_config.llm_models — dropping one
+# silently invalidates the model those teams have selected. New ids (auto) may
+# be added; retiring an old id needs a separate UPDATE on llm_models.
+
+providers:
+  deepseek:
+    api_base: https://api.deepseek.com
+    api_key_env: DEEPSEEK_API_KEY
+  openai:
+    api_base: https://api.openai.com/v1
+    api_key_env: OPENAI_API_KEY
+
+# ── credits pricing unit ─────────────────────────────────────────────
+# 1 credit = 0.000001 CNY of UPSTREAM COST, so a number here is simply
+#   <price in CNY per 1M tokens> * 1_000_000
+# The unit is deliberately this fine: at a coarser one, ceil() over-charges a
+# typical 5k-token agent request by ~10x, and agents are made of small requests.
+# See §4.4.1 of docs/specs/2026-08-28-team-ai-gateway-design.md.
+#
+# Credits are anchored to COST, not to sale price — the markup lives in the one
+# CNY→credits conversion at top-up, so this file stays a straight transcription
+# of the provider's price list.
+#
+# ⚠️ Write plain digits. YAML 1.2 parsers read 1_000_000 as a STRING, not an int.
+# ⚠️ The numbers below are PLACEHOLDERS — replace with the real price list.
+
+# Body keys forwarded upstream. Everything else is dropped with a debug log —
+# this replaces LiteLLM's `litellm_settings.drop_params: true`, which existed
+# because agent runtimes (opencode / pi) send a SUPERSET of OpenAI params and
+# upstreams 400 on keys they don't know. Overridable per backend_model.
+default_supported_params:
+  - model
+  - messages
+  - stream
+  - stream_options
+  - temperature
+  - top_p
+  - max_tokens
+  - stop
+  - tools
+  - tool_choice
+  - parallel_tool_calls
+  - response_format
+  - seed
+  - n
+  - presence_penalty
+  - frequency_penalty
+  - user
+
+backend_models:
+  ds-v4-pro:
+    provider: deepseek
+    upstream_model: deepseek-v4-pro
+    # Used to size the pre-flight reservation when the request omits max_tokens,
+    # and as the conservative settle amount when the upstream returns no usage.
+    default_max_output_tokens: 16000
+    pricing:
+      input_per_1m_credits: 2000000     # 2.00 CNY / 1M tokens
+      output_per_1m_credits: 4000000    # 4.00 CNY / 1M tokens
+
+  ds-v4-flash:
+    provider: deepseek
+    upstream_model: deepseek-v4-flash
+    default_max_output_tokens: 16000
+    pricing:
+      input_per_1m_credits: 500000      # 0.50 CNY / 1M tokens
+      output_per_1m_credits: 1000000    # 1.00 CNY / 1M tokens
+
+  gpt-4o:
+    provider: openai
+    upstream_model: gpt-4o
+    default_max_output_tokens: 16000
+    pricing:
+      input_per_1m_credits: 18000000    # 18.00 CNY / 1M tokens
+      output_per_1m_credits: 72000000   # 72.00 CNY / 1M tokens
+
+public_models:
+  # ── THE public contract: exactly three tiers ─────────────────────────
+  # The desktop hardcodes these three ids (design §4.3.1). They are STABLE
+  # NAMES — what changes is which backend they point at, and that mapping
+  # lives right here on the server. Re-point a tier, adjust weights, or swap
+  # vendors with no client release.
+  #
+  # Adding a FOURTH tier requires shipping a client. That is deliberate:
+  # adding a tier is a product decision, not a config tweak.
+
+  default:
+    name: 标准
+    routing: priority
+    routes:
+      - backend: ds-v4-flash
+
+  pro:
+    name: 高级
+    routing: priority
+    routes:
+      - backend: ds-v4-pro
+
+  # Mixed routing is exactly why pricing lives on backend_models: this tier
+  # bills gpt-4o on some calls and ds-v4-pro on others.
+  max:
+    name: 旗舰
+    routing: failover
+    routes:
+      - backend: gpt-4o
+      - backend: ds-v4-pro
+
+  # ── transition aliases — REMOVE IN PHASE 3 ───────────────────────────
+  # Old clients still send these vendor ids, and they are still sitting in
+  # team_workspace_config.llm_models. Keep them serving until those clients
+  # are gone (same gate as deleting LiteLLM), then drop both these entries
+  # and the dead llm_models rows. See design §4.3.2.
+  #
+  # Unknown model ids get 403 model_not_allowed — never a silent fallback to
+  # `default`, which would leave a mis-configured client on the wrong tier
+  # with no signal.
+  deepseek-v4-flash:
+    name: DeepSeek V4 Flash
+    routing: priority
+    routes:
+      - backend: ds-v4-flash
+
+  deepseek-v4-pro:
+    name: DeepSeek V4 Pro
+    routing: priority
+    routes:
+      - backend: ds-v4-pro

--- a/deploy/self-host/bootstrap/gen-secrets.sh
+++ b/deploy/self-host/bootstrap/gen-secrets.sh
@@ -57,6 +57,15 @@ if [ -z "$LITELLM_MASTER_KEY" ]; then
 fi
 set_kv LITELLM_MASTER_KEY "$LITELLM_MASTER_KEY"
 
+# Shared secret for the AI gateway's /internal/* routes (FC -> gateway). Never
+# handed to a client. Preserved across runs like the key above, so re-running
+# this script does not lock FC out of a gateway that is already deployed.
+AI_GATEWAY_SERVICE_TOKEN="$(grep '^AI_GATEWAY_SERVICE_TOKEN=' "$ENV_FILE" | cut -d= -f2- || true)"
+if [ -z "$AI_GATEWAY_SERVICE_TOKEN" ]; then
+  AI_GATEWAY_SERVICE_TOKEN="$(openssl rand -hex 32)"
+fi
+set_kv AI_GATEWAY_SERVICE_TOKEN "$AI_GATEWAY_SERVICE_TOKEN"
+
 LITELLM_UI_PASSWORD="$(grep '^LITELLM_UI_PASSWORD=' "$ENV_FILE" | cut -d= -f2- || true)"
 if [ -z "$LITELLM_UI_PASSWORD" ]; then
   set_kv LITELLM_UI_PASSWORD "$(openssl rand -hex 16)"

--- a/deploy/self-host/caddy/Caddyfile
+++ b/deploy/self-host/caddy/Caddyfile
@@ -44,6 +44,14 @@
 		reverse_proxy litellm:4000
 	}
 
+	# Team AI gateway. handle_path strips the /ai prefix, so
+	# https://<host>/ai/v1/teams/<id>/chat/completions arrives at the service as
+	# /v1/teams/<id>/chat/completions. Added ALONGSIDE /llm/* -- the litellm
+	# routes stay until Phase 3 (design §11.5).
+	handle_path /ai/* {
+		reverse_proxy ai-gateway:4001
+	}
+
 	# CORS is handled entirely by FC (Hono middleware in services/fc/src/app.ts),
 	# which is origin-aware (reflects the request Origin, allows tauri:// and
 	# localhost, honours CORS_ORIGINS). Do NOT also set CORS headers here — Caddy

--- a/deploy/self-host/docker-compose.yml
+++ b/deploy/self-host/docker-compose.yml
@@ -210,6 +210,51 @@ services:
       retries: 12
       start_period: 60s
 
+  # Team AI gateway. Replaces LiteLLM's role for clients, but ships ALONGSIDE it:
+  # every installed desktop still points at the old gateway until Phase 1 flips
+  # team_workspace_config.llm_base_url, so removing litellm here would break
+  # them all instantly. Deletion is Phase 3, behind the gate in
+  # docs/specs/2026-08-28-team-ai-gateway-design.md §11.5.
+  #
+  # Reached publicly through Caddy at /ai/* ; FC calls it in-network on :4001.
+  ai-gateway:
+    build:
+      context: ../../services/ai-gateway
+    restart: unless-stopped
+    depends_on:
+      db:
+        condition: service_healthy
+    environment:
+      PORT: "4001"
+      # Least-privilege role created by 20260828120000_ai_gateway_credits.sql.
+      # The migration makes it NOLOGIN on purpose; the operator grants login and
+      # sets this password out of band, so no credential lives in the repo.
+      DATABASE_URL: "${AI_GATEWAY_DB_URL}"
+      CATALOG_PATH: /app/catalog.yaml
+      AI_GATEWAY_SERVICE_TOKEN: "${AI_GATEWAY_SERVICE_TOKEN}"
+      BACKEND_KIND: "${BACKEND_KIND:-supabase}"
+      # supabase path: identity is established by asking GoTrue, exactly as FC
+      # does. The gateway holds no signing key.
+      SUPABASE_URL: "${SUPABASE_URL:-http://kong:8000}"
+      SUPABASE_ANON_KEY: "${ANON_KEY:-}"
+      AUTH_BASE_URL: "${AUTH_BASE_URL:-}"
+      # Upstream provider keys, same vars litellm already uses.
+      DEEPSEEK_API_KEY: "${DEEPSEEK_API_KEY:-}"
+      OPENAI_API_KEY: "${OPENAI_API_KEY:-}"
+      ANTHROPIC_API_KEY: "${ANTHROPIC_API_KEY:-}"
+    volumes:
+      - ./ai/catalog.yaml:/app/catalog.yaml:ro
+    healthcheck:
+      test:
+        - "CMD"
+        - "node"
+        - "-e"
+        - "fetch('http://127.0.0.1:4001/healthz').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 20s
+
   gitea:
     # Per-app private git repos for the Apps module. HTTP is fronted by Caddy on
     # GITEA_DOMAIN; SSH is published to the host on GITEA_SSH_PORT so developer
@@ -425,6 +470,12 @@ services:
       # Points FC at the bundled gateway. FC now fails closed on a blank value
       # rather than falling back to a hosted endpoint, so this default is a
       # convenience, not a safety net.
+      # Public, client-facing gateway URL. Already read by team-provisioning.ts,
+      # so it only needs re-pointing at the new gateway -- no code change.
+      # AI_GATEWAY_INTERNAL_URL / AI_GATEWAY_SERVICE_TOKEN are deliberately NOT
+      # here yet: FC does not call the gateway until the Phase 2 credits routes,
+      # and deploy-env-parity.test.ts fails a var declared but never read.
+      AI_GATEWAY_ENDPOINT: "${AI_GATEWAY_ENDPOINT:-}"
       LITELLM_URL: "${LITELLM_URL:-http://litellm:4000}"
       LITELLM_MASTER_KEY: "${LITELLM_MASTER_KEY:-}"
       # Per-team spend cap written at /team/new. Blank = no cap. This was absent

--- a/deploy/self-host/smoke/ai-gateway-smoke.sh
+++ b/deploy/self-host/smoke/ai-gateway-smoke.sh
@@ -1,0 +1,43 @@
+#!/bin/sh
+# Post-deploy smoke for services/ai-gateway. Runs alongside litellm-smoke.sh --
+# both gateways are live until Phase 3 (design §11.5).
+#
+# Deliberately does NOT spend upstream tokens: a completion needs a real member
+# JWT, which this script has no way to mint. What it proves is that the service
+# is up, its catalog validated at boot, and the authorization gate is closed.
+# The completion path is covered by services/ai-gateway/test/e2e.test.ts.
+set -eu
+
+BASE="${AI_GATEWAY_BASE:-http://127.0.0.1:4001}"
+fail() { echo "ai-gateway-smoke: FAIL — $1" >&2; exit 1; }
+code() { curl -s -o /dev/null -w '%{http_code}' --max-time 10 "$@"; }
+
+echo "ai-gateway-smoke: base=$BASE"
+
+[ "$(code "$BASE/healthz")" = "200" ] || fail "/healthz not 200"
+echo "  ok  healthz"
+
+# A booted gateway has already validated the catalog (missing tier, dangling
+# backend reference, or absent provider key all abort startup), so reaching this
+# point means the catalog is coherent.
+
+T="00000000-0000-4000-8000-000000000000"
+[ "$(code "$BASE/v1/teams/$T/models")" = "401" ] || fail "unauthenticated /models should be 401"
+echo "  ok  unauthenticated request rejected"
+
+[ "$(code -H 'Authorization: Bearer not-a-real-token' "$BASE/v1/teams/$T/models")" = "401" ] \
+  || fail "garbage bearer token should be 401"
+echo "  ok  invalid token rejected"
+
+# The internal surface must never accept an end-user credential.
+[ "$(code -H 'Authorization: Bearer not-a-real-token' "$BASE/internal/models")" = "401" ] \
+  || fail "internal routes should reject a non-service token"
+echo "  ok  internal routes gated by the service token"
+
+if [ -n "${AI_GATEWAY_SERVICE_TOKEN:-}" ]; then
+  [ "$(code -H "Authorization: Bearer $AI_GATEWAY_SERVICE_TOKEN" "$BASE/internal/models")" = "200" ] \
+    || fail "internal /models should accept the service token"
+  echo "  ok  internal /models serves the tier catalogue"
+fi
+
+echo "ai-gateway-smoke: PASS"

--- a/docs/specs/2026-08-28-billing-settings-mockup.html
+++ b/docs/specs/2026-08-28-billing-settings-mockup.html
@@ -1,0 +1,761 @@
+<title>TeamClu 账单页</title>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<style>
+  /* Editorial Calm tokens — AGENTS.md is the source of truth for packages/app.
+     Light-only by deliberate choice: light is the canonical theme for the
+     desktop app, and this sheet mirrors a specific in-app screen. Every color
+     is painted explicitly so the page holds on any host ground. */
+  :root {
+    --background: #fbfaf7;
+    --paper: #ffffff;
+    --panel: #efece4;
+    --selected: #e7e2d6;
+    --foreground: #1a1a14;
+    --ink-2: #3d3c34;
+    --muted: #75736a;
+    --faint: #a8a6a0;
+    --border: rgba(26, 26, 20, 0.08);
+    --border-soft: rgba(26, 26, 20, 0.05);
+    --coral: #e85a4a;
+    --coral-soft: #f5d6cf;
+    --warn: #b8791f;
+    --stop: #a8392c;
+    --warn-soft: #fbf1dd;
+    --shadow: 0 4px 16px -10px rgba(20, 20, 15, 0.12);
+    --shadow-lg: 0 18px 48px -20px rgba(20, 20, 15, 0.28);
+    --font: "PingFang SC", "Noto Sans SC", "Source Han Sans SC", -apple-system,
+      BlinkMacSystemFont, "Microsoft YaHei", system-ui, sans-serif;
+    --mono: "JetBrains Mono", "SF Mono", ui-monospace, Menlo, Consolas, monospace;
+  }
+
+  * { box-sizing: border-box; }
+
+  body {
+    margin: 0;
+    background: var(--background);
+    color: var(--foreground);
+    font-family: var(--font);
+    font-size: 13px;
+    line-height: 1.6;
+    -webkit-font-smoothing: antialiased;
+  }
+
+  .page { max-width: 1180px; margin: 0 auto; padding: 40px 24px 72px; }
+
+  .page-head { margin-bottom: 32px; }
+  .page-head h1 {
+    font-size: 20px; font-weight: 700; margin: 0 0 6px;
+    letter-spacing: -0.01em; text-wrap: balance;
+  }
+  .page-head p { margin: 0; color: var(--muted); font-size: 12.5px; max-width: 62ch; }
+  .page-head .ref {
+    display: inline-block; margin-top: 10px; font-family: var(--mono);
+    font-size: 11px; color: var(--faint);
+  }
+
+  .frame-label {
+    display: flex; align-items: baseline; gap: 10px;
+    margin: 40px 0 14px; padding-bottom: 8px;
+    border-bottom: 1px solid var(--border);
+  }
+  .frame-label .n {
+    font-family: var(--mono); font-size: 11px; font-weight: 600;
+    color: var(--faint);
+  }
+  .frame-label h2 { font-size: 15px; font-weight: 700; margin: 0; }
+  .frame-label .note { font-size: 12px; color: var(--muted); }
+
+  /* ---- settings modal chrome (mirrors the real 设置 dialog) ---- */
+  .shell {
+    display: grid; grid-template-columns: 208px 1fr;
+    background: var(--paper); border: 1px solid var(--border);
+    border-radius: 14px; overflow: hidden; box-shadow: var(--shadow-lg);
+  }
+  .nav { background: var(--panel); padding: 14px 10px; border-right: 1px solid var(--border); }
+  .nav-group {
+    font-size: 10.5px; font-weight: 600; text-transform: uppercase;
+    letter-spacing: 0.06em; color: var(--faint); padding: 6px 10px 8px;
+  }
+  .nav-item {
+    display: flex; align-items: center; gap: 8px;
+    padding: 7px 10px; border-radius: 7px; font-size: 12.5px; color: var(--ink-2);
+  }
+  .nav-item.is-active { background: var(--selected); font-weight: 600; color: var(--foreground); }
+  .nav-dot { width: 5px; height: 5px; border-radius: 50%; background: var(--faint); flex: none; }
+  .nav-item.is-active .nav-dot { background: var(--foreground); }
+
+  .content { padding: 26px 28px 30px; display: flex; flex-direction: column; gap: 16px; min-width: 0; }
+  .content-head h3 { font-size: 15px; font-weight: 700; margin: 0 0 4px; }
+  .content-head p { margin: 0; font-size: 12.5px; color: var(--muted); }
+
+  /* ---- cards ---- */
+  .card {
+    background: var(--paper); border: 1px solid var(--border);
+    border-radius: 12px; padding: 18px 20px;
+  }
+  .card-title {
+    font-size: 13px; font-weight: 600; margin: 0 0 2px;
+  }
+  .card-sub { font-size: 12px; color: var(--muted); margin: 0; }
+  .card-head { display: flex; justify-content: space-between; align-items: flex-start; gap: 16px; }
+
+  /* ---- balance ---- */
+  .balance-row { display: flex; align-items: flex-end; gap: 34px; flex-wrap: wrap; margin-top: 14px; }
+  .metric .k {
+    font-size: 11px; color: var(--muted); letter-spacing: 0.02em;
+    display: block; margin-bottom: 3px;
+  }
+  .metric .v {
+    font-family: var(--mono); font-variant-numeric: tabular-nums;
+    font-size: 30px; font-weight: 600; line-height: 1.1; letter-spacing: -0.02em;
+  }
+  .metric .v .unit { font-size: 13px; font-weight: 500; color: var(--muted); margin-left: 5px; }
+  .metric.sm .v { font-size: 18px; }
+  .metric.warn .v { color: var(--warn); }
+
+  .btn {
+    border: 1px solid var(--border); background: var(--paper); color: var(--ink-2);
+    border-radius: 8px; padding: 7px 14px; font-size: 12.5px; font-family: var(--font);
+    cursor: pointer; white-space: nowrap;
+  }
+  .btn:focus-visible { outline: 2px solid var(--foreground); outline-offset: 2px; }
+  /* Coral spot #1 of 2 — the single primary action on this screen. */
+  .btn-primary { background: var(--coral); border-color: var(--coral); color: #fff; font-weight: 600; }
+
+  /* ---- warning banner (semantic, not the brand accent) ---- */
+  .banner {
+    display: flex; gap: 11px; align-items: flex-start;
+    background: var(--warn-soft); border: 1px solid rgba(184, 121, 31, 0.22);
+    border-radius: 10px; padding: 12px 14px; margin-top: 14px;
+  }
+  .banner .icon { color: var(--warn); font-weight: 700; line-height: 1.4; flex: none; }
+  .banner .t { font-size: 12.5px; font-weight: 600; margin: 0 0 2px; color: #6b4711; }
+  .banner .d { font-size: 12px; margin: 0; color: #6b4711; opacity: 0.86; }
+
+  /* ---- tables ---- */
+  .tbl-wrap { overflow-x: auto; margin-top: 12px; }
+  table { width: 100%; border-collapse: collapse; font-size: 12.5px; }
+  th {
+    text-align: left; font-size: 11px; font-weight: 600; color: var(--muted);
+    letter-spacing: 0.03em; padding: 0 0 8px; border-bottom: 1px solid var(--border);
+    white-space: nowrap;
+  }
+  td { padding: 9px 0; border-bottom: 1px solid var(--border-soft); vertical-align: middle; }
+  tr:last-child td { border-bottom: none; }
+  .num {
+    text-align: right; font-family: var(--mono); font-variant-numeric: tabular-nums;
+    white-space: nowrap;
+  }
+  th.num { text-align: right; }
+  .tier { font-weight: 600; }
+  .tier-id { font-family: var(--mono); font-size: 11px; color: var(--faint); margin-left: 7px; font-weight: 400; }
+
+  .bar { height: 4px; border-radius: 2px; background: var(--panel); width: 110px; overflow: hidden; }
+  .bar > i { display: block; height: 100%; background: var(--ink-2); border-radius: 2px; }
+  .bar.is-warn > i { background: var(--warn); }
+  .bar.is-stop > i { background: var(--stop); }
+
+  .pill {
+    display: inline-block; font-size: 10.5px; font-weight: 600; padding: 2px 7px;
+    border-radius: 5px; background: var(--panel); color: var(--ink-2); white-space: nowrap;
+  }
+  .pill.owner { background: transparent; border: 1px solid var(--border); color: var(--muted); font-weight: 500; }
+  .pill.is-warn { background: var(--warn-soft); color: #6b4711; }
+  .pill.is-stop { background: #f7e3e0; color: var(--stop); }
+  .pill.agent { background: transparent; border: 1px solid var(--border); color: var(--muted); font-weight: 500; }
+  .unlimited { color: var(--faint); }
+  .field { display: flex; align-items: center; gap: 10px; }
+  .field label { font-size: 12px; color: var(--muted); min-width: 92px; }
+  .seg { display: inline-flex; background: var(--panel); border-radius: 7px; padding: 2px; gap: 2px; }
+  .seg span { font-size: 12px; padding: 4px 12px; border-radius: 5px; color: var(--ink-2); }
+  .seg span.on { background: var(--paper); font-weight: 600; box-shadow: var(--shadow); }
+  .inp {
+    font-family: var(--mono); font-variant-numeric: tabular-nums; font-size: 12.5px;
+    border: 1px solid var(--border); border-radius: 7px; padding: 5px 10px;
+    background: var(--paper); color: var(--foreground); width: 130px;
+  }
+  .pos { color: #1f7a4d; }
+
+  .foot {
+    font-size: 11.5px; color: var(--faint); margin: 12px 0 0; padding-top: 10px;
+    border-top: 1px dashed var(--border-soft);
+  }
+
+  /* ---- spec annotations ---- */
+  .spec {
+    background: var(--paper); border: 1px solid var(--border);
+    border-left: 3px solid var(--foreground);
+    border-radius: 0 10px 10px 0; padding: 16px 20px; margin-top: 18px;
+  }
+  .spec h4 {
+    font-size: 11px; font-weight: 600; text-transform: uppercase;
+    letter-spacing: 0.07em; color: var(--muted); margin: 0 0 10px;
+  }
+  .spec ul { margin: 0; padding-left: 17px; display: flex; flex-direction: column; gap: 7px; }
+  .spec li { font-size: 12.5px; color: var(--ink-2); }
+  .spec code {
+    font-family: var(--mono); font-size: 11.5px;
+    background: var(--panel); padding: 1px 5px; border-radius: 4px;
+  }
+  .spec .ph { font-family: var(--mono); font-size: 11px; color: var(--faint); }
+
+  @media (max-width: 820px) {
+    .shell { grid-template-columns: 1fr; }
+    .nav { display: none; }
+    .balance-row { gap: 22px; }
+  }
+</style>
+
+<div class="page">
+
+  <header class="page-head">
+    <h1>账单页 · 交互稿</h1>
+    <p>设置 → 账单。余额、充值入口、积分能买多少 token、充值历史，以及迁移到新数据模型后的用量视图。产品参考为 Cursor 的 Billing &amp; Invoices，但套餐制换成了预付费钱包。</p>
+    <span class="ref">依据 docs/specs/2026-08-28-team-ai-gateway-design.md §12 · 配色遵循 AGENTS.md「Editorial Calm」</span>
+  </header>
+
+  <!-- ============ FRAME 1 ============ -->
+  <div class="frame-label">
+    <span class="n">01</span>
+    <h2>常规状态</h2>
+    <span class="note">余额充足，本周期已有用量</span>
+  </div>
+
+  <div class="shell">
+    <nav class="nav">
+      <div class="nav-group">客户端</div>
+      <div class="nav-item"><span class="nav-dot"></span>通用</div>
+      <div class="nav-item"><span class="nav-dot"></span>快捷方式</div>
+      <div class="nav-item is-active"><span class="nav-dot"></span>账单</div>
+      <div class="nav-item"><span class="nav-dot"></span>Token 用量</div>
+      <div class="nav-item"><span class="nav-dot"></span>隐私与遥测</div>
+      <div class="nav-item"><span class="nav-dot"></span>本地缓存</div>
+      <div class="nav-item"><span class="nav-dot"></span>诊断与支持</div>
+      <div class="nav-group" style="margin-top:10px">Daemon</div>
+      <div class="nav-item"><span class="nav-dot"></span>运行时</div>
+    </nav>
+
+    <div class="content">
+      <div class="content-head">
+        <h3>账单</h3>
+        <p>团队共享钱包。所有成员的 AI 用量都从这里扣。</p>
+      </div>
+
+      <!-- 余额 -->
+      <section class="card">
+        <div class="card-head">
+          <div>
+            <p class="card-title">当前余额</p>
+            <p class="card-sub">2026 年 8 月 1 日 — 8 月 31 日</p>
+          </div>
+          <button class="btn btn-primary" type="button">充值</button>
+        </div>
+        <div class="balance-row">
+          <div class="metric">
+            <span class="k">可用余额</span>
+            <span class="v">2,880<span class="unit">积分</span></span>
+          </div>
+          <div class="metric sm">
+            <span class="k">本周期已消耗</span>
+            <span class="v">4,080<span class="unit">积分</span></span>
+          </div>
+          <div class="metric sm">
+            <span class="k">按当前速度可用</span>
+            <span class="v">约 20<span class="unit">天</span></span>
+          </div>
+        </div>
+      </section>
+
+      <!-- 积分能买多少 token -->
+      <section class="card">
+        <p class="card-title">积分能买多少 token</p>
+        <p class="card-sub">换算取决于档位，以及输入还是输出 —— 没有单一比值。</p>
+        <div class="tbl-wrap">
+          <table>
+            <thead>
+              <tr>
+                <th>档位</th>
+                <th class="num">1 积分 ≈ 输入 token</th>
+                <th class="num">1 积分 ≈ 输出 token</th>
+                <th class="num">当前余额 ≈ 输入 token</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td><span class="tier">标准</span><span class="tier-id">default</span></td>
+                <td class="num">20,000</td>
+                <td class="num">10,000</td>
+                <td class="num">5,760 万</td>
+              </tr>
+              <tr>
+                <td><span class="tier">高级</span><span class="tier-id">pro</span></td>
+                <td class="num">5,000</td>
+                <td class="num">2,500</td>
+                <td class="num">1,440 万</td>
+              </tr>
+              <tr>
+                <td><span class="tier">旗舰</span><span class="tier-id">max</span></td>
+                <td class="num">550</td>
+                <td class="num">138</td>
+                <td class="num">158 万</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <p class="foot">按当前价目表估算，实际以出账为准。旗舰档会在多个上游之间切换，这里按其中最贵的一条算。</p>
+      </section>
+
+      <!-- 本周期用量 -->
+      <section class="card">
+        <div class="card-head">
+          <div>
+            <p class="card-title">本周期用量</p>
+            <p class="card-sub">共 4,750 万 tokens · 8,540 次请求</p>
+          </div>
+          <button class="btn" type="button">查看明细</button>
+        </div>
+        <div class="tbl-wrap">
+          <table>
+            <thead>
+              <tr>
+                <th>档位</th>
+                <th class="num">Tokens</th>
+                <th class="num">消耗积分</th>
+                <th class="num">占比</th>
+                <th></th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td><span class="tier">标准</span><span class="tier-id">default</span></td>
+                <td class="num">4,200 万</td>
+                <td class="num">2,400</td>
+                <td class="num">58.8%</td>
+                <td><div class="bar"><i style="width:58.8%"></i></div></td>
+              </tr>
+              <tr>
+                <td><span class="tier">高级</span><span class="tier-id">pro</span></td>
+                <td class="num">525 万</td>
+                <td class="num">1,200</td>
+                <td class="num">29.4%</td>
+                <td><div class="bar"><i style="width:29.4%"></i></div></td>
+              </tr>
+              <tr>
+                <td><span class="tier">旗舰</span><span class="tier-id">max</span></td>
+                <td class="num">24.7 万</td>
+                <td class="num">480</td>
+                <td class="num">11.8%</td>
+                <td><div class="bar"><i style="width:11.8%"></i></div></td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <p class="foot">占比按消耗积分计，不按 token 数 —— 不同档位每 token 的成本差一个数量级。</p>
+      </section>
+
+      <!-- 充值历史 -->
+      <section class="card">
+        <div class="card-head">
+          <div>
+            <p class="card-title">充值历史</p>
+            <p class="card-sub">不含每次请求的扣费明细</p>
+          </div>
+          <span class="pill owner">仅团队所有者可见</span>
+        </div>
+        <div class="tbl-wrap">
+          <table>
+            <thead>
+              <tr>
+                <th>日期</th>
+                <th>类型</th>
+                <th class="num">积分</th>
+                <th>备注</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td class="num" style="text-align:left">2026-08-26</td>
+                <td><span class="pill">充值</span></td>
+                <td class="num pos">+5,000</td>
+                <td>Stripe · ¥100.00</td>
+              </tr>
+              <tr>
+                <td class="num" style="text-align:left">2026-08-12</td>
+                <td><span class="pill">调整</span></td>
+                <td class="num pos">+200</td>
+                <td>上游故障期间的补偿</td>
+              </tr>
+              <tr>
+                <td class="num" style="text-align:left">2026-08-01</td>
+                <td><span class="pill">充值</span></td>
+                <td class="num pos">+5,000</td>
+                <td>Stripe · ¥100.00</td>
+              </tr>
+              <tr>
+                <td class="num" style="text-align:left">2026-07-15</td>
+                <td><span class="pill">赠送</span></td>
+                <td class="num pos">+1,000</td>
+                <td>新团队开通赠送</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+    </div>
+  </div>
+
+  <div class="spec">
+    <h4>规格</h4>
+    <ul>
+      <li><strong>余额与用量对全体成员可见</strong>；充值历史与充值按钮仅团队所有者。余额耗尽是硬停，成员必须能自己看到为什么用不了。<span class="ph">§12.6</span></li>
+      <li><strong>换算表的价格由 <code>GET /models</code> 的 <code>estimatedPricing</code> 下发</strong>，不在客户端硬编码 —— 否则调价当天就变成错误信息。<span class="ph">§12.3</span></li>
+      <li><strong>「按当前速度可用 N 天」是派生值</strong>，由余额 ÷ 近 7 日日均消耗算出；日均为 0 时整个指标隐藏，不显示 ∞。</li>
+      <li>充值历史只取 <code>kind IN (top_up, grant, adjustment, refund)</code>，排除 <code>usage</code> 行。<span class="ph">§12.5</span></li>
+      <li>充值按钮：Phase 2 只有管理员手工充值，按钮改为说明文案；Phase 4 接 Stripe Checkout，走系统浏览器而非内嵌 webview。<span class="ph">§4.9.7</span></li>
+    </ul>
+  </div>
+
+  <!-- ============ FRAME 2 ============ -->
+  <div class="frame-label">
+    <span class="n">02</span>
+    <h2>余额不足</h2>
+    <span class="note">硬停状态 —— 不降级、不透支</span>
+  </div>
+
+  <div class="shell">
+    <nav class="nav">
+      <div class="nav-group">客户端</div>
+      <div class="nav-item"><span class="nav-dot"></span>通用</div>
+      <div class="nav-item"><span class="nav-dot"></span>快捷方式</div>
+      <div class="nav-item is-active"><span class="nav-dot"></span>账单</div>
+      <div class="nav-item"><span class="nav-dot"></span>Token 用量</div>
+      <div class="nav-item"><span class="nav-dot"></span>隐私与遥测</div>
+      <div class="nav-item"><span class="nav-dot"></span>本地缓存</div>
+      <div class="nav-item"><span class="nav-dot"></span>诊断与支持</div>
+      <div class="nav-group" style="margin-top:10px">Daemon</div>
+      <div class="nav-item"><span class="nav-dot"></span>运行时</div>
+    </nav>
+
+    <div class="content">
+      <div class="content-head">
+        <h3>账单</h3>
+        <p>团队共享钱包。所有成员的 AI 用量都从这里扣。</p>
+      </div>
+
+      <section class="card">
+        <div class="card-head">
+          <div>
+            <p class="card-title">当前余额</p>
+            <p class="card-sub">2026 年 8 月 1 日 — 8 月 31 日</p>
+          </div>
+          <button class="btn btn-primary" type="button">立即充值</button>
+        </div>
+        <div class="balance-row">
+          <div class="metric warn">
+            <span class="k">可用余额</span>
+            <span class="v">0<span class="unit">积分</span></span>
+          </div>
+          <div class="metric sm">
+            <span class="k">本周期已消耗</span>
+            <span class="v">10,000<span class="unit">积分</span></span>
+          </div>
+        </div>
+        <div class="banner">
+          <span class="icon">!</span>
+          <div>
+            <p class="t">余额已用完，团队的 AI 请求已停止</p>
+            <p class="d">充值后立即恢复，不需要重启。已经在跑的会话会收到「余额不足」并停在当前一步。</p>
+          </div>
+        </div>
+      </section>
+
+      <section class="card">
+        <p class="card-title">本周期用量</p>
+        <p class="card-sub">共 1.16 亿 tokens · 21,043 次请求</p>
+        <div class="tbl-wrap">
+          <table>
+            <thead>
+              <tr>
+                <th>档位</th>
+                <th class="num">Tokens</th>
+                <th class="num">消耗积分</th>
+                <th class="num">占比</th>
+                <th></th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td><span class="tier">标准</span><span class="tier-id">default</span></td>
+                <td class="num">1.02 亿</td>
+                <td class="num">5,800</td>
+                <td class="num">58.0%</td>
+                <td><div class="bar"><i style="width:58%"></i></div></td>
+              </tr>
+              <tr>
+                <td><span class="tier">高级</span><span class="tier-id">pro</span></td>
+                <td class="num">1,320 万</td>
+                <td class="num">3,000</td>
+                <td class="num">30.0%</td>
+                <td><div class="bar"><i style="width:30%"></i></div></td>
+              </tr>
+              <tr>
+                <td><span class="tier">旗舰</span><span class="tier-id">max</span></td>
+                <td class="num">61.5 万</td>
+                <td class="num">1,200</td>
+                <td class="num">12.0%</td>
+                <td><div class="bar"><i style="width:12%"></i></div></td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+    </div>
+  </div>
+
+  <div class="spec">
+    <h4>规格</h4>
+    <ul>
+      <li><strong>低水位在余额跌到零之前就要出现</strong>，不能等停机才提示。阈值与通知通道待定，是设计稿附录 F 仅剩的两条未决之一。</li>
+      <li><strong>不降级、不透支。</strong> 静默降到便宜档会让 agent 继续产出但质量下降且无人察觉 —— 定时任务尤其危险。失败是可见的，降级不是。<span class="ph">§4.2</span></li>
+      <li>错误码 <code>insufficient_credits</code>（团队余额不足）与 <code>quota_exceeded</code>（成员周期限额已满）要分开呈现，两者的解法不同：前者充值，后者调限额。</li>
+    </ul>
+  </div>
+
+  <!-- ============ FRAME 3 ============ -->
+  <div class="frame-label">
+    <span class="n">03</span>
+    <h2>Token 用量页 · 迁移后</h2>
+    <span class="note">现有页面换数据源，不是重做</span>
+  </div>
+
+  <div class="shell">
+    <nav class="nav">
+      <div class="nav-group">客户端</div>
+      <div class="nav-item"><span class="nav-dot"></span>通用</div>
+      <div class="nav-item"><span class="nav-dot"></span>快捷方式</div>
+      <div class="nav-item"><span class="nav-dot"></span>账单</div>
+      <div class="nav-item is-active"><span class="nav-dot"></span>Token 用量</div>
+      <div class="nav-item"><span class="nav-dot"></span>隐私与遥测</div>
+      <div class="nav-item"><span class="nav-dot"></span>本地缓存</div>
+      <div class="nav-item"><span class="nav-dot"></span>诊断与支持</div>
+      <div class="nav-group" style="margin-top:10px">Daemon</div>
+      <div class="nav-item"><span class="nav-dot"></span>运行时</div>
+    </nav>
+
+    <div class="content">
+      <div class="content-head">
+        <h3>Token 用量</h3>
+        <p>查看整个团队真实的 AI Token 消耗与积分。</p>
+      </div>
+
+      <section class="card">
+        <div class="card-head">
+          <div>
+            <span class="pill">当日</span>
+            <span class="pill">当周</span>
+            <span class="pill">当月</span>
+            <span class="pill" style="background:var(--selected);font-weight:600">当年</span>
+          </div>
+          <span style="font-family:var(--mono);font-size:11.5px;color:var(--muted)">2026-01-01 → 2026-12-31</span>
+        </div>
+        <div class="balance-row">
+          <div class="metric sm">
+            <span class="k">消耗积分</span>
+            <span class="v">4,080</span>
+          </div>
+          <div class="metric sm">
+            <span class="k">输入 tokens</span>
+            <span class="v">4,074 万</span>
+          </div>
+          <div class="metric sm">
+            <span class="k">输出 tokens</span>
+            <span class="v">676 万</span>
+          </div>
+          <div class="metric sm">
+            <span class="k">请求数</span>
+            <span class="v">8,540</span>
+          </div>
+        </div>
+      </section>
+
+      <section class="card">
+        <p class="card-title">成员排行榜</p>
+        <div class="tbl-wrap">
+          <table>
+            <thead>
+              <tr>
+                <th>成员</th>
+                <th class="num">Tokens</th>
+                <th class="num">消耗积分</th>
+                <th class="num">请求数</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr><td>周金亮</td><td class="num">2,666 万</td><td class="num">2,290</td><td class="num">4,793</td></tr>
+              <tr><td>海港</td><td class="num">1,281 万</td><td class="num">1,100</td><td class="num">2,303</td></tr>
+              <tr><td>weigan</td><td class="num">582 万</td><td class="num">500</td><td class="num">1,046</td></tr>
+              <tr><td>Mac-mini 值守 Agent <span class="pill" style="margin-left:6px">Agent</span></td><td class="num">221 万</td><td class="num">190</td><td class="num">398</td></tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <section class="card">
+        <div class="banner" style="margin-top:0">
+          <span class="icon">i</span>
+          <div>
+            <p class="t">2026 年 7 月 8 日之前没有统计数据</p>
+            <p class="d">用量统计自新账单系统上线起开始记录。更早的记录停留在旧网关，口径不同，没有迁移。</p>
+          </div>
+        </div>
+      </section>
+    </div>
+  </div>
+
+  <div class="spec">
+    <h4>规格</h4>
+    <ul>
+      <li><strong>「总费用 $0」改成「消耗积分」是语义变化，不是换个数字。</strong> 旧系统记的是美元花费，与积分没有确定换算，历史数据不迁移。<span class="ph">§11.4</span></li>
+      <li><strong>周期早于统计起始日时显示说明，不要显示 0。</strong> 显示 0 会被读成「那段时间没人用」，是错误信息。<span class="ph">§12.4</span></li>
+      <li>总 token 拆成输入/输出两个数 —— 上游本来就分开计费，合成一个数会让用户无法核对。</li>
+      <li>排行榜按 <code>actor_id</code> 分组，agent 与人一起排但要有标记：定时任务的消耗也是团队的钱。<span class="ph">§6.2.2</span></li>
+      <li>按档分组用 <code>public_model_id</code>（三档），不暴露实际上游模型名。<span class="ph">§4.3</span></li>
+      <li class="ph">现有响应的 summary / members / byModel 三段结构原样保留，只换数据源与字段语义，前端改动面因此可控。</li>
+    </ul>
+  </div>
+
+  <!-- ============ FRAME 4 ============ -->
+  <div class="frame-label">
+    <span class="n">04</span>
+    <h2>成员限额</h2>
+    <span class="note">团队有钱，但单个成员可以被单独拦住</span>
+  </div>
+
+  <div class="shell">
+    <nav class="nav">
+      <div class="nav-group">客户端</div>
+      <div class="nav-item"><span class="nav-dot"></span>通用</div>
+      <div class="nav-item"><span class="nav-dot"></span>快捷方式</div>
+      <div class="nav-item is-active"><span class="nav-dot"></span>账单</div>
+      <div class="nav-item"><span class="nav-dot"></span>Token 用量</div>
+      <div class="nav-item"><span class="nav-dot"></span>隐私与遥测</div>
+      <div class="nav-item"><span class="nav-dot"></span>本地缓存</div>
+      <div class="nav-item"><span class="nav-dot"></span>诊断与支持</div>
+      <div class="nav-group" style="margin-top:10px">Daemon</div>
+      <div class="nav-item"><span class="nav-dot"></span>运行时</div>
+    </nav>
+
+    <div class="content">
+      <div class="content-head">
+        <h3>成员限额</h3>
+        <p>限制单个成员在一个周期内最多能消耗多少积分。额度仍然从团队钱包里扣，不是各自的钱包。</p>
+      </div>
+
+      <section class="card">
+        <div class="card-head">
+          <div>
+            <p class="card-title">周期与默认值</p>
+            <p class="card-sub">周期对全团队统一。周一 00:00 / 每月 1 日 00:00 重置（北京时间）。</p>
+          </div>
+          <span class="pill owner">仅团队所有者可编辑</span>
+        </div>
+        <div style="display:flex;flex-direction:column;gap:12px;margin-top:16px">
+          <div class="field">
+            <label for="q-period">结算周期</label>
+            <span class="seg" id="q-period"><span>每周</span><span class="on">每月</span></span>
+          </div>
+          <div class="field">
+            <label for="q-default">新成员默认</label>
+            <input class="inp" id="q-default" value="不限" readonly />
+            <span style="font-size:11.5px;color:var(--faint)">留空 = 不限，仅受团队余额约束</span>
+          </div>
+        </div>
+      </section>
+
+      <section class="card">
+        <div class="card-head">
+          <div>
+            <p class="card-title">成员</p>
+            <p class="card-sub">2026 年 8 月 1 日 — 8 月 31 日</p>
+          </div>
+          <button class="btn btn-primary" type="button">保存</button>
+        </div>
+        <div class="tbl-wrap">
+          <table>
+            <thead>
+              <tr>
+                <th>成员</th>
+                <th class="num">本周期已用</th>
+                <th class="num">限额</th>
+                <th class="num">已用</th>
+                <th></th>
+                <th>状态</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>周金亮 <span class="pill owner" style="margin-left:6px">所有者</span></td>
+                <td class="num">2,290</td>
+                <td class="num unlimited">不限</td>
+                <td class="num unlimited">—</td>
+                <td></td>
+                <td><span class="pill">正常</span></td>
+              </tr>
+              <tr>
+                <td>海港</td>
+                <td class="num">1,100</td>
+                <td class="num">2,000</td>
+                <td class="num">55%</td>
+                <td><div class="bar"><i style="width:55%"></i></div></td>
+                <td><span class="pill">正常</span></td>
+              </tr>
+              <tr>
+                <td>weigan</td>
+                <td class="num">500</td>
+                <td class="num">500</td>
+                <td class="num">100%</td>
+                <td><div class="bar is-stop"><i style="width:100%"></i></div></td>
+                <td><span class="pill is-stop">已触顶</span></td>
+              </tr>
+              <tr>
+                <td>Mac-mini 值守 Agent <span class="pill agent" style="margin-left:6px">Agent</span></td>
+                <td class="num">190</td>
+                <td class="num unlimited">不限</td>
+                <td class="num unlimited">—</td>
+                <td></td>
+                <td><span class="pill">正常</span></td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <div class="banner">
+          <span class="icon">!</span>
+          <div>
+            <p class="t">weigan 本周期的 AI 请求已停止</p>
+            <p class="d">团队余额还够，只有这名成员被拦住。9 月 1 日自动恢复，或者现在把限额调高。</p>
+          </div>
+        </div>
+      </section>
+
+      <section class="card">
+        <p class="card-title">给 Agent 设限额前请三思</p>
+        <p class="card-sub">值守 Agent 和定时任务是无人值守运行的。给它设限额意味着额度用完时任务会在半夜静默失败，而没有人会看到那条错误。默认不限是刻意的。</p>
+      </section>
+    </div>
+  </div>
+
+  <div class="spec">
+    <h4>规格</h4>
+    <ul>
+      <li><strong>发现一处 schema 与 UI 的错配：</strong><code>member_credit_quota</code> 把 <code>period</code> 放在<em>每个成员</em>的行上，但这一屏按团队统一设置。成员各用各的周期会让「本周期已用」这一列不可比，报表也讲不通。建议把 <code>period</code> 提到团队级列；若保留现状，UI 必须强制向所有行写同一个值。<span class="ph">§5.2</span></li>
+      <li><strong><code>quota_exceeded</code> 与 <code>insufficient_credits</code> 要分开呈现。</strong> 前者只拦一个人、解法是调限额；后者全员停、解法是充值。两者混成一句「额度不足」会把人引向错误的操作。<span class="ph">§4.2</span></li>
+      <li><strong>把限额调到低于已用量时要提示。</strong> 该成员会立刻停到周期结束 —— 这是合法操作，但必须让所有者知道自己按下去会发生什么。</li>
+      <li><strong>Agent actor 无显式限额行时跳过 quota 检查</strong>，只受团队余额约束。给 Agent 设限额要二次确认。<span class="ph">§6.2.2</span></li>
+      <li><strong>「新成员默认」是附录 F 仅剩的两条未决之一。</strong> 现在按「不限」画；等有真实用量分布后再定，改的是数据不是结构。</li>
+      <li>周期口径与用量报表共用同一套 CST 换算，不要各写一份。<span class="ph">附录 A</span></li>
+      <li class="ph">编辑限额的弹层记得传 container —— 设置页是模态 dialog，默认 portal 到 body 会永远打不开。§12.7</li>
+    </ul>
+  </div>
+
+</div>

--- a/docs/specs/2026-08-28-billing-settings-mockup.html
+++ b/docs/specs/2026-08-28-billing-settings-mockup.html
@@ -270,40 +270,40 @@
       <!-- 积分能买多少 token -->
       <section class="card">
         <p class="card-title">积分能买多少 token</p>
-        <p class="card-sub">换算取决于档位，以及输入还是输出 —— 没有单一比值。</p>
+        <p class="card-sub">三档各一个固定单价。落到哪个上游都不改变金额。</p>
         <div class="tbl-wrap">
           <table>
             <thead>
               <tr>
                 <th>档位</th>
-                <th class="num">1 积分 ≈ 输入 token</th>
-                <th class="num">1 积分 ≈ 输出 token</th>
-                <th class="num">当前余额 ≈ 输入 token</th>
+                <th class="num">1 积分 = 输入 token</th>
+                <th class="num">1 积分 = 输出 token</th>
+                <th class="num">当前余额 = 输入 token</th>
               </tr>
             </thead>
             <tbody>
               <tr>
                 <td><span class="tier">标准</span><span class="tier-id">default</span></td>
-                <td class="num">20,000</td>
                 <td class="num">10,000</td>
-                <td class="num">5,760 万</td>
+                <td class="num">2,500</td>
+                <td class="num">2,880 万</td>
               </tr>
               <tr>
                 <td><span class="tier">高级</span><span class="tier-id">pro</span></td>
-                <td class="num">5,000</td>
                 <td class="num">2,500</td>
-                <td class="num">1,440 万</td>
+                <td class="num">625</td>
+                <td class="num">720 万</td>
               </tr>
               <tr>
                 <td><span class="tier">旗舰</span><span class="tier-id">max</span></td>
-                <td class="num">550</td>
-                <td class="num">138</td>
-                <td class="num">158 万</td>
+                <td class="num">500</td>
+                <td class="num">125</td>
+                <td class="num">144 万</td>
               </tr>
             </tbody>
           </table>
         </div>
-        <p class="foot">按当前价目表估算，实际以出账为准。旗舰档会在多个上游之间切换，这里按其中最贵的一条算。</p>
+        <p class="foot">价格由我们自己定，不随上游成本浮动。旗舰档会在多个上游之间切换，用户付的仍是同一个价。调价只影响之后的消费，不追溯已发生的用量。</p>
       </section>
 
       <!-- 本周期用量 -->
@@ -311,7 +311,7 @@
         <div class="card-head">
           <div>
             <p class="card-title">本周期用量</p>
-            <p class="card-sub">共 4,750 万 tokens · 8,540 次请求</p>
+            <p class="card-sub">共 2,346 万 tokens · 8,540 次请求</p>
           </div>
           <button class="btn" type="button">查看明细</button>
         </div>
@@ -329,21 +329,21 @@
             <tbody>
               <tr>
                 <td><span class="tier">标准</span><span class="tier-id">default</span></td>
-                <td class="num">4,200 万</td>
+                <td class="num">2,100 万</td>
                 <td class="num">2,400</td>
                 <td class="num">58.8%</td>
                 <td><div class="bar"><i style="width:58.8%"></i></div></td>
               </tr>
               <tr>
                 <td><span class="tier">高级</span><span class="tier-id">pro</span></td>
-                <td class="num">525 万</td>
+                <td class="num">225 万</td>
                 <td class="num">1,200</td>
                 <td class="num">29.4%</td>
                 <td><div class="bar"><i style="width:29.4%"></i></div></td>
               </tr>
               <tr>
                 <td><span class="tier">旗舰</span><span class="tier-id">max</span></td>
-                <td class="num">24.7 万</td>
+                <td class="num">21 万</td>
                 <td class="num">480</td>
                 <td class="num">11.8%</td>
                 <td><div class="bar"><i style="width:11.8%"></i></div></td>
@@ -472,7 +472,7 @@
 
       <section class="card">
         <p class="card-title">本周期用量</p>
-        <p class="card-sub">共 1.16 亿 tokens · 21,043 次请求</p>
+        <p class="card-sub">共 5,665 万 tokens · 21,043 次请求</p>
         <div class="tbl-wrap">
           <table>
             <thead>
@@ -487,21 +487,21 @@
             <tbody>
               <tr>
                 <td><span class="tier">标准</span><span class="tier-id">default</span></td>
-                <td class="num">1.02 亿</td>
+                <td class="num">5,050 万</td>
                 <td class="num">5,800</td>
                 <td class="num">58.0%</td>
                 <td><div class="bar"><i style="width:58%"></i></div></td>
               </tr>
               <tr>
                 <td><span class="tier">高级</span><span class="tier-id">pro</span></td>
-                <td class="num">1,320 万</td>
+                <td class="num">562 万</td>
                 <td class="num">3,000</td>
                 <td class="num">30.0%</td>
                 <td><div class="bar"><i style="width:30%"></i></div></td>
               </tr>
               <tr>
                 <td><span class="tier">旗舰</span><span class="tier-id">max</span></td>
-                <td class="num">61.5 万</td>
+                <td class="num">52.5 万</td>
                 <td class="num">1,200</td>
                 <td class="num">12.0%</td>
                 <td><div class="bar"><i style="width:12%"></i></div></td>
@@ -566,11 +566,11 @@
           </div>
           <div class="metric sm">
             <span class="k">输入 tokens</span>
-            <span class="v">4,074 万</span>
+            <span class="v">2,220 万</span>
           </div>
           <div class="metric sm">
             <span class="k">输出 tokens</span>
-            <span class="v">676 万</span>
+            <span class="v">126 万</span>
           </div>
           <div class="metric sm">
             <span class="k">请求数</span>
@@ -592,10 +592,10 @@
               </tr>
             </thead>
             <tbody>
-              <tr><td>周金亮</td><td class="num">2,666 万</td><td class="num">2,290</td><td class="num">4,793</td></tr>
-              <tr><td>海港</td><td class="num">1,281 万</td><td class="num">1,100</td><td class="num">2,303</td></tr>
-              <tr><td>weigan</td><td class="num">582 万</td><td class="num">500</td><td class="num">1,046</td></tr>
-              <tr><td>Mac-mini 值守 Agent <span class="pill" style="margin-left:6px">Agent</span></td><td class="num">221 万</td><td class="num">190</td><td class="num">398</td></tr>
+              <tr><td>周金亮</td><td class="num">1,317 万</td><td class="num">2,290</td><td class="num">4,793</td></tr>
+              <tr><td>海港</td><td class="num">633 万</td><td class="num">1,100</td><td class="num">2,303</td></tr>
+              <tr><td>weigan</td><td class="num">287 万</td><td class="num">500</td><td class="num">1,046</td></tr>
+              <tr><td>Mac-mini 值守 Agent <span class="pill" style="margin-left:6px">Agent</span></td><td class="num">109 万</td><td class="num">190</td><td class="num">398</td></tr>
             </tbody>
           </table>
         </div>
@@ -748,11 +748,11 @@
   <div class="spec">
     <h4>规格</h4>
     <ul>
-      <li><strong>发现一处 schema 与 UI 的错配：</strong><code>member_credit_quota</code> 把 <code>period</code> 放在<em>每个成员</em>的行上，但这一屏按团队统一设置。成员各用各的周期会让「本周期已用」这一列不可比，报表也讲不通。建议把 <code>period</code> 提到团队级列；若保留现状，UI 必须强制向所有行写同一个值。<span class="ph">§5.2</span></li>
+      <li><strong>周期是团队级的。</strong> 这一屏画出来时发现 DDL 把 <code>period</code> 放在每个成员行上 —— 成员各用各的周期会让「本周期已用」不可比。已改：<code>period</code> 与「新成员默认」落在新表 <code>team_credit_settings</code>，<code>member_credit_quota</code> 只存每人的 <code>limit_credits</code>。<span class="ph">§4.5 / §5.2</span></li>
       <li><strong><code>quota_exceeded</code> 与 <code>insufficient_credits</code> 要分开呈现。</strong> 前者只拦一个人、解法是调限额；后者全员停、解法是充值。两者混成一句「额度不足」会把人引向错误的操作。<span class="ph">§4.2</span></li>
       <li><strong>把限额调到低于已用量时要提示。</strong> 该成员会立刻停到周期结束 —— 这是合法操作，但必须让所有者知道自己按下去会发生什么。</li>
       <li><strong>Agent actor 无显式限额行时跳过 quota 检查</strong>，只受团队余额约束。给 Agent 设限额要二次确认。<span class="ph">§6.2.2</span></li>
-      <li><strong>「新成员默认」是附录 F 仅剩的两条未决之一。</strong> 现在按「不限」画；等有真实用量分布后再定，改的是数据不是结构。</li>
+      <li><strong>「新成员默认」的结构已落位</strong>（<code>team_credit_settings.default_limit_credits</code>），设成多少等有真实用量分布后再定 —— 改的是数据不是结构。</li>
       <li>周期口径与用量报表共用同一套 CST 换算，不要各写一份。<span class="ph">附录 A</span></li>
       <li class="ph">编辑限额的弹层记得传 container —— 设置页是模态 dialog，默认 portal 到 body 会永远打不开。§12.7</li>
     </ul>

--- a/docs/specs/2026-08-28-team-ai-gateway-design.md
+++ b/docs/specs/2026-08-28-team-ai-gateway-design.md
@@ -1,0 +1,1073 @@
+# Team AI Gateway：替换 LiteLLM 设计
+
+- **Date**: 2026-08-28
+- **Status**: DESIGN — 待评审后分期实现
+- **Scope**: `services/ai-gateway/`（新建）、`services/fc/`（业务 API + 充值/限额管理面）、`apps/daemon/`（本地转发）、`crates/teamclu-runtime-env/`、`apps/desktop/`（`sk-tc-` 派生逻辑）、`packages/app/`（设置页）、`services/supabase/migrations/`、`deploy/self-host/`、`docs/openapi/teamclu-api.v1.yaml`
+- **Replaces**: LiteLLM 容器、`/v1/teams/:id/litellm/*`、`_litellm` 数据库、`sk-tc-*` virtual key 体系
+- **Related**: `docs/specs/2026-06-15-litellm-token-usage-rds-design.md`（本设计落地后作废）、`docs/architecture/personal-env-and-runtime-env.md`（`TC_ACCESS_TOKEN_FILE`）、`docs/adr/0007-amuxd-holds-model-capability-not-preference.md`
+
+---
+
+## 1. 背景与问题
+
+当前团队共享 LLM 走 LiteLLM + virtual key。目标是用 **独立 `teamclu-ai-gateway` 服务** 替换，鉴权用 **JWT access token**，计费用 **Credits（积分）** 而非 LiteLLM 的 budget 概念。
+
+### 1.1 为什么不继续用 LiteLLM
+
+评审第一个问题一定是这个，所以先答。四条理由都能在仓库里指到证据：
+
+| 问题 | 证据 |
+|------|------|
+| **per-team token 统计要企业版** | `services/fc/src/lib/litellm-usage.ts:1-9` —— 开源版 HTTP API 给不出按团队的 token 数，我们只能绕过 API 直连 `_litellm` 库 SELECT `LiteLLM_SpendLogs`。等于已经在维护一个「读 LiteLLM 内部表」的耦合。 |
+| **virtual key 与登录态割裂** | key 是本地按 `sk-tc-{actor_id[..40]}` 推导的（`crates/teamclu-runtime-env/src/merge.rs:11`），既不是登录凭证也不能吊销；成员离职后 key 依然有效，除非单独去 LiteLLM 删。 |
+| **budget 是 USD，产品要的是积分** | `LITELLM_DEFAULT_TEAM_MAX_BUDGET_USD`（`litellm.ts:36`）只在 provisioning 时写一次，改它不影响已存在的团队；而且没有「充值」这个概念，只有一个封顶数。 |
+| **运维成本** | prisma 拥有 ~20 张表，必须独立数据库（`docker-compose.yml:102-133` 的 `litellm-init` 一次性服务就是为此存在），镜像 `litellm-database:v1.83.3-stable` 每次部署要单独拉+等 prisma migrate（`self-host-deploy.yml:263-310`）。 |
+
+### 1.2 前提：今天的上游全是 OpenAI 兼容端点
+
+这是自建网关可行的**技术前提**，必须显式记下来。`deploy/self-host/litellm/config.yaml` 里 5 条 `model_list` 全部是 `openai/<model>` + `api_base: https://api.deepseek.com`，没有一条走 Anthropic Messages / Gemini 原生协议。所以网关可以是一个 **纯 fetch 转发 + 少量 body 改写**，不需要任何协议翻译层。
+
+**推论（写进决策记录）**：一旦要接 Anthropic 原生 / Gemini 原生协议，必须补一个翻译层 —— 那正是 LiteLLM 今天在替我们干的事。接入非 OpenAI 协议的上游 = 一个独立的、需要重新评审的决定，不能顺手加进 catalog。
+
+### 1.3 一个不能丢的 LiteLLM 行为
+
+`litellm_settings.drop_params: true`（`config.yaml` 末尾）：agent runtime（opencode / pi）会发 OpenAI 参数的**超集**，LiteLLM 在静默丢弃上游不认的参数。自建网关必须提供等价能力，否则上游会因为未知参数直接 400。见 §6.6。
+
+---
+
+## 2. 设计原则
+
+1. **协议不变**：opencode / pi 继续 OpenAI Chat Completions；不重写 agent adapter。
+2. **独立网关服务**：LLM 流式、Credits 账本、限额校验放在 `services/ai-gateway/`，不塞进 FC。
+3. **JWT 鉴权**：`Authorization: Bearer <access_token>`；无 per-user API key 表。
+4. **Credits 模型**：团队有 **余额（balance）**；成员有 **周期限额（quota）**；充值加余额，用量扣余额。
+5. **配置分层**：operator 管上游 provider；team admin 管 model tier + 成员限额；用户不填 key。
+6. **只增不删地迁移**：新旧网关并存到观察期结束，客户端灰度切换，最后才删 LiteLLM。见 §11。
+
+---
+
+## 3. 目标架构
+
+```
+┌──────────────────────────────────────────────────────────────────────────┐
+│  Agent (opencode / pi)                                                    │
+│  provider.team.baseURL                                                    │
+│    → http://127.0.0.1:<amuxd>/v1/ai/teams/<teamId>                        │
+│  provider.team.options.apiKey → ${tc_gateway_token}（daemon 会话令牌）      │
+└───────────────────────────────┬──────────────────────────────────────────┘
+                                │  ai-sdk 自动拼 /chat/completions、/models
+                                ▼
+┌──────────────────────────────────────────────────────────────────────────┐
+│  amuxd 本地代理  /v1/ai/teams/:teamId/*                                    │
+│  ─ 校验 daemon 会话令牌（scope: ai:invoke）                                 │
+│  ─ 换成 cloud access token → Bearer JWT                                    │
+│  ─ 独立 body cap / 独立限流 / SSE 直通（见 §9）                             │
+└───────────────────────────────┬──────────────────────────────────────────┘
+                                │
+                                ▼
+┌──────────────────────────────────────────────────────────────────────────┐
+│  teamclu-ai-gateway  (services/ai-gateway/)                               │
+│  POST /v1/teams/:teamId/chat/completions                                  │
+│  GET  /v1/teams/:teamId/models                                            │
+│  ─ 校验 token → sub（照抄 FC，无签名密钥）                                  │
+│  ─ (teamId, sub) → amux.actors → actor_id（同时即成员资格证明）             │
+│  ─ 查团队 balance、成员 period quota → 不足则 402                          │
+│  ─ 路由 catalog.yaml → 上游；改写 body.model；注入 usage 采集               │
+│  ─ 记 usage + 扣 credits + 写 ledger                                       │
+└───────────────────────────────┬──────────────────────────────────────────┘
+                                │
+                                ▼
+                         DeepSeek / OpenAI / …（均为 OpenAI 兼容，见 §1.2）
+
+┌──────────────────────────────────────────────────────────────────────────┐
+│  FC (Cloud API) — 业务面，不 proxy LLM 字节流                              │
+│  workspace-config.llm（enabled / models / baseUrl）                        │
+│  GET 余额 & 用量展示、成员限额 CRUD、充值下单                                │
+│  → 经 AI_GATEWAY_INTERNAL_URL + service token 调网关 /internal/*           │
+└──────────────────────────────────────────────────────────────────────────┘
+```
+
+### 3.1 多部署目标
+
+`services/fc/` 有两个部署目标（见 CLAUDE.md「Deployment — one environment, two deploy targets」），且线上不止 self-host 一套：`services/fc/s.yaml` 那条手工部署路径上还跑着独立环境，用的是独立数据库。
+
+**决定：每个部署目标各跑一个 `ai-gateway` 实例，绑自己的数据库。** 理由：credits 账本必须和 `amux.actors` / `amux.teams` 在同一个库里（§5.1），跨环境共用一个网关就意味着跨库查成员资格，做不到。
+
+因此：
+
+- catalog.yaml 是 **per-deployment** 的运维配置，不是仓库里的单一真相；仓库只提供 `catalog.example.yaml`。
+- 上游 provider key 也是 per-deployment 的。
+- **Phase 3 删 LiteLLM 时必须两套都已经切完**，否则会打挂另一套。这条进 §11 的 gate 条件。
+
+---
+
+## 4. Credits 模型（不用 budget）
+
+### 4.1 概念
+
+| 概念 | 说明 |
+|------|------|
+| **Credit** | 团队消费单位。**1 credit = 1e-6 元上游成本**（§4.4.1）；DB/API 用 `bigint` credits，UI 展示「积分」= credits/10,000 |
+| **Team balance** | 团队共享钱包余额。充值、赠送、管理员调整 → **加**；AI 调用 → **减** |
+| **Member quota** | 成员在 **一个周期内** 最多可消耗的 credits 上限（从团队 balance 里扣，不是成员单独钱包） |
+| **Reservation** | 请求进行中的预留额度。防止并发超发，见 §4.6 |
+| **Usage log** | 每次请求记 token + 折算 credits，用于报表与 quota 累计 |
+
+**不用** LiteLLM 的 `max_budget` / `budget_exceeded` 术语；API 错误码用 `insufficient_credits`（团队余额不足）、`quota_exceeded`（成员周期限额已满）。
+
+### 4.2 两层控制
+
+```
+请求能否通过？
+  1. llm_enabled 且 model 在团队白名单内           → 否则 403 model_not_allowed
+  2. team.balance - 在途预留 >= 本次预留额          → 否则 402 insufficient_credits
+  3. member 本周期已用 + 在途预留 + 本次 <= quota   → 否则 402 quota_exceeded
+     （quota 为 null = 不限，仅受团队余额约束）
+```
+
+团队没钱 → 全员停；团队有钱但某成员触顶 → 只拦该成员。
+
+**余额耗尽是硬停，不降级。** 明确否掉「余额不足时自动路由到最便宜的 backend 继续服务」：
+
+- 静默降级会让 agent **继续工作但产出质量下降，且无人察觉**。定时任务尤其危险 —— 无人值守地持续产出低质量结果。失败是可见的，降级不是。
+- 降级还会和团队的模型白名单、§4.6 的预留逻辑打架（预留是按 public model 的最高价算的）。
+
+也不做透支宽限：账本出现负余额就需要一整套追缴逻辑，收益不抵复杂度。运营侧的正确解法是**余额低水位告警**，不是让它跌破零。
+
+### 4.3 模型目录：对外名 vs 上游名（1:n）
+
+客户端（opencode / pi / 设置页）只接触 **对外 model id**（public model）。网关内部再解析到 **上游 provider + 他们的 model name**。二者分开维护，**1 个对外 id 可对应 N 条上游路由**。
+
+```
+客户请求  model: "max"
+              │
+              ▼
+┌─────────────────────────┐
+│  public_models.max       │  对外 catalog（三档 tier，§4.3.1）        
+│  routes[] (1:n)          │
+└───────────┬─────────────┘
+            │ 路由策略 pick 一条
+            ▼
+┌─────────────────────────┐
+│  backend_models.gpt-4o  │  实际上游：provider + upstream_model + pricing
+│  → openai/gpt-4o
+└─────────────────────────┘
+            │
+            ▼
+        上游 API（body.model = upstream_model）
+```
+
+**维护位置**：operator 配置文件，容器内挂载为 `/app/catalog.yaml`。仓库里的示例见 `deploy/self-host/ai/catalog.example.yaml`。
+
+**路由策略**
+
+| `routing` | 行为 |
+|-----------|------|
+| `priority` | 按 `routes` 顺序，第一条可用即用 |
+| `weighted` | 在可用路由中按 `weight` 随机（如某档大部分走 flash、少部分走 pro） |
+| `failover` | 先试第一条，上游 429/5xx/超时则试下一条 |
+
+团队 `llm_models` / 设置页只存 **public id**，不出现 `deepseek-v4-pro`。
+
+`GET /v1/teams/:teamId/models` 返回 public 层 `{ id, name }`；**不**暴露 upstream 名。桌面端在 §4.3.1 之后不再调它（列表已写死），这个端点保留给 FC 的管理面、iOS 与将来的其他客户端。
+
+#### 4.3.1 对外只有三档：`default` / `pro` / `max`
+
+**决定：客户端侧的团队 provider 写死，模型固定为三档 tier。**
+
+```
+public_models = { default, pro, max }     ← 唯一对外契约
+```
+
+Tauri 端不再从云端拉团队的模型列表：`provider.team` 的形状与这三个 id 由客户端固定持有，只有 baseURL 在运行时拼（本地 amuxd 端口 + teamId），`llm_enabled` 仍来自云端。
+
+**为什么写死是安全的**：三档 tier 本来就是**稳定名字**，真正会变的是它们指向哪个上游 —— 而那层映射在服务端的 catalog 里（§4.3）。改后端、调价、加权重、切供应商都**不需要发客户端**。今天 `litellm/config.yaml` 的注释写的就是这个意图：「The app selects a capability tier, not a vendor model.」本设计把它变成硬契约。
+
+代价说清楚：**真要加第四档就需要发一次客户端**。这是刻意接受的 —— 加档是产品决策，不该是一次配置改动。
+
+#### 4.3.2 过渡期要保留 vendor 名作为别名
+
+线上今天还对外暴露着两个 vendor 名（`deepseek-v4-flash` / `deepseek-v4-pro`），而且它们已经存进了各团队的 `team_workspace_config.llm_models`。
+
+新客户端不再读 `llm_models`，所以那份存量数据变成死数据、不会造成故障。**但老客户端还在发这些 id**，所以：
+
+- **Phase 0–1**：catalog 的 `public_models` 里保留这两个 vendor 名，各指向对应 backend，作为**过渡别名**。收到就正常服务。
+- **Phase 3**（老客户端已全部退场，与删 LiteLLM 同一个 gate）：从 catalog 移除，同时清理 `llm_models` 里的死数据。
+
+网关对**未知 model id** 一律 403 `model_not_allowed`，不要静默回落到 `default` —— 静默回落会让一个发错 id 的客户端永远拿到错误档位却毫无征兆。
+
+### 4.4 Credits 折算（按实际上游 model 定价）
+
+**定价只挂在 `backend_models.*.pricing`**，不挂在 public model 上。原因：`max` 一次走 gpt-4o、一次 failover 到 ds-v4-pro，二者价格差一个数量级，必须按 **本次实际命中的 backend** 扣费。
+
+```
+credits = ceil(input_tokens  × input_per_1m_credits  / 1_000_000)
+        + ceil(output_tokens × output_per_1m_credits / 1_000_000)
+```
+
+#### 4.4.1 credit 单位：必须细到 `ceil` 落进噪声
+
+这个公式对单位的选取**不是中立的**。如果 1 credit 取得太粗，`ceil` 会系统性高估：
+
+```
+flash 输入 20 credits/1M token，一次 5,000 token 的请求：
+  5000 × 20 / 1_000_000 = 0.1  →  ceil = 1     ← 多收 10 倍
+```
+
+agent 一次会话有几十次这种小请求，所以这是常态而不是边缘情况。
+
+**决定：1 credit = 0.000001 元的「上游成本」。**
+
+| 项 | 取值 |
+|---|---|
+| catalog 里的数值 | 上游每 1M token 单价（元）× 1,000,000 |
+| 典型请求量级 | 5,000 input token ≈ 5,000 credits，`ceil` 误差 0.02% |
+| `bigint` 上限 | 9.2e18 credits = 9.2e12 元，不可能溢出 |
+| UI 显示 | 「积分」= `credits / 10_000`（1 积分 = 0.01 元成本） |
+
+**UI 只展示余额与聚合，不展示单次请求成本。** 余额（万级积分）和单次成本（0.0x 积分）差 5 个数量级，任何单一显示单位都会在一端难看；单次成本只出现在会话/日聚合里。
+
+**credits 锚定成本，不锚定售价。** 这是本节的关键取舍：
+
+- catalog 成为供应商价目表的**直接抄写**，可审计、改价即改一行，不需要重算加价。
+- 加价只发生在充值那**一次**换算里（例如按 2 倍成本卖：充 100 元 → 记 50,000,000 credits）。
+- **因此售价不阻塞本设计** —— 它是充值那一侧的运营参数，不是网关的常量。
+
+| 阶段 | 做法 |
+|------|------|
+| 请求前（预留） | 用该 public model **所有候选路由里最高价** × 预估 token 数，见 §4.6 |
+| 请求后（结算） | 按 **实际** `backend_model` 的 pricing + 上游 `usage` 精确扣费，冲销预留 |
+| 无 usage | 按 `max_tokens`（缺省时按该 backend 的 `default_max_output_tokens`）上限保守扣，并在 `ai_usage_logs.usage_source` 记 `estimated` |
+
+**用量日志**同时记 `public_model_id`（客户请求的）和 `backend_model_id`（实际路由的）。
+
+**Credit ↔ 货币**：见 §4.4.1。网关内部只认 credits，不做任何汇率换算；元 → credits 的换算（含加价）发生在 FC 的充值入口，货币金额由支付侧自己留痕在 `credit_ledger.note`。
+
+### 4.5 成员限额配置
+
+Team owner 可设 `period`（`week` | `month`）、`limit_credits`（null = 不限）。管理 API 在 FC；enforcement 在 gateway。周期口径见附录 A。
+
+### 4.6 并发与超发（一期就要有解）
+
+**问题**：「请求前查余额 > 0，请求后结算」在流式 + 并发下必然超发 —— N 个并发请求都看到余额充足，各自跑掉几十万 token。agent runtime 天然是并发的（一个会话里多个 tool call 并行），这不是边缘情况。
+
+**方案：预留（reservation）+ 结算冲销**，一个表 + 一次行锁：
+
+```
+请求开始（同一事务）：
+  SELECT balance_credits FROM amux.team_credit_balance
+    WHERE team_id = $1 FOR UPDATE;
+  reserved := SELECT COALESCE(SUM(amount_credits),0)
+                FROM amux.credit_reservation
+               WHERE team_id = $1 AND state = 'held';
+  hold := estimate(public_model, body)      -- 见下
+  IF balance - reserved < hold THEN 402 insufficient_credits
+  INSERT INTO amux.credit_reservation (..., state='held', expires_at=now()+interval '10 min')
+  COMMIT;                                    -- 锁只持有毫秒级，不跨越上游请求
+
+请求结束（同一事务）：
+  actual := settle(backend_model, usage)
+  UPDATE amux.team_credit_balance SET balance_credits = balance_credits - actual ...
+  INSERT INTO amux.credit_ledger (kind='usage', amount_credits = -actual, ...)
+  UPDATE amux.credit_reservation SET state='settled' WHERE id = $1
+  INSERT INTO amux.ai_usage_logs (...)
+```
+
+`estimate()` 一期用一个保守常数：`最高价路由 × (输入 token 估算 + max_tokens)`。输入 token 估算不引 tiktoken —— 按 `字节数 / 3` 粗算即可（宁可高估，预留是可退的）。
+
+**孤儿预留**：进程崩溃 / 客户端断连会留下 `held` 行。网关启动时 + 每分钟扫一次，把 `expires_at < now()` 的 `held` 置 `expired`。10 分钟是硬上限，超过它的长请求会被提前放开预留（接受这点风险，比永久漏额度好）。
+
+**member quota** 走同一套：`credit_reservation.actor_id` 参与 quota 侧的 SUM。
+
+**分期**：预留机制在 **Phase 2** 落地。Phase 0/1 网关**只记账不扣费**（写 `ai_usage_logs`，不动 balance），所以那两期没有超发风险 —— 因为根本没有强制。这一点必须在 Phase 0 上线前对运营讲清楚：**Phase 0/1 期间上限仍然只在上游 provider key 上**，和今天一样。
+
+### 4.7 充值
+
+FC `POST /v1/teams/:id/credits/top-up` → gateway `/internal/.../top-up` → `credit_ledger` + `team_credit_balance`。
+
+**幂等**：请求必须带 `idempotency_key`；`credit_ledger` 上有唯一索引，重复提交返回原记录而不是二次入账。一期只做管理员 manual top-up，但幂等键从第一天就要有 —— 支付回调重放是 Phase 4 必踩的坑，表结构不能到时候再改。
+
+**渠道：Stripe**（Phase 4，见 §4.9）。幂等键让表结构对渠道无感，所以 Phase 0–3 不受任何影响。
+
+### 4.8 新团队赠送额度
+
+**决定：每个团队创建时一次性 grant 10 元成本额度**（= 10,000,000 credits，按 §4.4.1 的单位；约 40 次典型 agent 会话）。
+
+- 走正常的 `credit_ledger`，`kind='grant'`，`idempotency_key = 'signup_grant:' || team_id` —— 幂等键保证重试或补跑都不会重复发放。
+- 不按成员人头发放：邀请是团队自己控制的，按人头等于可以靠拉人无限刷额度。
+- 由 FC 在 `createTeam` 成功后调 `/internal/.../top-up` 发放；失败不阻塞建团队（幂等键让补发安全）。
+
+#### 4.8.1 ⚠️ Phase 2 必须给存量团队补发
+
+这是赠送额度带来的**硬性迁移动作**，容易漏：Phase 0/1 只记账不扣费，Phase 2 一旦打开强制，**所有余额为 0 的存量团队会在同一时刻全部 402**。
+
+Phase 2 上线前必须先跑一次补发：
+
+```sql
+-- 给所有还没有余额行的团队补发起始额度（幂等键保证可重复执行）
+-- 实际通过 gateway /internal 接口批量调用，此处示意口径
+SELECT id FROM amux.teams t
+ WHERE NOT EXISTS (SELECT 1 FROM amux.team_credit_balance b WHERE b.team_id = t.id);
+```
+
+顺序不能反：**先补发、再打开强制**。这条进 §11 Phase 2 的完成判据。
+
+### 4.9 Stripe 充值（Phase 4）
+
+#### 4.9.1 放 FC，不放 ai-gateway
+
+沿用 §4.7 已经定下的边界：**ai-gateway 是 `credit_ledger` 的唯一写入者**，FC 只调它的 `/internal/teams/:teamId/credits/top-up`。Stripe 属于业务面（商品、税、发票、退款、客户档案），不该待在一个持有全部上游 provider key、刻意只有 5 个依赖的流式代理里。
+
+单写者不变量在这里有个直接回报：**webhook 处理器在 FC 内不需要任何新权限**。它不碰数据库，验签之后拿 `AI_GATEWAY_SERVICE_TOKEN` 调网关即可 —— 否则就得给一条免鉴权路由配一个特权 repository。
+
+#### 4.9.2 FC 侧的三个原语都是现成的
+
+`services/fc/src/lib/hono-adapter.ts` 已经具备全部所需能力，不用改 adapter：
+
+| 需要 | 已有 | 先例 |
+|---|---|---|
+| 免 bearer 鉴权的入站路由 | `{ auth: "none" }` | `routes/auth.ts`、`routes/invites.ts` 十余处 |
+| 原始请求字节（验签必需） | `router.postRaw(...)` → `ctx.rawBody` 是 `Buffer`（adapter:59） | `routes/attachments.ts:15` |
+| 公网可达 | Caddy 兜底 `handle { reverse_proxy fc:9000 }` | 无需新增规则 |
+
+```js
+// services/fc/src/lib/routes/stripe.ts
+export function registerStripe(router) {
+  // postRaw 把 { ...o, rawBody: true } 合进 options（见 adapter 末尾三行）
+  router.postRaw("/v1/stripe/webhook", { auth: "none" }, async (ctx) => {
+    // rawBody 模式下 ctx.json 被刻意置为 undefined，ctx.rawBody 是原始字节。
+    const event = stripe.webhooks.constructEvent(
+      ctx.rawBody,
+      ctx.getHeader("stripe-signature"),
+      process.env.STRIPE_WEBHOOK_SECRET,
+    );
+    ...
+  });
+}
+```
+
+⚠️ **必须用 `postRaw`。** Stripe 验签要的是原始字节，任何「先 `JSON.parse` 再重新序列化」的路径都会验签失败 —— 这是 Stripe 接入的头号 bug，而这条路 FC 已经为附件上传铺好了。
+
+注册顺序无所谓：`/v1/stripe/*` 不在 `/v1/teams/:teamId/*` 的遮蔽范围内。
+
+#### 4.9.3 换算表放 Stripe Price 的 metadata
+
+在 Stripe Price 上挂 `metadata.credits`，webhook 直接读；**没有该 metadata 就拒绝入账并告警**，不猜（钱的路径 fail closed）。
+
+三个好处：
+
+1. 买到的额度锚死在下单那一刻的商品上，事后改价不会追溯改变在途订单。
+2. 加价逻辑集中在 Stripe 后台一处，不散落在代码里 —— 与 §4.4.1「credits 锚成本、加价只发生在充值那一次换算」完全一致。
+3. **币种变得无关**：credits 锚的是元的上游成本，Stripe 收什么币种都不影响这张映射表。
+
+#### 4.9.4 幂等键用 Session id，不要用 event id
+
+```
+idempotency_key = 'stripe:cs:' + session.id      ← 对
+idempotency_key = 'stripe:evt:' + event.id       ← 错，会重复入账
+```
+
+同一个 Checkout Session 可能触发 `checkout.session.completed` **和** `checkout.session.async_payment_succeeded` 两个事件，它们有不同的 `evt_` id。按 event id 做键会发两次额度；按 session id 只发一次，`credit_ledger` 的 `(team_id, idempotency_key)` 唯一索引直接兜住。
+
+- 入账条件：`checkout.session.completed` 且 `payment_status === 'paid'`，外加 `checkout.session.async_payment_succeeded`。
+- 退款：`charge.refunded` → `kind='refund'`，键用 `'stripe:re:' + refund.id`。
+- `team_id` 走 Session 的 `metadata` + `client_reference_id`。Session 由服务端用已鉴权调用者的团队创建，所以可信；网关侧团队不存在直接 404，**不要静默忽略**。
+
+#### 4.9.5 为什么 §5.2 的余额表没有非负约束
+
+退款是这条约束站不住的原因，记在这里免得后人「顺手补上」。
+
+一个直觉上很自然的 `CHECK (balance_credits >= 0)` 会在这条正常路径上炸掉：用户充值 → 花掉额度 → 申请退款，那笔负向 ledger 让约束失败，整个事务回滚，退款做不成。
+
+**所以 §5.2 从一开始就不带这个约束。** 账本是真相，退款导致负余额是合法状态；花钱的闸门本来就在 §4.6 的 `balance - reserved >= hold`，余额为负时它自然拒绝。丢掉的那层安全网由 §5.3 的**负余额告警**补上（Phase 2 就位，早于 Stripe 接入）。
+
+#### 4.9.6 ⚠️ 不要把发额度只挂在 webhook 一条路上
+
+Stripe 从境外主动回调 `api.<domain>/v1/stripe/webhook`，而该域名解析到大陆机房。这条跨境链路的可靠性**必须实测**（本仓库已有跨境连通性受阻的先例：该机器访问 Google 被墙，靠境外代理绕行）。
+
+兜底两层，都靠幂等键保证补跑安全：
+
+1. Stripe 自身重试最多 3 天。
+2. 一个定时对账任务扫 `stripe.checkout.sessions.list`，把已支付但本地无 ledger 条目的补进来。
+
+#### 4.9.7 客户端
+
+Tauri 内嵌 webview **不要**用来打开 Checkout（3DS 与钱包会出问题，用户也看不到地址栏），走系统浏览器。返回后不阻塞 UI 等 webhook —— 显示「处理中」，让余额自行刷新。
+
+---
+
+## 5. 数据模型
+
+### 5.1 放哪个库：主库 `amux` schema
+
+**决定：新表放主 Postgres（`postgres` 库）的 `amux` schema，走 `services/supabase/migrations/`。**
+
+对比 LiteLLM 用独立 `_litellm` 库的理由（prisma 拥有 ~20 张表、名字通用、会和应用 schema 撞名），这里不成立：只有 4 张目的明确、带前缀的表。而放主库换来两件必需的事：
+
+1. 网关要用 `(teamId, sub) → amux.actors` 做成员资格校验（§6.2），跨库做不到。
+2. FC 的管理面（余额展示、quota CRUD）要 join `teams` / `actors` / `team_members`。
+
+代价：网关多一个数据库连接到主库。用**独立 role** `ai_gateway` 限制权限，不共用 FC 的连接串。
+
+**⚠️ 落地注意**：往 `amux` 加表/索引会撞 `services/supabase/tests/020_oss_sync_schema.sql` 里的 `indexes_are` **精确集合断言** —— 迁移是对的、红的是断言，必须在同一个 PR 里一起改。（参考本仓库 pgTAP 套件的既有约定。）
+
+迁移文件命名沿用 `YYYYMMDDHHMMSS_<slug>.sql`，由 `deploy/self-host/init/apply-migrations.sh` 按字典序幂等应用、记账在 `_selfhost.schema_migrations`。
+
+### 5.2 DDL 草案
+
+```sql
+-- 20260901000000_ai_gateway_credits.sql
+
+-- 团队余额。一行一团队，物化余额而不是每次 SUM(ledger)：
+-- 余额要被 SELECT ... FOR UPDATE 锁住做预留，ledger 聚合做不到这件事，
+-- 而且 ledger 是只增表，几个月后聚合会变慢。
+-- 不变量：balance_credits == SUM(credit_ledger.amount_credits)，由对账任务校验。
+CREATE TABLE amux.team_credit_balance (
+  team_id         uuid PRIMARY KEY REFERENCES amux.teams(id) ON DELETE CASCADE,
+  balance_credits bigint      NOT NULL DEFAULT 0,
+  updated_at      timestamptz NOT NULL DEFAULT now()
+  -- 刻意没有 CHECK (balance_credits >= 0)：退款可以合法地把余额打成负数
+  -- （§4.9.5）。花钱的闸门在 §4.6 的 balance - reserved >= hold，余额为负时
+  -- 它自然拒绝。丢掉的那层安全网由 §5.3 的「余额为负」对账告警补上。
+);
+
+-- 只增账本。充值/赠送/调整为正，用量为负。
+CREATE TABLE amux.credit_ledger (
+  id              uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  team_id         uuid NOT NULL REFERENCES amux.teams(id) ON DELETE CASCADE,
+  -- 用量行记到 actor；充值行为 NULL。
+  actor_id        uuid REFERENCES amux.actors(id) ON DELETE SET NULL,
+  kind            text NOT NULL
+                  CHECK (kind IN ('top_up','grant','adjustment','usage','refund')),
+  amount_credits  bigint NOT NULL,        -- 有符号：usage 为负
+  -- 幂等键。支付回调重放、FC 重试都靠它去重。手工 top-up 也必须带。
+  idempotency_key text,
+  usage_log_id    uuid,                   -- kind='usage' 时指向 ai_usage_logs
+  note            text,
+  created_at      timestamptz NOT NULL DEFAULT now()
+);
+CREATE UNIQUE INDEX credit_ledger_idem_uniq
+  ON amux.credit_ledger (team_id, idempotency_key)
+  WHERE idempotency_key IS NOT NULL;
+CREATE INDEX credit_ledger_team_created_idx
+  ON amux.credit_ledger (team_id, created_at DESC);
+
+-- 在途预留（§4.6）。请求开始 held，结束 settled，超时 expired。
+CREATE TABLE amux.credit_reservation (
+  id             uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  team_id        uuid NOT NULL REFERENCES amux.teams(id) ON DELETE CASCADE,
+  actor_id       uuid NOT NULL REFERENCES amux.actors(id) ON DELETE CASCADE,
+  amount_credits bigint NOT NULL CHECK (amount_credits >= 0),
+  state          text   NOT NULL DEFAULT 'held'
+                 CHECK (state IN ('held','settled','expired')),
+  created_at     timestamptz NOT NULL DEFAULT now(),
+  expires_at     timestamptz NOT NULL
+);
+-- 预留求和是每个请求的热路径，只扫 held 行。
+CREATE INDEX credit_reservation_held_idx
+  ON amux.credit_reservation (team_id, actor_id)
+  WHERE state = 'held';
+CREATE INDEX credit_reservation_expiry_idx
+  ON amux.credit_reservation (expires_at)
+  WHERE state = 'held';
+
+-- 成员周期限额。
+CREATE TABLE amux.member_credit_quota (
+  team_id       uuid NOT NULL REFERENCES amux.teams(id) ON DELETE CASCADE,
+  actor_id      uuid NOT NULL REFERENCES amux.actors(id) ON DELETE CASCADE,
+  period        text NOT NULL CHECK (period IN ('week','month')),
+  limit_credits bigint CHECK (limit_credits IS NULL OR limit_credits >= 0),
+  updated_at    timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (team_id, actor_id)
+);
+
+-- 每次请求一行。既是报表来源，也是 quota 周期累计的来源。
+CREATE TABLE amux.ai_usage_logs (
+  id                uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  team_id           uuid NOT NULL REFERENCES amux.teams(id) ON DELETE CASCADE,
+  actor_id          uuid REFERENCES amux.actors(id) ON DELETE SET NULL,
+  public_model_id   text NOT NULL,       -- 客户请求的
+  backend_model_id  text NOT NULL,       -- 实际路由到的
+  provider_id       text NOT NULL,
+  input_tokens      bigint NOT NULL DEFAULT 0,
+  output_tokens     bigint NOT NULL DEFAULT 0,
+  credits           bigint NOT NULL DEFAULT 0,
+  -- 'upstream' = 上游回了 usage；'estimated' = 按 max_tokens 保守扣（§4.4）
+  usage_source      text NOT NULL DEFAULT 'upstream'
+                    CHECK (usage_source IN ('upstream','estimated')),
+  status_code       int,
+  stream            boolean NOT NULL DEFAULT false,
+  latency_ms        int,
+  request_id        text,
+  created_at        timestamptz NOT NULL DEFAULT now()
+);
+-- quota 周期累计：WHERE team_id=? AND actor_id=? AND created_at >= 周期起点
+CREATE INDEX ai_usage_logs_team_actor_created_idx
+  ON amux.ai_usage_logs (team_id, actor_id, created_at DESC);
+CREATE INDEX ai_usage_logs_team_created_idx
+  ON amux.ai_usage_logs (team_id, created_at DESC);
+
+-- 网关专用 role：只有这 5 张表 + actors 只读。不走 RLS —— 网关自己做 authz，
+-- 且它不持有终端用户 JWT 去 PostgREST，RLS 在这条路径上没有作用点。
+GRANT USAGE ON SCHEMA amux TO ai_gateway;
+GRANT SELECT, INSERT, UPDATE ON amux.team_credit_balance,
+      amux.credit_reservation TO ai_gateway;
+GRANT SELECT, INSERT ON amux.credit_ledger, amux.ai_usage_logs TO ai_gateway;
+GRANT SELECT ON amux.member_credit_quota, amux.actors, amux.teams,
+      amux.team_workspace_config TO ai_gateway;
+```
+
+### 5.3 保留与对账
+
+- `ai_usage_logs` 无限增长。**保留 13 个月**（够同比），超期由一个 FC cron 归档删除。Phase 2 一起做，不要留到表大了再补。
+- **对账任务**（Phase 2）：每日校验 `team_credit_balance.balance_credits == SUM(credit_ledger.amount_credits)`，不一致告警。物化余额的代价就是要有这个任务。
+- **负余额告警**（Phase 2）：`balance_credits < 0` 的团队一律告警。§5.2 刻意去掉了非负 CHECK（退款可合法致负，§4.9.5），这条告警是它的替代品 —— 结算逻辑的 bug 只能靠它兜住。
+- **不做 BI 只读副本。** §5.2 的两个索引够撑报表查询；量大了先做月度 rollup 表，副本是再之后的事。
+- ⚠️ **报表查询只能由网关（`ai_gateway` role）或 FC 服务端跑，不要暴露成 PostgREST 上 `authenticated` 角色的查询** —— 那个角色有 8 秒 statement_timeout，本仓库已经在会话列表上栽过一次同样的坑。
+
+---
+
+## 6. `services/ai-gateway/`
+
+### 6.1 职责
+
+OpenAI-compatible 代理、JWT 验证与成员资格校验、Credits/quota、账本、内网 admin API（FC 调用）。
+
+### 6.2 鉴权：JWT → actor（同时即成员资格证明）
+
+这是本设计的安全核心，必须写死：
+
+```
+Authorization: Bearer <access_token>
+   │
+   ├─ 1. 校验 token，拿到 sub。方式与 FC 一致，按 BACKEND_KIND 分两条路
+   │      （见 §6.2.1）—— 网关不持有任何签名密钥。
+   │
+   ├─ 2. sub → actor。路径里的 :teamId 不可信，token 只证明「你是谁」。
+   │      SELECT id, actor_type FROM amux.actors
+   │       WHERE team_id = :teamId AND user_id = sub;
+   │      查不到 → 403 not_a_team_member
+   │
+   └─ 3. actors 表上有 UNIQUE (team_id, user_id) WHERE user_id IS NOT NULL
+          （services/fc/src/db/schema/teams.ts:52），所以这一条查询同时完成
+          「解析 actor」和「证明该 user 属于该 team」两件事，无需第二次查询。
+```
+
+**为什么是 `actors` 而不是 `team_members`**：`actors` 是 team 域的（`team_id` 是它的列），而 `team_members` 走 `members`→`actors` 两跳。用 `actors` 一跳到位，且拿到的就是计费主体。
+
+#### 6.2.1 token 校验：照抄 FC，不引入新密钥
+
+**网关不需要持有任何签名密钥。** FC 已经有两条成熟路径，按 `BACKEND_KIND`（`services/fc/src/lib/backend-kind.ts`）分叉，网关原样照抄：
+
+| `BACKEND_KIND` | 校验方式 | 依据 |
+|---|---|---|
+| `supabase`（**self-host 与线上默认**，`docker-compose.yml:274`） | 调 GoTrue `/auth/v1/user`（即 `supabase.auth.getUser(token)`），由 GoTrue 自己校验并返回 user | `services/fc/src/lib/supabase-repo.ts:405` 等十余处、`lib/sync-auth.ts:82` |
+| `postgres` | `jose` + JWKS 本地验签（非对称，只需公钥） | `services/fc/src/auth/verify.ts` |
+
+两条路径都**不需要对称密钥**。早期草案里写的「网关持有 `GOTRUE_JWT_SECRET` 做 HS256 验签」是错的 —— FC 从来没这么干过，网关也不该开这个先例。
+
+**代价**：`supabase` 路径下每个请求多一次到 GoTrue 的 HTTP 往返。这在 LLM 请求（2–60 秒）面前是噪声，且是容器网络内调用。仍然要加一层 **按 token 哈希的 60 秒内存缓存**，避免一个 agent 会话里几十次 tool call 反复打 GoTrue；缓存只存 `sub`，不存 token 本身。
+
+**注意**：缓存的是「token → sub」，**不是**「token → 有权访问 teamId」。第 2 步的 actor 查询每次都要真查，否则成员被移出团队后还能继续花钱到缓存过期。
+
+#### 6.2.2 daemon / agent actor 的归属
+
+daemon 用的是它自己的 hosted agent actor（见 `apps/daemon/src/runtime/managed_llm.rs` 的 member-key kick 逻辑、`cloud_api/mod.rs:754-757` 的注释）。它的 `actor_type` 是 `agent` 而不是 `member`。
+
+**决定**：
+- **余额**：agent actor 的消耗一样扣团队 balance —— 团队的钱就是团队的钱。
+- **quota**：`member_credit_quota` 按 actor_id 建，所以 agent actor 也可以单独设限额，缺省不限。
+- 定时任务触发的 agent 不受 quota 拦截（无人值守，卡住就跑不过）—— **`actor_type='agent'` 且无显式 quota 行时，跳过 §4.2 第 3 步**，只受团队余额约束。
+
+### 6.3 对外路由（JWT）
+
+| 方法 | 路径 | 说明 |
+|------|------|------|
+| `POST` | `/v1/teams/:teamId/chat/completions` | 主路径，支持 `stream: true` |
+| `GET` | `/v1/teams/:teamId/models` | public 层 `{ id, name }` |
+| `GET` | `/v1/teams/:teamId/credits/balance` | |
+| `GET` | `/v1/teams/:teamId/credits/usage` | `range=day\|week\|month\|year`，口径同附录 A |
+| `GET` | `/healthz` | 无鉴权，供 compose healthcheck 与 CI 等待 |
+
+baseURL 契约：客户端拿到的 baseURL 是 `<gateway>/v1/teams/<teamId>`，`@ai-sdk/openai-compatible` 自动拼 `/chat/completions` 和 `/models`。
+
+### 6.4 内网路由（FC service token）
+
+`Authorization: Bearer <AI_GATEWAY_SERVICE_TOKEN>`，与 JWT 路径完全分开的中间件。
+
+| 方法 | 路径 |
+|------|------|
+| `POST` | `/internal/teams/:teamId/credits/top-up`（带 `idempotencyKey`） |
+| `GET` | `/internal/teams/:teamId/credits/summary` |
+| `PUT` | `/internal/teams/:teamId/members/:actorId/quota` |
+| `GET` | `/internal/models` |
+
+**`/internal/models` 是必需的**，别漏：FC 的 `getWorkspaceConfig` 今天用 `LITELLM_MASTER_KEY` 去拉模型目录填 `availableModels`（`services/fc/src/lib/pg-repo/teams.ts:159-186`）。换成网关后 FC 没有终端用户 JWT，只能走内网 token 拿 catalog 的 public 层。
+
+### 6.5 实现栈
+
+**TypeScript / Node 20 + Hono**，独立 npm 包 `services/ai-gateway/`（自带 `package.json` + `package-lock.json` + Dockerfile）。依赖只有五个：`hono`、`@hono/node-server`、`postgres`、`jose`、`yaml`。`catalog.yaml` 只读挂载；转发用原生 `fetch`，零 AI SDK。
+
+#### 为什么不是 Rust
+
+仓库里有成熟的 Rust 服务端能力（amuxd 用 axum），所以这个选择需要理由：
+
+1. **构建发生在生产机上。** `self-host-deploy.yml:261` 是 SSH 上去 `docker compose build fc`，没有 registry、没有预构建镜像。那台机器 4 核、根盘 40G 已用 79%（剩 ~8G）。Node 的 `npm ci` + `tsc` 是 1–2 分钟且 lockfile 不变时整层命中缓存；Rust 的 `COPY . .` 每次改源码都失效，冷编译 5–15 分钟并在只剩 8G 的盘上堆几 GB 中间产物。而这个 workflow 已经因为机器负载撞过 30 分钟 e2e 超时。要用 Rust，得先把部署改成「CI 构建 + 推 registry + 机器上只 pull」—— 那是一次独立的基础设施改动，不该由本模块顺带推动。
+2. **要用的东西 FC 里全都有且已在这台机器上跑通**：`hono`/`postgres`/`jose` 已在依赖树里；`amux.actors` / `amux.teams` 的表定义已经写好（`services/fc/src/db/schema/teams.ts`）；token 校验的两条路径已经实现（§6.2.1）。
+3. **负载画像是纯 I/O。** 每请求 = 一次身份校验 + 两个短事务 + 一次 2–60 秒的上游 fetch + SSE 转发。Rust 能赢的是常驻内存（~15MB vs ~80MB），在 15G 内存的机器上不构成理由；而唯一的 CPU 热点已被 §4.6 刻意避开（不引 tiktoken）。
+
+#### 为什么不做成 FC 的第二个入口
+
+同一个包、不同 `CMD` 能省一套依赖树，但：网关要持有**全部上游 provider key**，不该背上 FC 的 alicloud SDK / aws-sdk / mqtt 等 20 个依赖；且 FC 每次发布都会重启网关，掐断进行中的 LLM 流。
+
+`services/*` 本来就在 pnpm workspace 之外、各自用 npm 管理（`pnpm-workspace.yaml` 只含 `apps/*` 和 `packages/*`），新增一个独立包是既有模式。
+
+**共享代码的处理**：`auth/verify.ts` 和它需要的几张 drizzle 表定义**复制**过去，文件头注明来源。两个文件的重叠不值得提前抽 workspace 包 —— 但这是已知的漂移点，schema 变更时要记得两边都改。
+
+### 6.6 请求改写
+
+**「透明」是有限度的** —— 转发前后共有四处必做改写，写进文档避免实现时漏：
+
+1. **`body.model`**：public id → 选中路由的 `upstream_model`。
+2. **参数白名单**（替代 LiteLLM 的 `drop_params`，见 §1.3）：按 backend 的 `supported_params` 过滤 body 顶层键，未知键丢弃并记 debug 日志。catalog 里每个 provider 可声明一份，缺省用 OpenAI Chat Completions 的标准集。
+3. **`stream_options.include_usage = true`**：流式请求必须注入，否则上游不回 usage，只能落到 §4.4 的 `estimated` 分支。同时要判断客户端**原本有没有**要这个字段 —— 没有的话，网关在转发下行 SSE 时要把那个只含 usage 的末尾 chunk **吃掉**，不能让 agent runtime 收到它预期外的帧。
+4. **鉴权头替换**：入站 JWT 剥掉，出站换成 provider 的 `api_key`。
+
+**SSE 处理**：下行必须逐 chunk 直通（不 buffer 整个响应），同时旁路解析出末尾的 `usage`。实现上是「一边 pipe 一边 tee 出最后一帧」，不是「收完再转」—— 后者会毁掉 agent 的流式体验。
+
+**上游错误**：4xx/5xx 原样透传给客户端（agent runtime 依赖这些语义），但**不结算 credits**，预留直接置 `expired`。只有 `failover` 策略下才换下一条路由重试。
+
+---
+
+## 7. FC 职责
+
+不 proxy LLM 字节流。负责：
+
+- `workspace-config` 的 `llm` 段（enabled / models / baseUrl / availableModels）
+- credits / quota 的读写管理面（转调网关 `/internal/*`）
+- 充值下单入口
+- 设置页数据聚合
+
+### 7.1 端点变更
+
+**新增**（Phase 2）：
+
+| 方法 | 路径 |
+|------|------|
+| `GET` | `/v1/teams/:teamId/credits` — 余额 + 本周期用量 |
+| `GET` | `/v1/teams/:teamId/credits/usage` — 报表，替代 `/litellm/usage` |
+| `POST` | `/v1/teams/:teamId/credits/top-up` — owner only |
+| `GET`/`PUT` | `/v1/teams/:teamId/members/:actorId/quota` — owner only |
+
+**新增**（Phase 4，Stripe，见 §4.9）：
+
+| 方法 | 路径 |
+|------|------|
+| `POST` | `/v1/teams/:teamId/credits/checkout-session` — 建 Stripe Checkout Session，owner only |
+| `POST` | `/v1/stripe/webhook` — `{ auth: "none" }` + `postRaw`，由 `stripe-signature` 验签 |
+
+Stripe 路由单独放 `services/fc/src/lib/routes/stripe.ts`（不混进 team-credits：一条是免鉴权入站回调，一条是普通业务端点，鉴权模型不同）。
+
+新增路由文件 `services/fc/src/lib/routes/team-credits.ts`，在 `routes/index.ts` 里 **注册在 `registerWorkspaces` 之前**（和 `registerTeamShare` / `registerTeamSkills` 同理，否则被 workspaces 的宽匹配 `/v1/teams/:teamId/*` 遮蔽 —— 那个文件里已有三处注释在讲这件事）。
+
+设置页对这些端点的具体消费方式见 §12。
+
+**删除**（Phase 3，不是更早）：`routes/team-litellm.ts` 全部 5 条、`lib/litellm.ts`、`lib/litellm-usage.ts`，以及 repository contract 里对应的 `setupLiteLlm` / `ensureMemberKey` / `getLiteLlmUsage` / `listLiteLlmKeys` / `setLiteLlmBudget`。
+
+---
+
+## 8. 契约迁移（openapi）
+
+CLAUDE.md 规定新增业务端点必须**先**写进 `docs/openapi/teamclu-api.v1.yaml`。这一节列出全部契约动作，因为其中有一条是 breaking change。
+
+| 动作 | 位置 | 期 |
+|------|------|-----|
+| 新增 4 条 `/v1/teams/{teamId}/credits*` + quota | paths | Phase 2 |
+| 新增 `GET /v1/teams/{teamId}/credits/ledger`（充值历史，§12.5） | paths | Phase 2 |
+| `GET /v1/teams/{teamId}/credits/usage` 加 `groupBy` 参数 | paths | Phase 2 |
+| 新增 `POST /v1/teams/{teamId}/credits/checkout-session` | paths | Phase 4 |
+| `POST /v1/stripe/webhook` **不进 openapi** —— 它不是客户端契约，是 Stripe→FC 的入站回调，形状由 Stripe 定 | — | Phase 4 |
+| 新增 `CreditsSummary` / `CreditUsageReport` / `MemberQuota` schema | components | Phase 2 |
+| **`MergedWorkspaceConfig.required` 去掉 `litellmTeamId`** | `:6720` | Phase 2 |
+| 删除 `/v1/teams/{teamId}/litellm/{setup,member-key,keys,budget}` | `:2607`/`:2637`/`:2669`/`:2698` | Phase 3 |
+| 删除 `LiteLlmSetupResponse` / `LiteLlmMemberKeyResponse` | `:6730`/`:6738` | Phase 3 |
+| `POST /v1/teams` 响应里的 `aiGatewayEndpoint` / `litellmKey` | `:141-158` | Phase 3 改为只留 `aiGatewayEndpoint` |
+
+### 8.1 `litellmTeamId` 是 breaking change
+
+`MergedWorkspaceConfig` 目前 `required: [syncMode, litellmTeamId]`。读它的客户端有：
+
+- `packages/app/src/lib/backend/cloud-api/teams.ts`
+- `apps/daemon/src/backend/cloud_api/mod.rs:686-740`（`managed_llm_config`）
+- iOS `CloudAPIClient` / `CloudAPIRepositories`
+
+**做法：先松后删。** Phase 2 把它从 `required` 挪到可选并保持**继续返回**（值可以是 null）；等所有客户端版本都不再读它之后，Phase 3 才从 response 里去掉。绝不能一步到位 —— 老版本 iOS / 桌面端不会一夜之间升完。
+
+daemon 那侧 `base_url` 的解析优先级 `llm.baseUrl → llm.aiGatewayEndpoint`（`cloud_api/mod.rs:718-721`）保持不变，切换靠改 `llm_base_url` 的**数据**，不靠改代码。见 §11.2。
+
+---
+
+## 9. amuxd 本地代理
+
+路由：`/v1/ai/teams/:teamId/*path` → `<AI_GATEWAY_PUBLIC_URL>/v1/teams/:teamId/*path`。
+
+teamId 放在路径里而不是让 daemon 隐式推断 —— baseURL 本来就是 per-team 写进 `provider.team` 的，显式传递省掉一整类「切团队后打到旧团队账上」的 bug。
+
+### 9.1 `apiKey` 字段填什么
+
+**这不是可选项**：`@ai-sdk/openai-compatible` 一定会发 `Authorization: Bearer <apiKey>`，而 amuxd 的 HTTP 路由是按 handler 挂 scope 鉴权的（`apps/daemon/src/http/routes.rs`）。删掉 `tc_api_key` 之后必须有替代物。
+
+**决定**：新增 daemon scope `ai:invoke`，`provider.team.options.apiKey` 写占位符 `${tc_gateway_token}`，在 spawn 时由现有的 secret 解析链路（`assemble_runtime_env` + `SecretResolveScope::FullConfig`）解析成一个只带 `ai:invoke` 的 daemon 会话令牌。
+
+`crates/teamclu-runtime-env/src/team_provider.rs:118-129` 那段「保住已解析的 key、不要用占位符覆盖」的逻辑**原样保留**，只是把匹配的前缀从 `sk-tc-` 换成新令牌格式。
+
+**受影响的 `sk-tc-` 派生点**（Scope 里必须都列上）：
+
+| 文件 | 内容 |
+|------|------|
+| `crates/teamclu-runtime-env/src/merge.rs:11` | `format!("sk-tc-{suffix}")` 派生本体 |
+| `crates/teamclu-runtime-env/src/team_provider.rs:118` | 跨 reconcile 保住已解析 key |
+| `crates/teamclu-runtime-env/src/{env_catalog,personal_secrets,mcp_resolve}.rs` | `tc_api_key` 作为已知 secret 名 |
+| `apps/desktop/src/commands/env_vars.rs:251` | **桌面侧另有一份同样的派生逻辑** |
+| `packages/app/src/lib/team-provider.ts:11` | 注释里的契约描述 |
+
+### 9.2 绑定地址不一定是 loopback
+
+`apps/daemon/src/http/server.rs:74-96` 明确支持绑 `0.0.0.0` / `[::]`。所以**不能**用「跑在本地所以安全」来省鉴权：公网绑定下 `/v1/ai/*` 就是一个对外的 LLM 中继。`ai:invoke` scope 校验是硬要求，不是加固项。
+
+### 9.3 三个全局中间件会挡路
+
+`routes.rs:272-274` 上挂了全局的 body cap 和限流。默认值（`apps/daemon/src/config/daemon_config.rs`）对 LLM 流量都太紧：
+
+| 限制 | 默认值 | 为什么会撞 |
+|------|--------|-----------|
+| `max_body_bytes` | **1 MiB** | `provider.team` 声明的 context limit 是 256k token（`team_provider.rs`），对应的 JSON 请求体轻松超过 1 MiB。**这条会直接 413。** |
+| `rate_limit_rps` / `burst` | 20 / 60 | agent 的并行 tool call 会突刺 |
+| `max_sse_per_token` | **8** | 每个流式补全占一条 SSE；8 条并发很容易打满 |
+
+**要求**：`/v1/ai/*` 走独立配置 —— 新增 `http.ai_max_body_bytes`（默认 32 MiB）、独立的限流桶（或直接豁免），且 AI 流不计入 `max_sse_per_token`。这三条在 Phase 1 的实现清单里。
+
+### 9.4 SSE 直通
+
+daemon 侧同样必须逐 chunk 转发、不 buffer。已有的 `/v1/sessions/:id/stream` 是 daemon **自己产**的 SSE，这里是**转发上游**的 SSE，是新场景，要单独测（首字节延迟、断连传播、客户端取消能否传到上游）。
+
+---
+
+## 10. 部署
+
+### 10.1 环境变量：命名与两个部署目标
+
+已经存在一个 `AI_GATEWAY_ENDPOINT`（`services/fc/src/lib/team-provisioning.ts:15`），语义是**对外的、给客户端的、带 `/v1` 的** URL。再引入一个含义相反的 `AI_GATEWAY_URL`（FC→网关内网）几乎必然被搞混，所以：
+
+| 变量 | 含义 | self-host 值 |
+|------|------|-------------|
+| `AI_GATEWAY_ENDPOINT` | **沿用原义**：对外、给客户端。指向新网关 | `https://api.<domain>/ai/v1` |
+| `AI_GATEWAY_INTERNAL_URL` | FC → 网关，容器网络内 | `http://ai-gateway:4001` |
+| `AI_GATEWAY_SERVICE_TOKEN` | FC ↔ 网关 `/internal/*` 鉴权 | 由 `bootstrap/gen-secrets.sh` 生成 |
+
+**⚠️ 三个都必须同时声明在 `services/fc/s.yaml` 和 `deploy/self-host/docker-compose.yml` 的 `fc:` `environment:` 映射里。** compose 的 environment 是显式白名单，漏一个就在那个目标上静默丢失；而且 `services/fc/test/deploy-env-parity.test.ts` 和 `scripts/lib/env-manifest.test.js` 会红。
+
+**Phase 4 追加（Stripe，见 §4.9）**：`STRIPE_SECRET_KEY`、`STRIPE_WEBHOOK_SECRET`、`STRIPE_PRICE_IDS`（允许的 Price 白名单）。同样是**两个目标都要声明**。
+
+⚠️ 两个部署目标用的是**独立数据库**，所以要么两个 Stripe 账号，要么一个账号配两个 webhook endpoint —— 一笔支付绝不能记到另一套环境的团队头上。团队不存在时网关返回 404，FC 必须把它当失败告警，不能吞掉。
+
+网关自己的 env：`DATABASE_URL`（`ai_gateway` role）、`AI_GATEWAY_SERVICE_TOKEN`、`BACKEND_KIND` + 对应的 token 校验配置（`supabase` 路径用 `SUPABASE_URL` / anon key，与 FC 同源，见 §6.2.1）、各 provider key（`DEEPSEEK_API_KEY` 等，从 litellm 服务移过来）。**没有签名密钥。** 同样要在 `.env.example` 里补文档。
+
+### 10.2 compose
+
+**Phase 0 只增不删**：加 `ai-gateway` 服务（build context `../../services/fc` 同级的 `../../services/ai-gateway`），healthcheck 打 `/healthz`，`depends_on: db healthy`。`litellm` / `litellm-init` 原样保留。
+
+**Phase 3 才删**：`litellm`、`litellm-init` 两个服务，以及 `fc:` 环境里的 `LITELLM_URL` / `LITELLM_MASTER_KEY` / `LITELLM_DEFAULT_TEAM_MAX_BUDGET_USD` / `LITELLM_DB_NAME`。`_litellm` 数据库**保留到 Phase 3 之后至少一个月**再手工 drop —— 里面是历史用量数据，见 §11.4。
+
+`docker-compose.podman.yml` 有同样的服务定义，两份都要改。
+
+### 10.3 Caddy
+
+`deploy/self-host/caddy/Caddyfile` 今天有三段 litellm 反代：`/litellm-asset-prefix/*`、`/ui/*`、`/llm/*`（:37-45）。
+
+- **Phase 0**：新增 `handle_path /ai/* { reverse_proxy ai-gateway:4001 }`。三段旧的保留。
+- **Phase 3**：删掉那三段。注意 `/ui/*` 挂的是 LiteLLM 的 admin UI，删掉即失去后台 —— 新网关**没有 admin UI**（catalog 是文件、余额管理在 TeamClu 设置页里），这是有意的，要在 Phase 3 的 checklist 里跟运营确认。
+
+### 10.4 CI（`.github/workflows/self-host-deploy.yml`）
+
+删 litellm 会连带炸部署流水线，逐条列出：
+
+| 行 | 内容 | 动作 |
+|----|------|------|
+| :213 | `upsert_env LITELLM_URL "http://litellm:4000"` | Phase 0 旁边加三条 `upsert_env AI_GATEWAY_*`；Phase 3 删这条 |
+| :263-276 | 拉 litellm 镜像（5 次重试） | Phase 3 删；`ai-gateway` 是本地 build，不需要对应逻辑 |
+| :308-310 | `until docker compose ps litellm \| grep -q healthy` | Phase 0 旁边加 `ai-gateway` 的同款等待；Phase 3 删 litellm 那条 |
+| :321-322 | `sh .../smoke/litellm-smoke.sh` | Phase 0 新增 `smoke/ai-gateway-smoke.sh` 并列跑；Phase 3 删旧的 |
+
+新的 `deploy/self-host/smoke/ai-gateway-smoke.sh` 至少覆盖：`/healthz`、无 JWT → 401、错误 teamId 的 JWT → 403、`GET /models` 返回非空、一次非流式 `chat/completions` 打通并落一行 `ai_usage_logs`。
+
+`tests/e2e/smoke-team-share-onboarding.test.ts` 也引用了 litellm 流程，Phase 3 一起改。
+
+---
+
+## 11. 分期实施
+
+**核心原则：新旧并存，客户端灰度切完再删旧的。** 原方案里 Phase 0 就「compose 替换 litellm」而 Phase 1 才切客户端 —— 那会在 Phase 0 上线的瞬间打挂全部已安装桌面端（它们的 `provider.team.baseURL` 指向 LiteLLM），并且要等到 Phase 1 才恢复。
+
+| Phase | 内容 | 完成判据（gate） |
+|-------|------|-----------------|
+| **0** | 网关 MVP：JWT + 成员校验 + catalog 路由 + SSE 直通 + `ai_usage_logs`（**只记账不扣费**）。compose/Caddy/CI **只增不删**。migration 建 5 张表 + 改 pgTAP 断言。 | smoke 全绿；LiteLLM 路径完全未受影响 |
+| **1** | amuxd `/v1/ai/teams/:teamId/*` 代理（含 §9.3 的三项限制放宽）+ `${tc_gateway_token}`；桌面端/crate 侧 `sk-tc-` 清理。**按团队灰度**改 `llm_base_url`。 | 灰度团队正常出字；`ai_usage_logs` 有数据且 token 数与上游对得上 |
+| **2** | Credits 闭环：预留 + 结算 + quota 强制；FC credits 端点；设置页；openapi 的 `litellmTeamId` 松绑；保留策略 + 对账任务。**打开强制之前先给存量团队补发起始额度（§4.8.1）。** 设置页：新建账单页 + 现有 Token 用量页迁移数据源（§12）。 | 存量团队补发完成且余额行齐全；并发压测不超发；对账连续 7 天零差异 |
+| **3** | 全部团队切完 + **两个部署目标都切完** + 观察期 ≥ 2 周后：删 LiteLLM 容器 / FC 代码 / openapi 条目 / Caddy 三段 / CI 四处 / smoke。 | 见 §11.5 |
+| **4** | **Stripe 充值**（§4.9）：FC 的 checkout-session + webhook 路由、Price metadata 换算表、`stripe.checkout.sessions.list` 补账任务、桌面端走系统浏览器。**不动任何表结构** —— 幂等键从 Phase 2 起就在表里，余额表也从 Phase 0 起就没有非负约束（§4.9.5）。 | 跨境 webhook 投递实测通过；断开 webhook 后补账任务能独立把额度发对；重复投递同一 Session 不重复入账；退款能把余额打成负数而不报错 |
+
+### 11.1 Phase 1 的灰度开关
+
+切换不需要新开关：daemon 读的是 `team_workspace_config.llm_base_url`（`cloud_api/mod.rs:718`），**按团队 UPDATE 这一列就是天然的灰度粒度**。回滚同样是一条 UPDATE。
+
+⚠️ **客户端写死之后这条杠杆依然成立，但读它的人变了**：客户端的 baseURL 恒指向本地 amuxd（附录 B），由 **amuxd** 读 `llm_base_url` 决定把请求转发到新网关还是老 LiteLLM。灰度粒度、回滚方式都不变，只是解析点后移了一跳。这也是为什么 P1 的 amuxd 代理必须支持转发到**两种**上游，而不只是新网关。
+
+### 11.2 数据迁移：`llm_base_url`
+
+这是切换的真正动作，不是代码发布：
+
+```sql
+-- 灰度：单个团队
+UPDATE amux.team_workspace_config
+   SET llm_base_url = 'https://api.<domain>/ai/v1/teams/' || team_id::text
+ WHERE team_id = '<uuid>';
+
+-- 全量（Phase 1 末尾）
+UPDATE amux.team_workspace_config
+   SET llm_base_url = 'https://api.<domain>/ai/v1/teams/' || team_id::text
+ WHERE llm_base_url IS NULL OR llm_base_url LIKE '%/llm/v1%';
+```
+
+同时 `AI_GATEWAY_ENDPOINT` 改指向新网关，这样**没有显式 `llm_base_url` 的团队**（走 fallback 分支）也自动切过去。
+
+### 11.3 残留 `sk-tc-*` 的清洗
+
+`team_provider.rs:118-129` 是**刻意**保住已解析 key 不被占位符覆盖的。这意味着切到 JWT 之后，老 key 会一直赖在设备的 `opencode.json` 里，`ensure_global_team_provider` 不会自己清掉它。
+
+**要求**：Phase 1 的 reconcile 逻辑里加一条一次性清洗 —— 若 `options.apiKey` 匹配 `^sk-tc-`，视同「未解析」，用新占位符覆盖。没有这一步，老设备升级后会拿着一个作废的 key 打新网关，表现为持续 401，而且用户没有任何自愈手段。
+
+### 11.4 历史用量数据
+
+`/litellm/usage` 今天直连 `_litellm` 库聚合 `LiteLLM_SpendLogs`（`litellm-usage.ts`）。新的 `ai_usage_logs` 从 Phase 0 起才有数据。
+
+**决定：不迁移历史数据。** 理由：口径不同（LiteLLM 记的是 USD spend，新表记的是 credits，两者没有确定的换算 —— credits 定价是 Phase 2 才定的），强行换算会造出假的历史账。
+
+**做法**：Phase 2 的设置页在用量图表上标一条「统计起始日」分界；`_litellm` 库在 Phase 3 后保留至少一个月供人工查旧账，之后手工 drop。这条必须提前跟运营讲，别让人以为数据丢了。
+
+### 11.5 Phase 3 的 gate
+
+删任何东西之前，全部满足：
+
+- [ ] 两个部署目标（self-host + `s.yaml` 那套）都已完成 Phase 1 全量切换
+- [ ] 所有团队的 `llm_base_url` 都已指向新网关（`SELECT count(*) ... WHERE llm_base_url LIKE '%/llm/%'` 为 0）
+- [ ] 观察期 ≥ 2 周，`ai_usage_logs` 有持续流量，LiteLLM 侧流量归零（查 `LiteLLM_SpendLogs` 最近 14 天无新行）
+- [ ] 最低支持的桌面端 / iOS 版本已不读 `litellmTeamId`
+- [ ] 运营已确认不再需要 LiteLLM admin UI（§10.3）
+
+---
+
+## 12. 设置页：账单与用量
+
+### 12.1 两个页面，一份数据
+
+| 页面 | 内容 | 状态 |
+|---|---|---|
+| **账单**（新增） | 余额、充值入口、积分↔token 换算、充值历史、本周期汇总 | Phase 2 新建 |
+| **Token 用量**（现有） | 周期切换、总量三卡、成员排行榜、按档分组 | Phase 2 **迁移数据源** |
+
+两页读同一批数据（`ai_usage_logs` + `credit_ledger`），周期口径统一走附录 A 的 CST 换算 —— 报表和 quota 用同一套，不要各写一份。
+
+分工：**账单页给「还剩多少、怎么充」，用量页给「花在哪了」。** 账单页只放本周期汇总，明细留在用量页，避免两页各写一份聚合逻辑。
+
+### 12.2 账单页布局
+
+对照 Cursor 的 Billing & Invoices（产品参考）：
+
+| Cursor | 本设计 | 说明 |
+|---|---|---|
+| Plan 卡（Pro / Annual / $16 per mo.） | **余额卡** | 我们不是订阅制，顶部卡片是钱包余额而非套餐 |
+| Payment（Manage in Stripe） | **充值卡** | Phase 2 只有管理员手工充值；Phase 4 接 Stripe（§4.9） |
+| Included Usage（按模型的 token + 占比） | **本周期用量** | 按三档 tier 分组，不暴露 upstream 名（§4.3） |
+| —— | **充值历史** | Cursor 没有；我们是预付费钱包，必须有 |
+
+余额卡要素：当前余额（积分）、本周期已消耗、低水位警示（§4.2 的硬停策略决定了这个提示必须显眼）、充值按钮。
+
+### 12.3 「1 积分 = 多少 token」不是一个数
+
+这是本节最容易做错的地方。credits 锚定的是**上游成本**（§4.4.1），所以积分到 token 的换算**取决于用哪一档、以及输入还是输出**——不存在单一比值。UI 上写「1 积分 = N tokens」就是在撒谎。
+
+正确做法是一张按档的小表，输入/输出分列：
+
+| 档位 | 1 积分 ≈ 输入 token | 1 积分 ≈ 输出 token |
+|---|---|---|
+| 标准 default | ~20,000 | ~10,000 |
+| 高级 pro | ~5,000 | ~2,500 |
+| 旗舰 max | ~550 | ~140 |
+
+（按 `catalog.example.yaml` 的**占位价**算出来的示意；1 积分 = 10,000 credits，credits 数由 catalog 给。真实数字随价目表变。）
+
+三条硬要求：
+
+1. **必须标注是估算**，并说明「实际以出账为准」——价目表会变，混合路由的档位每次命中的成本也不同。
+2. **混合路由的档位取该档所有路由里最高价那条**（`max` 会 failover 到差一个数量级的两个 backend）。这与 §4.4 预留用的口径一致，且对用户是保守估计，不会让人以为能用更多。
+3. 数据来自 `GET /models` 新增的 `estimatedPricing` 字段（§12.5），**不要在客户端硬编码价格**——那会在调价当天变成错误信息。
+
+### 12.4 现有 Token 用量页的迁移
+
+现在这页读 `/v1/teams/:id/litellm/usage`，后者直连 `_litellm` 库聚合 `LiteLLM_SpendLogs`（`services/fc/src/lib/litellm-usage.ts`）。迁到 `ai_usage_logs` 后：
+
+| 现状 | 迁移后 | 注意 |
+|---|---|---|
+| 总费用 `$0`（USD） | **消耗积分** | **语义变了，不是换个数字**——USD spend 与 credits 无确定换算（§11.4） |
+| 总 Token 数 | `SUM(input_tokens + output_tokens)` | 建议拆成输入/输出两个数，上游计费本来就分开 |
+| 请求数 | `COUNT(*)` | 直接对应 |
+| 成员排行榜 | `GROUP BY actor_id` | §5.2 的 `ai_usage_logs_team_actor_created_idx` 正是为它建的 |
+| 按模型分组 | `GROUP BY public_model_id` | **用 public 层**，不要暴露 `backend_model_id`（§4.3） |
+| `maxBudget`（USD 封顶） | 删除 | 概念不存在了，换成余额（§4.1） |
+| 错误码 `litellm_usage_unavailable` / `litellm_unavailable` | 退役 | `TokenUsageSection.tsx:64` 在判这两个码，要一起改 |
+
+⚠️ **统计起始日断层**：`ai_usage_logs` 从 Phase 0 才开始有数据，历史用量不迁移（§11.4）。所以「当年」视图必然出现一条断层。要求：**周期早于起始日时显示说明文案，而不是显示 0** ——显示 0 会被读成「那段时间没人用」，是错误信息。
+
+现有的 `summary` / `members` / `byModel` 三段响应结构可以原样保留，只换数据源和字段语义，前端改动面因此可控。
+
+### 12.5 端点
+
+在 §7.1 的基础上补两项：
+
+| 方法 | 路径 | 用途 |
+|------|------|------|
+| `GET` | `/v1/teams/:teamId/credits/ledger` | 充值历史。**只返回 `kind IN (top_up, grant, adjustment, refund)`**，排除 `usage` 行（那是每请求一行，量级完全不同） |
+| `GET` | `/v1/teams/:teamId/credits/usage` | 加 `groupBy=actor\|model` 参数，供排行榜与分档表复用同一端点 |
+
+`GET /v1/teams/:teamId/models`（网关）响应加 `estimatedPricing: { inputPer1mCredits, outputPer1mCredits }`，取该档最高价路由（§12.3 第 2 条）。仍然**不暴露 upstream 名**。
+
+### 12.6 权限
+
+| 内容 | 可见范围 | 理由 |
+|---|---|---|
+| 余额、低水位警示 | **全体成员** | 余额耗尽是硬停（§4.2），成员必须能自己看到为什么用不了 |
+| 用量、成员排行榜 | 全体成员 | 现状即如此，不收紧 |
+| 充值历史、充值按钮 | **仅 owner** | 涉及金额与支付 |
+
+### 12.7 实现注意
+
+- ⚠️ **设置页是模态 dialog，任何 Popover / Dropdown 必须显式传 `container`**，否则默认 portal 到 `body` 会永远打不开，而触发器看起来完全正常（判据：`body` 上有 `pointer-events: none`）。充值确认框、周期选择器都要注意。
+- 新组件放 `packages/app/src/components/settings/BillingSection.tsx`，在 `section-registry.tsx` 注册（现有 `tokenUsage` / `leaderboard` 就在那里）。
+- i18n：新 key 加进 `packages/app/src/locales/{en,zh-CN}.json` 两份，注意仓库有 i18n-parity 死键守卫。
+
+---
+
+## 13. 决策记录
+
+| 决策 | 理由 |
+|------|------|
+| 独立 `ai-gateway` | 流式、Credits、限额与 FC 解耦；FC 的另一个部署目标是事件函数，不适合承载长连接流式 |
+| 只做 OpenAI 兼容转发，零翻译层 | 今天全部上游已是 OpenAI 兼容（§1.2）。接原生协议上游是一次独立决策 |
+| Credits + balance + quota | 充值余额；成员周期限额；替代 LiteLLM 的 USD budget |
+| public / backend 双层 catalog | 对外包装名；1:n 路由；定价按实际上游 |
+| 首版 catalog 必须是现有 public id 的超集 | 团队 `llm_models` 已存旧 id，换目录会让选中模型失效（§4.3.1） |
+| JWT，无 user API key | 与登录态统一；离职即失效 |
+| `(team_id, user_id)` 一次查询完成 actor 解析 + 成员校验 | `actors` 是 team 域表且有该唯一索引；避免路径 `:teamId` 被伪造 |
+| 新表放主库 `amux` schema | 网关和 FC 都要 join `actors`/`teams`；LiteLLM 用独立库的理由（20 张 prisma 表）不适用 |
+| 物化 balance + 只增 ledger + 对账任务 | 预留需要行锁，聚合做不到；代价是必须有对账 |
+| 预留机制而非「查余额>0」 | agent 并发是常态，后者必然超发（§4.6） |
+| Phase 0/1 只记账不扣费 | 先验证转发与计量正确，再上强制；这两期上限仍在上游 provider key |
+| daemon 本地代理 | JWT 刷新；用户不填 key |
+| 新旧并存 + 按 `llm_base_url` 灰度 | 不需要新开关，回滚是一条 UPDATE |
+| 不迁移历史用量 | USD spend 与 credits 无确定换算，强转会造假账（§11.4） |
+| 客户端 provider 写死为 default/pro/max 三档 | tier 是稳定名字，tier→backend 的映射在服务端；改后端/调价/换供应商都不需发客户端（§4.3.1） |
+| 上游解析后移到 amuxd | 客户端写死的同时保留 §11.2 的一条 UPDATE 灰度与回滚（附录 B） |
+| 未知 model id 一律 403，不静默回落 default | 静默回落会让发错 id 的客户端长期拿到错档位且无征兆（§4.3.2） |
+| 账单与用量分两页，共用一批端点 | 账单答「还剩多少、怎么充」，用量答「花在哪了」；避免两处聚合逻辑（§12.1） |
+| 积分↔token 按档分列展示，不给单一比值 | credits 锚成本，换算随档位与输入/输出而变，单一比值是错误信息（§12.3） |
+| 换算价格由 `GET /models` 下发，不在客户端硬编码 | 调价当天硬编码就变成错误信息（§12.3） |
+| 周期早于统计起始日时显示说明而非 0 | 显示 0 会被读成「那段时间没人用」（§12.4） |
+| 1 credit = 1e-6 元上游成本 | 单位取粗会让 `ceil` 对小请求系统性高估 10 倍；agent 全是小请求（§4.4.1） |
+| credits 锚成本而非售价 | catalog 变成价目表的直接抄写；加价集中在充值一次换算，售价因此不阻塞本设计 |
+| 余额耗尽硬停 402，不降级不透支 | 静默降级让 agent 继续产出低质量结果且无人察觉，定时任务尤其危险；负余额需要整套追缴逻辑（§4.2） |
+| 建团队一次性 grant 10 元额度，不按人头 | 去掉 onboarding 门槛同时封住上限；按人头可靠拉人无限刷（§4.8） |
+| 不做 BI 只读副本 | 两个索引够用；下一步是月度 rollup 而非副本（§5.3） |
+| Stripe 放 FC，网关仍是账本唯一写入者 | 支付是业务面；单写者让 webhook 在 FC 内不需要任何新权限（§4.9.1） |
+| 幂等键用 Checkout Session id 而非 event id | 同一 Session 的两个事件有不同 evt_ id，按 event 键会重复入账（§4.9.4） |
+| credits 换算表放 Stripe Price metadata | 额度锚死在下单那一刻的商品上；加价集中一处；币种变得无关（§4.9.3） |
+| 去掉余额非负 CHECK，改用负余额告警 | 退款可合法致负；花钱闸门本就在预留逻辑里（§4.9.5） |
+| token 校验照抄 FC，网关不持签名密钥 | `supabase` 路径调 GoTrue `/auth/v1/user`、`postgres` 路径用 JWKS 公钥；两条都无对称密钥（§6.2.1） |
+| TypeScript / Node 20 + Hono | 部署是在生产机上 `docker compose build`，Rust 冷编译撞 4 核 / 剩 8G 盘；依赖与 token 校验代码 FC 已备齐；负载纯 I/O（§6.5） |
+| 独立 npm 包而非 FC 第二入口 | 网关持有全部 provider key，不该背 FC 的 20 个依赖；FC 发布不应掐断进行中的 LLM 流（§6.5） |
+
+---
+
+## 附录 A：quota 周期（CST）
+
+`week` = 周一 00:00 CST；`month` = 当月 1 日 00:00 CST。
+
+与今天 `services/fc/src/lib/litellm-usage.ts:21` 的口径一致（固定 UTC+8，不处理 DST），报表和 quota 用同一套换算，不要各写一份。
+
+## 附录 B：客户端 baseURL 与「写死」的边界
+
+| 客户端 | baseURL |
+|--------|---------|
+| Desktop（Phase 1 后） | `http://127.0.0.1:{amuxd_port}/v1/ai/teams/{teamId}` |
+| iOS（远期） | 直连 `https://api.<domain>/ai/v1/teams/{teamId}` + JWT |
+
+**写死的是什么、不是什么**（§4.3.1）：
+
+| 项 | 来源 |
+|---|---|
+| provider 形状、三档 model id | **客户端写死** |
+| baseURL | 运行时拼：本地 amuxd 端口 + teamId |
+| `llm_enabled` | 云端 `workspace-config.llm.enabled` |
+| **上游到底打新网关还是老 LiteLLM** | **云端 `llm_base_url`，由 amuxd 解析**（见 §11.2） |
+
+最后一行是关键：解析上游的职责从客户端**往后移了一跳**到 amuxd。客户端写死的同时，§11.2 那个「一条 UPDATE 灰度、一条 UPDATE 回滚」的杠杆完整保留 —— 只是现在读 `llm_base_url` 的是 daemon 而不是客户端。daemon 侧优先级不变：`llm.baseUrl` → `llm.aiGatewayEndpoint`（`apps/daemon/src/backend/cloud_api/mod.rs:718-721`）。
+
+## 附录 C：LiteLLM 对照
+
+| LiteLLM | 本设计 |
+|---------|--------|
+| virtual key `sk-tc-*` | Supabase JWT（对网关）+ daemon `ai:invoke` 令牌（对本地代理） |
+| `max_budget`（USD） | `team_credit_balance` + `member_credit_quota`（credits） |
+| `model_name` | `public_models.id` |
+| `litellm_params.model` | `backend_models.upstream_model` |
+| `drop_params: true` | catalog 的 `supported_params` 白名单（§6.6） |
+| `LiteLLM_SpendLogs` | `amux.ai_usage_logs` |
+| admin UI `/ui` | 无（catalog 是文件；余额在设置页） |
+| `_litellm` 独立库 | 主库 `amux` schema |
+
+## 附录 D：单次请求解析流程
+
+```
+入站 JWT
+  → 校验 token（GoTrue /auth/v1/user 或 JWKS，60s 缓存）→ sub
+  → (teamId, sub) → amux.actors → actor_id       [403 not_a_team_member]
+  → llm_enabled + model ∈ 团队白名单               [403 model_not_allowed]
+  → estimate() → 预留 (FOR UPDATE + held 行)       [402 insufficient/quota]
+  → body.model 改写 + 参数白名单 + include_usage 注入
+  → 上游 POST
+  → SSE 直通（旁路 tee 出末帧 usage）
+  → settle: 扣 balance + 写 ledger + 写 ai_usage_logs + 预留置 settled
+  （上游报错：原样透传，不结算，预留置 expired）
+```
+
+## 附录 E：pricing 不在 public model 上
+
+`max` 这类混路由 tier 每次命中的成本不同；调价改 `backend_models`，三档 public id 只是稳定的产品包装（§4.3.1）。
+
+## 附录 F：已拍板与仍未决
+
+### 已拍板（2026-08-28）
+
+| 问题 | 结论 | 位置 |
+|------|------|------|
+| credit 对货币的量纲 | 1 credit = 1e-6 元上游成本；UI 积分 = credits/10,000 | §4.4.1 |
+| 售价（用户花多少买 1 积分） | **不阻塞本设计** —— 锚的是成本，加价在充值那一次换算里，属运营参数 | §4.4.1 |
+| 默认赠送额度 | 建团队一次性 grant 10 元额度（10,000,000 credits），不按人头 | §4.8 |
+| 余额耗尽的行为 | 402 硬停；不降级、不透支；靠低水位告警兜 | §4.2 |
+| 支付渠道 | **Stripe**（Phase 4）。幂等键让 Phase 0–3 完全不受影响 | §4.9 |
+| BI 只读副本 | 不做；下一步是月度 rollup | §5.3 |
+
+### 仍未决（不阻塞 Phase 0）
+
+1. **低水位告警的阈值与通道** —— 余额硬停既然是设计选择，告警就是它的配套。阈值（剩余额度 or 预计可用天数）和通道（设置页 / 企微 / 邮件）留到 Phase 2 做设置页时一并定。
+2. **成员 quota 的默认值** —— 目前设计是「缺省不限，仅受团队余额约束」。是否要给新成员一个默认周期上限，等有真实用量分布后再看，改的是数据不是结构。

--- a/docs/specs/2026-08-28-team-ai-gateway-design.md
+++ b/docs/specs/2026-08-28-team-ai-gateway-design.md
@@ -143,14 +143,14 @@
               │
               ▼
 ┌─────────────────────────┐
-│  public_models.max       │  对外 catalog（三档 tier，§4.3.1）        
+│  public_models.max       │  对外 catalog + **定价**（§4.4）          
 │  routes[] (1:n)          │
 └───────────┬─────────────┘
             │ 路由策略 pick 一条
             ▼
 ┌─────────────────────────┐
-│  backend_models.gpt-4o  │  实际上游：provider + upstream_model + pricing
-│  → openai/gpt-4o
+│  backend_models.gpt-4o  │  实际上游：provider + upstream_model（无定价）
+│  → openai/gpt-4o        │  cost 可选，仅供毛利报表
 └─────────────────────────┘
             │
             ▼
@@ -196,14 +196,42 @@ Tauri 端不再从云端拉团队的模型列表：`provider.team` 的形状与�
 
 网关对**未知 model id** 一律 403 `model_not_allowed`，不要静默回落到 `default` —— 静默回落会让一个发错 id 的客户端永远拿到错误档位却毫无征兆。
 
-### 4.4 Credits 折算（按实际上游 model 定价）
+### 4.4 Credits 折算（按三档 tier 自主定价）
 
-**定价只挂在 `backend_models.*.pricing`**，不挂在 public model 上。原因：`max` 一次走 gpt-4o、一次 failover 到 ds-v4-pro，二者价格差一个数量级，必须按 **本次实际命中的 backend** 扣费。
+**定价挂在 `public_models.*.pricing`（default / pro / max），不挂在 backend 上。** 我们自己定价，不锚定上游成本。
 
 ```
 credits = ceil(input_tokens  × input_per_1m_credits  / 1_000_000)
         + ceil(output_tokens × output_per_1m_credits / 1_000_000)
 ```
+
+三档各一组 `(input_per_1m_credits, output_per_1m_credits)`，就这么多。
+
+#### 4.4.0 自主定价换掉了什么
+
+早期草案把 credits 锚定在上游成本、定价挂在 `backend_models` 上。实测上游之后那条路会背上三层复杂度，而自主定价把它们**全部消掉**：
+
+| 锚定上游会带来的问题 | 自主定价后 |
+|---|---|
+| **峰谷价差 2 倍**（DeepSeek 谷时价是峰时一半，峰时为 UTC 周一至周五 01:00–04:00 与 06:00–10:00） | 消失。这是我们的成本波动，不是用户的价格波动，由毛利吸收 |
+| **prompt 缓存命中价约为未命中的 1/30**，实测同前缀命中率 99.4%（`hit=3456 / miss=20`），不拆分计价就等于按 30 倍收费 | 消失。缓存省下来的是**我们的毛利**，用户看到的是稳定单价 |
+| **混合路由的档位单价不确定**（`max` 会 failover 到差一个数量级的两个 backend），预留只能按最高价估 | 消失。`max` 无论落到哪个 backend，用户付的都是同一个价 |
+| 上游价目表是美元，需要 FX 换算且会漂 | 消失。credits 是我们自己的单位 |
+
+**但仍然要记录成本侧的明细。** `ai_usage_logs` 保留 `cached_input_tokens` 与实际命中的 `backend_model_id` —— **计费不看它们，毛利分析看**。缓存命中率掉下来、或某档路由成本翻倍，只有这两列能提前告诉我们。**计费简单，记录详细**，这是两件事。
+
+`backend_models.*.cost` 是**可选**字段，纯给毛利报表用，不参与任何扣费；不维护也不影响系统运行。
+
+#### 4.4.0.1 一条仍然躲不掉的上游适配
+
+定价与上游脱钩了，但 **usage 的取法仍是 per-provider 的协议差异**：
+
+- **DeepSeek**：无条件返回 usage，挂在**最后一个正常 chunk**（带 `finish_reason`）上，不是独立帧。
+- **OpenAI**：需要注入 `stream_options.include_usage`，且会额外发一个 `choices` 为空的独立 usage 帧 —— 客户端原本没要的话，网关要把这一帧吞掉。
+
+所以 catalog 的 provider 上要声明 `usage_mode: always | needs_stream_options`，§6.6 按它分支。
+
+另两条实测结论：**未知参数被容忍**（`some_bogus_param` 照样 200），§1.3 的 `drop_params` 替代降级为防御性、不阻塞 Phase 0；**`reasoning_tokens` 已计入 `completion_tokens`**（实测 24 = 24），输出不用单独加，但 reasoning 会吃光 `max_tokens`（实测 24 token 全被 reasoning 用掉、`content` 为空），§4.6 的预留要按「输出全是 reasoning」估。
 
 #### 4.4.1 credit 单位：必须细到 `ceil` 落进噪声
 
@@ -216,36 +244,36 @@ flash 输入 20 credits/1M token，一次 5,000 token 的请求：
 
 agent 一次会话有几十次这种小请求，所以这是常态而不是边缘情况。
 
-**决定：1 credit = 0.000001 元的「上游成本」。**
+**约束：单价要定得让「一次典型请求 ≥ 数千 credits」。** 具体数值是产品定价决策（附录 F），但无论定多少都必须满足这条，否则 `ceil` 会吃掉小请求。
+
+满足该约束的一个量纲示例：`default` 档输入定为 `1,000,000 credits / 1M token`（即 1 credit ≈ 1 个输入 token），其余档按倍数展开。
 
 | 项 | 取值 |
 |---|---|
-| catalog 里的数值 | 上游每 1M token 单价（元）× 1,000,000 |
+| catalog 里的数值 | 每 1M token 收多少 credits，由我们自己定 |
 | 典型请求量级 | 5,000 input token ≈ 5,000 credits，`ceil` 误差 0.02% |
 | `bigint` 上限 | 9.2e18 credits = 9.2e12 元，不可能溢出 |
-| UI 显示 | 「积分」= `credits / 10_000`（1 积分 = 0.01 元成本） |
+| UI 显示 | 「积分」= `credits / 10_000` |
 
 **UI 只展示余额与聚合，不展示单次请求成本。** 余额（万级积分）和单次成本（0.0x 积分）差 5 个数量级，任何单一显示单位都会在一端难看；单次成本只出现在会话/日聚合里。
 
-**credits 锚定成本，不锚定售价。** 这是本节的关键取舍：
-
-- catalog 成为供应商价目表的**直接抄写**，可审计、改价即改一行，不需要重算加价。
-- 加价只发生在充值那**一次**换算里（例如按 2 倍成本卖：充 100 元 → 记 50,000,000 credits）。
-- **因此售价不阻塞本设计** —— 它是充值那一侧的运营参数，不是网关的常量。
+**credits 是我们自己的定价单位，与上游成本无关。** 上游涨价、换供应商、缓存命中率变化都不改变用户看到的单价 —— 变的是毛利。充值时的元↔积分换算是另一个独立的运营参数。
 
 | 阶段 | 做法 |
 |------|------|
-| 请求前（预留） | 用该 public model **所有候选路由里最高价** × 预估 token 数，见 §4.6 |
-| 请求后（结算） | 按 **实际** `backend_model` 的 pricing + 上游 `usage` 精确扣费，冲销预留 |
+| 请求前（预留） | 该档的单价 × 预估 token 数（输入按字节估、输出按 `max_tokens` 上限），见 §4.6 |
+| 请求后（结算） | 按**该档单价** + 上游 usage 的 token 数精确扣费，冲销预留。落哪个 backend 不影响金额 |
 | 无 usage | 按 `max_tokens`（缺省时按该 backend 的 `default_max_output_tokens`）上限保守扣，并在 `ai_usage_logs.usage_source` 记 `estimated` |
 
-**用量日志**同时记 `public_model_id`（客户请求的）和 `backend_model_id`（实际路由的）。
+**用量日志**同时记 `public_model_id`（计费依据）与 `backend_model_id` + `cached_input_tokens`（成本/毛利依据，不参与计费）。
 
 **Credit ↔ 货币**：见 §4.4.1。网关内部只认 credits，不做任何汇率换算；元 → credits 的换算（含加价）发生在 FC 的充值入口，货币金额由支付侧自己留痕在 `credit_ledger.note`。
 
 ### 4.5 成员限额配置
 
-Team owner 可设 `period`（`week` | `month`）、`limit_credits`（null = 不限）。管理 API 在 FC；enforcement 在 gateway。周期口径见附录 A。
+Team owner 可设 `limit_credits`（null = 不限）。管理 API 在 FC；enforcement 在 gateway。周期口径见附录 A。
+
+**`period` 是团队级的，不是成员级。** 画限额界面时发现的错配：如果成员各用各的周期，「本周期已用」这一列就不可比，报表也讲不通。所以 `period` 落在 `team_credit_settings` 上，`member_credit_quota` 只存每人的 `limit_credits`。
 
 ### 4.6 并发与超发（一期就要有解）
 
@@ -472,10 +500,20 @@ CREATE INDEX credit_reservation_expiry_idx
   WHERE state = 'held';
 
 -- 成员周期限额。
+-- 团队级的限额设置。period 放这里而不是放在每个成员行上：成员各用各的
+-- 周期会让「本周期已用」不可比（§4.5）。default_limit_credits 是新成员的
+-- 缺省值，null = 不限。
+CREATE TABLE amux.team_credit_settings (
+  team_id               uuid PRIMARY KEY REFERENCES amux.teams(id) ON DELETE CASCADE,
+  period                text NOT NULL DEFAULT 'month' CHECK (period IN ('week','month')),
+  default_limit_credits bigint CHECK (default_limit_credits IS NULL OR default_limit_credits >= 0),
+  low_balance_credits   bigint,   -- 低水位告警阈值，null = 不告警
+  updated_at            timestamptz NOT NULL DEFAULT now()
+);
+
 CREATE TABLE amux.member_credit_quota (
   team_id       uuid NOT NULL REFERENCES amux.teams(id) ON DELETE CASCADE,
   actor_id      uuid NOT NULL REFERENCES amux.actors(id) ON DELETE CASCADE,
-  period        text NOT NULL CHECK (period IN ('week','month')),
   limit_credits bigint CHECK (limit_credits IS NULL OR limit_credits >= 0),
   updated_at    timestamptz NOT NULL DEFAULT now(),
   PRIMARY KEY (team_id, actor_id)
@@ -489,8 +527,13 @@ CREATE TABLE amux.ai_usage_logs (
   public_model_id   text NOT NULL,       -- 客户请求的
   backend_model_id  text NOT NULL,       -- 实际路由到的
   provider_id       text NOT NULL,
-  input_tokens      bigint NOT NULL DEFAULT 0,
+  -- 输入拆两段：缓存命中的单价约为未命中的 1/30（§4.4.0 ①）。
+  -- 合成一个 input_tokens 会让账单无法复核。
+  cached_input_tokens bigint NOT NULL DEFAULT 0,
+  input_tokens      bigint NOT NULL DEFAULT 0,   -- cache miss 部分
   output_tokens     bigint NOT NULL DEFAULT 0,
+  -- 结算时套用的峰谷系数（§4.4.0 ②），留档以便复核账单。
+  peak_factor       numeric(4,2) NOT NULL DEFAULT 1,
   credits           bigint NOT NULL DEFAULT 0,
   -- 'upstream' = 上游回了 usage；'estimated' = 按 max_tokens 保守扣（§4.4）
   usage_source      text NOT NULL DEFAULT 'upstream'
@@ -513,8 +556,8 @@ GRANT USAGE ON SCHEMA amux TO ai_gateway;
 GRANT SELECT, INSERT, UPDATE ON amux.team_credit_balance,
       amux.credit_reservation TO ai_gateway;
 GRANT SELECT, INSERT ON amux.credit_ledger, amux.ai_usage_logs TO ai_gateway;
-GRANT SELECT ON amux.member_credit_quota, amux.actors, amux.teams,
-      amux.team_workspace_config TO ai_gateway;
+GRANT SELECT ON amux.member_credit_quota, amux.team_credit_settings,
+      amux.actors, amux.teams, amux.team_workspace_config TO ai_gateway;
 ```
 
 ### 5.3 保留与对账
@@ -895,23 +938,22 @@ UPDATE amux.team_workspace_config
 
 ### 12.3 「1 积分 = 多少 token」不是一个数
 
-这是本节最容易做错的地方。credits 锚定的是**上游成本**（§4.4.1），所以积分到 token 的换算**取决于用哪一档、以及输入还是输出**——不存在单一比值。UI 上写「1 积分 = N tokens」就是在撒谎。
+积分到 token 的换算**取决于用哪一档、以及输入还是输出**——不存在单一比值。UI 上写「1 积分 = N tokens」就是在撒谎。
 
-正确做法是一张按档的小表，输入/输出分列：
+好消息是自主定价（§4.4）让这张表变成**精确值而非估算**：三档各一个固定单价，落到哪个上游都不改变金额。按档的小表，输入/输出分列：
 
-| 档位 | 1 积分 ≈ 输入 token | 1 积分 ≈ 输出 token |
+| 档位 | 1 积分 = 输入 token | 1 积分 = 输出 token |
 |---|---|---|
-| 标准 default | ~20,000 | ~10,000 |
-| 高级 pro | ~5,000 | ~2,500 |
-| 旗舰 max | ~550 | ~140 |
+| 标准 default | 10,000 | 2,500 |
+| 高级 pro | 2,500 | 625 |
+| 旗舰 max | 500 | 125 |
 
-（按 `catalog.example.yaml` 的**占位价**算出来的示意；1 积分 = 10,000 credits，credits 数由 catalog 给。真实数字随价目表变。）
+（按 `catalog.example.yaml` 的**占位价**算出来的示意；1 积分 = 10,000 credits。真实数字待定价决策，见附录 F。）
 
-三条硬要求：
+两条硬要求：
 
-1. **必须标注是估算**，并说明「实际以出账为准」——价目表会变，混合路由的档位每次命中的成本也不同。
-2. **混合路由的档位取该档所有路由里最高价那条**（`max` 会 failover 到差一个数量级的两个 backend）。这与 §4.4 预留用的口径一致，且对用户是保守估计，不会让人以为能用更多。
-3. 数据来自 `GET /models` 新增的 `estimatedPricing` 字段（§12.5），**不要在客户端硬编码价格**——那会在调价当天变成错误信息。
+1. **数据来自 `GET /models` 的 `pricing` 字段**（§12.5），**不要在客户端硬编码价格** —— 那会在调价当天变成错误信息。
+2. 不需要标注「估算」，但要说明**调价会影响后续消费、不追溯已发生的用量**。
 
 ### 12.4 现有 Token 用量页的迁移
 
@@ -940,7 +982,7 @@ UPDATE amux.team_workspace_config
 | `GET` | `/v1/teams/:teamId/credits/ledger` | 充值历史。**只返回 `kind IN (top_up, grant, adjustment, refund)`**，排除 `usage` 行（那是每请求一行，量级完全不同） |
 | `GET` | `/v1/teams/:teamId/credits/usage` | 加 `groupBy=actor\|model` 参数，供排行榜与分档表复用同一端点 |
 
-`GET /v1/teams/:teamId/models`（网关）响应加 `estimatedPricing: { inputPer1mCredits, outputPer1mCredits }`，取该档最高价路由（§12.3 第 2 条）。仍然**不暴露 upstream 名**。
+`GET /v1/teams/:teamId/models`（网关）响应加 `pricing: { inputPer1mCredits, outputPer1mCredits }`，直接来自该档的 `public_models.*.pricing`。仍然**不暴露 upstream 名**。
 
 ### 12.6 权限
 
@@ -982,12 +1024,16 @@ UPDATE amux.team_workspace_config
 | 账单与用量分两页，共用一批端点 | 账单答「还剩多少、怎么充」，用量答「花在哪了」；避免两处聚合逻辑（§12.1） |
 | 积分↔token 按档分列展示，不给单一比值 | credits 锚成本，换算随档位与输入/输出而变，单一比值是错误信息（§12.3） |
 | 换算价格由 `GET /models` 下发，不在客户端硬编码 | 调价当天硬编码就变成错误信息（§12.3） |
+| 积分↔token 是精确值不是估算 | 自主定价后三档单价固定，落到哪个上游都不改金额（§4.4） |
 | 周期早于统计起始日时显示说明而非 0 | 显示 0 会被读成「那段时间没人用」（§12.4） |
-| 1 credit = 1e-6 元上游成本 | 单位取粗会让 `ceil` 对小请求系统性高估 10 倍；agent 全是小请求（§4.4.1） |
-| credits 锚成本而非售价 | catalog 变成价目表的直接抄写；加价集中在充值一次换算，售价因此不阻塞本设计 |
+| credit 单位要细到一次请求 ≥ 数千 credits | 单位取粗会让 `ceil` 对小请求系统性高估；agent 全是小请求（§4.4.1） |
 | 余额耗尽硬停 402，不降级不透支 | 静默降级让 agent 继续产出低质量结果且无人察觉，定时任务尤其危险；负余额需要整套追缴逻辑（§4.2） |
 | 建团队一次性 grant 10 元额度，不按人头 | 去掉 onboarding 门槛同时封住上限；按人头可靠拉人无限刷（§4.8） |
 | 不做 BI 只读副本 | 两个索引够用；下一步是月度 rollup 而非副本（§5.3） |
+| **自主定价，挂在 default/pro/max 三档上** | 一举消掉峰谷价、缓存分段、混合路由单价不定、FX 四层复杂度（§4.4.0） |
+| 计费简单、记录详细 | `cached_input_tokens` 与 `backend_model_id` 只进日志不进账单，供毛利分析（§4.4.0） |
+| `usage_mode` 按 provider 声明 | DeepSeek 无条件回 usage，OpenAI 需 include_usage 且发独立帧（§4.4.0 ③） |
+| `period` 提到团队级 | 成员各用各的周期会让「本周期已用」不可比（§4.5） |
 | Stripe 放 FC，网关仍是账本唯一写入者 | 支付是业务面；单写者让 webhook 在 FC 内不需要任何新权限（§4.9.1） |
 | 幂等键用 Checkout Session id 而非 event id | 同一 Session 的两个事件有不同 evt_ id，按 event 键会重复入账（§4.9.4） |
 | credits 换算表放 Stripe Price metadata | 额度锚死在下单那一刻的商品上；加价集中一处；币种变得无关（§4.9.3） |
@@ -1050,9 +1096,9 @@ UPDATE amux.team_workspace_config
   （上游报错：原样透传，不结算，预留置 expired）
 ```
 
-## 附录 E：pricing 不在 public model 上
+## 附录 E：pricing 就在 public model 上
 
-`max` 这类混路由 tier 每次命中的成本不同；调价改 `backend_models`，三档 public id 只是稳定的产品包装（§4.3.1）。
+三档 tier 是我们**自主定价**的单位。`max` 落到哪个 backend 不改变用户付多少 —— 那是成本波动，由毛利吸收。调价只改 `public_models.*.pricing` 一处；`backend_models` 只描述「怎么打到上游」，其 `cost` 字段可选且不参与扣费（§4.4.0）。
 
 ## 附录 F：已拍板与仍未决
 
@@ -1060,8 +1106,8 @@ UPDATE amux.team_workspace_config
 
 | 问题 | 结论 | 位置 |
 |------|------|------|
-| credit 对货币的量纲 | 1 credit = 1e-6 元上游成本；UI 积分 = credits/10,000 | §4.4.1 |
-| 售价（用户花多少买 1 积分） | **不阻塞本设计** —— 锚的是成本，加价在充值那一次换算里，属运营参数 | §4.4.1 |
+| 定价是否锚定上游成本 | **否，自主定价**，挂三档 tier | §4.4 |
+| UI 量纲 | 积分 = credits / 10,000；单价须满足 §4.4.1 的 ceil 约束 | §4.4.1 |
 | 默认赠送额度 | 建团队一次性 grant 10 元额度（10,000,000 credits），不按人头 | §4.8 |
 | 余额耗尽的行为 | 402 硬停；不降级、不透支；靠低水位告警兜 | §4.2 |
 | 支付渠道 | **Stripe**（Phase 4）。幂等键让 Phase 0–3 完全不受影响 | §4.9 |
@@ -1069,5 +1115,6 @@ UPDATE amux.team_workspace_config
 
 ### 仍未决（不阻塞 Phase 0）
 
+0. **三档的实际定价数值** —— 机制已定（`public_models.*.pricing`，§4.4），填多少是产品决策。唯一的工程约束见 §4.4.1。Phase 0/1 不扣费，真正需要它的时间点是 Phase 2。
 1. **低水位告警的阈值与通道** —— 余额硬停既然是设计选择，告警就是它的配套。阈值（剩余额度 or 预计可用天数）和通道（设置页 / 企微 / 邮件）留到 Phase 2 做设置页时一并定。
-2. **成员 quota 的默认值** —— 目前设计是「缺省不限，仅受团队余额约束」。是否要给新成员一个默认周期上限，等有真实用量分布后再看，改的是数据不是结构。
+2. **成员 quota 的默认值** —— 结构上已落位（`team_credit_settings.default_limit_credits`，见 §5.2），设成多少等有真实用量分布后再定，**改的是数据不是结构**，不阻塞任何一期。

--- a/docs/specs/2026-08-28-team-ai-gateway-design.md
+++ b/docs/specs/2026-08-28-team-ai-gateway-design.md
@@ -527,15 +527,15 @@ CREATE TABLE amux.ai_usage_logs (
   public_model_id   text NOT NULL,       -- 客户请求的
   backend_model_id  text NOT NULL,       -- 实际路由到的
   provider_id       text NOT NULL,
-  -- 输入拆两段：缓存命中的单价约为未命中的 1/30（§4.4.0 ①）。
-  -- 合成一个 input_tokens 会让账单无法复核。
-  cached_input_tokens bigint NOT NULL DEFAULT 0,
-  input_tokens      bigint NOT NULL DEFAULT 0,   -- cache miss 部分
+  -- 计费按 input+output 与该档单价（§4.4）。cached_input_tokens 只是
+  -- 其中命中缓存的那部分，**不参与计费**，纯供毛利分析：实测命中率
+  -- 99.4%、命中成本约为未命中的 1/30，这一列是成本变化的早期信号。
+  input_tokens      bigint NOT NULL DEFAULT 0,
+  cached_input_tokens bigint NOT NULL DEFAULT 0,  -- input_tokens 的子集，不计费
   output_tokens     bigint NOT NULL DEFAULT 0,
-  -- 结算时套用的峰谷系数（§4.4.0 ②），留档以便复核账单。
-  peak_factor       numeric(4,2) NOT NULL DEFAULT 1,
   credits           bigint NOT NULL DEFAULT 0,
   -- 'upstream' = 上游回了 usage；'estimated' = 按 max_tokens 保守扣（§4.4）
+  -- DeepSeek 实测无条件回 usage，estimated 基本只在上游异常时出现
   usage_source      text NOT NULL DEFAULT 'upstream'
                     CHECK (usage_source IN ('upstream','estimated')),
   status_code       int,

--- a/docs/specs/2026-08-28-team-ai-gateway-plan.md
+++ b/docs/specs/2026-08-28-team-ai-gateway-plan.md
@@ -26,11 +26,12 @@ P1    amuxd /v1/ai 代理 + tc_gateway_token + 按团队灰度改 llm_base_url
 
 这三件事的结论会改设计，**必须在动手写网关之前拿到**。
 
-### 0.1 上游在 `stream_options.include_usage` 下是否真回 usage
+### 0.1 上游 usage 行为 — ✅ 已完成（2026-08-28）
 
-- [ ] 直接 curl DeepSeek 的 `/chat/completions`，`stream: true` + `stream_options: {include_usage: true}`，看末帧有没有 `usage`。
-- [ ] 记录：不带该字段时是否完全没有 usage（决定 §4.4「无 usage → estimated」这条分支有多常走）。
-- [ ] 若上游根本不支持该字段：设计稿 §6.6 第 3 条要改写，estimated 变成主路径而非兜底，§4.6 的预留额度也要相应放大。
+- [x] DeepSeek **无条件返回 usage**，带不带 `stream_options` 都回，且挂在最后一个正常 chunk（带 `finish_reason`）上，**不是独立帧**。
+- [x] 结论已回写设计稿 §4.4.0.1：catalog 的 provider 上声明 `usage_mode: always | needs_stream_options`，DeepSeek 用前者、OpenAI 用后者。
+- [x] 顺带测出：未知参数被容忍（`drop_params` 替代降级为防御性）；`reasoning_tokens` 计入 `completion_tokens`，且 reasoning 会吃光 `max_tokens`（预留要按「输出全是 reasoning」估）。
+- [x] 实测 prompt 缓存同前缀命中率 99.4%、命中价约为未命中 1/30；峰谷价差 2 倍。**自主定价后这两条都不影响计费**，但要记进 `ai_usage_logs.cached_input_tokens` 供毛利分析。
 
 ### 0.2 GoTrue `/auth/v1/user` 的延迟与限流
 
@@ -38,11 +39,11 @@ P1    amuxd /v1/ai 代理 + tc_gateway_token + 按团队灰度改 llm_base_url
 - [ ] 结论决定 §6.2.1 的 60 秒缓存是否够用，或者要不要退回 JWKS 本地验签。
 - [ ] 顺带确认：token 被吊销后该接口多久开始拒绝（缓存 TTL 的安全上界）。
 
-### 0.3 真实价目表
+### 0.3 三档定价 — ⚠️ 不阻塞 Phase 0
 
-- [ ] 拿到 DeepSeek（及任何要接的上游）**当前**的每 1M token 单价。
-- [ ] 按 §4.4.1 换算成 credits（元/1M × 1,000,000）填进 catalog。
-- [ ] `deploy/self-host/ai/catalog.example.yaml` 里现在全是**占位数字**，别当真。
+- [x] 上游模型 id 已确认为真：`deepseek-v4-flash` / `deepseek-v4-pro`（另有 `deepseek-v4-flash-vision-exp`）。
+- [ ] **三档的实际定价数值是产品决策**（设计稿附录 F），不锚定上游成本。唯一的工程约束见 §4.4.1：单价要让一次典型请求 ≥ 数千 credits。
+- [ ] Phase 0/1 **只记账不扣费**，所以真正需要这个数字的时间点是 Phase 2 —— 不阻塞开工。catalog 里现在是满足该约束的占位值。
 
 ---
 
@@ -85,7 +86,7 @@ P1    amuxd /v1/ai 代理 + tc_gateway_token + 按团队灰度改 llm_base_url
 ### 5. 转发与四处改写
 
 - [ ] `POST /v1/teams/:teamId/chat/completions`、`GET /v1/teams/:teamId/models`、`GET /healthz`。
-- [ ] `GET /models` 的每档带上 `estimatedPricing`（取该档**最高价**路由，与 §4.4 预留口径一致）。Phase 2 的账单页要用它算积分↔token 换算表（§12.3）——**现在顺手加，免得 Phase 2 再回来改网关**。
+- [ ] `GET /models` 的每档带上 `pricing`（直接来自 `public_models.*.pricing`）。Phase 2 的账单页要用它算积分↔token 换算表（§12.3）——**现在顺手加，免得 Phase 2 再回来改网关**。
 - [ ] 四处必做改写（§6.6）：`body.model` 换成 upstream 名、按 `supported_params` 过滤未知参数、注入 `stream_options.include_usage`、替换鉴权头。
 - [ ] **客户端原本没要 usage 时，要把末尾那个只含 usage 的 chunk 吃掉**，别让 agent runtime 收到预期外的帧。
 - [ ] SSE 逐 chunk 直通、不 buffer；旁路 tee 出末帧 usage。

--- a/docs/specs/2026-08-28-team-ai-gateway-plan.md
+++ b/docs/specs/2026-08-28-team-ai-gateway-plan.md
@@ -1,0 +1,250 @@
+# 实现计划：Team AI Gateway（Phase 0 + Phase 1）
+
+> 依据：[`docs/specs/2026-08-28-team-ai-gateway-design.md`](./2026-08-28-team-ai-gateway-design.md)（待评审）
+> 日期：2026-08-28
+> 范围：只覆盖设计稿的 **Phase 0（网关 MVP，只增不删）** 与 **Phase 1（客户端切换）**。
+> Phase 2（Credits 强制）/ 3（删 LiteLLM）/ 4（Stripe）不在本计划内，见设计稿 §11。
+> 本文中裸写的 `§x.y` 一律指**设计稿**的章节。
+
+---
+
+## 总览
+
+```text
+P0.0  三个阻塞验证 —— 结论可能改设计，先做
+P0    services/ai-gateway 起来 + migration + compose/Caddy/CI 只增不删
+      → 网关能出字、能落 ai_usage_logs；LiteLLM 一行未动
+P1    amuxd /v1/ai 代理 + tc_gateway_token + 按团队灰度改 llm_base_url
+      → 灰度团队的流量走新网关；随时可用一条 UPDATE 回滚
+```
+
+**贯穿全程的铁律：Phase 0/1 不删除任何 LiteLLM 相关的东西**（容器、路由、env、Caddy 段、CI 步骤）。设计稿 §11 的排期就是为了避免「Phase 0 上线瞬间打挂全部已装桌面端」。
+
+---
+
+## P0.0 — 阻塞验证（先做，结论回写设计稿）
+
+这三件事的结论会改设计，**必须在动手写网关之前拿到**。
+
+### 0.1 上游在 `stream_options.include_usage` 下是否真回 usage
+
+- [ ] 直接 curl DeepSeek 的 `/chat/completions`，`stream: true` + `stream_options: {include_usage: true}`，看末帧有没有 `usage`。
+- [ ] 记录：不带该字段时是否完全没有 usage（决定 §4.4「无 usage → estimated」这条分支有多常走）。
+- [ ] 若上游根本不支持该字段：设计稿 §6.6 第 3 条要改写，estimated 变成主路径而非兜底，§4.6 的预留额度也要相应放大。
+
+### 0.2 GoTrue `/auth/v1/user` 的延迟与限流
+
+- [ ] 在 compose 网络内压一下 `supabase.auth.getUser(token)`：P50/P99 延迟、有没有速率限制。
+- [ ] 结论决定 §6.2.1 的 60 秒缓存是否够用，或者要不要退回 JWKS 本地验签。
+- [ ] 顺带确认：token 被吊销后该接口多久开始拒绝（缓存 TTL 的安全上界）。
+
+### 0.3 真实价目表
+
+- [ ] 拿到 DeepSeek（及任何要接的上游）**当前**的每 1M token 单价。
+- [ ] 按 §4.4.1 换算成 credits（元/1M × 1,000,000）填进 catalog。
+- [ ] `deploy/self-host/ai/catalog.example.yaml` 里现在全是**占位数字**，别当真。
+
+---
+
+## P0 — 网关 MVP（只增不删）
+
+### 1. `services/ai-gateway/` 骨架
+
+- [ ] `package.json`：独立 npm 包（**不进 pnpm workspace** —— `pnpm-workspace.yaml` 只含 `apps/*` 和 `packages/*`，`services/*` 各自用 npm，照抄 `services/fc/` 的模式）。
+- [ ] 依赖只有五个：`hono`、`@hono/node-server`、`postgres`、`jose`、`yaml`。
+- [ ] `Dockerfile`：照抄 `services/fc/Dockerfile` 的两阶段（`node:20-slim` build → runtime，`npm ci --omit=dev`，`USER node`，HEALTHCHECK 打 `/healthz`）。
+- [ ] `tsconfig.json` 用于构建，`tsconfig.test.json` 用于 typecheck。
+      ⚠️ **两个必须分开且都要能过** —— FC 的 `build` 用 `tsconfig.json`、`typecheck` 用 `tsconfig.test.json`，所以 typecheck 绿**不代表**镜像能构建成功，而镜像构建失败会连带整个 self-host 部署挂掉。
+
+### 2. Migration + pgTAP
+
+- [ ] 新建 `services/supabase/migrations/<ts>_ai_gateway_credits.sql`，内容见设计稿 §5.2 的五张表。
+- [ ] **`team_credit_balance` 不要加 `CHECK (balance_credits >= 0)`** —— 退款会合法地把余额打成负数（§4.9.5），注释要一起写进去挡住后人。
+- [ ] 建 `ai_gateway` role 并按 §5.2 末尾授权（只给这五张表 + `actors`/`teams`/`team_workspace_config` 只读）。
+- [ ] ⚠️ **同一个 PR 里改 `services/supabase/tests/020_oss_sync_schema.sql`** —— 那里的 `indexes_are` 是精确集合断言，加了索引它必红。迁移是对的、红的是断言。
+- [ ] 本地跑一遍 pgTAP 套件确认 42 个用例仍全绿。
+
+### 3. catalog 加载与启动校验
+
+- [ ] 读 `/app/catalog.yaml`，解析三层（providers / backend_models / public_models）。
+- [ ] **启动时校验，不通过就拒绝启动**（fail fast 好过运行时半残）：
+  - 每条 route 的 `backend` 存在；每个 backend 的 `provider` 存在；每个 provider 的 `api_key_env` 在环境里有值。
+  - `public_models` 必须含**三档 tier**：`default` / `pro` / `max`（§4.3.1，客户端写死的唯一契约），缺任何一个就拒绝启动。
+  - 外加两个**过渡别名** `deepseek-v4-flash` / `deepseek-v4-pro`（§4.3.2）—— 老客户端还在发它们，Phase 3 才移除。
+- [ ] **未知 model id → 403 `model_not_allowed`，绝不静默回落到 `default`**。静默回落会让发错 id 的客户端长期跑在错档位上且毫无征兆。
+- [ ] ⚠️ YAML 里价格写**纯数字**，不要下划线分隔：YAML 1.2 会把 `1_000_000` 解析成字符串。
+
+### 4. token 校验 + actor 解析
+
+- [ ] 从 `services/fc/src/auth/verify.ts` **复制**校验逻辑，文件头注明来源（§6.5 已接受这处复制，代价是 schema 变更要两边改）。
+- [ ] 按 `BACKEND_KIND` 分两条路：`supabase` → 调 GoTrue `/auth/v1/user`；`postgres` → `jose` + JWKS。**两条都不需要签名密钥。**
+- [ ] 按 token 哈希做 60 秒缓存，**只缓存 `sub`**。
+- [ ] ⚠️ **不要缓存「有权访问 teamId」** —— 成员被移出团队后必须立刻失效，所以 `actors` 那条查询每次都真查。
+- [ ] 成员校验就是那一条查询：`SELECT id, actor_type FROM amux.actors WHERE team_id = $1 AND user_id = $2`，查不到 → 403 `not_a_team_member`。
+
+### 5. 转发与四处改写
+
+- [ ] `POST /v1/teams/:teamId/chat/completions`、`GET /v1/teams/:teamId/models`、`GET /healthz`。
+- [ ] `GET /models` 的每档带上 `estimatedPricing`（取该档**最高价**路由，与 §4.4 预留口径一致）。Phase 2 的账单页要用它算积分↔token 换算表（§12.3）——**现在顺手加，免得 Phase 2 再回来改网关**。
+- [ ] 四处必做改写（§6.6）：`body.model` 换成 upstream 名、按 `supported_params` 过滤未知参数、注入 `stream_options.include_usage`、替换鉴权头。
+- [ ] **客户端原本没要 usage 时，要把末尾那个只含 usage 的 chunk 吃掉**，别让 agent runtime 收到预期外的帧。
+- [ ] SSE 逐 chunk 直通、不 buffer；旁路 tee 出末帧 usage。
+- [ ] 客户端断连 → `AbortController` 传到上游。
+- [ ] 上游 4xx/5xx 原样透传，**不结算**；只有 `failover` 策略换下一条路由。
+
+### 6. 用量落库（只记不扣）
+
+- [ ] 每请求写一行 `amux.ai_usage_logs`，含 `public_model_id` + `backend_model_id` + `usage_source`。
+- [ ] **Phase 0 不碰 `team_credit_balance`、不写 `credit_ledger`、不做预留** —— 强制是 Phase 2 的事。
+- [ ] 这一点必须提前跟运营讲清楚：**Phase 0/1 期间上限仍然只在上游 provider key 上**，和今天一样。
+
+### 7. `/internal/*` 路由
+
+- [ ] service token 中间件，与 JWT 路径完全分开。
+- [ ] `GET /internal/models` —— **别漏这条**。FC 的 `getWorkspaceConfig`（`services/fc/src/lib/pg-repo/teams.ts:159-186`）今天靠 `LITELLM_MASTER_KEY` 拉模型目录填 `availableModels`；换网关后 FC 没有终端用户 JWT，只能走内网 token。
+- [ ] top-up / quota 两条可以先留桩（Phase 2 才用），但路由和鉴权先搭好。
+
+### 8. compose + Caddy（只增不删）
+
+- [ ] `deploy/self-host/docker-compose.yml` 新增 `ai-gateway` 服务，`depends_on: db healthy`，healthcheck 打 `/healthz`。
+- [ ] `docker-compose.podman.yml` **同步改一份**（两份都在用）。
+- [ ] Caddyfile 新增 `handle_path /ai/* { reverse_proxy ai-gateway:4001 }`。
+      注意用 `handle_path`（会剥掉 `/ai` 前缀）而不是 `handle`：请求 `https://api.<domain>/ai/v1/teams/X/chat/completions` 到网关时是 `/v1/teams/X/chat/completions`，正好对上路由。
+- [ ] `litellm` / `litellm-init` / `/llm/*` / `/ui/*` / `/litellm-asset-prefix/*` **一个都不动**。
+
+### 9. env：两个目标都要声明
+
+- [ ] `AI_GATEWAY_ENDPOINT`（沿用原义：对外、给客户端）指向 `https://api.<domain>/ai/v1`。
+- [ ] 新增 `AI_GATEWAY_INTERNAL_URL`、`AI_GATEWAY_SERVICE_TOKEN`。
+- [ ] ⚠️ **三个都必须同时写进 `services/fc/s.yaml` 和 compose 的 `fc:` `environment:` 映射** —— compose 的 environment 是显式白名单，漏一个就在那个目标上静默丢失，而且 `services/fc/test/deploy-env-parity.test.ts` 和 `scripts/lib/env-manifest.test.js` 会红。
+- [ ] `AI_GATEWAY_SERVICE_TOKEN` 加进 `deploy/self-host/bootstrap/gen-secrets.sh`。
+- [ ] `.env.example` 和 `.env.local.example` 补文档。
+
+### 10. CI：加等待与 smoke，不删旧的
+
+- [ ] ⚠️ **`.github/workflows/self-host-deploy.yml` 的 `on.paths` 加 `services/ai-gateway/**`** —— 现在只有 `deploy/self-host/**`、`services/fc/**`、`services/supabase/migrations/**`，不加的话推了网关代码根本不触发部署。
+- [ ] `upsert_env` 三个 `AI_GATEWAY_*`（在现有 `LITELLM_URL` 那行旁边加，**不要替换它**）。
+- [ ] 加 `until docker compose ps ai-gateway | grep -q healthy` 的等待，与现有 litellm 等待**并列**。
+- [ ] 新增 `deploy/self-host/smoke/ai-gateway-smoke.sh`，与 `litellm-smoke.sh` 并列跑。
+
+### 11. smoke 覆盖面
+
+- [ ] `/healthz` 通。
+- [ ] 无 token → 401。
+- [ ] 有效 token 但 teamId 不是自己的团队 → **403**（这条是 §6.2 那个越权口子的回归测试，别省）。
+- [ ] `GET /models` 返回非空且包含全部现网 id。
+- [ ] 一次非流式 `chat/completions` 打通，并在 `ai_usage_logs` 落一行。
+- [ ] 一次流式请求，确认首字节及时到达（不是收完才吐）。
+- [ ] 三档 tier 各打一次通；发一个不存在的 model id → 403（不是 200 也不是回落）。
+
+---
+
+## P1 — 客户端切换
+
+### 12. daemon `ai:invoke` scope + 代理路由
+
+- [ ] `apps/daemon/src/http/` 新增模块，路由 `/v1/ai/teams/:teamId/*path` → 上游 `/v1/teams/:teamId/*path`。
+- [ ] ⚠️ **上游地址由 daemon 读云端 `llm_base_url` 解析，必须支持转发到两种上游**（新网关 / 老 LiteLLM）。客户端写死之后，§11.1 那条「一条 UPDATE 灰度、一条 UPDATE 回滚」的杠杆就落在这里 —— 解析点从客户端后移了一跳到 daemon。只支持新网关等于没有回滚路径。
+- [ ] teamId 走路径显式传递，不靠 daemon 推断（省掉一整类「切团队后记到旧团队账上」的 bug）。
+- [ ] 新增 scope `ai:invoke`，加进 `daemon_config.rs` 的 scope 列表。
+- [ ] ⚠️ **绑定地址不一定是 loopback**：`apps/daemon/src/http/server.rs:74-96` 明确支持绑 `0.0.0.0`/`[::]`，所以鉴权是硬要求，不能靠「本地所以安全」。
+- [ ] ⚠️ **新模块要在 `apps/daemon/tests/support/crate_modules.rs` 和 `apps/daemon/tests/http_apps.rs` 各声明一份**。漏了会让 5 个集成测试二进制编译失败，而 `--bin` 跑起来全绿看不出来。提交前跑 `cargo test -p amuxd --all-targets --no-run`。
+
+### 13. 放宽三个全局中间件
+
+`apps/daemon/src/config/daemon_config.rs` 的默认值对 LLM 流量都太紧：
+
+- [ ] `max_body_bytes` 默认 **1 MiB** —— `provider.team` 声明的 context limit 是 256k token，对应 JSON 请求体轻松超过，**会直接 413**。新增 `http.ai_max_body_bytes`，默认 32 MiB。
+- [ ] `rate_limit_rps` 20 / `burst` 60 —— agent 的并行 tool call 会突刺。`/v1/ai/*` 走独立桶或豁免。
+- [ ] `max_sse_per_token` **8** —— 每个流式补全占一条，很容易打满。AI 流不计入这个计数。
+- [ ] SSE 逐 chunk 转发；客户端取消要能传到上游。注意这与现有 `/v1/sessions/:id/stream` 不同：那个是 daemon 自己产的 SSE，这个是**转发上游**的，是新场景，单独测。
+
+### 13.5 客户端 provider 写死
+
+- [ ] `crates/teamclu-runtime-env/src/team_provider.rs` 的 `mutate_team_provider`：`models_out` 不再从云端 `provider.models` 构造，改为固定三档 `default` / `pro` / `max`（§4.3.1）。
+- [ ] baseURL 仍在运行时拼（本地 amuxd 端口 + teamId）；`llm_enabled` 仍来自云端。**只有模型列表和 provider 形状写死。**
+- [ ] 随之可以简化的：`managed_llm_config` 返回的 `models` 字段、FC `getWorkspaceConfig` 的 `availableModels`（`services/fc/src/lib/pg-repo/teams.ts:159-186`，今天靠 `LITELLM_MASTER_KEY` 拉目录）。
+      ⚠️ **但先不要删** —— iOS 和 FC 管理面还可能在读；本期只让桌面端不依赖它，清理留到 Phase 3 与 openapi 收敛一起做。
+- [ ] `apps/daemon/src/runtime/managed_llm.rs` 的 reconcile TTL 缓存**保留**：它现在的作用退化为跟踪 `enabled` 与 `base_url` 的变化，而 `base_url` 正是灰度杠杆，不能停。
+
+### 14. `${tc_gateway_token}` 替换 `${tc_api_key}`
+
+五处派生点，一个都不能漏：
+
+- [ ] `crates/teamclu-runtime-env/src/merge.rs:11` —— `sk-tc-` 派生本体
+- [ ] `crates/teamclu-runtime-env/src/team_provider.rs:118-129` —— 跨 reconcile 保住已解析 key 的逻辑**原样保留**，只把匹配前缀换掉
+- [ ] `crates/teamclu-runtime-env/src/{env_catalog,personal_secrets,mcp_resolve}.rs` —— `tc_api_key` 作为已知 secret 名
+- [ ] `apps/desktop/src/commands/env_vars.rs:251` —— **桌面侧另有一份同样的派生逻辑**
+- [ ] `packages/app/src/lib/team-provider.ts:11` —— 注释里的契约描述
+
+### 15. 残留 `sk-tc-*` 清洗
+
+- [ ] reconcile 时若 `options.apiKey` 匹配 `^sk-tc-`，视同「未解析」，用新占位符覆盖。
+- [ ] **没有这一步，老设备升级后会拿着作废 key 打新网关，表现为持续 401 且用户无任何自愈手段。**
+
+### 16. 灰度切换（改数据，不改代码）
+
+- [ ] 单团队灰度：`UPDATE amux.team_workspace_config SET llm_base_url = 'https://api.<domain>/ai/v1/teams/' || team_id::text WHERE team_id = '<uuid>';`
+- [ ] 回滚就是同一条 UPDATE 改回去。
+- [ ] 观察：该团队正常出字，且 `ai_usage_logs` 的 token 数与上游对得上。
+- [ ] 全量后再把 `AI_GATEWAY_ENDPOINT` 指向新网关，让没有显式 `llm_base_url` 的团队（走 fallback 分支）也自动切过去。
+
+### 17. 验证
+
+- [ ] 桌面端跑一个真实会话，确认流式体验没退化（首字节延迟、中断能传到上游）。
+- [ ] `tests/e2e/smoke-team-share-onboarding.test.ts` 仍绿（它引用了 litellm 流程，Phase 1 不该动它）。
+- [ ] `pnpm test:unit`、`pnpm rust:clippy`、`cargo test -p amuxd --all-targets --no-run`。
+
+---
+
+## 本计划不含
+
+| 内容 | 在哪 |
+|---|---|
+| Credits 预留 / 结算 / quota 强制、存量团队补发额度 | 设计稿 §4.6 / §4.8.1，Phase 2 |
+| FC credits 端点、openapi 的 `litellmTeamId` 松绑 | §7.1 / §8，Phase 2 |
+| **设置页账单页 + 现有 Token 用量页迁移数据源** | §12，Phase 2。P0 只需把 `estimatedPricing` 提前加进 `GET /models` |
+| 删 LiteLLM 容器 / 路由 / Caddy 段 / CI 步骤 / `_litellm` 库 | §11.5 的 gate，Phase 3 |
+| Stripe 充值 | §4.9，Phase 4 |
+
+---
+
+## 风险检查清单
+
+| 项 | 动作 |
+|----|------|
+| 上游不回 usage | P0.0.1 必验；结论会改 §4.4 和 §4.6 的预留额度 |
+| **推 `services/fc/**` 或 `migrations/**` 到 main 会立即自动部署** | 迁移和 FC 改动合并即上线，不要在没准备好时合 |
+| 新目录不在部署触发路径里 | P0.10 第一条，`on.paths` 加 `services/ai-gateway/**` |
+| typecheck 绿但镜像构建失败 | 两个 tsconfig 都要过；构建失败会连带整个 self-host 部署挂 |
+| pgTAP `indexes_are` 精确断言 | 同 PR 改 `020_oss_sync_schema.sql` |
+| daemon 新模块漏声明在测试 crate root | `cargo test -p amuxd --all-targets --no-run` |
+| `cargo fmt` 在 apps/daemon 上会重排 ~51 个无关文件 | 只 fmt 自己改的文件，别跑裸 `cargo fmt` |
+| 桌面端裸 `cargo test` 必挂在 build.rs | 用 `rust-cli.js test` 或 `CI=1` |
+| env 只写了一个部署目标 | `deploy-env-parity.test.ts` 会红，两边都写 |
+| 灰度切换后老 key 残留 | P1.15 的清洗逻辑 |
+| 客户端写死后误删灰度杠杆 | P1.12 第二条：daemon 必须能转发到两种上游，否则无回滚路径 |
+| 老客户端仍在发 vendor model id | catalog 保留过渡别名到 Phase 3（§4.3.2） |
+
+---
+
+## 建议提交切分
+
+1. `feat(ai-gateway): service skeleton + catalog loader + healthz`
+2. `feat(db): ai gateway credits tables + pgtap index assertions`
+3. `feat(ai-gateway): token verify, actor resolution, membership check`
+4. `feat(ai-gateway): openai-compatible proxy with SSE passthrough + usage logging`
+5. `feat(deploy): add ai-gateway to compose/caddy/CI (litellm untouched)`
+6. `feat(daemon): /v1/ai proxy with ai:invoke scope and relaxed limits`
+7. `feat(runtime-env): pin team provider to default/pro/max tiers`
+8. `refactor(runtime-env): tc_api_key → tc_gateway_token + stale key cleanup`
+
+前五条是 Phase 0，可以整体合并后独立验证；后三条是 Phase 1。
+
+---
+
+## 开始前
+
+等你说 **「按计划实现」**，或指定先做 P0.0 的哪一项。
+
+⚠️ 另外：设计文档和 `deploy/self-host/ai/` 目前在工作区仍是 untracked，git 里唯一的副本是一个既不在分支上也不在 reflog 里的游离 commit。动手之前建议先把它们正式提交到 `docs/ai-gateway-design` 分支上。

--- a/services/ai-gateway/.dockerignore
+++ b/services/ai-gateway/.dockerignore
@@ -1,0 +1,4 @@
+node_modules
+dist
+test
+*.log

--- a/services/ai-gateway/Dockerfile
+++ b/services/ai-gateway/Dockerfile
@@ -1,0 +1,22 @@
+# Mirrors services/fc/Dockerfile: this image is built ON the deploy box by
+# `docker compose build`, so the layer cache and a small dep tree matter.
+# ---- build stage ----
+FROM node:20-slim AS build
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci
+COPY . .
+RUN npm run build
+
+# ---- runtime stage ----
+FROM node:20-slim AS runtime
+ENV NODE_ENV=production
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci --omit=dev && npm cache clean --force
+COPY --from=build /app/dist ./dist
+EXPOSE 4001
+USER node
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+  CMD node -e "fetch('http://127.0.0.1:'+(process.env.PORT||4001)+'/healthz').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"
+CMD ["node", "dist/server.js"]

--- a/services/ai-gateway/package-lock.json
+++ b/services/ai-gateway/package-lock.json
@@ -1,0 +1,631 @@
+{
+  "name": "teamclu-ai-gateway",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "teamclu-ai-gateway",
+      "version": "1.0.0",
+      "dependencies": {
+        "@hono/node-server": "^1.19.14",
+        "hono": "^4.12.23",
+        "jose": "^5.9.0",
+        "postgres": "^3.4.9",
+        "yaml": "^2.6.1"
+      },
+      "devDependencies": {
+        "@types/node": "^20.16.0",
+        "tsx": "^4.19.0",
+        "typescript": "^5.6.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.2.tgz",
+      "integrity": "sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.2.tgz",
+      "integrity": "sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.2.tgz",
+      "integrity": "sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.2.tgz",
+      "integrity": "sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.2.tgz",
+      "integrity": "sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.2.tgz",
+      "integrity": "sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.2.tgz",
+      "integrity": "sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.2.tgz",
+      "integrity": "sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.2.tgz",
+      "integrity": "sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.2.tgz",
+      "integrity": "sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.2.tgz",
+      "integrity": "sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.2.tgz",
+      "integrity": "sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.2.tgz",
+      "integrity": "sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.2.tgz",
+      "integrity": "sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.2.tgz",
+      "integrity": "sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.2.tgz",
+      "integrity": "sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.2.tgz",
+      "integrity": "sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.2.tgz",
+      "integrity": "sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.2.tgz",
+      "integrity": "sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.2.tgz",
+      "integrity": "sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.2.tgz",
+      "integrity": "sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.17",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.17.tgz",
+      "integrity": "sha512-dSneS5qhiauZWGDCeK4o695Xd9nUNjviSZCMQrj10eetr8Uln1ucn6bbphOM6UynAMMtNIzZNSpL9vnASJwrPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.2.tgz",
+      "integrity": "sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.2",
+        "@esbuild/android-arm": "0.28.2",
+        "@esbuild/android-arm64": "0.28.2",
+        "@esbuild/android-x64": "0.28.2",
+        "@esbuild/darwin-arm64": "0.28.2",
+        "@esbuild/darwin-x64": "0.28.2",
+        "@esbuild/freebsd-arm64": "0.28.2",
+        "@esbuild/freebsd-x64": "0.28.2",
+        "@esbuild/linux-arm": "0.28.2",
+        "@esbuild/linux-arm64": "0.28.2",
+        "@esbuild/linux-ia32": "0.28.2",
+        "@esbuild/linux-loong64": "0.28.2",
+        "@esbuild/linux-mips64el": "0.28.2",
+        "@esbuild/linux-ppc64": "0.28.2",
+        "@esbuild/linux-riscv64": "0.28.2",
+        "@esbuild/linux-s390x": "0.28.2",
+        "@esbuild/linux-x64": "0.28.2",
+        "@esbuild/netbsd-arm64": "0.28.2",
+        "@esbuild/netbsd-x64": "0.28.2",
+        "@esbuild/openbsd-arm64": "0.28.2",
+        "@esbuild/openbsd-x64": "0.28.2",
+        "@esbuild/openharmony-arm64": "0.28.2",
+        "@esbuild/sunos-x64": "0.28.2",
+        "@esbuild/win32-arm64": "0.28.2",
+        "@esbuild/win32-ia32": "0.28.2",
+        "@esbuild/win32-x64": "0.28.2"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.13.5",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.5.tgz",
+      "integrity": "sha512-O6+/eCYRkzzzy0rPWwKLiGBR1nFuUPZynnwjxN1MBA62NNqbT0wQEzQyK2gSO5yDIDB336sXQleAhOHrzlYyKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/jose": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.10.0.tgz",
+      "integrity": "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/postgres": {
+      "version": "3.4.9",
+      "resolved": "https://registry.npmjs.org/postgres/-/postgres-3.4.9.tgz",
+      "integrity": "sha512-GD3qdB0x1z9xgFI6cdRD6xu2Sp2WCOEoe3mtnyB5Ee0XrrL5Pe+e4CCnJrRMnL1zYtRDZmQQVbvOttLnKDLnaw==",
+      "license": "Unlicense",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/porsager"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.23.12",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.12.tgz",
+      "integrity": "sha512-FDf4L4sYzKtzWYhU/Xm0AQFdTjdIxNo9ElTf2mxXM6k8YMHXzYUe4yODVaXP4V9uMFbVg8c0qyBccK2OOxb45Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    }
+  }
+}

--- a/services/ai-gateway/package.json
+++ b/services/ai-gateway/package.json
@@ -7,7 +7,7 @@
     "start": "node dist/server.js",
     "build": "tsc -p tsconfig.json",
     "typecheck": "tsc -p tsconfig.test.json",
-    "test": "node --import tsx --test \"test/**/*.test.ts\""
+    "test": "node --import tsx --test test/*.test.ts"
   },
   "dependencies": {
     "@hono/node-server": "^1.19.14",

--- a/services/ai-gateway/package.json
+++ b/services/ai-gateway/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "teamclu-ai-gateway",
+  "version": "1.0.0",
+  "type": "module",
+  "private": true,
+  "scripts": {
+    "start": "node dist/server.js",
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc -p tsconfig.test.json",
+    "test": "node --import tsx --test \"test/**/*.test.ts\""
+  },
+  "dependencies": {
+    "@hono/node-server": "^1.19.14",
+    "hono": "^4.12.23",
+    "jose": "^5.9.0",
+    "postgres": "^3.4.9",
+    "yaml": "^2.6.1"
+  },
+  "devDependencies": {
+    "@types/node": "^20.16.0",
+    "tsx": "^4.19.0",
+    "typescript": "^5.6.0"
+  }
+}

--- a/services/ai-gateway/src/app.ts
+++ b/services/ai-gateway/src/app.ts
@@ -1,0 +1,218 @@
+import { Hono } from "hono";
+import type { Config } from "./config.js";
+import type { Catalog } from "./catalog.js";
+import { pickRoute } from "./catalog.js";
+import { TokenCache, bearer } from "./auth.js";
+import { resolveActor, recordUsage, getBalance, type Sql } from "./db.js";
+import { computeCredits, prepareUpstream, readUsage, teeSseUsage } from "./proxy.js";
+
+export type Deps = {
+  cfg: Config;
+  catalog: Catalog;
+  sql: Sql;
+  tokens: TokenCache;
+  env?: NodeJS.ProcessEnv;
+  fetchImpl?: typeof fetch;
+};
+
+const err = (code: string, message: string, status: number) =>
+  ({ error: { code, message } }) as const;
+
+export function createApp(deps: Deps) {
+  const { cfg, catalog, sql, tokens } = deps;
+  const env = deps.env ?? process.env;
+  const doFetch = deps.fetchImpl ?? fetch;
+  const app = new Hono();
+
+  app.get("/healthz", (c) => c.json({ ok: true }));
+
+  // ── caller identity + membership ─────────────────────────────────────────
+  // The :teamId in the path is untrusted. A token proves who you are; only the
+  // actors lookup proves you may spend this team's credits (design §6.2).
+  const authed = async (c: any) => {
+    const token = bearer(c.req.header("authorization"));
+    if (!token) return { error: c.json(err("unauthorized", "bearer token required", 401), 401) };
+    let sub: string;
+    try {
+      sub = await tokens.resolve(token);
+    } catch {
+      return { error: c.json(err("invalid_token", "invalid or expired access token", 401), 401) };
+    }
+    const teamId = c.req.param("teamId");
+    if (!/^[0-9a-f-]{36}$/i.test(teamId)) {
+      return { error: c.json(err("invalid_request", "teamId must be a uuid", 400), 400) };
+    }
+    const actor = await resolveActor(sql, teamId, sub);
+    if (!actor) {
+      return { error: c.json(err("not_a_team_member", "caller is not a member of this team", 403), 403) };
+    }
+    return { teamId, actor };
+  };
+
+  app.get("/v1/teams/:teamId/models", async (c) => {
+    const a = await authed(c);
+    if ("error" in a) return a.error;
+    return c.json({
+      object: "list",
+      data: Object.entries(catalog.public_models).map(([id, m]) => ({
+        id,
+        name: m.name,
+        description: m.description ?? null,
+        // Exact, not an estimate: we set the tier price ourselves, so the
+        // billing screen can convert credits to tokens without hedging (§12.3).
+        pricing: {
+          inputPer1mCredits: m.pricing.input_per_1m_credits,
+          outputPer1mCredits: m.pricing.output_per_1m_credits,
+        },
+      })),
+    });
+  });
+
+  app.get("/v1/teams/:teamId/credits/balance", async (c) => {
+    const a = await authed(c);
+    if ("error" in a) return a.error;
+    return c.json({ teamId: a.teamId, balanceCredits: await getBalance(sql, a.teamId) });
+  });
+
+  app.post("/v1/teams/:teamId/chat/completions", async (c) => {
+    const a = await authed(c);
+    if ("error" in a) return a.error;
+    const started = Date.now();
+
+    let body: Record<string, unknown>;
+    try {
+      body = (await c.req.json()) as Record<string, unknown>;
+    } catch {
+      return c.json(err("invalid_request", "body must be JSON", 400), 400);
+    }
+
+    const publicId = String(body.model ?? "");
+    const tier = catalog.public_models[publicId];
+    if (!tier) {
+      // Never fall back to `default`: a client sent the wrong id and would
+      // otherwise sit on the wrong tier indefinitely with no signal (§4.3.2).
+      return c.json(
+        err("model_not_allowed", `unknown model "${publicId}"`, 403),
+        403,
+      );
+    }
+
+    const wantsStream = body.stream === true;
+    const clientAskedForUsage =
+      (body.stream_options as { include_usage?: boolean } | undefined)?.include_usage === true;
+
+    const maxAttempts = tier.routing === "failover" ? tier.routes.length : 1;
+    let lastStatus = 502;
+    let lastText = "upstream unavailable";
+
+    for (let attempt = 0; attempt < maxAttempts; attempt++) {
+      const picked = pickRoute(catalog, publicId, attempt);
+      if (!picked) break;
+      const apiKey = env[picked.provider.api_key_env] ?? "";
+      const prepared = prepareUpstream(
+        catalog, picked.provider, picked.backendId, picked.backend, body, apiKey, c.req.raw.signal,
+      );
+
+      let res: Response;
+      try {
+        res = await doFetch(prepared.url, prepared.init);
+      } catch (e) {
+        lastStatus = 502;
+        lastText = `upstream request failed: ${(e as Error).message}`;
+        continue;
+      }
+
+      if (!res.ok) {
+        lastStatus = res.status;
+        lastText = await res.text();
+        // Only failover retries; a 4xx from a healthy upstream is the client's
+        // problem and retrying it just burns another call.
+        if (tier.routing === "failover" && res.status >= 500) continue;
+        // Pass the upstream error through verbatim — agent runtimes depend on
+        // these semantics — and do not settle anything.
+        return new Response(lastText, {
+          status: res.status,
+          headers: { "Content-Type": res.headers.get("content-type") ?? "application/json" },
+        });
+      }
+
+      const log = (u: { inputTokens: number; cachedInputTokens: number; outputTokens: number } | null, source: "upstream" | "estimated") =>
+        recordUsage(sql, {
+          teamId: a.teamId,
+          actorId: a.actor.id,
+          publicModelId: publicId,
+          backendModelId: picked.backendId,
+          providerId: picked.backend.provider,
+          inputTokens: u?.inputTokens ?? 0,
+          cachedInputTokens: u?.cachedInputTokens ?? 0,
+          outputTokens: u?.outputTokens ?? 0,
+          credits: u ? computeCredits(tier.pricing, u.inputTokens, u.outputTokens) : 0,
+          usageSource: source,
+          statusCode: res.status,
+          stream: wantsStream,
+          latencyMs: Date.now() - started,
+          requestId: c.req.header("x-request-id") ?? null,
+        });
+
+      if (!wantsStream || !res.body) {
+        const json = await res.json().catch(() => null);
+        const usage = readUsage(json);
+        void log(usage, usage ? "upstream" : "estimated");
+        return c.json(json as any, res.status as any);
+      }
+
+      let seen: { inputTokens: number; cachedInputTokens: number; outputTokens: number } | null = null;
+      const stream = teeSseUsage(res.body, {
+        dropUsageOnlyFrame: prepared.injectedUsageOption && !clientAskedForUsage,
+        onUsage: (u) => { seen = u; },
+      });
+      // The usage frame is the last thing on the wire, so the log write is
+      // queued after the stream drains rather than before it starts.
+      const done = new TransformStream<Uint8Array, Uint8Array>({
+        flush() { void log(seen, seen ? "upstream" : "estimated"); },
+      });
+      return new Response(stream.pipeThrough(done), {
+        status: res.status,
+        headers: {
+          "Content-Type": res.headers.get("content-type") ?? "text/event-stream",
+          "Cache-Control": "no-cache",
+        },
+      });
+    }
+
+    return c.json(err("upstream_error", lastText.slice(0, 500), lastStatus), lastStatus as any);
+  });
+
+  // ── internal (FC service token) ──────────────────────────────────────────
+  // Entirely separate from the JWT path: no end-user token ever reaches these.
+  const internal = new Hono();
+  internal.use("*", async (c, next) => {
+    const t = bearer(c.req.header("authorization"));
+    if (!t || t !== cfg.serviceToken) {
+      return c.json(err("unauthorized", "service token required", 401), 401);
+    }
+    await next();
+  });
+  // FC has no end-user JWT when it assembles workspace-config, so the tier
+  // catalogue is served here too (design §6.4).
+  internal.get("/models", (c) =>
+    c.json({
+      object: "list",
+      data: Object.entries(catalog.public_models).map(([id, m]) => ({
+        id,
+        name: m.name,
+        pricing: {
+          inputPer1mCredits: m.pricing.input_per_1m_credits,
+          outputPer1mCredits: m.pricing.output_per_1m_credits,
+        },
+      })),
+    }),
+  );
+  internal.get("/teams/:teamId/credits/summary", async (c) => {
+    const teamId = c.req.param("teamId");
+    return c.json({ teamId, balanceCredits: await getBalance(sql, teamId) });
+  });
+  app.route("/internal", internal);
+
+  return app;
+}

--- a/services/ai-gateway/src/auth.ts
+++ b/services/ai-gateway/src/auth.ts
@@ -1,0 +1,70 @@
+import { createRemoteJWKSet, jwtVerify } from "jose";
+import type { Config } from "./config.js";
+
+/**
+ * Token verification, copied in behaviour from services/fc/src/auth/verify.ts
+ * and the supabase repo's `auth.getUser` path.
+ *
+ * The gateway holds NO signing key. Both of FC's paths avoid one:
+ *   supabase (the deployed default) — ask GoTrue who the token belongs to
+ *   postgres                        — verify against a public JWKS
+ *
+ * ⚠️ Kept in step with services/fc/src/auth/verify.ts by hand. If that file
+ * changes how identity is established, this one has to follow.
+ */
+export type Verifier = (token: string) => Promise<string>;
+
+export function makeVerifier(cfg: Config): Verifier {
+  if (cfg.backendKind === "postgres") {
+    const jwks = createRemoteJWKSet(new URL(`${cfg.authBaseUrl}/api/auth/jwks`));
+    return async (token) => {
+      const { payload } = await jwtVerify(token, jwks, {
+        issuer: cfg.authBaseUrl,
+        audience: cfg.authBaseUrl,
+      });
+      if (!payload.sub) throw new Error("jwt_missing_sub");
+      return payload.sub;
+    };
+  }
+  return async (token) => {
+    const res = await fetch(`${cfg.supabaseUrl.replace(/\/+$/, "")}/auth/v1/user`, {
+      headers: { Authorization: `Bearer ${token}`, apikey: cfg.supabaseAnonKey },
+    });
+    if (!res.ok) throw new Error(`invalid_token (${res.status})`);
+    const body = (await res.json()) as { id?: string };
+    if (!body?.id) throw new Error("jwt_missing_sub");
+    return body.id;
+  };
+}
+
+/**
+ * Caches token -> sub only.
+ *
+ * Deliberately NOT "token -> may access team X": a member removed from a team
+ * must lose access immediately, so the actor lookup runs on every request.
+ * Caching identity is safe because a token's subject never changes.
+ */
+export class TokenCache {
+  private readonly entries = new Map<string, { sub: string; at: number }>();
+  constructor(private readonly ttlMs: number, private readonly verify: Verifier) {}
+
+  async resolve(token: string): Promise<string> {
+    const hit = this.entries.get(token);
+    const now = Date.now();
+    if (hit && now - hit.at < this.ttlMs) return hit.sub;
+    const sub = await this.verify(token);
+    this.entries.set(token, { sub, at: now });
+    if (this.entries.size > 5000) {
+      for (const [k, v] of this.entries) {
+        if (now - v.at >= this.ttlMs) this.entries.delete(k);
+      }
+    }
+    return sub;
+  }
+}
+
+export function bearer(header: string | undefined | null): string | null {
+  if (!header) return null;
+  const m = /^Bearer\s+(.+)$/i.exec(header.trim());
+  return m ? m[1].trim() : null;
+}

--- a/services/ai-gateway/src/catalog.ts
+++ b/services/ai-gateway/src/catalog.ts
@@ -1,0 +1,140 @@
+import { readFileSync } from "node:fs";
+import { parse } from "yaml";
+
+export type UsageMode = "always" | "needs_stream_options";
+
+export type Provider = {
+  api_base: string;
+  api_key_env: string;
+  usage_mode: UsageMode;
+};
+export type BackendModel = {
+  provider: string;
+  upstream_model: string;
+  default_max_output_tokens?: number;
+  supported_params?: string[];
+};
+export type Route = { backend: string; weight?: number };
+export type Pricing = { input_per_1m_credits: number; output_per_1m_credits: number };
+export type PublicModel = {
+  name: string;
+  description?: string;
+  routing: "priority" | "weighted" | "failover";
+  pricing: Pricing;
+  routes: Route[];
+};
+
+export type Catalog = {
+  providers: Record<string, Provider>;
+  backend_models: Record<string, BackendModel>;
+  public_models: Record<string, PublicModel>;
+  default_supported_params: string[];
+};
+
+/**
+ * The three tiers the desktop hardcodes (design §4.3.1). A catalog missing any
+ * of them would silently invalidate the model every team has selected, so the
+ * gateway refuses to start rather than serve a broken menu.
+ */
+export const REQUIRED_TIERS = ["default", "pro", "max"] as const;
+
+const DEFAULT_PARAMS = [
+  "model", "messages", "stream", "stream_options", "temperature", "top_p",
+  "max_tokens", "stop", "tools", "tool_choice", "parallel_tool_calls",
+  "response_format", "seed", "n", "presence_penalty", "frequency_penalty", "user",
+];
+
+/**
+ * Parse and fully validate a catalog. Throws on the first problem: a
+ * half-usable catalog produces requests that fail deep in the proxy with a
+ * confusing upstream error, hours after deploy.
+ */
+export function parseCatalog(text: string, env: NodeJS.ProcessEnv = process.env): Catalog {
+  const raw = parse(text) as Partial<Catalog> | null;
+  if (!raw || typeof raw !== "object") throw new Error("catalog: not a YAML mapping");
+
+  const providers = raw.providers ?? {};
+  const backends = raw.backend_models ?? {};
+  const publics = raw.public_models ?? {};
+
+  if (!Object.keys(providers).length) throw new Error("catalog: no providers");
+  if (!Object.keys(backends).length) throw new Error("catalog: no backend_models");
+
+  for (const [id, p] of Object.entries(providers)) {
+    if (!p?.api_base) throw new Error(`catalog: provider ${id} has no api_base`);
+    if (!p?.api_key_env) throw new Error(`catalog: provider ${id} has no api_key_env`);
+    if (p.usage_mode !== "always" && p.usage_mode !== "needs_stream_options") {
+      throw new Error(
+        `catalog: provider ${id} usage_mode must be "always" or "needs_stream_options"`,
+      );
+    }
+    if (!env[p.api_key_env]?.trim()) {
+      throw new Error(`catalog: provider ${id} needs ${p.api_key_env} in the environment`);
+    }
+  }
+
+  for (const [id, b] of Object.entries(backends)) {
+    if (!providers[b?.provider]) {
+      throw new Error(`catalog: backend ${id} references unknown provider ${b?.provider}`);
+    }
+    if (!b?.upstream_model) throw new Error(`catalog: backend ${id} has no upstream_model`);
+  }
+
+  for (const [id, m] of Object.entries(publics)) {
+    if (!m?.routes?.length) throw new Error(`catalog: public model ${id} has no routes`);
+    for (const r of m.routes) {
+      if (!backends[r?.backend]) {
+        throw new Error(`catalog: public model ${id} routes to unknown backend ${r?.backend}`);
+      }
+    }
+    const pr = m.pricing;
+    if (!pr || !Number.isFinite(pr.input_per_1m_credits) || !Number.isFinite(pr.output_per_1m_credits)) {
+      throw new Error(`catalog: public model ${id} needs numeric pricing (see §4.4)`);
+    }
+    if (pr.input_per_1m_credits < 0 || pr.output_per_1m_credits < 0) {
+      throw new Error(`catalog: public model ${id} has negative pricing`);
+    }
+  }
+
+  for (const tier of REQUIRED_TIERS) {
+    if (!publics[tier]) {
+      throw new Error(
+        `catalog: public model "${tier}" is required — the desktop hardcodes the ` +
+          `default/pro/max tiers, so omitting one invalidates every team that picked it`,
+      );
+    }
+  }
+
+  return {
+    providers,
+    backend_models: backends,
+    public_models: publics,
+    default_supported_params: raw.default_supported_params ?? DEFAULT_PARAMS,
+  };
+}
+
+export function loadCatalog(path: string, env: NodeJS.ProcessEnv = process.env): Catalog {
+  return parseCatalog(readFileSync(path, "utf8"), env);
+}
+
+/** Pick one route for this request. Unknown ids are the caller's problem. */
+export function pickRoute(cat: Catalog, publicId: string, attempt = 0): { backendId: string; backend: BackendModel; provider: Provider } | null {
+  const m = cat.public_models[publicId];
+  if (!m) return null;
+  let route: Route | undefined;
+  if (m.routing === "weighted" && m.routes.length > 1) {
+    const total = m.routes.reduce((s, r) => s + (r.weight ?? 1), 0);
+    let x = Math.random() * total;
+    for (const r of m.routes) {
+      x -= r.weight ?? 1;
+      if (x <= 0) { route = r; break; }
+    }
+    route ??= m.routes[0];
+  } else {
+    // priority and failover both walk the list in order; failover advances the
+    // attempt index when the previous upstream errored.
+    route = m.routes[Math.min(attempt, m.routes.length - 1)];
+  }
+  const backend = cat.backend_models[route.backend];
+  return { backendId: route.backend, backend, provider: cat.providers[backend.provider] };
+}

--- a/services/ai-gateway/src/config.ts
+++ b/services/ai-gateway/src/config.ts
@@ -1,0 +1,37 @@
+/** Process configuration. Every value is read once, at startup. */
+export type Config = {
+  port: number;
+  databaseUrl: string;
+  catalogPath: string;
+  serviceToken: string;
+  /** Which auth path FC is on; the gateway copies its behaviour. See auth.ts. */
+  backendKind: "supabase" | "postgres";
+  supabaseUrl: string;
+  supabaseAnonKey: string;
+  authBaseUrl: string;
+  /** How long a verified token -> sub mapping is trusted. */
+  tokenCacheTtlMs: number;
+};
+
+function req(name: string): string {
+  const v = process.env[name]?.trim();
+  if (!v) throw new Error(`${name} is required`);
+  return v;
+}
+
+export function loadConfig(env: NodeJS.ProcessEnv = process.env): Config {
+  const backendKind = env.BACKEND_KIND === "postgres" ? "postgres" : "supabase";
+  return {
+    port: Number(env.PORT || 4001),
+    databaseUrl: req("DATABASE_URL"),
+    catalogPath: env.CATALOG_PATH?.trim() || "/app/catalog.yaml",
+    serviceToken: req("AI_GATEWAY_SERVICE_TOKEN"),
+    backendKind,
+    // Only the supabase path needs these; fail loudly at startup rather than on
+    // the first request, which is how a mis-set env becomes a 3am page.
+    supabaseUrl: backendKind === "supabase" ? req("SUPABASE_URL") : "",
+    supabaseAnonKey: backendKind === "supabase" ? req("SUPABASE_ANON_KEY") : "",
+    authBaseUrl: env.AUTH_BASE_URL?.trim() || "",
+    tokenCacheTtlMs: Number(env.TOKEN_CACHE_TTL_MS || 60_000),
+  };
+}

--- a/services/ai-gateway/src/db.ts
+++ b/services/ai-gateway/src/db.ts
@@ -1,0 +1,78 @@
+import postgres from "postgres";
+
+export type Sql = postgres.Sql<{}>;
+
+export function connect(url: string): Sql {
+  return postgres(url, { max: 10, prepare: false });
+}
+
+export type Actor = { id: string; actorType: string };
+
+/**
+ * Resolve the caller's actor within this team.
+ *
+ * One call does two jobs: it produces the billing subject AND proves
+ * membership. The `:teamId` in the path is caller-supplied and untrusted — a
+ * token only says who you are, never which team you may spend from. The unique
+ * index `actors_team_user_idx (team_id, user_id) where user_id is not null`
+ * makes a single lookup sufficient.
+ *
+ * Goes through a security-definer function rather than selecting from
+ * amux.actors directly: that table has RLS, the gateway is not service_role,
+ * and it never sets a request JWT on its connection — so a plain select returns
+ * zero rows and every legitimate member would get 403.
+ */
+export async function resolveActor(sql: Sql, teamId: string, userId: string): Promise<Actor | null> {
+  const rows = await sql<{ id: string; actor_type: string }[]>`
+    select id, actor_type from amux.ai_gateway_resolve_actor(${teamId}::uuid, ${userId}::uuid)`;
+  const r = rows[0];
+  return r ? { id: r.id, actorType: r.actor_type } : null;
+}
+
+export type UsageRow = {
+  teamId: string;
+  actorId: string | null;
+  publicModelId: string;
+  backendModelId: string;
+  providerId: string;
+  inputTokens: number;
+  cachedInputTokens: number;
+  outputTokens: number;
+  credits: number;
+  usageSource: "upstream" | "estimated";
+  statusCode: number | null;
+  stream: boolean;
+  latencyMs: number | null;
+  requestId: string | null;
+};
+
+/**
+ * Metering. Phase 0/1 write this and nothing else — no balance mutation, no
+ * ledger row. Enforcement arrives in Phase 2, after existing teams are
+ * back-filled with a starting grant (design §4.8.1).
+ *
+ * Never allowed to fail the request: the customer already got their tokens, and
+ * losing one usage row is cheaper than 500-ing a completed completion.
+ */
+export async function recordUsage(sql: Sql, u: UsageRow): Promise<void> {
+  try {
+    await sql`
+      insert into amux.ai_usage_logs
+        (team_id, actor_id, public_model_id, backend_model_id, provider_id,
+         input_tokens, cached_input_tokens, output_tokens, credits,
+         usage_source, status_code, stream, latency_ms, request_id)
+      values
+        (${u.teamId}::uuid, ${u.actorId}::uuid, ${u.publicModelId}, ${u.backendModelId},
+         ${u.providerId}, ${u.inputTokens}, ${u.cachedInputTokens}, ${u.outputTokens},
+         ${u.credits}, ${u.usageSource}, ${u.statusCode}, ${u.stream},
+         ${u.latencyMs}, ${u.requestId})`;
+  } catch (err) {
+    console.error("[usage] failed to record usage row", err);
+  }
+}
+
+export async function getBalance(sql: Sql, teamId: string): Promise<number> {
+  const rows = await sql<{ balance_credits: string }[]>`
+    select balance_credits from amux.team_credit_balance where team_id = ${teamId}::uuid`;
+  return rows[0] ? Number(rows[0].balance_credits) : 0;
+}

--- a/services/ai-gateway/src/proxy.ts
+++ b/services/ai-gateway/src/proxy.ts
@@ -1,0 +1,167 @@
+import type { Catalog, Pricing, Provider, BackendModel } from "./catalog.js";
+
+export type UpstreamUsage = {
+  inputTokens: number;
+  cachedInputTokens: number;
+  outputTokens: number;
+};
+
+/**
+ * Charge input and output at the TIER's price (design §4.4). Which backend the
+ * request actually landed on does not change the amount — that variance is
+ * margin, not the customer's problem.
+ *
+ * ceil() per direction is why the unit has to be fine (§4.4.1): at a coarse
+ * unit a 5k-token request rounds up by multiples, and agent traffic is all
+ * small requests.
+ */
+export function computeCredits(p: Pricing, inputTokens: number, outputTokens: number): number {
+  return (
+    Math.ceil((inputTokens * p.input_per_1m_credits) / 1_000_000) +
+    Math.ceil((outputTokens * p.output_per_1m_credits) / 1_000_000)
+  );
+}
+
+/**
+ * Drop body keys the upstream does not know about. Replaces LiteLLM's
+ * `drop_params: true`: agent runtimes send a superset of the OpenAI params.
+ * DeepSeek was measured to tolerate unknown keys, so this is defensive — it
+ * earns its keep the day a stricter provider is added.
+ */
+export function filterBody(body: Record<string, unknown>, supported: string[]): Record<string, unknown> {
+  const allow = new Set(supported);
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(body)) if (allow.has(k)) out[k] = v;
+  return out;
+}
+
+/** Pull usage out of a parsed chunk / response body, normalising DeepSeek's cache fields. */
+export function readUsage(obj: any): UpstreamUsage | null {
+  const u = obj?.usage;
+  if (!u || typeof u !== "object") return null;
+  const input = Number(u.prompt_tokens ?? 0);
+  const cached = Number(u.prompt_cache_hit_tokens ?? u.prompt_tokens_details?.cached_tokens ?? 0);
+  return {
+    inputTokens: input,
+    cachedInputTokens: Number.isFinite(cached) ? cached : 0,
+    outputTokens: Number(u.completion_tokens ?? 0),
+  };
+}
+
+export type PreparedRequest = {
+  url: string;
+  init: RequestInit;
+  /** True when the gateway added stream_options itself and must hide the effect. */
+  injectedUsageOption: boolean;
+};
+
+export function prepareUpstream(
+  cat: Catalog,
+  provider: Provider,
+  backendId: string,
+  backend: BackendModel,
+  body: Record<string, unknown>,
+  apiKey: string,
+  signal: AbortSignal,
+): PreparedRequest {
+  const supported = backend.supported_params ?? cat.default_supported_params;
+  const out = filterBody(body, supported);
+  out.model = backend.upstream_model;
+
+  // Providers differ in how streaming usage is reported (§4.4.0.1):
+  //   always               — DeepSeek returns it on the last normal chunk.
+  //   needs_stream_options — OpenAI needs the flag and then emits an EXTRA
+  //                          usage-only frame, which we hide from a client
+  //                          that never asked for it.
+  let injected = false;
+  if (out.stream === true && provider.usage_mode === "needs_stream_options") {
+    const existing = out.stream_options as Record<string, unknown> | undefined;
+    if (!existing?.include_usage) {
+      out.stream_options = { ...(existing ?? {}), include_usage: true };
+      injected = true;
+    }
+  }
+
+  return {
+    url: `${provider.api_base.replace(/\/+$/, "")}/chat/completions`,
+    init: {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${apiKey}` },
+      body: JSON.stringify(out),
+      signal,
+    },
+    injectedUsageOption: injected,
+  };
+}
+
+/**
+ * Pipe an upstream SSE body straight through while tee-ing the usage frame out
+ * of it. Chunk-by-chunk: buffering the whole response first would destroy the
+ * streaming experience that the agent runtime depends on.
+ */
+export function teeSseUsage(
+  upstream: ReadableStream<Uint8Array>,
+  opts: { dropUsageOnlyFrame: boolean; onUsage: (u: UpstreamUsage) => void },
+): ReadableStream<Uint8Array> {
+  const decoder = new TextDecoder();
+  const encoder = new TextEncoder();
+  let buf = "";
+
+  return new ReadableStream<Uint8Array>({
+    async start(controller) {
+      const reader = upstream.getReader();
+      try {
+        for (;;) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          buf += decoder.decode(value, { stream: true });
+
+          // Keep the trailing partial event in the buffer; SSE events are
+          // separated by a blank line and a chunk can split one anywhere.
+          let idx: number;
+          while ((idx = buf.indexOf("\n\n")) !== -1) {
+            const rawEvent = buf.slice(0, idx + 2);
+            buf = buf.slice(idx + 2);
+            controller.enqueue(encoder.encode(handleEvent(rawEvent, opts)));
+          }
+        }
+        if (buf) controller.enqueue(encoder.encode(handleEvent(buf, opts)));
+        controller.close();
+      } catch (err) {
+        controller.error(err);
+      } finally {
+        reader.releaseLock();
+      }
+    },
+    cancel(reason) {
+      // Client hung up -> propagate upstream so we stop paying for tokens
+      // nobody will read.
+      return upstream.cancel(reason);
+    },
+  });
+}
+
+function handleEvent(
+  rawEvent: string,
+  opts: { dropUsageOnlyFrame: boolean; onUsage: (u: UpstreamUsage) => void },
+): string {
+  const line = rawEvent.split("\n").find((l) => l.startsWith("data:"));
+  if (!line) return rawEvent;
+  const payload = line.slice(5).trim();
+  if (!payload || payload === "[DONE]") return rawEvent;
+  let obj: any;
+  try {
+    obj = JSON.parse(payload);
+  } catch {
+    return rawEvent;
+  }
+  const usage = readUsage(obj);
+  if (usage) opts.onUsage(usage);
+
+  // A usage-only frame (no choices) exists solely because we asked for it.
+  // Passing it to a client that never set stream_options would be a frame it
+  // does not expect.
+  const isUsageOnly = usage != null && Array.isArray(obj.choices) && obj.choices.length === 0;
+  if (isUsageOnly && opts.dropUsageOnlyFrame) return "";
+  return rawEvent;
+}

--- a/services/ai-gateway/src/server.ts
+++ b/services/ai-gateway/src/server.ts
@@ -1,0 +1,21 @@
+import { serve } from "@hono/node-server";
+import { loadConfig } from "./config.js";
+import { loadCatalog } from "./catalog.js";
+import { connect } from "./db.js";
+import { TokenCache, makeVerifier } from "./auth.js";
+import { createApp } from "./app.js";
+
+const cfg = loadConfig();
+// Fail fast: a half-valid catalog turns into confusing upstream errors hours
+// after deploy, so every reference is resolved and every provider key checked
+// before the listener opens.
+const catalog = loadCatalog(cfg.catalogPath);
+const sql = connect(cfg.databaseUrl);
+const tokens = new TokenCache(cfg.tokenCacheTtlMs, makeVerifier(cfg));
+
+const app = createApp({ cfg, catalog, sql, tokens });
+serve({ fetch: app.fetch, port: cfg.port }, (info) => {
+  console.log(
+    `[ai-gateway] listening on :${info.port} — tiers: ${Object.keys(catalog.public_models).join(", ")}`,
+  );
+});

--- a/services/ai-gateway/test/catalog.test.ts
+++ b/services/ai-gateway/test/catalog.test.ts
@@ -1,0 +1,65 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { parseCatalog, pickRoute, REQUIRED_TIERS } from "../src/catalog.js";
+import { readFileSync } from "node:fs";
+
+const ENV = { DEEPSEEK_API_KEY: "k1", OPENAI_API_KEY: "k2" } as NodeJS.ProcessEnv;
+const SHIPPED = readFileSync(
+  new URL("../../../deploy/self-host/ai/catalog.example.yaml", import.meta.url),
+  "utf8",
+);
+
+test("the shipped example catalog is valid", () => {
+  const cat = parseCatalog(SHIPPED, ENV);
+  for (const tier of REQUIRED_TIERS) assert.ok(cat.public_models[tier], `missing ${tier}`);
+});
+
+test("every shipped tier carries pricing (billing basis is the tier, not the backend)", () => {
+  const cat = parseCatalog(SHIPPED, ENV);
+  for (const [id, m] of Object.entries(cat.public_models)) {
+    assert.ok(m.pricing.input_per_1m_credits > 0, `${id} input price`);
+    assert.ok(m.pricing.output_per_1m_credits > 0, `${id} output price`);
+  }
+});
+
+test("transition aliases are priced identically to the tier they shadow", () => {
+  // Phase 3 removes these. Until then a client on an old vendor id must not be
+  // billed differently from one on the tier.
+  const cat = parseCatalog(SHIPPED, ENV);
+  assert.deepEqual(cat.public_models["deepseek-v4-flash"].pricing, cat.public_models["default"].pricing);
+  assert.deepEqual(cat.public_models["deepseek-v4-pro"].pricing, cat.public_models["pro"].pricing);
+});
+
+test("refuses to start when a required tier is missing", () => {
+  const cat = parseCatalog(SHIPPED, ENV);
+  delete (cat as any).public_models.pro;
+  const yaml = JSON.stringify(cat); // JSON is valid YAML
+  assert.throws(() => parseCatalog(yaml, ENV), /public model "pro" is required/);
+});
+
+test("refuses a route pointing at an unknown backend", () => {
+  const broken = SHIPPED.replace("backend: ds-v4-flash", "backend: nope");
+  assert.throws(() => parseCatalog(broken, ENV), /unknown backend nope/);
+});
+
+test("refuses to start when a provider key is absent from the environment", () => {
+  assert.throws(() => parseCatalog(SHIPPED, { DEEPSEEK_API_KEY: "k" } as NodeJS.ProcessEnv),
+    /needs OPENAI_API_KEY/);
+});
+
+test("refuses an unknown usage_mode", () => {
+  const broken = SHIPPED.replace("usage_mode: always", "usage_mode: sometimes");
+  assert.throws(() => parseCatalog(broken, ENV), /usage_mode must be/);
+});
+
+test("failover walks the route list by attempt", () => {
+  const cat = parseCatalog(SHIPPED, ENV);
+  assert.equal(pickRoute(cat, "max", 0)!.backendId, "gpt-4o");
+  assert.equal(pickRoute(cat, "max", 1)!.backendId, "ds-v4-pro");
+  // Past the end it clamps rather than throwing.
+  assert.equal(pickRoute(cat, "max", 9)!.backendId, "ds-v4-pro");
+});
+
+test("unknown public id resolves to nothing (caller turns this into 403)", () => {
+  assert.equal(pickRoute(parseCatalog(SHIPPED, ENV), "gpt-9", 0), null);
+});

--- a/services/ai-gateway/test/e2e.test.ts
+++ b/services/ai-gateway/test/e2e.test.ts
@@ -1,0 +1,206 @@
+/**
+ * End-to-end: the real Hono app, against a real Postgres carrying the real
+ * migrations, talking to the real upstream.
+ *
+ * Only token verification is stubbed — that path needs GoTrue, and what it
+ * would prove (does a signature check work) is not what these tests are for.
+ * Everything downstream of "this token belongs to user X" is genuine: the
+ * membership lookup, tier routing, upstream call, SSE relay and usage row.
+ *
+ * Skips cleanly when DATABASE_URL is absent so a checkout without a local
+ * database still runs the rest of the suite.
+ */
+import { test, before, after } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { parseCatalog } from "../src/catalog.js";
+import { connect, type Sql } from "../src/db.js";
+import { TokenCache } from "../src/auth.js";
+import { createApp } from "../src/app.js";
+import type { Config } from "../src/config.js";
+
+// The app connects with the gateway's own least-privilege role, so the suite
+// exercises the real grant set — an over-tight grant fails here, not in prod.
+const DB = process.env.DATABASE_URL;
+// Fixtures need to write auth.users / amux.teams, which ai_gateway cannot.
+const ADMIN_DB = process.env.ADMIN_DATABASE_URL ?? DB;
+const KEY = process.env.DEEPSEEK_API_KEY;
+const SERVICE_TOKEN = "svc-test-token";
+
+const MEMBER_SUB = "11111111-1111-4111-8111-111111111111";
+const OUTSIDER_SUB = "22222222-2222-4222-8222-222222222222";
+
+let sql: Sql;      // gateway role — what the app itself uses
+let admin: Sql;    // fixture role
+let app: ReturnType<typeof createApp>;
+let teamId: string;
+let otherTeamId: string;
+
+const CATALOG = readFileSync(
+  new URL("../../../deploy/self-host/ai/catalog.example.yaml", import.meta.url),
+  "utf8",
+);
+
+before(async () => {
+  if (!DB) return;
+  sql = connect(DB);
+  admin = connect(ADMIN_DB!);
+  // amux.actors.user_id is FK'd to auth.users, so the fixture needs real users.
+  await admin`insert into auth.users (id) values (${MEMBER_SUB}::uuid), (${OUTSIDER_SUB}::uuid)
+            on conflict (id) do nothing`;
+  const slug = `e2e-${Date.now()}`;
+  [{ id: teamId }] = await admin<{ id: string }[]>`
+    insert into amux.teams (slug, name) values (${slug}, 'e2e team') returning id`;
+  [{ id: otherTeamId }] = await admin<{ id: string }[]>`
+    insert into amux.teams (slug, name) values (${slug + "-b"}, 'other team') returning id`;
+  await admin`insert into amux.actors (team_id, actor_type, display_name, user_id)
+            values (${teamId}::uuid, 'member', 'E2E Member', ${MEMBER_SUB})`;
+
+  const cfg = {
+    port: 0, databaseUrl: DB, catalogPath: "", serviceToken: SERVICE_TOKEN,
+    backendKind: "supabase", supabaseUrl: "", supabaseAnonKey: "",
+    authBaseUrl: "", tokenCacheTtlMs: 60_000,
+  } as Config;
+
+  // Stubbed verifier: "token-<sub>" resolves to that subject, anything else is
+  // rejected the way an expired JWT would be.
+  const tokens = new TokenCache(60_000, async (t) => {
+    if (!t.startsWith("token-")) throw new Error("invalid_token");
+    return t.slice("token-".length);
+  });
+
+  app = createApp({
+    cfg, sql, tokens,
+    catalog: parseCatalog(CATALOG, { DEEPSEEK_API_KEY: KEY ?? "x", OPENAI_API_KEY: "unused" } as NodeJS.ProcessEnv),
+    env: { DEEPSEEK_API_KEY: KEY ?? "", OPENAI_API_KEY: "" } as NodeJS.ProcessEnv,
+  });
+});
+
+after(async () => {
+  if (!DB) return;
+  await admin`delete from amux.teams where id in (${teamId}::uuid, ${otherTeamId}::uuid)`;
+  await admin`delete from auth.users where id in (${MEMBER_SUB}::uuid, ${OUTSIDER_SUB}::uuid)`;
+  await sql.end();
+  await admin.end();
+});
+
+const req = (path: string, init: RequestInit = {}) =>
+  app.fetch(new Request(`http://gw${path}`, init));
+const asMember = (extra: Record<string, string> = {}) =>
+  ({ Authorization: `Bearer token-${MEMBER_SUB}`, ...extra });
+
+test("healthz needs no auth", { skip: !DB }, async () => {
+  assert.equal((await req("/healthz")).status, 200);
+});
+
+test("no token is 401", { skip: !DB }, async () => {
+  assert.equal((await req(`/v1/teams/${teamId}/models`)).status, 401);
+});
+
+test("a bad token is 401", { skip: !DB }, async () => {
+  const r = await req(`/v1/teams/${teamId}/models`, { headers: { Authorization: "Bearer nope" } });
+  assert.equal(r.status, 401);
+});
+
+test("valid token for a team you are NOT in is 403", { skip: !DB }, async () => {
+  // The regression test for the authorization hole: :teamId is caller-supplied,
+  // and a token alone must never be enough to spend another team's credits.
+  const r = await req(`/v1/teams/${otherTeamId}/models`, { headers: asMember() });
+  assert.equal(r.status, 403);
+  assert.equal((await r.json() as any).error.code, "not_a_team_member");
+});
+
+test("a member who exists in no team at all is 403", { skip: !DB }, async () => {
+  const r = await req(`/v1/teams/${teamId}/models`, {
+    headers: { Authorization: `Bearer token-${OUTSIDER_SUB}` },
+  });
+  assert.equal(r.status, 403);
+});
+
+test("models lists all tiers with exact pricing, and no upstream names", { skip: !DB }, async () => {
+  const r = await req(`/v1/teams/${teamId}/models`, { headers: asMember() });
+  assert.equal(r.status, 200);
+  const body = await r.json() as any;
+  const ids = body.data.map((m: any) => m.id);
+  for (const tier of ["default", "pro", "max"]) assert.ok(ids.includes(tier), `missing ${tier}`);
+  assert.ok(body.data.every((m: any) => m.pricing.inputPer1mCredits > 0));
+  assert.ok(!JSON.stringify(body).includes("deepseek-v4-flash-vision"), "must not leak upstream catalogue");
+});
+
+test("an unknown model is 403, never a silent fallback to default", { skip: !DB }, async () => {
+  const r = await req(`/v1/teams/${teamId}/chat/completions`, {
+    method: "POST",
+    headers: asMember({ "Content-Type": "application/json" }),
+    body: JSON.stringify({ model: "gpt-9-turbo", messages: [{ role: "user", content: "hi" }] }),
+  });
+  assert.equal(r.status, 403);
+  assert.equal((await r.json() as any).error.code, "model_not_allowed");
+});
+
+test("internal routes reject an end-user token and accept the service token", { skip: !DB }, async () => {
+  assert.equal((await req("/internal/models", { headers: asMember() })).status, 401);
+  const ok = await req("/internal/models", { headers: { Authorization: `Bearer ${SERVICE_TOKEN}` } });
+  assert.equal(ok.status, 200);
+  assert.ok((await ok.json() as any).data.length >= 3);
+});
+
+test("non-streaming completion round-trips and writes a usage row", { skip: !DB || !KEY }, async () => {
+  const before = await sql`select count(*)::int as n from amux.ai_usage_logs where team_id = ${teamId}::uuid`;
+  const r = await req(`/v1/teams/${teamId}/chat/completions`, {
+    method: "POST",
+    headers: asMember({ "Content-Type": "application/json" }),
+    body: JSON.stringify({ model: "default", messages: [{ role: "user", content: "只回复:好" }], max_tokens: 32 }),
+  });
+  assert.equal(r.status, 200);
+  const body = await r.json() as any;
+  assert.ok(Array.isArray(body.choices), "upstream returned a completion");
+
+  // The write is fire-and-forget; give it a moment to land.
+  for (let i = 0; i < 40; i++) {
+    const now = await sql`select count(*)::int as n from amux.ai_usage_logs where team_id = ${teamId}::uuid`;
+    if (now[0].n > before[0].n) break;
+    await new Promise((res) => setTimeout(res, 50));
+  }
+  const [row] = await sql<any[]>`
+    select * from amux.ai_usage_logs where team_id = ${teamId}::uuid
+     order by created_at desc limit 1`;
+  assert.ok(row, "a usage row was written");
+  assert.equal(row.public_model_id, "default", "billed against the tier the client asked for");
+  assert.equal(row.backend_model_id, "ds-v4-flash", "records the backend it actually landed on");
+  assert.equal(row.usage_source, "upstream");
+  assert.ok(Number(row.input_tokens) > 0, "input tokens recorded");
+  assert.ok(Number(row.credits) > 0, "credits computed");
+  assert.equal(row.stream, false);
+});
+
+test("streaming completion relays SSE and still records usage", { skip: !DB || !KEY }, async () => {
+  const r = await req(`/v1/teams/${teamId}/chat/completions`, {
+    method: "POST",
+    headers: asMember({ "Content-Type": "application/json" }),
+    body: JSON.stringify({
+      model: "default", stream: true, max_tokens: 32,
+      messages: [{ role: "user", content: "只回复:好" }],
+    }),
+  });
+  assert.equal(r.status, 200);
+  assert.match(r.headers.get("content-type") ?? "", /event-stream/);
+
+  const text = await r.text();
+  assert.ok(text.includes("data:"), "SSE frames relayed");
+  assert.ok(text.includes("[DONE]"), "terminator relayed");
+
+  for (let i = 0; i < 40; i++) {
+    const [row] = await sql<any[]>`
+      select stream from amux.ai_usage_logs where team_id = ${teamId}::uuid
+       order by created_at desc limit 1`;
+    if (row?.stream === true) break;
+    await new Promise((res) => setTimeout(res, 50));
+  }
+  const [row] = await sql<any[]>`
+    select * from amux.ai_usage_logs where team_id = ${teamId}::uuid
+     order by created_at desc limit 1`;
+  assert.equal(row.stream, true, "streaming request logged");
+  assert.equal(row.usage_source, "upstream",
+    "DeepSeek returns usage unconditionally — falling back to estimated means the tee broke");
+  assert.ok(Number(row.output_tokens) > 0, "output tokens recorded from the streamed usage frame");
+});

--- a/services/ai-gateway/test/proxy.test.ts
+++ b/services/ai-gateway/test/proxy.test.ts
@@ -1,0 +1,105 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { computeCredits, filterBody, readUsage, teeSseUsage } from "../src/proxy.js";
+
+const PRICE = { input_per_1m_credits: 1_000_000, output_per_1m_credits: 4_000_000 };
+
+test("credits charge input and output at the tier price", () => {
+  // 1 credit per input token, 4 per output token at this tier.
+  assert.equal(computeCredits(PRICE, 5_000, 0), 5_000);
+  assert.equal(computeCredits(PRICE, 0, 1_000), 4_000);
+  assert.equal(computeCredits(PRICE, 5_000, 1_000), 9_000);
+});
+
+test("the unit is fine enough that ceil() does not distort a small request", () => {
+  // The failure this guards: at a coarse unit a 5k-token request rounds up by
+  // multiples, and agent traffic is all small requests (design §4.4.1).
+  const exact = (5_000 * PRICE.input_per_1m_credits) / 1_000_000;
+  const charged = computeCredits(PRICE, 5_000, 0);
+  assert.ok((charged - exact) / exact < 0.001, `rounding error too large: ${charged} vs ${exact}`);
+});
+
+test("unknown params are dropped", () => {
+  const out = filterBody(
+    { model: "x", messages: [], some_bogus_param: 1, temperature: 0.5 },
+    ["model", "messages", "temperature"],
+  );
+  assert.deepEqual(out, { model: "x", messages: [], temperature: 0.5 });
+});
+
+test("reads DeepSeek's cache split out of usage", () => {
+  const u = readUsage({
+    usage: {
+      prompt_tokens: 3476, completion_tokens: 8,
+      prompt_cache_hit_tokens: 3456, prompt_cache_miss_tokens: 20,
+    },
+  });
+  assert.deepEqual(u, { inputTokens: 3476, cachedInputTokens: 3456, outputTokens: 8 });
+});
+
+test("reads OpenAI's cached_tokens shape too", () => {
+  const u = readUsage({
+    usage: { prompt_tokens: 100, completion_tokens: 5, prompt_tokens_details: { cached_tokens: 64 } },
+  });
+  assert.equal(u!.cachedInputTokens, 64);
+});
+
+function sse(...events: string[]) {
+  const body = events.map((e) => `data: ${e}\n\n`).join("");
+  return new ReadableStream<Uint8Array>({
+    start(c) { c.enqueue(new TextEncoder().encode(body)); c.close(); },
+  });
+}
+async function drain(s: ReadableStream<Uint8Array>) {
+  let out = ""; const r = s.getReader();
+  for (;;) { const { done, value } = await r.read(); if (done) break; out += new TextDecoder().decode(value); }
+  return out;
+}
+
+test("streams through chunk by chunk and tees the usage frame", async () => {
+  let seen: any = null;
+  const out = await drain(teeSseUsage(
+    sse('{"choices":[{"delta":{"content":"hi"}}]}',
+        '{"choices":[{"finish_reason":"stop"}],"usage":{"prompt_tokens":10,"completion_tokens":2}}',
+        "[DONE]"),
+    { dropUsageOnlyFrame: false, onUsage: (u) => { seen = u; } },
+  ));
+  assert.deepEqual(seen, { inputTokens: 10, cachedInputTokens: 0, outputTokens: 2 });
+  assert.ok(out.includes('"content":"hi"'));
+  assert.ok(out.includes("[DONE]"));
+});
+
+test("swallows the usage-only frame the gateway asked for, keeps the rest", async () => {
+  // OpenAI emits an extra choices:[] frame when include_usage is injected. A
+  // client that never set stream_options must not receive it.
+  const out = await drain(teeSseUsage(
+    sse('{"choices":[{"delta":{"content":"hi"}}]}',
+        '{"choices":[],"usage":{"prompt_tokens":10,"completion_tokens":2}}',
+        "[DONE]"),
+    { dropUsageOnlyFrame: true, onUsage: () => {} },
+  ));
+  assert.ok(out.includes('"content":"hi"'));
+  assert.ok(!out.includes('"usage"'), "usage-only frame should be dropped");
+  assert.ok(out.includes("[DONE]"));
+});
+
+test("keeps a usage frame that also carries content (DeepSeek's shape)", async () => {
+  // DeepSeek rides usage on the last NORMAL chunk; dropping it would eat output.
+  const out = await drain(teeSseUsage(
+    sse('{"choices":[{"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1}}'),
+    { dropUsageOnlyFrame: true, onUsage: () => {} },
+  ));
+  assert.ok(out.includes('"finish_reason":"stop"'), "must not drop a frame carrying choices");
+});
+
+test("reassembles events split across chunk boundaries", async () => {
+  const parts = ['data: {"choices":[],"usa', 'ge":{"prompt_tokens":7,"completion_tokens":1}}\n\n'];
+  let seen: any = null;
+  await drain(teeSseUsage(
+    new ReadableStream<Uint8Array>({
+      start(c) { for (const p of parts) c.enqueue(new TextEncoder().encode(p)); c.close(); },
+    }),
+    { dropUsageOnlyFrame: false, onUsage: (u) => { seen = u; } },
+  ));
+  assert.equal(seen?.inputTokens, 7);
+});

--- a/services/ai-gateway/tsconfig.json
+++ b/services/ai-gateway/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/services/ai-gateway/tsconfig.test.json
+++ b/services/ai-gateway/tsconfig.test.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts"]
+}

--- a/services/fc/s.yaml
+++ b/services/fc/s.yaml
@@ -53,6 +53,11 @@ resources:
         SYNC_MAX_BYTES_PER_TEAM: ${env('SYNC_MAX_BYTES_PER_TEAM', '')}
         # OSS addresses buckets virtual-host style; only MinIO needs path style.
         S3_FORCE_PATH_STYLE: ${env('S3_FORCE_PATH_STYLE', '')}
+        # Keep in step with the compose `fc` environment map: a var declared on
+        # only one target silently goes missing on the other, which is what
+        # deploy-env-parity.test.ts guards. The INTERNAL url and service token
+        # join in Phase 2, when FC starts calling the gateway.
+        AI_GATEWAY_ENDPOINT: ${env('AI_GATEWAY_ENDPOINT', '')}
         LITELLM_URL: ${env('LITELLM_URL', 'https://ai.ucar.cc')}
         LITELLM_MASTER_KEY: ${env('LITELLM_MASTER_KEY', '')}
         # Blank = no cap, matching the compose default. Keep the two targets in

--- a/services/supabase/migrations/20260828120000_ai_gateway_credits.sql
+++ b/services/supabase/migrations/20260828120000_ai_gateway_credits.sql
@@ -1,0 +1,210 @@
+-- Credits ledger for the team AI gateway (services/ai-gateway).
+--
+-- Replaces LiteLLM's USD `max_budget` with a prepaid credits wallet: a team has
+-- a BALANCE, a member has a per-period QUOTA, and every request writes a usage
+-- row. See docs/specs/2026-08-28-team-ai-gateway-design.md §5.
+--
+-- Why these tables live in `amux` and not in their own database (which is what
+-- LiteLLM needed): the gateway resolves membership with
+--   select id from amux.actors where team_id = $1 and user_id = $2
+-- on every request, and FC joins teams/actors for the billing screen. Both are
+-- impossible across databases. LiteLLM needed isolation because prisma owned
+-- ~20 generically-named tables; four purpose-named tables do not.
+--
+-- Phase 0/1 only WRITE ai_usage_logs (metering, no enforcement). The balance /
+-- reservation / quota machinery goes live in Phase 2, after existing teams are
+-- back-filled with a starting grant — turning enforcement on before that would
+-- 402 every team at once (§4.8.1).
+
+-- ── team wallet ─────────────────────────────────────────────────────────────
+-- Balance is materialised rather than summed from the ledger on demand: the
+-- reservation path takes `select ... for update` on this row (§4.6), which an
+-- aggregate cannot do, and the ledger is append-only so the sum gets slower
+-- forever. Invariant `balance = sum(ledger)` is checked by a daily job.
+--
+-- Deliberately NO `check (balance_credits >= 0)`: a refund after the credits
+-- were spent legitimately drives the balance negative (§4.9.5), and that check
+-- would roll the refund back. Spending is gated by `balance - reserved >= hold`
+-- in the reservation path, which already refuses at zero. The safety net that
+-- the check would have provided is the daily negative-balance alert instead.
+create table if not exists amux.team_credit_balance (
+  team_id         uuid primary key references amux.teams(id) on delete cascade,
+  balance_credits bigint      not null default 0,
+  updated_at      timestamptz not null default now()
+);
+
+-- ── append-only ledger ──────────────────────────────────────────────────────
+create table if not exists amux.credit_ledger (
+  id              uuid primary key default gen_random_uuid(),
+  team_id         uuid not null references amux.teams(id) on delete cascade,
+  -- Usage rows attribute to an actor; top-ups and grants do not.
+  actor_id        uuid references amux.actors(id) on delete set null,
+  kind            text not null
+                  check (kind in ('top_up','grant','adjustment','usage','refund')),
+  amount_credits  bigint not null,          -- signed: usage is negative
+  -- Dedupe key. Payment webhooks retry and can deliver the same purchase under
+  -- two different event ids, so this keys on the PURCHASE (checkout session),
+  -- not the event — see §4.9.4. Signup grants use 'signup_grant:<team_id>'.
+  idempotency_key text,
+  usage_log_id    uuid,                     -- set when kind = 'usage'
+  note            text,
+  created_at      timestamptz not null default now()
+);
+create unique index if not exists credit_ledger_idem_uniq
+  on amux.credit_ledger (team_id, idempotency_key)
+  where idempotency_key is not null;
+create index if not exists credit_ledger_team_created_idx
+  on amux.credit_ledger (team_id, created_at desc);
+
+-- ── in-flight reservations ──────────────────────────────────────────────────
+-- Without these, N concurrent requests all read a healthy balance and each
+-- spends it. Agent traffic is concurrent by nature (parallel tool calls), so
+-- this is the common case, not an edge case (§4.6).
+create table if not exists amux.credit_reservation (
+  id             uuid primary key default gen_random_uuid(),
+  team_id        uuid not null references amux.teams(id) on delete cascade,
+  actor_id       uuid not null references amux.actors(id) on delete cascade,
+  amount_credits bigint not null check (amount_credits >= 0),
+  state          text   not null default 'held'
+                 check (state in ('held','settled','expired')),
+  created_at     timestamptz not null default now(),
+  expires_at     timestamptz not null
+);
+-- Summing held rows is on every request's hot path; both indexes are partial so
+-- they stay small as settled rows accumulate.
+create index if not exists credit_reservation_held_idx
+  on amux.credit_reservation (team_id, actor_id) where state = 'held';
+create index if not exists credit_reservation_expiry_idx
+  on amux.credit_reservation (expires_at) where state = 'held';
+
+-- ── team-level limit settings ───────────────────────────────────────────────
+-- `period` is TEAM-level, not per-member: if members ran on different periods
+-- the "used this period" column would not be comparable across the roster and
+-- the report would not add up (§4.5).
+create table if not exists amux.team_credit_settings (
+  team_id               uuid primary key references amux.teams(id) on delete cascade,
+  period                text not null default 'month' check (period in ('week','month')),
+  default_limit_credits bigint check (default_limit_credits is null or default_limit_credits >= 0),
+  low_balance_credits   bigint,   -- alert threshold; null = no alert
+  updated_at            timestamptz not null default now()
+);
+
+-- ── per-member limit ────────────────────────────────────────────────────────
+-- null limit_credits = unlimited, constrained only by the team balance.
+-- An `agent` actor with no row here skips the quota check entirely: cron and
+-- unattended agents must not stall waiting for someone to raise a limit
+-- (§6.2.2).
+create table if not exists amux.member_credit_quota (
+  team_id       uuid not null references amux.teams(id) on delete cascade,
+  actor_id      uuid not null references amux.actors(id) on delete cascade,
+  limit_credits bigint check (limit_credits is null or limit_credits >= 0),
+  updated_at    timestamptz not null default now(),
+  primary key (team_id, actor_id)
+);
+
+-- ── per-request usage ───────────────────────────────────────────────────────
+create table if not exists amux.ai_usage_logs (
+  id                  uuid primary key default gen_random_uuid(),
+  team_id             uuid not null references amux.teams(id) on delete cascade,
+  actor_id            uuid references amux.actors(id) on delete set null,
+  public_model_id     text not null,   -- the tier the client asked for; BILLING basis
+  backend_model_id    text not null,   -- where it actually landed; COST basis only
+  provider_id         text not null,
+  -- Billing uses input + output against the tier price (§4.4). cached_input_tokens
+  -- is the subset of input_tokens that hit the upstream prompt cache and is NOT
+  -- billed separately — it is kept purely for margin analysis. Measured 99.4%
+  -- hit rate on a repeated prefix, at roughly 1/30 the cost of a miss, so this
+  -- column is the early warning when upstream cost moves.
+  input_tokens        bigint not null default 0,
+  cached_input_tokens bigint not null default 0,
+  output_tokens       bigint not null default 0,
+  credits             bigint not null default 0,
+  -- 'upstream' = the provider returned usage; 'estimated' = charged against the
+  -- max_tokens ceiling because it did not. DeepSeek returns usage unconditionally,
+  -- so 'estimated' should only appear when an upstream misbehaves.
+  usage_source        text not null default 'upstream'
+                      check (usage_source in ('upstream','estimated')),
+  status_code         int,
+  stream              boolean not null default false,
+  latency_ms          int,
+  request_id          text,
+  created_at          timestamptz not null default now()
+);
+-- Quota accrual: where team_id = ? and actor_id = ? and created_at >= period start.
+create index if not exists ai_usage_logs_team_actor_created_idx
+  on amux.ai_usage_logs (team_id, actor_id, created_at desc);
+create index if not exists ai_usage_logs_team_created_idx
+  on amux.ai_usage_logs (team_id, created_at desc);
+
+-- ── gateway role ────────────────────────────────────────────────────────────
+-- Created NOLOGIN and without a password: secrets never live in this repo. The
+-- operator grants login out of band, e.g.
+--   alter role ai_gateway login password '…';
+-- The gateway gets exactly these tables plus read-only access to the three it
+-- needs for authorization and config. It does NOT reuse FC's connection.
+--
+-- No RLS on these tables: the gateway does its own authorization and never
+-- forwards an end-user JWT to PostgREST, so RLS has no attachment point here.
+do $$
+begin
+  if not exists (select 1 from pg_roles where rolname = 'ai_gateway') then
+    create role ai_gateway nologin;
+  end if;
+end
+$$;
+
+grant usage on schema amux to ai_gateway;
+grant select, insert, update on
+  amux.team_credit_balance, amux.credit_reservation to ai_gateway;
+grant select, insert on
+  amux.credit_ledger, amux.ai_usage_logs to ai_gateway;
+grant select on
+  amux.member_credit_quota, amux.team_credit_settings,
+  amux.actors, amux.teams, amux.team_workspace_config to ai_gateway;
+
+-- FC reads the balance/ledger for the billing screen and writes quota settings,
+-- and it connects as service_role like every other amux table (see the grants
+-- on team_skills / marketplace_skills).
+grant select, insert, update, delete on
+  amux.team_credit_balance, amux.credit_ledger, amux.credit_reservation,
+  amux.team_credit_settings, amux.member_credit_quota, amux.ai_usage_logs
+  to service_role;
+
+-- DELIBERATELY no grant to `authenticated` / `anon`. These tables carry no RLS
+-- (the gateway authorizes in application code and never forwards an end-user
+-- JWT to PostgREST), so exposing them to the authenticated role would let any
+-- logged-in user read every team's spend. Billing data reaches clients only
+-- through FC.
+
+-- ── membership lookup ───────────────────────────────────────────────────────
+-- amux.actors carries RLS, and the gateway is not service_role, so a plain
+-- select returns zero rows and every legitimate member gets 403. The gateway
+-- cannot satisfy those policies either: it authorizes in application code and
+-- never sets a request JWT on the connection.
+--
+-- Same shape as amux.amuxc_team_live_bytes: security definer, pinned
+-- search_path, revoked from everyone, granted to exactly the roles that need
+-- it. Narrower than granting the role BYPASSRLS, which would open every table.
+--
+-- Returning actor_type matters: an `agent` actor with no explicit quota row
+-- skips the quota check entirely, because cron and unattended agents must not
+-- stall waiting for someone to raise a limit (design §6.2.2).
+create or replace function amux.ai_gateway_resolve_actor(p_team_id uuid, p_user_id uuid)
+returns table (id uuid, actor_type text)
+language sql
+stable
+security definer
+set search_path = amux, public
+as $$
+  select a.id, a.actor_type
+    from amux.actors a
+   where a.team_id = p_team_id
+     and a.user_id = p_user_id
+   limit 1
+$$;
+
+comment on function amux.ai_gateway_resolve_actor(uuid, uuid) is
+  'Resolves a caller to their actor within one team. Proves membership at the same time: the :teamId in a gateway request path is untrusted.';
+
+revoke all on function amux.ai_gateway_resolve_actor(uuid, uuid) from public, anon, authenticated;
+grant execute on function amux.ai_gateway_resolve_actor(uuid, uuid) to ai_gateway, service_role;

--- a/services/supabase/tests/035_ai_gateway_credits.sql
+++ b/services/supabase/tests/035_ai_gateway_credits.sql
@@ -1,0 +1,71 @@
+-- Schema guards for the AI gateway credits ledger (20260828120000).
+--
+-- These assert the properties the billing design actually depends on, not the
+-- shape of the DDL: getting any of them wrong produces wrong money, silently.
+begin;
+
+select plan(11);
+
+-- The reservation path takes `select ... for update` on this row, so it has to
+-- be one row per team.
+select has_column('amux', 'team_credit_balance', 'balance_credits',
+  'team wallet carries a materialised balance');
+
+-- A refund issued after the credits were spent legitimately drives the balance
+-- negative. A `check (balance_credits >= 0)` would roll that refund back, so it
+-- must NOT exist -- spending is gated by `balance - reserved >= hold` instead.
+-- See design §4.9.5. This is the assertion that stops someone "tidying up" by
+-- adding the constraint that looks obviously missing.
+select is_empty($$
+  select conname from pg_constraint
+   where conrelid = 'amux.team_credit_balance'::regclass
+     and contype = 'c'
+     and pg_get_constraintdef(oid) ilike '%balance_credits%>=%0%'
+$$, 'balance has NO non-negative check (refunds must be able to go negative)');
+
+-- Payment webhooks retry, and one purchase can arrive under two different
+-- provider event ids. Without this unique index the same top-up credits twice.
+select has_index('amux', 'credit_ledger', 'credit_ledger_idem_uniq',
+  'ledger dedupes top-ups on (team_id, idempotency_key)');
+
+-- Concurrent agent requests each reserve before calling upstream; summing held
+-- rows is on every request's hot path.
+select has_index('amux', 'credit_reservation', 'credit_reservation_held_idx',
+  'held reservations are indexed for the per-request sum');
+select has_index('amux', 'credit_reservation', 'credit_reservation_expiry_idx',
+  'expired reservations can be swept without a full scan');
+
+-- `period` is team-level. If it lived on member_credit_quota, members could run
+-- on different periods and "used this period" would not be comparable across
+-- the roster (design §4.5).
+select has_column('amux', 'team_credit_settings', 'period',
+  'settlement period is a TEAM-level setting');
+select hasnt_column('amux', 'member_credit_quota', 'period',
+  'period is NOT per-member');
+
+-- Billing charges input+output at the tier price; cached_input_tokens is a
+-- subset kept only for margin analysis. Both must exist for the usage report
+-- and the cost report to be separable.
+select has_column('amux', 'ai_usage_logs', 'cached_input_tokens',
+  'usage log records the cache-hit subset for margin analysis');
+
+-- Quota accrual scans this every request: team + actor + period window.
+select has_index('amux', 'ai_usage_logs', 'ai_usage_logs_team_actor_created_idx',
+  'usage log supports per-member period accrual');
+
+-- The gateway is not service_role and never sets a request JWT, so it cannot
+-- satisfy the RLS policies on amux.actors. Without this security-definer
+-- function every legitimate member gets 403 -- which is exactly how it failed
+-- the first time the e2e suite ran against the least-privilege role.
+select has_function('amux', 'ai_gateway_resolve_actor', array['uuid','uuid'],
+  'gateway can resolve membership past RLS on amux.actors');
+
+-- Billing rows carry no RLS, so a grant to `authenticated` would let any
+-- logged-in user read every team's spend.
+select ok(
+  not has_table_privilege('authenticated', 'amux.credit_ledger', 'SELECT'),
+  'the authenticated role cannot read the credit ledger directly'
+);
+
+select * from finish();
+rollback;


### PR DESCRIPTION
Replaces LiteLLM with a self-hosted `services/ai-gateway`: JWT auth instead of derived virtual keys, and a prepaid **credits** wallet instead of a USD budget.

Three doc commits then one implementation commit. **Nothing is deleted** — the new gateway ships alongside LiteLLM and every installed desktop keeps working untouched.

## What's here

| | |
|---|---|
| `docs/specs/…-design.md` | Full design: credits model, DDL, concurrency reservations, auth, deployment, phases 0–4 |
| `docs/specs/…-plan.md` | Phase 0/1 implementation checklist |
| `docs/specs/…-mockup.html` | Four-frame billing settings mockup |
| `services/ai-gateway/` | The service — Hono, 5 deps, 28 tests |
| `…/20260828120000_ai_gateway_credits.sql` | Six tables + membership resolver |

## Phase 0 meters, it does not charge

`ai_usage_logs` is written; balances are untouched. Enforcement is Phase 2, **after** existing teams get a starting grant — switching it on first would 402 every team at once. Spend limits stay where they are today: on the upstream provider key.

## Verified, not assumed

Run against the deployment's own Postgres image (`supabase/postgres:17.6.1.106`) with all 90 migrations applied, and against the live DeepSeek API:

- **28/28** gateway tests — including a real streaming completion whose usage frame is teed out mid-stream and logged through the least-privilege role
- **43/43** pgTAP — 42 pre-existing, unchanged, plus new schema guards
- **4/4** FC deploy-env parity

## Two things the tests found that the design had wrong

**`amux.actors` has RLS.** The gateway is neither `service_role` nor a JWT-bearing connection, so a plain select returned zero rows and *every legitimate member got 403*. Fixed with a security-definer resolver — same shape as `amux.amuxc_team_live_bytes` — rather than `BYPASSRLS`, which would have opened every table.

**The migration only granted the gateway role.** FC reads the ledger for the billing screen, so `service_role` needs the grants too. `authenticated` deliberately gets none: these tables carry no RLS, so granting it would let any logged-in user read every team's spend.

The env-parity suite also caught `AI_GATEWAY_INTERNAL_URL` / `_SERVICE_TOKEN` being declared for FC before FC reads them — they now land in Phase 2 with the credits routes.

## Upstream findings that shaped the design

Measured against the live API:

- **Prompt cache hit rate 99.4%** on a repeated prefix, at roughly **1/30** the cost of a miss
- **Peak/off-peak spread is 2×**
- DeepSeek returns usage **unconditionally**, riding the last normal chunk; OpenAI needs `include_usage` and emits a separate frame

The first two would each have forced a layer of billing complexity had credits stayed anchored to upstream cost. Pricing the three tiers ourselves collapses both into margin. `cached_input_tokens` is still recorded — billing ignores it, margin analysis needs it.

The third does not go away: `usage_mode` is declared per provider in the catalog.

## Review notes

- CI runs the gateway suite inside the existing pgTAP job. The "valid token for a team you are **not** in is 403" regression only means anything against the real `actors` table with its real RLS. Upstream tests skip without `DEEPSEEK_API_KEY`.
- `ai_gateway` is created **NOLOGIN** with no password — the operator grants login out of band, so no credential enters the repo.
- The three tier prices in `catalog.example.yaml` are **placeholders**. The one engineering constraint is documented (§4.4.1): a typical request must cost ≥ a few thousand credits or `ceil()` swallows small requests, and agent traffic is all small requests.
- Phase 1 (amuxd proxy + client cutover) is **not** in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)