### PR TITLE
fix(fc): return display names for explicit by-ids lookups

### DIFF
--- a/services/fc/src/lib/pg-repo/actors.ts
+++ b/services/fc/src/lib/pg-repo/actors.ts
@@ -354,27 +354,15 @@ export function makeActorsRepo(db: DbLike, ctx: ActorsCtx = {}) {
     /**
      * Batch actor-directory lookup by ids, optionally scoped to a team.
      * Returns the full directory-actor shape (parity with supabase-repo
-     * `listActorDirectoryByIds`). Agent-visibility filtering is applied here (the
-     * pg `actor_directory` view is caller-independent) using the caller's actor
-     * so personal agents owned by others are excluded — matching what RLS does on
-     * the Supabase side.
+     * `listActorDirectoryByIds`).
+     *
+     * No agent-visibility filter here: callers pass ids they already hold
+     * (session participants, the daemon naming its own actor). Listing endpoints
+     * such as `listTeamActors` still apply visibility.
      */
     async listActorDirectoryByIds(actorIds: string[], teamId: string | null) {
       if (!Array.isArray(actorIds) || actorIds.length === 0) return [];
-      const callerActorId =
-        ctx.callerActorId ??
-        (ctx.userId && teamId
-          ? (await resolveActorForTeam(db, ctx.userId, teamId)) ?? undefined
-          : undefined);
-      // Batch by-id lookup is used to name seats the caller already holds (e.g.
-      // session participants, the daemon resolving its own actor). Always return
-      // the caller's own row when explicitly requested — visibility otherwise
-      // compares ownerMemberId (a member id) to callerActorId (often an agent
-      // id) and would hide a personal agent from itself.
-      const visibility = callerActorId
-        ? or(visibilityFilter(callerActorId)!, eq(actorDirectory.id, callerActorId))
-        : visibilityFilter(callerActorId)!;
-      const conditions = [inArray(actorDirectory.id, actorIds), visibility];
+      const conditions = [inArray(actorDirectory.id, actorIds)];
       if (teamId) conditions.push(eq(actorDirectory.teamId, teamId));
       const rows = await db
         .select()

--- a/services/fc/test/pg-repo-actors.test.ts
+++ b/services/fc/test/pg-repo-actors.test.ts
@@ -423,19 +423,35 @@ test("listActorDirectoryByIds scopes to the given team", async () => {
   assert.equal(items[0].id, a.id);
 });
 
-test("listActorDirectoryByIds hides other members' personal agents", async () => {
+test("listActorDirectoryByIds returns explicitly requested personal agents", async () => {
   const { db } = await makeTestDb();
   const team = await seedTeam(db);
   const owner = await seedMemberActor(db, team.id, { userId: "owner-u" });
   const other = await seedMemberActor(db, team.id, { userId: "other-u" });
   const personalAgent = await seedAgentActor(db, team.id, owner.id, "private");
-  // caller = other member, should NOT see owner's private agent
+  // by-ids is a direct id lookup (supabase-repo parity): if the caller already
+  // knows an actor id — e.g. from session participants — return its directory row.
   const repo = createPgBusinessRepository({ db, userId: "other-u" });
 
   const items = await repo.listActorDirectoryByIds([other.id, personalAgent.id], team.id);
   const ids = items.map((i: any) => i.id);
   assert.ok(ids.includes(other.id));
-  assert.ok(!ids.includes(personalAgent.id), "private agent of another owner must be hidden");
+  assert.ok(ids.includes(personalAgent.id), "explicit id lookup must return the row");
+  const personal = items.find((i: any) => i.id === personalAgent.id);
+  assert.equal(personal?.displayName, "Bot");
+});
+
+test("listActorDirectoryByIds returns a personal agent without callerActorId", async () => {
+  const { db } = await makeTestDb();
+  const team = await seedTeam(db);
+  const owner = await seedMemberActor(db, team.id, { userId: "owner-u" });
+  const personalAgent = await seedAgentActor(db, team.id, owner.id, "private");
+  const repo = createPgBusinessRepository({ db });
+
+  const items = await repo.listActorDirectoryByIds([personalAgent.id], team.id);
+  assert.equal(items.length, 1);
+  assert.equal(items[0].id, personalAgent.id);
+  assert.equal(items[0].displayName, "Bot");
 });
 
 test("listActorDirectoryByIds returns a personal agent looking up itself", async () => {


### PR DESCRIPTION
## Summary

- Remove agent-visibility filtering from `listActorDirectoryByIds` (pg-repo) so `POST /v1/actors/by-ids` matches supabase-repo behavior.
- Callers pass actor ids they already hold (session participants, daemon naming its own agent); this endpoint should resolve names, not re-apply directory listing rules.
- Replaces the partial self-lookup bypass in #1131, which still returned empty when `callerActorId` could not be resolved (common for daemon agent tokens).

## Problem

Personal agents (visibility = personal) were filtered out of by-ids responses. Daemons then fell back to UUID prefixes like `e08fb571` instead of the UI display name `MDC`. Live verification on accounting confirmed `by-ids` returned `items: []` for the personal agent while team-visible agents worked.

## Compatibility

- Backward compatible API shape; only widens by-ids results for explicitly requested ids.
- `listTeamActors` and other listing endpoints still enforce visibility.
- Safe to deploy independently of daemon session-prompt work.

## Test plan

- [ ] `node --test test/pg-repo-actors.test.ts`
- [ ] Deploy FC to accounting/self-host and verify agent-token `POST /v1/actors/by-ids` returns `displayName: "MDC"` for personal agent `e08fb571-…`
- [ ] Restart daemon + new Pi session; injected prompt should say `Your display name is "MDC"`


Made with [Cursor](https://cursor.com)