### PR TITLE
fix(skills): fail-closed native skill fallback guard (PR3 review)

### DIFF
--- a/apps/daemon/src/daemon/server/messaging.rs
+++ b/apps/daemon/src/daemon/server/messaging.rs
@@ -339,20 +339,11 @@ impl DaemonServer {
         if let Some(amux::acp_event::Event::StatusChange(ref sc)) = acp_event.event {
             let became_idle = sc.old_status == amux::AgentStatus::Active as i32
                 && sc.new_status == amux::AgentStatus::Idle as i32;
-            let turn_opened = sc.old_status == amux::AgentStatus::Idle as i32
-                && sc.new_status == amux::AgentStatus::Active as i32;
             {
                 let mut agents = self.agents.lock().await;
                 if let Some(handle) = agents.get_handle_mut(agent_id) {
                     handle.status = amux::AgentStatus::try_from(sc.new_status)
                         .unwrap_or(amux::AgentStatus::Unknown);
-                    if turn_opened && crate::runtime::guard_enabled() {
-                        handle.native_skill_baseline = Some(
-                            crate::runtime::snapshot_baseline(std::path::Path::new(
-                                &handle.worktree,
-                            )),
-                        );
-                    }
                 }
             }
             self.publish_runtime_state_by_id(agent_id).await;
@@ -413,36 +404,39 @@ impl DaemonServer {
                 .aggregator(agent_id)
                 .and_then(|a| a.current_turn_id())
                 .map(str::to_string);
+            let violations = if !is_child_event {
+                agents
+                    .get_handle_mut(agent_id)
+                    .map(|h| {
+                        crate::runtime::prepare_guard_for_acp_event(
+                            &mut h.native_skill_turn_guard,
+                            std::path::Path::new(&h.worktree),
+                            &h.acp_session_id,
+                            is_child_event,
+                            &acp_event,
+                            turn_id_before.as_deref(),
+                        )
+                    })
+                    .unwrap_or_default()
+            } else {
+                Vec::new()
+            };
             let mut emitted = match agents.aggregator_mut(agent_id) {
                 Some(agg) if !is_child_event => agg.ingest(&acp_event),
                 _ => Vec::new(),
             };
-            if clear_reply_to {
-                if let Some(handle) = agents.get_handle_mut(agent_id) {
-                    if let Some(baseline) = handle.native_skill_baseline.take() {
-                        let violations = crate::runtime::violations_after_turn(
-                            &baseline,
-                            std::path::Path::new(&handle.worktree),
-                        );
-                        if !violations.is_empty() {
-                            tracing::warn!(
-                                agent_id = %agent_id,
-                                workspace = %handle.worktree,
-                                count = violations.len(),
-                                slugs = ?violations.iter().map(|v| v.slug.as_str()).collect::<Vec<_>>(),
-                                "native skill written to unsupported directory during turn"
-                            );
-                            emitted.push(crate::runtime::turn_aggregator::EmittedMessage {
-                                kind: crate::proto::teamclu::MessageKind::AgentReply,
-                                content: crate::runtime::AGENT_REPLY_CONTENT.to_string(),
-                                metadata_json: crate::runtime::AGENT_REPLY_METADATA_JSON
-                                    .to_string(),
-                                turn_id: turn_id_before.clone().unwrap_or_default(),
-                                cloud_persist: true,
-                            });
-                        }
-                    }
+            if !violations.is_empty() {
+                if let Some(handle) = agents.get_handle(agent_id) {
+                    tracing::warn!(
+                        agent_id = %agent_id,
+                        workspace = %handle.worktree,
+                        count = violations.len(),
+                        slugs = ?violations.iter().map(|v| v.slug.as_str()).collect::<Vec<_>>(),
+                        "native skill written to unsupported directory during turn"
+                    );
                 }
+                let tid = turn_id_before.clone().unwrap_or_default();
+                crate::runtime::apply_violations_to_emitted(&mut emitted, &violations, &tid);
             }
             let turn_id = turn_id_before.unwrap_or_default();
             (emitted, turn_id, seq, reply_to_message_id, clear_reply_to)

--- a/apps/daemon/src/runtime/handle.rs
+++ b/apps/daemon/src/runtime/handle.rs
@@ -111,8 +111,8 @@ pub struct RuntimeHandle {
     /// Another session on the shared OpenCode host may have dropped MCP; refresh
     /// on the next Idle transition (never detach/resume while Active).
     pub remote_tools_mcp_refresh_pending: bool,
-    /// Forbidden native skill slugs present when the current turn opened.
-    pub native_skill_baseline: Option<crate::runtime::NativeSkillBaseline>,
+    /// Turn-scoped native skill baseline for unsupported-directory detection.
+    pub native_skill_turn_guard: Option<crate::runtime::NativeSkillTurnGuard>,
 }
 
 impl RuntimeHandle {
@@ -167,7 +167,7 @@ impl RuntimeHandle {
             env_snapshot: None,
             env_team_id: None,
             remote_tools_mcp_refresh_pending: false,
-            native_skill_baseline: None,
+            native_skill_turn_guard: None,
         }
     }
 
@@ -448,7 +448,7 @@ impl RuntimeHandle {
             env_snapshot: None,
             env_team_id: None,
             remote_tools_mcp_refresh_pending: false,
-            native_skill_baseline: None,
+            native_skill_turn_guard: None,
         }
     }
 }

--- a/apps/daemon/src/runtime/mod.rs
+++ b/apps/daemon/src/runtime/mod.rs
@@ -21,8 +21,10 @@ pub mod managed_llm;
 mod manager;
 mod native_skill_fallback_guard;
 pub(crate) use native_skill_fallback_guard::{
-    guard_enabled, snapshot_baseline, violations_after_turn, AGENT_REPLY_CONTENT,
-    AGENT_REPLY_METADATA_JSON, NativeSkillBaseline,
+    apply_violations_to_emitted, ensure_turn_guard, event_may_open_implicit_turn,
+    guard_enabled, prepare_guard_for_acp_event, snapshot_baseline,
+    take_violations_for_turn_end, violations_after_turn, AGENT_REPLY_CONTENT,
+    NativeSkillBaseline, NativeSkillTurnGuard, NativeSkillViolation,
 };
 pub mod permission_policy;
 pub mod prompt_attachments;

--- a/apps/daemon/src/runtime/native_skill_fallback_guard.rs
+++ b/apps/daemon/src/runtime/native_skill_fallback_guard.rs
@@ -1,14 +1,18 @@
 //! Turn-scoped detection when agents write skill packs to native runtime dirs
 //! instead of `manage_skills` → `~/.agents/skills/<slug>/`.
 //!
-//! PR3 ships **fail-closed detect** only: violations surface on turn end and
-//! instruct the agent to recreate via `manage_skills`. Auto-adoption is gated
-//! behind `TEAMCLU_NATIVE_SKILL_AUTO_ADOPTION` (default off).
+//! PR3 ships **fail-closed detect** only: violations replace the turn-final
+//! agent success reply and instruct recreation via `manage_skills`.
+//! `TEAMCLU_NATIVE_SKILL_AUTO_ADOPTION` is reserved for a future adoption path
+//! and must not disable detection until that path exists.
 
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 
+use crate::proto::amux;
+use crate::proto::teamclu::MessageKind;
 use crate::runtime::claude_skills;
+use crate::runtime::turn_aggregator::{EmittedMessage, TurnAggregator};
 
 pub const ERROR_CODE: &str = "skill_created_in_unsupported_directory";
 
@@ -18,8 +22,13 @@ agent directory (.opencode/skills, .pi/skills, or .claude/skills) instead of \
 through manage_skills. The native copy was not adopted. Remove it and recreate \
 the skill with manage_skills action=create so it lands in ~/.agents/skills/<slug>/.";
 
-pub const AGENT_REPLY_METADATA_JSON: &str =
-    r#"{"turn_status":"skill_created_in_unsupported_directory"}"#;
+/// Per-parent-session guard opened at logical turn start and closed at turn end.
+#[derive(Debug, Clone)]
+pub struct NativeSkillTurnGuard {
+    pub turn_id: String,
+    pub acp_session_id: String,
+    pub baseline: NativeSkillBaseline,
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 enum NativeRootKind {
@@ -99,6 +108,137 @@ pub fn auto_adoption_enabled() -> bool {
     )
 }
 
+pub fn event_may_open_implicit_turn(event: &Option<amux::acp_event::Event>) -> bool {
+    matches!(
+        event,
+        Some(amux::acp_event::Event::Output(_))
+            | Some(amux::acp_event::Event::Thinking(_))
+            | Some(amux::acp_event::Event::ToolUse(_))
+    )
+}
+
+pub fn ensure_turn_guard(
+    guard: &mut Option<NativeSkillTurnGuard>,
+    workspace: &Path,
+    parent_acp_session_id: &str,
+    turn_id: Option<&str>,
+) {
+    if !guard_enabled() || guard.is_some() {
+        return;
+    }
+    *guard = Some(NativeSkillTurnGuard {
+        turn_id: turn_id.unwrap_or("").to_string(),
+        acp_session_id: parent_acp_session_id.to_string(),
+        baseline: snapshot_baseline(workspace),
+    });
+}
+
+pub fn take_violations_for_turn_end(
+    guard: &mut Option<NativeSkillTurnGuard>,
+    parent_acp_session_id: &str,
+    workspace: &Path,
+) -> Vec<NativeSkillViolation> {
+    let Some(active) = guard.take() else {
+        return Vec::new();
+    };
+    if active.acp_session_id != parent_acp_session_id {
+        *guard = Some(active);
+        return Vec::new();
+    }
+    violations_after_turn(&active.baseline, workspace)
+}
+
+pub fn failure_metadata_json(violations: &[NativeSkillViolation]) -> String {
+    serde_json::json!({
+        "turn_status": ERROR_CODE,
+        "error_code": ERROR_CODE,
+        "violations": violations
+            .iter()
+            .map(|v| {
+                serde_json::json!({
+                    "slug": v.slug,
+                    "root": v.root_label,
+                    "path": v.path.to_string_lossy(),
+                })
+            })
+            .collect::<Vec<_>>(),
+    })
+    .to_string()
+}
+
+pub fn is_failure_emitted_message(msg: &EmittedMessage) -> bool {
+    msg.kind == MessageKind::AgentReply
+        && msg
+            .metadata_json
+            .contains(&format!("\"turn_status\":\"{ERROR_CODE}\""))
+}
+
+pub fn apply_violations_to_emitted(
+    emitted: &mut Vec<EmittedMessage>,
+    violations: &[NativeSkillViolation],
+    turn_id: &str,
+) {
+    if violations.is_empty() {
+        return;
+    }
+    emitted.retain(|msg| {
+        !(msg.kind == MessageKind::AgentReply
+            && TurnAggregator::cloud_persistent(msg)
+            && !is_failure_emitted_message(msg))
+    });
+    emitted.push(EmittedMessage {
+        kind: MessageKind::AgentReply,
+        content: AGENT_REPLY_CONTENT.to_string(),
+        metadata_json: failure_metadata_json(violations),
+        turn_id: turn_id.to_string(),
+        cloud_persist: true,
+    });
+}
+
+/// Guard lifecycle for one ACP event. Must run **before** `TurnAggregator::ingest`
+/// on parent-session events so turn-end detection sees the pre-ingest filesystem
+/// and implicit turns open a baseline before the first content event allocates
+/// `turn_id`.
+pub fn prepare_guard_for_acp_event(
+    guard: &mut Option<NativeSkillTurnGuard>,
+    workspace: &Path,
+    parent_acp_session_id: &str,
+    is_child_event: bool,
+    event: &amux::AcpEvent,
+    current_turn_id: Option<&str>,
+) -> Vec<NativeSkillViolation> {
+    if is_child_event || !guard_enabled() {
+        return Vec::new();
+    }
+    let turn_opened = matches!(
+        event.event.as_ref(),
+        Some(amux::acp_event::Event::StatusChange(sc))
+            if sc.old_status == amux::AgentStatus::Idle as i32
+                && sc.new_status == amux::AgentStatus::Active as i32
+    );
+    let implicit_turn_event =
+        event_may_open_implicit_turn(&event.event) && current_turn_id.is_none();
+    if turn_opened || implicit_turn_event {
+        ensure_turn_guard(
+            guard,
+            workspace,
+            parent_acp_session_id,
+            current_turn_id,
+        );
+    }
+    let clear_reply_to = matches!(
+        event.event.as_ref(),
+        Some(amux::acp_event::Event::StatusChange(sc))
+            if sc.old_status == amux::AgentStatus::Active as i32
+                && sc.new_status == amux::AgentStatus::Idle as i32
+    );
+    if clear_reply_to {
+        take_violations_for_turn_end(guard, parent_acp_session_id, workspace)
+    } else {
+        Vec::new()
+    }
+}
+
 pub fn snapshot_baseline(workspace: &Path) -> NativeSkillBaseline {
     NativeSkillBaseline {
         entries: scan_native_skills(workspace),
@@ -109,8 +249,14 @@ pub fn violations_after_turn(
     baseline: &NativeSkillBaseline,
     workspace: &Path,
 ) -> Vec<NativeSkillViolation> {
-    if !guard_enabled() || auto_adoption_enabled() {
+    if !guard_enabled() {
         return Vec::new();
+    }
+    if auto_adoption_enabled() {
+        tracing::warn!(
+            "TEAMCLU_NATIVE_SKILL_AUTO_ADOPTION is set but auto-adoption is not implemented; \
+             native skill fallback detection remains active"
+        );
     }
     let current = scan_native_skills(workspace);
     current
@@ -184,12 +330,73 @@ fn is_valid_native_skill_pack(path: &Path, workspace: &Path, root: NativeRootKin
 mod tests {
     use super::*;
     use crate::config::{create_pack, ClaimedTeamContext, CreatePackRequest};
+    use crate::proto::amux;
     use crate::runtime::claude_skills::reconcile_after_managed_mutation;
+    use crate::runtime::turn_aggregator::TurnAggregator;
 
     fn write_native_pack(root: &Path, slug: &str, body: &str) {
         let dir = root.join(slug);
         std::fs::create_dir_all(&dir).unwrap();
         std::fs::write(dir.join("SKILL.md"), body).unwrap();
+    }
+
+    fn status_change(old: amux::AgentStatus, new: amux::AgentStatus) -> amux::AcpEvent {
+        amux::AcpEvent {
+            event: Some(amux::acp_event::Event::StatusChange(amux::AcpStatusChange {
+                old_status: old as i32,
+                new_status: new as i32,
+            })),
+            model: String::new(),
+        }
+    }
+
+    fn output_chunk(text: &str) -> amux::AcpEvent {
+        amux::AcpEvent {
+            event: Some(amux::acp_event::Event::Output(amux::AcpOutput {
+                text: text.into(),
+                is_complete: false,
+            })),
+            model: String::new(),
+        }
+    }
+
+    fn ingest_with_guard(
+        workspace: &Path,
+        parent_acp: &str,
+        guard: &mut Option<NativeSkillTurnGuard>,
+        agg: &mut TurnAggregator,
+        event: &amux::AcpEvent,
+        is_child: bool,
+    ) -> Vec<EmittedMessage> {
+        let turn_id_before = agg.current_turn_id().map(str::to_string);
+        let violations = prepare_guard_for_acp_event(
+            guard,
+            workspace,
+            parent_acp,
+            is_child,
+            event,
+            turn_id_before.as_deref(),
+        );
+        let mut emitted = if !is_child {
+            agg.ingest(event)
+        } else {
+            Vec::new()
+        };
+        if !violations.is_empty() {
+            apply_violations_to_emitted(
+                &mut emitted,
+                &violations,
+                turn_id_before.as_deref().unwrap_or(""),
+            );
+        }
+        emitted
+    }
+
+    fn cloud_persistent_replies(emitted: &[EmittedMessage]) -> Vec<&EmittedMessage> {
+        emitted
+            .iter()
+            .filter(|msg| TurnAggregator::cloud_persistent(msg))
+            .collect()
     }
 
     #[test]
@@ -206,6 +413,38 @@ mod tests {
         assert_eq!(violations.len(), 1);
         assert_eq!(violations[0].slug, "native-demo");
         assert_eq!(violations[0].root_label, ".opencode/skills");
+    }
+
+    #[test]
+    fn detects_new_pi_native_skill_after_turn() {
+        let _guard = crate::test_brand_env::BrandEnvGuard::set("teamclu");
+        let ws = tempfile::tempdir().unwrap();
+        let baseline = snapshot_baseline(ws.path());
+        write_native_pack(
+            &ws.path().join(".pi/skills"),
+            "pi-native",
+            "---\nname: pi-native\ndescription: Pi native.\n---\n",
+        );
+        let violations = violations_after_turn(&baseline, ws.path());
+        assert_eq!(violations.len(), 1);
+        assert_eq!(violations[0].slug, "pi-native");
+        assert_eq!(violations[0].root_label, ".pi/skills");
+    }
+
+    #[test]
+    fn detects_new_claude_native_skill_after_turn() {
+        let _guard = crate::test_brand_env::BrandEnvGuard::set("teamclu");
+        let ws = tempfile::tempdir().unwrap();
+        let baseline = snapshot_baseline(ws.path());
+        write_native_pack(
+            &ws.path().join(".claude/skills"),
+            "claude-native",
+            "---\nname: claude-native\ndescription: Claude native.\n---\n",
+        );
+        let violations = violations_after_turn(&baseline, ws.path());
+        assert_eq!(violations.len(), 1);
+        assert_eq!(violations[0].slug, "claude-native");
+        assert_eq!(violations[0].root_label, ".claude/skills");
     }
 
     #[test]
@@ -276,5 +515,291 @@ mod tests {
         let violations = violations_after_turn(&baseline, ws.path());
         assert!(violations.is_empty());
         std::env::remove_var("TEAMCLU_NATIVE_SKILL_FALLBACK_GUARD");
+    }
+
+    #[test]
+    fn auto_adoption_flag_does_not_disable_detection() {
+        let _guard = crate::test_brand_env::BrandEnvGuard::set("teamclu");
+        std::env::set_var("TEAMCLU_NATIVE_SKILL_AUTO_ADOPTION", "true");
+        let ws = tempfile::tempdir().unwrap();
+        let baseline = snapshot_baseline(ws.path());
+        write_native_pack(
+            &ws.path().join(".opencode/skills"),
+            "still-detected",
+            "---\nname: still-detected\ndescription: Still detected.\n---\n",
+        );
+        let violations = violations_after_turn(&baseline, ws.path());
+        assert_eq!(violations.len(), 1);
+        std::env::remove_var("TEAMCLU_NATIVE_SKILL_AUTO_ADOPTION");
+    }
+
+    #[test]
+    fn apply_violations_replaces_cloud_persistent_success_reply() {
+        let violations = vec![NativeSkillViolation {
+            root_label: ".opencode/skills",
+            slug: "demo".into(),
+            path: PathBuf::from("/tmp/ws/.opencode/skills/demo"),
+        }];
+        let mut emitted = vec![EmittedMessage {
+            kind: MessageKind::AgentReply,
+            content: "Skill created successfully.".into(),
+            metadata_json: String::new(),
+            turn_id: "turn-1".into(),
+            cloud_persist: true,
+        }];
+        apply_violations_to_emitted(&mut emitted, &violations, "turn-1");
+        assert_eq!(emitted.len(), 1);
+        assert!(is_failure_emitted_message(&emitted[0]));
+        assert!(!emitted[0].content.contains("successfully"));
+        assert!(emitted[0].metadata_json.contains("demo"));
+        assert!(emitted[0].metadata_json.contains(".opencode/skills"));
+    }
+
+    #[test]
+    fn child_session_guard_does_not_consume_parent_turn_end() {
+        let ws = tempfile::tempdir().unwrap();
+        let baseline = snapshot_baseline(ws.path());
+        let mut guard = Some(NativeSkillTurnGuard {
+            turn_id: "turn-parent".into(),
+            acp_session_id: "child-session".into(),
+            baseline,
+        });
+        write_native_pack(
+            &ws.path().join(".opencode/skills"),
+            "child-write",
+            "---\nname: child-write\ndescription: Child.\n---\n",
+        );
+        let violations = take_violations_for_turn_end(&mut guard, "parent-session", ws.path());
+        assert!(violations.is_empty());
+        assert_eq!(guard.as_ref().unwrap().acp_session_id, "child-session");
+    }
+
+    #[test]
+    fn ensure_turn_guard_only_opens_once() {
+        let ws = tempfile::tempdir().unwrap();
+        let mut guard = None;
+        ensure_turn_guard(&mut guard, ws.path(), "parent", Some("turn-1"));
+        let first = guard.clone().unwrap();
+        write_native_pack(
+            &ws.path().join(".opencode/skills"),
+            "late",
+            "---\nname: late\ndescription: Late.\n---\n",
+        );
+        ensure_turn_guard(&mut guard, ws.path(), "parent", Some("turn-1"));
+        assert_eq!(guard.unwrap().baseline.entries, first.baseline.entries);
+    }
+
+    #[test]
+    fn messaging_flow_explicit_turn_suppresses_success_on_violation() {
+        let _guard = crate::test_brand_env::BrandEnvGuard::set("teamclu");
+        let ws = tempfile::tempdir().unwrap();
+        let parent_acp = "parent-session";
+        let mut turn_guard = None;
+        let mut agg = TurnAggregator::new();
+
+        assert!(ingest_with_guard(
+            ws.path(),
+            parent_acp,
+            &mut turn_guard,
+            &mut agg,
+            &status_change(amux::AgentStatus::Idle, amux::AgentStatus::Active),
+            false,
+        )
+        .is_empty());
+
+        write_native_pack(
+            &ws.path().join(".opencode/skills"),
+            "bypass-demo",
+            "---\nname: bypass-demo\ndescription: Bypass.\n---\n",
+        );
+
+        assert!(ingest_with_guard(
+            ws.path(),
+            parent_acp,
+            &mut turn_guard,
+            &mut agg,
+            &output_chunk("Skill created successfully."),
+            false,
+        )
+        .is_empty());
+
+        let emitted = ingest_with_guard(
+            ws.path(),
+            parent_acp,
+            &mut turn_guard,
+            &mut agg,
+            &status_change(amux::AgentStatus::Active, amux::AgentStatus::Idle),
+            false,
+        );
+        let finals = cloud_persistent_replies(&emitted);
+        assert_eq!(finals.len(), 1, "expected one cloud-final reply: {emitted:?}");
+        assert!(is_failure_emitted_message(finals[0]));
+        assert!(finals[0].metadata_json.contains("bypass-demo"));
+        assert!(finals[0].metadata_json.contains(".opencode/skills"));
+        assert!(!finals[0].content.contains("successfully"));
+    }
+
+    #[test]
+    fn messaging_flow_implicit_turn_detects_native_write_before_active() {
+        let _guard = crate::test_brand_env::BrandEnvGuard::set("teamclu");
+        let ws = tempfile::tempdir().unwrap();
+        let parent_acp = "parent-session";
+        let mut turn_guard = None;
+        let mut agg = TurnAggregator::new();
+
+        assert!(ingest_with_guard(
+            ws.path(),
+            parent_acp,
+            &mut turn_guard,
+            &mut agg,
+            &output_chunk("Starting work…"),
+            false,
+        )
+        .is_empty());
+        assert!(turn_guard.is_some(), "implicit turn should open guard baseline");
+
+        write_native_pack(
+            &ws.path().join(".pi/skills"),
+            "implicit-pi",
+            "---\nname: implicit-pi\ndescription: Implicit.\n---\n",
+        );
+
+        assert!(ingest_with_guard(
+            ws.path(),
+            parent_acp,
+            &mut turn_guard,
+            &mut agg,
+            &status_change(amux::AgentStatus::Idle, amux::AgentStatus::Active),
+            false,
+        )
+        .is_empty());
+
+        assert!(ingest_with_guard(
+            ws.path(),
+            parent_acp,
+            &mut turn_guard,
+            &mut agg,
+            &output_chunk("Done."),
+            false,
+        )
+        .is_empty());
+
+        let emitted = ingest_with_guard(
+            ws.path(),
+            parent_acp,
+            &mut turn_guard,
+            &mut agg,
+            &status_change(amux::AgentStatus::Active, amux::AgentStatus::Idle),
+            false,
+        );
+        let finals = cloud_persistent_replies(&emitted);
+        assert_eq!(finals.len(), 1);
+        assert!(is_failure_emitted_message(finals[0]));
+        assert!(finals[0].metadata_json.contains("implicit-pi"));
+    }
+
+    #[test]
+    fn messaging_flow_child_idle_does_not_consume_parent_guard() {
+        let _guard = crate::test_brand_env::BrandEnvGuard::set("teamclu");
+        let ws = tempfile::tempdir().unwrap();
+        let parent_acp = "parent-session";
+        let mut turn_guard = None;
+        let mut agg = TurnAggregator::new();
+
+        assert!(ingest_with_guard(
+            ws.path(),
+            parent_acp,
+            &mut turn_guard,
+            &mut agg,
+            &status_change(amux::AgentStatus::Idle, amux::AgentStatus::Active),
+            false,
+        )
+        .is_empty());
+        assert!(turn_guard.is_some());
+
+        write_native_pack(
+            &ws.path().join(".claude/skills"),
+            "parent-skill",
+            "---\nname: parent-skill\ndescription: Parent.\n---\n",
+        );
+
+        assert!(ingest_with_guard(
+            ws.path(),
+            parent_acp,
+            &mut turn_guard,
+            &mut agg,
+            &status_change(amux::AgentStatus::Active, amux::AgentStatus::Idle),
+            true,
+        )
+        .is_empty());
+        assert!(
+            turn_guard.is_some(),
+            "child Idle should not consume parent guard"
+        );
+
+        assert!(ingest_with_guard(
+            ws.path(),
+            parent_acp,
+            &mut turn_guard,
+            &mut agg,
+            &output_chunk("Skill created successfully."),
+            false,
+        )
+        .is_empty());
+
+        let emitted = ingest_with_guard(
+            ws.path(),
+            parent_acp,
+            &mut turn_guard,
+            &mut agg,
+            &status_change(amux::AgentStatus::Active, amux::AgentStatus::Idle),
+            false,
+        );
+        let finals = cloud_persistent_replies(&emitted);
+        assert_eq!(finals.len(), 1);
+        assert!(is_failure_emitted_message(finals[0]));
+        assert!(finals[0].metadata_json.contains("parent-skill"));
+    }
+
+    #[test]
+    fn messaging_flow_clean_turn_keeps_success_reply() {
+        let _guard = crate::test_brand_env::BrandEnvGuard::set("teamclu");
+        let ws = tempfile::tempdir().unwrap();
+        let parent_acp = "parent-session";
+        let mut turn_guard = None;
+        let mut agg = TurnAggregator::new();
+
+        assert!(ingest_with_guard(
+            ws.path(),
+            parent_acp,
+            &mut turn_guard,
+            &mut agg,
+            &status_change(amux::AgentStatus::Idle, amux::AgentStatus::Active),
+            false,
+        )
+        .is_empty());
+
+        assert!(ingest_with_guard(
+            ws.path(),
+            parent_acp,
+            &mut turn_guard,
+            &mut agg,
+            &output_chunk("All good."),
+            false,
+        )
+        .is_empty());
+
+        let emitted = ingest_with_guard(
+            ws.path(),
+            parent_acp,
+            &mut turn_guard,
+            &mut agg,
+            &status_change(amux::AgentStatus::Active, amux::AgentStatus::Idle),
+            false,
+        );
+        let finals = cloud_persistent_replies(&emitted);
+        assert_eq!(finals.len(), 1);
+        assert!(!is_failure_emitted_message(finals[0]));
+        assert_eq!(finals[0].content, "All good.");
     }
 }

--- a/apps/daemon/src/runtime/turn_aggregator.rs
+++ b/apps/daemon/src/runtime/turn_aggregator.rs
@@ -23,6 +23,8 @@
 //!   - `{"turn_status":"interrupted"}` — user abort
 //!   - `{"turn_status":"no_final_reply"}` — Idle with no final prose
 //!     (frontends hide the English notice and render a localized strip)
+//!   - `{"turn_status":"skill_created_in_unsupported_directory", ...}` —
+//!     native-only skill write detected (fail-closed; replaces turn success)
 //!
 //! Always emit all keys for a kind (use empty strings/false rather than
 //! omitting). New keys may be added; existing keys must not be removed
@@ -332,6 +334,7 @@ impl TurnAggregator {
         let trimmed = content.trim_start();
         trimmed.starts_with("[Turn interrupted by user]")
             || trimmed.starts_with("[Turn completed with no final reply]")
+            || trimmed.starts_with("[Skill created in unsupported directory]")
     }
 
     /// Current per-turn correlation id, or `None` between turns. Read by the

--- a/packages/app/src/components/chat/ChatMessage.tsx
+++ b/packages/app/src/components/chat/ChatMessage.tsx
@@ -102,6 +102,8 @@ export const ChatMessage = React.memo(function ChatMessage({
   const isUser = message.role === "user";
   const isInterruptedTurn = !isUser && message.turnStatus === "interrupted";
   const isNoFinalReplyTurn = !isUser && message.turnStatus === "no_final_reply";
+  const isUnsupportedNativeSkillTurn =
+    !isUser && message.turnStatus === "skill_created_in_unsupported_directory";
   const [copied, setCopied] = React.useState(false);
   const [hydratedProcessParts, setHydratedProcessParts] = React.useState<
     MessagePart[] | null
@@ -662,6 +664,43 @@ export const ChatMessage = React.memo(function ChatMessage({
               "No additional written reply was produced.",
             )}
           </p>
+        </div>
+      ) : null}
+
+      {/* Daemon unsupported native skill AGENT_REPLY — fail-closed turn outcome */}
+      {isUnsupportedNativeSkillTurn ? (
+        <div
+          className="mt-1 flex max-w-[520px] flex-wrap items-baseline gap-x-2 gap-y-1 pl-1 text-[12.5px] leading-[1.5] text-ink-2"
+          data-testid="unsupported-native-skill-reply"
+        >
+          <span
+            className="inline-block h-1.5 w-1.5 shrink-0 translate-y-[-1px] rounded-[1px] bg-destructive/80"
+            aria-hidden
+          />
+          <span className="font-semibold">
+            {t("chat.unsupportedNativeSkill.failedTitle", "Skill not created")}
+          </span>
+          <span className="font-mono text-[11px] text-faint">
+            ·{" "}
+            {t(
+              "chat.unsupportedNativeSkill.statusLabel",
+              "unsupported directory",
+            )}
+          </span>
+          <p className="mt-0.5 w-full text-[12.5px] leading-[1.55] text-muted-foreground">
+            {t(
+              "chat.unsupportedNativeSkill.description",
+              "A skill was written under a native agent directory instead of through manage_skills. Remove the native copy and recreate with manage_skills action=create.",
+            )}
+          </p>
+          {(message.nativeSkillViolations ?? []).map((v) => (
+            <p
+              key={`${v.slug}-${v.root}`}
+              className="w-full font-mono text-[11px] text-faint"
+            >
+              {v.slug} · {v.root}
+            </p>
+          ))}
         </div>
       ) : null}
 

--- a/packages/app/src/components/chat/__tests__/ChatMessage.test.tsx
+++ b/packages/app/src/components/chat/__tests__/ChatMessage.test.tsx
@@ -339,6 +339,26 @@ describe('ChatMessage', () => {
     expect(text).not.toContain('Turn completed with no final reply');
   });
 
+  it('renders unsupported native skill agent status strip', () => {
+    const message = makeMessage({
+      id: 'msg-native-skill-1',
+      role: 'assistant',
+      content: '',
+      isStreaming: false,
+      senderActorId: 'actor-1',
+      turnStatus: 'skill_created_in_unsupported_directory',
+      nativeSkillViolations: [{ slug: 'demo', root: '.opencode/skills' }],
+    });
+
+    const { container } = render(<ChatMessage message={message} />);
+    const strip = container.querySelector('[data-testid="unsupported-native-skill-reply"]');
+
+    expect(strip).toBeTruthy();
+    expect(container.textContent).toContain('Skill not created');
+    expect(container.textContent).toContain('demo');
+    expect(container.textContent).toContain('.opencode/skills');
+  });
+
   it('does not render hidden synthetic messages', () => {
     const message = makeMessage({
       id: 'msg-hidden',

--- a/packages/app/src/lib/__tests__/agent-reply-transcript.test.ts
+++ b/packages/app/src/lib/__tests__/agent-reply-transcript.test.ts
@@ -25,6 +25,11 @@ describe("agent reply transcript", () => {
         "[Turn completed with no final reply] The agent finished this turn",
       ),
     ).toBe(true);
+    expect(
+      isAgentFacingStatusNotice(
+        "[Skill created in unsupported directory] A skill pack was written",
+      ),
+    ).toBe(true);
     const pending = [
       createMessage(MessageSchema, {
         messageId: "nfr-1",

--- a/packages/app/src/lib/__tests__/v2-message-adapter.test.ts
+++ b/packages/app/src/lib/__tests__/v2-message-adapter.test.ts
@@ -782,6 +782,28 @@ describe("adaptTeamcluMessages", () => {
     expect(result?.[0]?.parts ?? []).toEqual([]);
   });
 
+  it("maps unsupported native skill AGENT_REPLY metadata to turnStatus and violations", () => {
+    const result = adaptTeamcluMessages([
+      tmsg({
+        kind: MessageKind.AGENT_REPLY,
+        content:
+          "[Skill created in unsupported directory] A skill pack was written under a native agent directory.",
+        turnId: "t-native",
+        metadataJson: JSON.stringify({
+          turn_status: "skill_created_in_unsupported_directory",
+          error_code: "skill_created_in_unsupported_directory",
+          violations: [{ slug: "demo", root: ".opencode/skills", path: "/ws/.opencode/skills/demo" }],
+        }),
+      }),
+    ]);
+    expect(result).toHaveLength(1);
+    expect(result?.[0]?.turnStatus).toBe("skill_created_in_unsupported_directory");
+    expect(result?.[0]?.content).toBe("");
+    expect(result?.[0]?.nativeSkillViolations).toEqual([
+      { slug: "demo", root: ".opencode/skills", path: "/ws/.opencode/skills/demo" },
+    ]);
+  });
+
   it("maps no_final_reply AGENT_REPLY metadata to turnStatus and hides agent-facing body", () => {
     const result = adaptTeamcluMessages([
       tmsg({

--- a/packages/app/src/lib/agent-reply-transcript.ts
+++ b/packages/app/src/lib/agent-reply-transcript.ts
@@ -21,7 +21,8 @@ export function isAgentFacingStatusNotice(content: string): boolean {
   const trimmed = content.trimStart();
   return (
     trimmed.startsWith("[Turn interrupted by user]") ||
-    trimmed.startsWith("[Turn completed with no final reply]")
+    trimmed.startsWith("[Turn completed with no final reply]") ||
+    trimmed.startsWith("[Skill created in unsupported directory]")
   );
 }
 

--- a/packages/app/src/lib/v2-message-adapter.ts
+++ b/packages/app/src/lib/v2-message-adapter.ts
@@ -55,6 +55,10 @@ export function adaptTeamcluMessageToSdk(m: TeamcluMessage): SdkMessage {
   const turnId = m.turnId?.trim() || undefined;
   const interrupted = isInterruptedReply(m);
   const noFinalReply = isNoFinalReply(m);
+  const unsupportedNativeSkill = isUnsupportedNativeSkillReply(m);
+  const nativeSkillViolations = unsupportedNativeSkill
+    ? parseNativeSkillViolations(m)
+    : undefined;
   const displayContent = displayContentForReply(m);
   return {
     id: m.messageId,
@@ -72,7 +76,10 @@ export function adaptTeamcluMessageToSdk(m: TeamcluMessage): SdkMessage {
       ? "interrupted"
       : noFinalReply
         ? "no_final_reply"
-        : undefined,
+        : unsupportedNativeSkill
+          ? "skill_created_in_unsupported_directory"
+          : undefined,
+    nativeSkillViolations,
     parts: displayContent
       ? [
           {
@@ -105,6 +112,25 @@ function isNoFinalReply(m: TeamcluMessage): boolean {
   return isAgentFacingNoFinalReplyNotice(m.content ?? "");
 }
 
+function isUnsupportedNativeSkillReply(m: TeamcluMessage): boolean {
+  return parseMetadata(m).turn_status === "skill_created_in_unsupported_directory";
+}
+
+function parseNativeSkillViolations(
+  m: TeamcluMessage,
+): { slug: string; root: string; path?: string }[] {
+  const raw = parseMetadata(m).violations;
+  if (!Array.isArray(raw)) return [];
+  return raw
+    .filter((v): v is Record<string, unknown> => !!v && typeof v === "object" && !Array.isArray(v))
+    .map((v) => ({
+      slug: typeof v.slug === "string" ? v.slug : "",
+      root: typeof v.root === "string" ? v.root : "",
+      path: typeof v.path === "string" ? v.path : undefined,
+    }))
+    .filter((v) => v.slug.length > 0 && v.root.length > 0);
+}
+
 /** Daemon English instruction when there was no prose to keep. */
 function isAgentFacingInterruptNotice(content: string): boolean {
   return content.trimStart().startsWith("[Turn interrupted by user]");
@@ -114,10 +140,18 @@ function isAgentFacingNoFinalReplyNotice(content: string): boolean {
   return content.trimStart().startsWith("[Turn completed with no final reply]");
 }
 
+function isAgentFacingUnsupportedNativeSkillNotice(content: string): boolean {
+  return content.trimStart().startsWith("[Skill created in unsupported directory]");
+}
+
 /** User-visible body for an AGENT_REPLY (hide agent-facing status notices). */
 function displayContentForReply(m: TeamcluMessage): string {
   const raw = m.content ?? "";
-  if (isAgentFacingInterruptNotice(raw) || isAgentFacingNoFinalReplyNotice(raw)) {
+  if (
+    isAgentFacingInterruptNotice(raw) ||
+    isAgentFacingNoFinalReplyNotice(raw) ||
+    isAgentFacingUnsupportedNativeSkillNotice(raw)
+  ) {
     return "";
   }
   return raw;
@@ -125,9 +159,28 @@ function displayContentForReply(m: TeamcluMessage): string {
 
 function turnStatusFromReplies(
   replies: TeamcluMessage[],
-): "interrupted" | "no_final_reply" | undefined {
+):
+  | "interrupted"
+  | "no_final_reply"
+  | "skill_created_in_unsupported_directory"
+  | undefined {
   if (replies.some(isInterruptedReply)) return "interrupted";
+  if (replies.some(isUnsupportedNativeSkillReply)) {
+    return "skill_created_in_unsupported_directory";
+  }
   if (replies.some(isNoFinalReply)) return "no_final_reply";
+  return undefined;
+}
+
+function nativeSkillViolationsFromReplies(
+  replies: TeamcluMessage[],
+): { slug: string; root: string; path?: string }[] | undefined {
+  for (const reply of replies) {
+    if (isUnsupportedNativeSkillReply(reply)) {
+      const parsed = parseNativeSkillViolations(reply);
+      if (parsed.length > 0) return parsed;
+    }
+  }
   return undefined;
 }
 
@@ -421,7 +474,7 @@ export function buildFullTurnSdkMessageFromGroup(group: TeamcluMessage[]): SdkMe
     uniqueReplyIds.add(reply.messageId);
   }
   const turnStatus = turnStatusFromReplies(uniqueReplies);
-  // Keep generated prose on interrupted replies; only drop the English notice.
+  const nativeSkillViolations = nativeSkillViolationsFromReplies(uniqueReplies);
   const replyText = uniqueReplies
     .map((r) => displayContentForReply(r))
     .filter((text) => text.trim().length > 0)
@@ -467,6 +520,7 @@ export function buildFullTurnSdkMessageFromGroup(group: TeamcluMessage[]): SdkMe
       replyToMessageId: firstNonEmptyReplyToMessageId(group),
       turnId: group[0]?.turnId?.trim() || undefined,
       turnStatus,
+      nativeSkillViolations,
       timestamp: new Date(Number(group[0].createdAt) * 1000),
     };
   }
@@ -502,6 +556,7 @@ export function buildFullTurnSdkMessageFromGroup(group: TeamcluMessage[]): SdkMe
         replyToMessageId: firstNonEmptyReplyToMessageId(group),
         turnId: group[0]?.turnId?.trim() || undefined,
         turnStatus,
+        nativeSkillViolations,
         timestamp: new Date(Number(group[0].createdAt) * 1000),
       };
     }
@@ -567,6 +622,7 @@ export function buildFullTurnSdkMessageFromGroup(group: TeamcluMessage[]): SdkMe
     replyToMessageId: firstNonEmptyReplyToMessageId(group),
     turnId: group[0]?.turnId?.trim() || undefined,
     turnStatus,
+    nativeSkillViolations,
     timestamp: new Date(Number(group[0].createdAt) * 1000),
   };
 }
@@ -695,6 +751,7 @@ function buildDeferredProcessTurnSdkMessage(group: TeamcluMessage[]): SdkMessage
   }
 
   const turnStatus = turnStatusFromReplies(uniqueReplies);
+  const nativeSkillViolations = nativeSkillViolationsFromReplies(uniqueReplies);
   const finalParts = extractFinalTextPartsForDeferredTurn(group);
   const finalText = finalParts
     .map((p) => p.text || p.content || "")
@@ -723,6 +780,7 @@ function buildDeferredProcessTurnSdkMessage(group: TeamcluMessage[]): SdkMessage
     replyToMessageId: firstNonEmptyReplyToMessageId(group),
     turnId,
     turnStatus,
+    nativeSkillViolations,
     timestamp: new Date(Number(group[0].createdAt) * 1000),
     processDeferred: true,
     processMeta,

--- a/packages/app/src/locales/en.json
+++ b/packages/app/src/locales/en.json
@@ -857,6 +857,12 @@
       "statusLabel": "no final reply",
       "description": "No additional written reply was produced."
     },
+    "unsupportedNativeSkill": {
+      "failedTitle": "Skill not created",
+      "statusLabel": "unsupported directory",
+      "description": "A skill was written under a native agent directory instead of through manage_skills. Remove the native copy and recreate with manage_skills action=create.",
+      "violationLine": "{{slug}} in {{root}}"
+    },
     "acpDebug": {
       "title": "ACP stream debug",
       "lineCount": "{{count}} line",

--- a/packages/app/src/locales/zh-CN.json
+++ b/packages/app/src/locales/zh-CN.json
@@ -857,6 +857,12 @@
       "statusLabel": "no final reply",
       "description": "没有额外的文字回复。"
     },
+    "unsupportedNativeSkill": {
+      "failedTitle": "技能未创建",
+      "statusLabel": "unsupported directory",
+      "description": "技能被写入了原生 agent 目录，而不是通过 manage_skills。请删除原生副本，并用 manage_skills action=create 重新创建。",
+      "violationLine": "{{slug}} · {{root}}"
+    },
     "acpDebug": {
       "title": "ACP 流调试",
       "lineCount": "{{count}} 条",

--- a/packages/app/src/stores/session-types.ts
+++ b/packages/app/src/stores/session-types.ts
@@ -176,7 +176,13 @@ export interface Message {
   /** ACP turn correlation id when available (debug / grouping). */
   turnId?: string | null;
   /** Daemon AGENT_REPLY metadata.turn_status — e.g. user abort. */
-  turnStatus?: "interrupted" | "no_final_reply" | null;
+  turnStatus?:
+    | "interrupted"
+    | "no_final_reply"
+    | "skill_created_in_unsupported_directory"
+    | null;
+  /** Structured native skill violations when turnStatus is unsupported-directory. */
+  nativeSkillViolations?: { slug: string; root: string; path?: string }[];
   /** Historical turn: process parts omitted until user expands collapsible. */
   processDeferred?: boolean;
   /** Lightweight process summary while {@link processDeferred} is true. */


### PR DESCRIPTION
## Summary

- **Fail-closed turn outcome (F1):** On native-only skill detection at turn end, suppress cloud-persistent success `AgentReply` rows and emit a single structured failure with `error_code` + per-violation slug/root/path metadata.
- **Guard lifecycle (F2):** Replace single baseline with `NativeSkillTurnGuard` keyed by parent `acp_session_id`; open baseline on implicit turns (output/thinking/tool before Active); child session Idle cannot consume parent guard.
- **Auto-adoption flag (F3):** `TEAMCLU_NATIVE_SKILL_AUTO_ADOPTION=true` no longer disables detection (logs a warning until adoption exists).
- **Tests (F4):** 14 daemon unit/integration tests including full turn flows (explicit/implicit/child/clean); web adapter, ChatMessage, and transcript tests for `skill_created_in_unsupported_directory`.

## Test plan

- [x] `cargo test -p amuxd --bin amuxd native_skill_fallback_guard` (14 passed)
- [x] `vitest` — v2-message-adapter, ChatMessage, agent-reply-transcript (56 passed)
- [ ] Manual: agent writes to `.opencode/skills` via file tool → thread shows localized failure strip, not success prose
- [ ] Follow-up: three-runtime bypass E2E + Expo/iOS rendering (out of scope for this PR)


Made with [Cursor](https://cursor.com)