### PR TITLE
fix(fc): allow agents to resolve own display name via by-ids

### DIFF
--- a/services/fc/src/lib/pg-repo/actors.ts
+++ b/services/fc/src/lib/pg-repo/actors.ts
@@ -366,7 +366,15 @@ export function makeActorsRepo(db: DbLike, ctx: ActorsCtx = {}) {
         (ctx.userId && teamId
           ? (await resolveActorForTeam(db, ctx.userId, teamId)) ?? undefined
           : undefined);
-      const conditions = [inArray(actorDirectory.id, actorIds), visibilityFilter(callerActorId)!];
+      // Batch by-id lookup is used to name seats the caller already holds (e.g.
+      // session participants, the daemon resolving its own actor). Always return
+      // the caller's own row when explicitly requested — visibility otherwise
+      // compares ownerMemberId (a member id) to callerActorId (often an agent
+      // id) and would hide a personal agent from itself.
+      const visibility = callerActorId
+        ? or(visibilityFilter(callerActorId)!, eq(actorDirectory.id, callerActorId))
+        : visibilityFilter(callerActorId)!;
+      const conditions = [inArray(actorDirectory.id, actorIds), visibility];
       if (teamId) conditions.push(eq(actorDirectory.teamId, teamId));
       const rows = await db
         .select()

--- a/services/fc/test/pg-repo-actors.test.ts
+++ b/services/fc/test/pg-repo-actors.test.ts
@@ -437,3 +437,16 @@ test("listActorDirectoryByIds hides other members' personal agents", async () =>
   assert.ok(ids.includes(other.id));
   assert.ok(!ids.includes(personalAgent.id), "private agent of another owner must be hidden");
 });
+
+test("listActorDirectoryByIds returns a personal agent looking up itself", async () => {
+  const { db } = await makeTestDb();
+  const team = await seedTeam(db);
+  const owner = await seedMemberActor(db, team.id, { userId: "owner-u" });
+  const personalAgent = await seedAgentActor(db, team.id, owner.id, "private");
+  const repo = createPgBusinessRepository({ db, callerActorId: personalAgent.id });
+
+  const items = await repo.listActorDirectoryByIds([personalAgent.id], team.id);
+  assert.equal(items.length, 1);
+  assert.equal(items[0].id, personalAgent.id);
+  assert.equal(items[0].displayName, "Bot");
+});


### PR DESCRIPTION
## Summary

- Fix `listActorDirectoryByIds` so an agent caller can resolve its **own** row when that id is explicitly requested in `POST /v1/actors/by-ids`.
- Previously, personal agents were filtered out because visibility compared `ownerMemberId` (member id) to `callerActorId` (agent id), so daemon/agent-token lookups returned empty and clients fell back to UUID prefixes (e.g. `e08fb571`).
- Add pg-repo test covering personal agent self-lookup.

## Compatibility

- Backward compatible: response shape unchanged; only widens visibility for the caller's own id.
- Does **not** expose other members' personal agents.
- Safe to deploy independently of daemon/desktop session-prompt work.

## Test plan

- [ ] `node --test test/pg-repo-actors.test.ts` (includes new self-lookup case)
- [ ] Deploy to self-host FC and verify agent-token `POST /v1/actors/by-ids` returns own `displayName`


Made with [Cursor](https://cursor.com)