### PR TITLE
feat(fc): add session roster endpoint for agent display names

### DIFF
--- a/docs/openapi/teamclu-api.v1.yaml
+++ b/docs/openapi/teamclu-api.v1.yaml
@@ -745,6 +745,38 @@ paths:
           $ref: "#/components/responses/Error"
         "401":
           $ref: "#/components/responses/Error"
+  /v1/sessions/{sessionId}/roster:
+    get:
+      operationId: listSessionRoster
+      summary: List session participant display names
+      description: |
+        Returns display names for actors seated in this session, read from
+        `actors` directly. Unlike `GET …/participants`, this bypasses the
+        `actor_directory` visibility filter so a personal agent authenticated
+        as itself can resolve its own display name (e.g. for session-context
+        injection).
+
+        Caller must be a participant in the session. Only seated actor ids are
+        returned — no team-wide directory leak.
+      tags: [Sessions]
+      parameters:
+        - $ref: "#/components/parameters/SessionId"
+      responses:
+        "200":
+          description: Session roster labels.
+          headers:
+            X-Request-Id:
+              $ref: "#/components/headers/RequestId"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SessionRoster"
+        "403":
+          $ref: "#/components/responses/Error"
+        "404":
+          $ref: "#/components/responses/Error"
+        "401":
+          $ref: "#/components/responses/Error"
   /v1/sessions/{sessionId}/participants/{actorId}:
     delete:
       operationId: removeSessionParticipant
@@ -7051,6 +7083,39 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/SessionParticipant"
+    SessionRoster:
+      type: object
+      required: [sessionId, callerActorId, items]
+      properties:
+        sessionId:
+          type: string
+          format: uuid
+        callerActorId:
+          type: string
+          format: uuid
+        items:
+          type: array
+          items:
+            $ref: "#/components/schemas/SessionRosterEntry"
+    SessionRosterEntry:
+      type: object
+      required: [actorId, displayName, kind, isSelf]
+      properties:
+        actorId:
+          type: string
+          format: uuid
+        displayName:
+          type:
+            - string
+            - "null"
+        kind:
+          type:
+            - string
+            - "null"
+          description: Actor type (`member`, `agent`, `external`, …).
+        isSelf:
+          type: boolean
+          description: True when this row is the authenticated caller.
     TeamMember:
       type: object
       required: [actorId, teamId, role]

--- a/services/fc/src/lib/pg-repo/sessions.ts
+++ b/services/fc/src/lib/pg-repo/sessions.ts
@@ -66,6 +66,7 @@ export interface SessionsRepoDeps {
 
 interface SessionsCtx {
   userId?: string;
+  callerActorId?: string;
 }
 
 function mapSession(r: any) {
@@ -848,6 +849,70 @@ export function makeSessionsRepo(db: DbLike, ctx: SessionsCtx = {}, deps: Sessio
         .from(sessionParticipants)
         .where(eq(sessionParticipants.actorId, actorId));
       return rows.map((r) => r.sessionId).filter(Boolean);
+    },
+
+    // ── listSessionRoster ─────────────────────────────────────────────────────
+    /**
+     * Display names for session participants, read from `actors` directly.
+     *
+     * Unlike `listSessionParticipants` (which joins `actor_directory`), this path
+     * bypasses agent-visibility filtering so a personal agent authenticated as
+     * itself can resolve its own display name for session-context injection.
+     *
+     * AUTHZ: caller must be a participant in the session (403 otherwise).
+     * Only returns rows for actors already seated in `session_participants`.
+     */
+    async listSessionRoster(sessionId: string) {
+      const [s] = await db
+        .select({ id: sessions.id, teamId: sessions.teamId })
+        .from(sessions)
+        .where(eq(sessions.id, sessionId))
+        .limit(1);
+      if (!s) throw new ApiError(404, "not_found", "session not found");
+
+      const callerActorId =
+        ctx.callerActorId ??
+        (ctx.userId ? await resolveActorForTeam(db, ctx.userId, s.teamId) : null);
+      if (!callerActorId) {
+        throw new ApiError(401, "missing_identity", "authentication required");
+      }
+
+      const seats = await db
+        .select()
+        .from(sessionParticipants)
+        .where(eq(sessionParticipants.sessionId, sessionId));
+      const isParticipant = seats.some((seat: any) => seat.actorId === callerActorId);
+      if (!isParticipant) {
+        throw new ApiError(403, "forbidden", "not a participant in this session");
+      }
+
+      const actorIds = seats.map((seat: any) => seat.actorId).filter(Boolean);
+      const actorRows =
+        actorIds.length === 0
+          ? []
+          : await db
+              .select({
+                id: actors.id,
+                displayName: actors.displayName,
+                actorType: actors.actorType,
+              })
+              .from(actors)
+              .where(inArray(actors.id, actorIds));
+      const actorsById = new Map(actorRows.map((row: any) => [row.id, row]));
+
+      return {
+        sessionId,
+        callerActorId,
+        items: seats.map((seat: any) => {
+          const actor = actorsById.get(seat.actorId);
+          return {
+            actorId: seat.actorId,
+            displayName: actor?.displayName ?? null,
+            kind: actor?.actorType ?? null,
+            isSelf: seat.actorId === callerActorId,
+          };
+        }),
+      };
     },
 
     // ── listSessionParticipants ───────────────────────────────────────────────

--- a/services/fc/src/lib/repository-contract.ts
+++ b/services/fc/src/lib/repository-contract.ts
@@ -207,6 +207,15 @@ export function runBusinessRepositoryContract({ test, assert, createRepository }
     assert.ok(Array.isArray(out.items), "items should be an array");
   });
 
+  test("repository contract: listSessionRoster returns roster items", async () => {
+    const repo = createRepository();
+    const out = await repo.listSessionRoster("session-1");
+    assert.equal(out.sessionId, "session-1");
+    assert.ok(Array.isArray(out.items), "items should be an array");
+    assert.ok(out.items.length >= 1, "contract fixture includes participants");
+    assert.ok("displayName" in out.items[0], "roster items expose displayName");
+  });
+
   test("repository contract: upsertSessionParticipant returns participant", async () => {
     const repo = createRepository();
     const p = await repo.upsertSessionParticipant("session-1", { actorId: "actor-new", role: "member" });

--- a/services/fc/src/lib/routes/sessions.ts
+++ b/services/fc/src/lib/routes/sessions.ts
@@ -135,6 +135,12 @@ export function registerSessions(router) {
     return { body: out };
   });
 
+  router.get("/v1/sessions/:sessionId/roster", async (ctx) => {
+    const sessionId = decodeURIComponent(ctx.params.sessionId);
+    const out = await ctx.repository.listSessionRoster(sessionId);
+    return { body: out };
+  });
+
   router.post("/v1/sessions/:sessionId/participants", async (ctx) => {
     const sessionId = decodeURIComponent(ctx.params.sessionId);
     const body = ctx.json ?? {};

--- a/services/fc/src/lib/supabase-repo.ts
+++ b/services/fc/src/lib/supabase-repo.ts
@@ -2611,6 +2611,60 @@ export function createSupabaseBusinessRepository(options) {
       return { items };
     },
 
+    async listSessionRoster(sessionId) {
+      const { data: sessionRow, error: sessionErr } = await supabase
+        .from("sessions")
+        .select("id, team_id")
+        .eq("id", sessionId)
+        .maybeSingle();
+      if (sessionErr) throw sessionErr;
+      if (!sessionRow) throw new ApiError(404, "not_found", "session not found");
+
+      const caller = await this.resolveCallerActorForTeam(sessionRow.team_id);
+      const callerActorId = caller?.id ?? null;
+      if (!callerActorId) {
+        throw new ApiError(401, "missing_identity", "authentication required");
+      }
+
+      const { data: seats, error: seatsErr } = await supabase
+        .from("session_participants")
+        .select("session_id, actor_id")
+        .eq("session_id", sessionId);
+      if (seatsErr) throw seatsErr;
+      const participantRows = seats ?? [];
+      if (!participantRows.some((seat) => seat.actor_id === callerActorId)) {
+        throw new ApiError(403, "forbidden", "not a participant in this session");
+      }
+
+      const actorIds = participantRows.map((seat) => seat.actor_id).filter(Boolean);
+      let actorsById = new Map();
+      if (actorIds.length > 0) {
+        const actorRows = await chunkedIn(actorIds, async (chunk) => {
+          const { data, error } = await supabase
+            .from("actors")
+            .select("id, display_name, actor_type")
+            .in("id", chunk);
+          if (error) throw error;
+          return data ?? [];
+        });
+        actorsById = new Map(actorRows.map((row) => [row.id, row]));
+      }
+
+      return {
+        sessionId,
+        callerActorId,
+        items: participantRows.map((seat) => {
+          const actor = actorsById.get(seat.actor_id);
+          return {
+            actorId: seat.actor_id,
+            displayName: actor?.display_name ?? null,
+            kind: actor?.actor_type ?? null,
+            isSelf: seat.actor_id === callerActorId,
+          };
+        }),
+      };
+    },
+
     async upsertSessionParticipant(sessionId, input) {
       const row: any = {
         session_id: sessionId,

--- a/services/fc/test/business-api.test.ts
+++ b/services/fc/test/business-api.test.ts
@@ -1068,6 +1068,21 @@ test("GET /v1/sessions/:sessionId/participants returns participant list", async 
   assert.deepEqual(repo.calls[0], { method: "listSessionParticipants", sessionId: "session-1" });
 });
 
+test("GET /v1/sessions/:sessionId/roster returns participant display names", async () => {
+  const repo = fakeRepo();
+  const response = await handleBusinessApiRequest({
+    httpMethod: "GET",
+    path: "/v1/sessions/session-1/roster",
+    headers: { Authorization: "Bearer token" },
+  }, { createRepository: () => repo });
+
+  assert.equal(response.statusCode, 200);
+  const body = JSON.parse(response.body);
+  assert.equal(body.sessionId, "session-1");
+  assert.ok(Array.isArray(body.items));
+  assert.deepEqual(repo.calls[0], { method: "listSessionRoster", sessionId: "session-1" });
+});
+
 test("POST /v1/sessions/:sessionId/participants upserts participant", async () => {
   const repo = fakeRepo();
   const response = await handleBusinessApiRequest({
@@ -2022,6 +2037,7 @@ function fakeRepo({ sessions = [], error = null, teamWorkspaceConfigs = {}, work
     async markSessionUnread(sessionId) { calls.push({ method: "markSessionUnread", sessionId }); if (error) throw error; },
     async listAgentRuntimesForTeam(teamId) { calls.push({ method: "listAgentRuntimesForTeam", teamId }); if (error) throw error; return [{ id: "rt-1", teamId, agentId: "agent-1", sessionId: "session-1", workspaceId: null, backendType: "claude_code", status: "ready", backendSessionId: "bs-1", runtimeId: "rt12abcd", currentModel: "claude-opus-4-7", lastSeenAt: "2026-05-27T01:00:00Z", createdAt: "2026-05-27T00:00:00Z", updatedAt: "2026-05-27T01:00:00Z" }]; },
     async listSessionParticipants(sessionId) { calls.push({ method: "listSessionParticipants", sessionId }); if (error) throw error; const store = sessions.length > 0 ? sessions : sessionStore; const s = store.find(s => s.id === sessionId); return { items: s?.participants ?? [] }; },
+    async listSessionRoster(sessionId) { calls.push({ method: "listSessionRoster", sessionId }); if (error) throw error; const store = sessions.length > 0 ? sessions : sessionStore; const s = store.find(s => s.id === sessionId); const participants = s?.participants ?? []; return { sessionId, callerActorId: participants[0]?.actorId ?? "actor-1", items: participants.map(p => ({ actorId: p.actorId, displayName: "Alice", kind: "member", isSelf: p.actorId === (participants[0]?.actorId ?? "actor-1") })) }; },
     async upsertSessionParticipant(sessionId, input) { calls.push({ method: "upsertSessionParticipant", sessionId, input }); if (error) throw error; const store = sessions.length > 0 ? sessions : sessionStore; const s = store.find(s => s.id === sessionId); const existing = s?.participants?.find(p => p.actorId === input.actorId); if (existing) { existing.role = input.role ?? existing.role; return existing; } const newP = { sessionId, actorId: input.actorId, role: input.role ?? "member", joinedAt: null }; if (s) s.participants.push(newP); return newP; },
     async updateParticipantModel(sessionId, actorId, input) { calls.push({ method: "updateParticipantModel", sessionId, actorId, input }); if (error) throw error; const store = sessions.length > 0 ? sessions : sessionStore; const s = store.find(s => s.id === sessionId); const p = s?.participants?.find(p => p.actorId === actorId); if (p) p.model = input.model; },
     async removeSessionParticipant(sessionId, actorId) { calls.push({ method: "removeSessionParticipant", sessionId, actorId }); if (error) throw error; const store = sessions.length > 0 ? sessions : sessionStore; const s = store.find(s => s.id === sessionId); if (s?.participants) s.participants = s.participants.filter(p => p.actorId !== actorId); },

--- a/services/fc/test/pg-repo-sessions.test.ts
+++ b/services/fc/test/pg-repo-sessions.test.ts
@@ -19,6 +19,7 @@ import {
   teamMembers,
   sessions,
   sessionParticipants,
+  agents,
 } from "../src/db/schema/index.js";
 
 // ── Seed helpers ─────────────────────────────────────────────────────────────
@@ -44,6 +45,26 @@ async function seedActor(db: any, teamId: string, opts: { kind?: string; userId?
   await db.insert(members).values({ id: actor.id, status: "active" });
   await db.insert(teamMembers).values({ teamId, memberId: actor.id, role: "member" });
   return actor;
+}
+
+async function seedPersonalAgent(
+  db: any,
+  teamId: string,
+  ownerMemberId: string,
+  displayName = "MDC",
+) {
+  const [agentActor] = await db
+    .insert(actors)
+    .values({ teamId, actorType: "agent", displayName })
+    .returning();
+  await db.insert(agents).values({
+    id: agentActor.id,
+    agentKind: "pi",
+    status: "active",
+    visibility: "personal",
+    ownerMemberId,
+  });
+  return agentActor;
 }
 
 // ── listSessions ──────────────────────────────────────────────────────────────
@@ -792,4 +813,57 @@ test("listSessionParticipantsForSync returns participant rows", async () => {
   const r = rows[0];
   assert.ok("session_id" in r && "actor_id" in r && "joined_at" in r, "must be snake_case");
   assert.ok(!("sessionId" in r), "must not leak camelCase keys");
+});
+
+// ── listSessionRoster ─────────────────────────────────────────────────────────
+
+test("listSessionRoster returns personal agent display name for caller agent", async () => {
+  const { db } = await makeTestDb();
+  const team = await seedTeam(db);
+  const member = await seedActor(db, team.id, { userId: "member-u" });
+  const personalAgent = await seedPersonalAgent(db, team.id, member.id, "MDC");
+  const repo = createPgBusinessRepository({ db, callerActorId: personalAgent.id });
+
+  const s = await repo.createSession({
+    teamId: team.id,
+    title: "Roster",
+    mode: "collab",
+    participantActorIds: [member.id, personalAgent.id],
+  });
+  const out = await repo.listSessionRoster(s.id);
+
+  assert.equal(out.sessionId, s.id);
+  assert.equal(out.callerActorId, personalAgent.id);
+  const self = out.items.find((item: any) => item.actorId === personalAgent.id);
+  assert.ok(self, "personal agent should appear in roster");
+  assert.equal(self.displayName, "MDC");
+  assert.equal(self.kind, "agent");
+  assert.equal(self.isSelf, true);
+
+  const human = out.items.find((item: any) => item.actorId === member.id);
+  assert.ok(human);
+  assert.equal(human.displayName, "Test Actor");
+  assert.equal(human.kind, "member");
+  assert.equal(human.isSelf, false);
+});
+
+test("listSessionRoster rejects non-participants", async () => {
+  const { db } = await makeTestDb();
+  const team = await seedTeam(db);
+  const member = await seedActor(db, team.id);
+  const outsider = await seedActor(db, team.id);
+  const personalAgent = await seedPersonalAgent(db, team.id, member.id);
+  const repo = createPgBusinessRepository({ db, callerActorId: outsider.id });
+
+  const s = await repo.createSession({
+    teamId: team.id,
+    title: "Private roster",
+    mode: "solo",
+    participantActorIds: [member.id, personalAgent.id],
+  });
+
+  await assert.rejects(
+    () => repo.listSessionRoster(s.id),
+    (err: any) => err.code === "forbidden",
+  );
 });

--- a/services/fc/test/repository-contract.test.ts
+++ b/services/fc/test/repository-contract.test.ts
@@ -216,6 +216,20 @@ function contractRepo() {
       const s = sessionStore.find(s => s.id === sessionId);
       return { items: s?.participants ?? [] };
     },
+    async listSessionRoster(sessionId) {
+      const s = sessionStore.find(s => s.id === sessionId);
+      const participants = s?.participants ?? [];
+      return {
+        sessionId,
+        callerActorId: participants[0]?.actorId ?? "actor-1",
+        items: participants.map((p) => ({
+          actorId: p.actorId,
+          displayName: p.actorId === "actor-1" ? "Alice" : null,
+          kind: p.actorId === "actor-1" ? "member" : null,
+          isSelf: p.actorId === (participants[0]?.actorId ?? "actor-1"),
+        })),
+      };
+    },
     async upsertSessionParticipant(sessionId, input) {
       const s = sessionStore.find(s => s.id === sessionId);
       const existing = s?.participants?.find(p => p.actorId === input.actorId);


### PR DESCRIPTION
## Summary
- Add `GET /v1/sessions/:sessionId/roster` to resolve display names for seated session participants from the `actors` table directly.
- Caller must already be a session participant; response is scoped to seated actor ids only, so existing `by-ids` / directory visibility behavior stays unchanged.
- Implement in both `supabase-repo` and `pg-repo`, with OpenAPI schema and tests.

## Context
Personal agents authenticated with an agent token cannot see themselves in `actor_directory`, so daemon session-context injection falls back to UUID prefixes (e.g. `e08fb571`). This endpoint is intentionally narrow: it does not broaden team-wide actor lookup.

## Test plan
- [x] `pnpm exec node --import tsx --test test/pg-repo-sessions.test.ts` (roster tests pass)
- [ ] Deploy FC to accounting and verify `GET /v1/sessions/{id}/roster` returns `displayName: "MDC"` for personal agent token
- [ ] Follow-up: wire daemon `session_prompt` to use `/roster` instead of `by-ids`


Made with [Cursor](https://cursor.com)