### PR TITLE
fix(skills): dispose opencode instance so new sessions see new skills

### DIFF
--- a/apps/daemon/src/runtime/opencode_http/host_pool.rs
+++ b/apps/daemon/src/runtime/opencode_http/host_pool.rs
@@ -871,6 +871,56 @@ impl OpenCodeHostPool {
         }
     }
 
+    /// Drop the cached opencode instance for `directory` on every ready
+    /// generation whose serve process is actually running. The next request
+    /// for that directory re-reads config (skills included); the serve
+    /// processes themselves keep running, so other workspaces are unaffected.
+    ///
+    /// Returns the number of serve processes that acknowledged the dispose.
+    /// Generations without a running process are skipped — a process that is
+    /// not up holds no cached instance, so there is nothing to invalidate.
+    /// opencode answers 404 for a directory with no cached instance, which the
+    /// client already treats as success: disposal is idempotent.
+    ///
+    /// A dispose that fails on the wire propagates as `Err` so callers can
+    /// retry instead of silently leaving a stale instance cache behind.
+    pub async fn dispose_workspace_instance(
+        &self,
+        directory: &str,
+    ) -> crate::error::Result<usize> {
+        let generations: Vec<Arc<HostGeneration>> = {
+            let domains = self.domains.lock();
+            domains
+                .values()
+                .filter_map(|slot| slot.state.lock().current.clone())
+                .filter(|generation| generation.lifecycle() == HostLifecycle::Ready)
+                .collect()
+        };
+        let mut disposed = 0usize;
+        let mut last_error: Option<crate::error::AmuxError> = None;
+        for generation in generations {
+            let Some(client) = generation.serve.running_client() else {
+                continue;
+            };
+            match client.dispose_instance(directory).await {
+                Ok(()) => disposed += 1,
+                Err(error) => {
+                    tracing::warn!(
+                        generation_id = %generation.generation_id,
+                        directory,
+                        %error,
+                        "failed to dispose opencode instance for workspace"
+                    );
+                    last_error = Some(error);
+                }
+            }
+        }
+        if let Some(error) = last_error {
+            return Err(error);
+        }
+        Ok(disposed)
+    }
+
     pub async fn shutdown_all(&self) {
         let slots: Vec<Arc<DomainSlot>> = self.domains.lock().values().cloned().collect();
         for slot in slots {
@@ -1864,5 +1914,111 @@ mod tests {
             .iter()
             .all(|lease| Arc::ptr_eq(&lease.generation, &leases[0].generation)));
         assert_eq!(leases[0].generation.route_count(), 100);
+    }
+
+    /// Factory whose serve supervisors answer HTTP through a mock server, so
+    /// dispose calls are observable without a real opencode process.
+    struct BaseUrlFactory {
+        base_url: String,
+    }
+
+    #[async_trait]
+    impl GenerationFactory for BaseUrlFactory {
+        async fn start(
+            &self,
+            generation_id: String,
+            _domain: IsolationDomainKey,
+            revision: ProcessEnvRevision,
+            _env: HashMap<String, String>,
+        ) -> Result<Arc<ServeSupervisor>, String> {
+            Ok(Arc::new(ServeSupervisor::test_with_base_url(
+                generation_id,
+                revision,
+                self.base_url.clone(),
+            )))
+        }
+
+        fn stop(&self, _generation: &HostGeneration) -> ShutdownOutcome {
+            ShutdownOutcome::Stopped
+        }
+    }
+
+    #[tokio::test]
+    async fn dispose_workspace_instance_posts_to_running_ready_generations() {
+        use wiremock::matchers::{method, path, query_param};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/instance/dispose"))
+            .and(query_param("directory", "/tmp/ws-a"))
+            .respond_with(ResponseTemplate::new(200))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let pool = OpenCodeHostPool::new(Arc::new(BaseUrlFactory {
+            base_url: server.uri(),
+        }));
+        let lease = pool
+            .acquire(domain("a"), revision("1"), HashMap::new(), deadline())
+            .await
+            .unwrap();
+        drop(lease);
+
+        let disposed = pool.dispose_workspace_instance("/tmp/ws-a").await.unwrap();
+
+        assert_eq!(disposed, 1);
+        // The mock's `expect(1)` verifies on server drop that exactly one
+        // dispose request arrived.
+    }
+
+    #[tokio::test]
+    async fn dispose_workspace_instance_skips_generations_without_a_running_process() {
+        // FakeGenerationFactory supervisors have no running serve process
+        // (and no test client), so there is nothing to dispose — and
+        // importantly no spawn is triggered just to dispose.
+        let factory = FakeGenerationFactory::new();
+        let pool = OpenCodeHostPool::new(factory.clone());
+        let lease = pool
+            .acquire(domain("a"), revision("1"), HashMap::new(), deadline())
+            .await
+            .unwrap();
+        drop(lease);
+
+        let disposed = pool.dispose_workspace_instance("/tmp/ws-a").await.unwrap();
+
+        assert_eq!(disposed, 0);
+        assert_eq!(
+            factory.start_count(),
+            1,
+            "dispose must not spawn a serve process"
+        );
+    }
+
+    #[tokio::test]
+    async fn dispose_workspace_instance_propagates_http_failure_for_retry() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/instance/dispose"))
+            .respond_with(ResponseTemplate::new(500))
+            .mount(&server)
+            .await;
+
+        let pool = OpenCodeHostPool::new(Arc::new(BaseUrlFactory {
+            base_url: server.uri(),
+        }));
+        let lease = pool
+            .acquire(domain("a"), revision("1"), HashMap::new(), deadline())
+            .await
+            .unwrap();
+        drop(lease);
+
+        pool.dispose_workspace_instance("/tmp/ws-a")
+            .await
+            .expect_err("a failed dispose must surface so the caller retries");
     }
 }

--- a/apps/daemon/src/runtime/opencode_http/supervisor.rs
+++ b/apps/daemon/src/runtime/opencode_http/supervisor.rs
@@ -273,6 +273,31 @@ impl ServeSupervisor {
         self.spawn().await
     }
 
+    /// Client for the currently-running serve process, or `None` when the
+    /// process is not up. Never spawns.
+    ///
+    /// Cache-invalidation paths (instance dispose after a skills change) use
+    /// this: a serve process that is not running holds no cached instance, so
+    /// there is nothing to invalidate — spawning one just to dispose would be
+    /// pure cost.
+    pub(crate) fn running_client(&self) -> Option<ServeClient> {
+        #[cfg(test)]
+        if let Some(client) = self.test_client.clone() {
+            return Some(client);
+        }
+        match self.client_if_running() {
+            Ok(client) => client,
+            Err(error) => {
+                warn!(
+                    generation_id = %self.generation_id,
+                    %error,
+                    "serve process state unreadable; treating as not running"
+                );
+                None
+            }
+        }
+    }
+
     fn client_if_running(&self) -> crate::error::Result<Option<ServeClient>> {
         let mut guard = self.state.lock();
         let Some(inst) = guard.as_mut() else {

--- a/apps/daemon/src/runtime/refresh.rs
+++ b/apps/daemon/src/runtime/refresh.rs
@@ -558,13 +558,19 @@ impl RefreshChangeKind {
     /// Whether applying this change requires restarting the global
     /// `opencode serve` process so freshly-created sessions pick it up.
     ///
-    /// Only provider-auth / provider-config kinds do. `Skills` and
-    /// `TeamcluConfig` don't touch the serve process; `Mcp` config is merged
+    /// Only provider-auth / provider-config kinds do. `Mcp` config is merged
     /// into the worktree's `opencode.json` at `attach_session(mcp_config_path)`
     /// time rather than baked into the process; `Permissions` are enforced
     /// per-turn. Restarting for those merely discards a warm serve instance
     /// and forces the next session to cold-start the binary again — the exact
     /// regression this predicate guards against.
+    ///
+    /// `Skills` and `TeamcluConfig` don't touch the serve *process* either,
+    /// but opencode memoizes skills per directory instance inside it, so
+    /// applying them does dispose that cached instance (see
+    /// `OpenCodeHostPool::dispose_workspace_instance`, wired from
+    /// `reload_workspace`) — a far cheaper invalidation that leaves the
+    /// process warm.
     pub fn requires_provider_host_evict(self) -> bool {
         matches!(
             self,

--- a/apps/daemon/src/runtime/supervisor.rs
+++ b/apps/daemon/src/runtime/supervisor.rs
@@ -1591,11 +1591,25 @@ impl RuntimeSupervisor {
         );
         prepare_workspace(workspace_path)?;
 
-        let stopped = if self.host_pool.is_some() {
+        let stopped = if let Some(pool) = self.host_pool.as_ref() {
             if evict_provider_hosts {
                 self.request_workspace_host_refresh(workspace_id, workspace_path)
                     .await
             } else {
+                // Skills/MCP/opencode.json-class changes don't need a
+                // serve-process restart, but opencode memoizes config and
+                // skills per directory instance inside the long-running serve
+                // process — a freshly created session on the same directory
+                // keeps reading the stale cache. Dropping that cached instance
+                // (not the process) is what makes the next session re-read the
+                // files `prepare_workspace` just rewrote.
+                pool.dispose_workspace_instance(&workspace_path.to_string_lossy())
+                    .await
+                    .map_err(|e| {
+                        WorkspaceControlError::Io(format!(
+                            "dispose opencode instance for workspace: {e}"
+                        ))
+                    })?;
                 0
             }
         } else {
@@ -1797,10 +1811,20 @@ impl RuntimeSupervisor {
     }
 }
 
-fn auto_applicable_refresh(_state: &WorkspaceRefreshState) -> bool {
-    // Capability config changes activate on the next runtime start; nothing
+fn auto_applicable_refresh(state: &WorkspaceRefreshState) -> bool {
+    // Skills are the one change kind that is both cheap and safe to apply
+    // automatically: applying one disposes the workspace's cached opencode
+    // instance (see `reload_workspace`), which never interrupts a running
+    // turn — the busy check in `auto_apply_pending_refresh_state` and the
+    // ActiveTurn refusal in `reload_workspace` see to that — and lets the next
+    // session re-read the skill dirs. Everything heavier (MCP, env, provider
+    // auth) keeps the "next runtime start" semantics and stays manual: nothing
     // pending in the coordinator should trigger reload/stop via the scheduler.
-    false
+    !state.change_kinds.is_empty()
+        && state
+            .change_kinds
+            .iter()
+            .all(|kind| matches!(kind, RefreshChangeKind::Skills))
 }
 
 #[cfg(test)]
@@ -2225,13 +2249,16 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn skills_refresh_stays_pending_without_auto_apply() {
+    async fn skills_refresh_auto_applies_when_workspace_is_idle() {
         let dir = tempfile::tempdir().unwrap();
         let workspace_id = refresh_watch::workspace_runtime_id(dir.path());
-        let supervisor = RuntimeSupervisor::new(Arc::new(AsyncMutex::new(RuntimeManager::new(
-            RuntimeManager::default_launch_configs(),
-            None,
-        ))));
+        let supervisor = RuntimeSupervisor::new_with_host_pool(
+            Arc::new(AsyncMutex::new(RuntimeManager::new(
+                RuntimeManager::default_launch_configs(),
+                None,
+            ))),
+            crate::runtime::test_support::test_host_pool(),
+        );
 
         supervisor
             .refresh_coordinator()
@@ -2246,12 +2273,15 @@ mod tests {
 
         let applied = supervisor.auto_apply_pending_refreshes().await;
 
-        assert_eq!(applied, 0);
+        assert_eq!(
+            applied, 1,
+            "a skills-only change is cheap and safe: it should auto-apply"
+        );
         let dto = supervisor
             .refresh_coordinator()
             .runtime_refresh_dto(&workspace_id)
             .await;
-        assert_eq!(dto.status, "pending");
+        assert_eq!(dto.status, "clean");
         assert!(!dto.auto_apply_blocked_by_active_runtime);
         assert_eq!(dto.recommended_action, "none");
     }
@@ -2377,18 +2407,22 @@ mod tests {
             .runtime_refresh_dto(&workspace_id)
             .await;
         assert_eq!(dto.status, "pending");
-        // Not auto-applicable at all — busy gating must not mark it blocked.
-        assert!(!dto.auto_apply_blocked_by_active_runtime);
+        // Auto-applicable but gated by the active turn — the busy marker is
+        // what makes the deferral visible in the UI.
+        assert!(dto.auto_apply_blocked_by_active_runtime);
     }
 
     #[tokio::test]
-    async fn skills_refresh_stays_pending_after_workspace_becomes_idle() {
+    async fn skills_refresh_auto_applies_after_workspace_becomes_idle() {
         let dir = tempfile::tempdir().unwrap();
         let workspace_id = refresh_watch::workspace_runtime_id(dir.path());
-        let supervisor = RuntimeSupervisor::new(Arc::new(AsyncMutex::new(RuntimeManager::new(
-            RuntimeManager::default_launch_configs(),
-            None,
-        ))));
+        let supervisor = RuntimeSupervisor::new_with_host_pool(
+            Arc::new(AsyncMutex::new(RuntimeManager::new(
+                RuntimeManager::default_launch_configs(),
+                None,
+            ))),
+            crate::runtime::test_support::test_host_pool(),
+        );
         {
             let mut manager = supervisor.agents.lock().await;
             manager.add_test_workspace_runtime(
@@ -2409,7 +2443,11 @@ mod tests {
             )
             .await
             .unwrap();
-        assert_eq!(supervisor.auto_apply_pending_refreshes().await, 0);
+        assert_eq!(
+            supervisor.auto_apply_pending_refreshes().await,
+            0,
+            "an active turn defers the apply"
+        );
 
         {
             let mut manager = supervisor.agents.lock().await;
@@ -2418,13 +2456,91 @@ mod tests {
 
         let applied = supervisor.auto_apply_pending_refreshes().await;
 
-        assert_eq!(applied, 0);
+        assert_eq!(applied, 1, "once idle, the pending skills change applies");
         let dto = supervisor
             .refresh_coordinator()
             .runtime_refresh_dto(&workspace_id)
             .await;
-        assert_eq!(dto.status, "pending");
+        assert_eq!(dto.status, "clean");
         assert_eq!(dto.recommended_action, "none");
+    }
+
+    /// Factory whose serve supervisors answer HTTP through a mock server, so
+    /// dispose calls are observable without a real opencode process.
+    struct BaseUrlFactory {
+        base_url: String,
+    }
+
+    #[async_trait]
+    impl GenerationFactory for BaseUrlFactory {
+        async fn start(
+            &self,
+            generation_id: String,
+            _domain: IsolationDomainKey,
+            revision: ProcessEnvRevision,
+            _env: HashMap<String, String>,
+        ) -> Result<Arc<ServeSupervisor>, String> {
+            Ok(Arc::new(ServeSupervisor::test_with_base_url(
+                generation_id,
+                revision,
+                self.base_url.clone(),
+            )))
+        }
+
+        fn stop(&self, _generation: &HostGeneration) -> ShutdownOutcome {
+            ShutdownOutcome::Stopped
+        }
+    }
+
+    #[tokio::test]
+    async fn skills_auto_apply_disposes_workspace_instance_through_pool() {
+        use wiremock::matchers::{method, path, query_param};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        let dir = tempfile::tempdir().unwrap();
+        let workspace_id = refresh_watch::workspace_runtime_id(dir.path());
+        let directory = dir.path().to_string_lossy().into_owned();
+        Mock::given(method("POST"))
+            .and(path("/instance/dispose"))
+            .and(query_param("directory", directory))
+            .respond_with(ResponseTemplate::new(200))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let pool = OpenCodeHostPool::new(Arc::new(BaseUrlFactory {
+            base_url: server.uri(),
+        }));
+        let supervisor = RuntimeSupervisor::new_with_host_pool(
+            Arc::new(AsyncMutex::new(RuntimeManager::new(
+                RuntimeManager::default_launch_configs(),
+                None,
+            ))),
+            pool.clone(),
+        );
+        // A live host generation is serving this workspace.
+        let (_revision, _lease) = seed_domain(&pool, &workspace_id, "v1").await;
+
+        supervisor
+            .refresh_coordinator()
+            .record_change(
+                &workspace_id,
+                dir.path(),
+                refresh::RefreshChangeKind::Skills,
+                refresh::RefreshSource::UiMutation,
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(supervisor.auto_apply_pending_refreshes().await, 1);
+        let dto = supervisor
+            .refresh_coordinator()
+            .runtime_refresh_dto(&workspace_id)
+            .await;
+        assert_eq!(dto.status, "clean");
+        // The mock's `expect(1)` verifies on server drop that the dispose
+        // request actually reached the serve process.
     }
 
     #[tokio::test]
@@ -2497,13 +2613,16 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn auto_applier_loop_leaves_idle_pending_skills_refresh() {
+    async fn auto_applier_loop_applies_idle_skills_refresh() {
         let dir = tempfile::tempdir().unwrap();
         let workspace_id = refresh_watch::workspace_runtime_id(dir.path());
-        let supervisor = RuntimeSupervisor::new(Arc::new(AsyncMutex::new(RuntimeManager::new(
-            RuntimeManager::default_launch_configs(),
-            None,
-        ))));
+        let supervisor = RuntimeSupervisor::new_with_host_pool(
+            Arc::new(AsyncMutex::new(RuntimeManager::new(
+                RuntimeManager::default_launch_configs(),
+                None,
+            ))),
+            crate::runtime::test_support::test_host_pool(),
+        );
         let handle = supervisor
             .clone()
             .start_refresh_auto_applier_with_interval(std::time::Duration::from_millis(20));
@@ -2524,7 +2643,10 @@ mod tests {
             .refresh_coordinator()
             .runtime_refresh_dto(&workspace_id)
             .await;
-        assert_eq!(dto.status, "pending");
+        assert_eq!(
+            dto.status, "clean",
+            "a skills-only change auto-applies on the first idle tick"
+        );
         assert_eq!(dto.recommended_action, "none");
 
         handle.abort();


### PR DESCRIPTION
## Problem

opencode memoizes skills per directory instance inside the long-running `opencode serve` process, so a freshly created session on the same directory kept reading the stale cache. A skill written to `~/.agents/skills` (directly, or via `manage_skills`) was invisible until the whole serve process restarted — i.e. the 5-minute idle host eviction (`HOST_IDLE_TTL`), or a daemon restart. `manage_skills` only *looked* like it worked because enough idle time had usually passed for the host to be evicted first.

Root cause was confirmed empirically against the shipped opencode 1.18.15 binary: same directory + new session after a direct write → skill not found; after `POST /instance/dispose` → found; a fresh directory → found immediately.

## Fix

Wire the disposal the daemon already had but never called:

- **`ServeSupervisor::running_client()`** — returns the client for a running serve process **without spawning one**; a process that is not up holds no cached instance, so there is nothing to dispose.
- **`OpenCodeHostPool::dispose_workspace_instance(directory)`** — posts `/instance/dispose` to every ready generation whose serve is actually running; 404 is a no-op (idempotent). HTTP failure propagates as `Err` so the caller retries instead of leaving a stale cache behind silently.
- **`reload_workspace`** (host-pool, non-evict branch) calls that instead of no-op'ing — the next session re-reads the files `prepare_workspace` just rewrote, with **no process restart** and **no impact on other workspaces**.
- **`auto_applicable_refresh`** now returns `true` for **skills-only** pending changes so the existing 1s auto-applier picks them up once the workspace has no active turn. Everything heavier (MCP, env, provider auth) keeps its "next runtime start" semantics and stays manual.

## Semantics (by design)

- ✅ A new session sees skills created after the workspace went idle.
- ✅ A running turn is never interrupted — the auto-applier's busy check plus the `ActiveTurn` refusal in `reload_workspace` double-gate disposal.
- ✅ No serve-process restart, no cold start, no impact on other workspaces.
- ✅ Desktop UI's pending-skills refresh now actually clears when idle (previously sat `pending` forever).

## Known trade-offs

- "New session生效" is **directory-instance-level**, not per-session: a resumed old session in the same directory will also see new skills on its next message. opencode has no per-session skill state, so this is the finest granularity achievable.
- Millisecond race between the busy check and the dispose call (same class as the pre-existing `stop_runtimes` path).
- A transient dispose HTTP failure leaves the refresh state `Failed` (visible in UI with error + manual "apply changes"); the next skill mutation resets it to `Pending` via `record_change`, so it self-heals.

## Tests

- `host_pool`: dispose hits a running generation (wiremock verifies exactly one call); a generation with no running process is skipped **and not spawned**; an HTTP failure propagates.
- `supervisor`: skills-only auto-applies when idle; busy defers with the blocked marker; busy→idle then applies; an end-to-end test (wiremock) confirms `record_change → auto-apply → dispose` actually reaches the serve process; skills+env mixed stays non-auto-applicable.
- Full supervisor suite (28) and the `managed_skill_three_runtime` integration target (1166) pass. One unrelated pre-existing failure (`skill_path_change_maps_to_skills_kind`) is red on the baseline too and is out of scope.
