### PR TITLE
feat(daemon): Pi session system prompt via Cloud roster

### DIFF
--- a/apps/daemon/assets/pi-extension/session-context.test.mjs
+++ b/apps/daemon/assets/pi-extension/session-context.test.mjs
@@ -103,3 +103,129 @@ test("non allowlist PI tools ignore session identity", async () => {
   assert.deepEqual(next, params);
   assert.equal(called, false);
 });
+
+/** Mirrors session prompt cache key in teamclu.ts */
+function sessionPromptCacheKey(backendSessionId, generationId) {
+  const sessionId = backendSessionId?.trim();
+  const gen = generationId?.trim();
+  if (!sessionId || !gen) return undefined;
+  return `${gen}:${sessionId}`;
+}
+
+/** Mirrors session prompt cache + before_agent_start append in teamclu.ts */
+async function appendSystemPromptForTurn(event, ctx, deps = {}) {
+  const cache = deps.cache ?? new Map();
+  const backendSessionId = backendSessionIdFromContext(ctx);
+  if (!backendSessionId) return undefined;
+
+  const cacheKey = sessionPromptCacheKey(
+    backendSessionId,
+    deps.generationId ?? "gen-test",
+  );
+  let append = cacheKey ? cache.get(cacheKey) : undefined;
+  if (!append) {
+    const fetchPrompt = deps.fetchPrompt;
+    if (!fetchPrompt) return undefined;
+    const fetched = await fetchPrompt(backendSessionId);
+    if (!fetched?.append) return undefined;
+    append = fetched.append;
+    if (cacheKey && fetched.rosterResolved === true) {
+      cache.set(cacheKey, append);
+    }
+  }
+
+  const base = String(event?.systemPrompt ?? "").trim();
+  const systemPrompt = base ? `${base}\n\n${append}` : append;
+  return { systemPrompt };
+}
+
+test("before_agent_start appends session prompt and caches by generation plus backendSessionId", async () => {
+  const cache = new Map();
+  let fetchCount = 0;
+  const ctx = { ui: makeUiContext("pi:/tmp/session-a.json") };
+  const fetchPrompt = async (id) => {
+    fetchCount += 1;
+    return { append: `[TeamClu]\nbackend=${id}`, rosterResolved: true };
+  };
+
+  const first = await appendSystemPromptForTurn(
+    { systemPrompt: "base prompt" },
+    ctx,
+    { cache, fetchPrompt, generationId: "gen-1" },
+  );
+  assert.match(first.systemPrompt, /^base prompt\n\n\[TeamClu\]/);
+  assert.equal(fetchCount, 1);
+
+  await appendSystemPromptForTurn({ systemPrompt: "turn two" }, ctx, {
+    cache,
+    fetchPrompt,
+    generationId: "gen-1",
+  });
+  assert.equal(fetchCount, 1, "same generation should hit cache");
+
+  await appendSystemPromptForTurn({ systemPrompt: "turn three" }, ctx, {
+    cache,
+    fetchPrompt,
+    generationId: "gen-2",
+  });
+  assert.equal(fetchCount, 2, "new pi host generation should refetch");
+});
+
+test("before_agent_start cache key includes host generation id", () => {
+  const keyA = sessionPromptCacheKey("pi:/tmp/a.json", "gen-1");
+  const keyB = sessionPromptCacheKey("pi:/tmp/a.json", "gen-2");
+  assert.notEqual(keyA, keyB);
+});
+
+test("before_agent_start fail-open when fetch returns nothing", async () => {
+  const result = await appendSystemPromptForTurn(
+    { systemPrompt: "keep me" },
+    { ui: makeUiContext("pi:/tmp/a.json") },
+    {
+      fetchPrompt: async () => undefined,
+    },
+  );
+  assert.equal(result, undefined);
+});
+
+test("before_agent_start does not cache degraded roster prompts", async () => {
+  const cache = new Map();
+  let fetchCount = 0;
+  const ctx = { ui: makeUiContext("pi:/tmp/degraded.json") };
+  const fetchPrompt = async () => {
+    fetchCount += 1;
+    return {
+      append: "[TeamClu Session Context]\n\nParticipants: no roster available.",
+      rosterResolved: false,
+    };
+  };
+
+  await appendSystemPromptForTurn({ systemPrompt: "turn one" }, ctx, {
+    cache,
+    fetchPrompt,
+    generationId: "gen-1",
+  });
+  await appendSystemPromptForTurn({ systemPrompt: "turn two" }, ctx, {
+    cache,
+    fetchPrompt,
+    generationId: "gen-1",
+  });
+  assert.equal(fetchCount, 2, "degraded prompt must refetch each turn");
+  assert.equal(cache.size, 0);
+});
+
+test("before_agent_start skips when ctx.ui.sessionId is missing", async () => {
+  let called = false;
+  const result = await appendSystemPromptForTurn(
+    { systemPrompt: "base" },
+    { ui: makeUiContext("") },
+    {
+      fetchPrompt: async () => {
+        called = true;
+        return "x";
+      },
+    },
+  );
+  assert.equal(result, undefined);
+  assert.equal(called, false);
+});

--- a/apps/daemon/assets/pi-extension/session-context.test.mjs
+++ b/apps/daemon/assets/pi-extension/session-context.test.mjs
@@ -145,7 +145,10 @@ test("before_agent_start appends session prompt and caches by generation plus ba
   const ctx = { ui: makeUiContext("pi:/tmp/session-a.json") };
   const fetchPrompt = async (id) => {
     fetchCount += 1;
-    return { append: `[TeamClu]\nbackend=${id}`, rosterResolved: true };
+    return {
+      append: `[Acme Session Context]\nbackend=${id}`,
+      rosterResolved: true,
+    };
   };
 
   const first = await appendSystemPromptForTurn(
@@ -153,7 +156,7 @@ test("before_agent_start appends session prompt and caches by generation plus ba
     ctx,
     { cache, fetchPrompt, generationId: "gen-1" },
   );
-  assert.match(first.systemPrompt, /^base prompt\n\n\[TeamClu\]/);
+  assert.match(first.systemPrompt, /^base prompt\n\n\[Acme Session Context\]/);
   assert.equal(fetchCount, 1);
 
   await appendSystemPromptForTurn({ systemPrompt: "turn two" }, ctx, {
@@ -188,29 +191,28 @@ test("before_agent_start fail-open when fetch returns nothing", async () => {
   assert.equal(result, undefined);
 });
 
-test("before_agent_start does not cache degraded roster prompts", async () => {
+test("before_agent_start skips injection when roster is unresolved", async () => {
   const cache = new Map();
   let fetchCount = 0;
-  const ctx = { ui: makeUiContext("pi:/tmp/degraded.json") };
+  const ctx = { ui: makeUiContext("pi:/tmp/unresolved.json") };
   const fetchPrompt = async () => {
     fetchCount += 1;
-    return {
-      append: "[TeamClu Session Context]\n\nParticipants: no roster available.",
-      rosterResolved: false,
-    };
+    return { append: "", rosterResolved: false };
   };
 
-  await appendSystemPromptForTurn({ systemPrompt: "turn one" }, ctx, {
+  const first = await appendSystemPromptForTurn({ systemPrompt: "turn one" }, ctx, {
     cache,
     fetchPrompt,
     generationId: "gen-1",
   });
+  assert.equal(first, undefined);
+
   await appendSystemPromptForTurn({ systemPrompt: "turn two" }, ctx, {
     cache,
     fetchPrompt,
     generationId: "gen-1",
   });
-  assert.equal(fetchCount, 2, "degraded prompt must refetch each turn");
+  assert.equal(fetchCount, 2, "unresolved roster must refetch each turn");
   assert.equal(cache.size, 0);
 });
 

--- a/apps/daemon/assets/pi-extension/teamclu.ts
+++ b/apps/daemon/assets/pi-extension/teamclu.ts
@@ -87,6 +87,13 @@ type ExtensionAPI = {
       ctx: ExtensionContext,
     ) => Promise<{ block: boolean; reason?: string } | undefined>,
   ): void;
+  on(
+    event: "before_agent_start",
+    handler: (
+      event: { systemPrompt?: string },
+      ctx: ExtensionContext,
+    ) => Promise<{ systemPrompt?: string } | undefined>,
+  ): void;
   registerTool(tool: {
     name: string;
     label: string;
@@ -164,6 +171,63 @@ async function resolveTeamcluSessionId(backendSessionId: string): Promise<string
     throw new Error("session_context_unavailable");
   }
   return teamcluSessionId;
+}
+
+const sessionPromptAppendByCacheKey = new Map<string, string>();
+
+function sessionPromptCacheKey(backendSessionId: string): string | undefined {
+  const generationId = process.env.TEAMCLU_HOST_GENERATION_ID?.trim();
+  const sessionId = backendSessionId.trim();
+  if (!generationId || !sessionId) return undefined;
+  return `${generationId}:${sessionId}`;
+}
+
+async function fetchSessionPromptAppend(backendSessionId: string): Promise<string | undefined> {
+  const cacheKey = sessionPromptCacheKey(backendSessionId);
+  if (cacheKey) {
+    const cached = sessionPromptAppendByCacheKey.get(cacheKey);
+    if (cached) return cached;
+  }
+
+  const baseUrl = process.env.TEAMCLU_RUNTIME_CONTEXT_URL?.trim()?.replace(/\/$/, "");
+  const token = process.env.TEAMCLU_RUNTIME_CONTEXT_TOKEN?.trim();
+  const generationId = process.env.TEAMCLU_HOST_GENERATION_ID?.trim();
+  const backendKind = process.env.TEAMCLU_AGENT_BACKEND?.trim();
+  const sessionId = backendSessionId.trim();
+  if (!baseUrl || !token || !generationId || !backendKind || !sessionId) {
+    return undefined;
+  }
+  try {
+    const resp = await fetch(`${baseUrl}/internal/runtime-context/session-prompt`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        backendSessionId: sessionId,
+        hostGenerationId: generationId,
+        backendKind,
+      }),
+    });
+    if (!resp.ok) {
+      return undefined;
+    }
+    const body = (await resp.json()) as {
+      appendSystemPrompt?: string;
+      rosterResolved?: boolean;
+    };
+    const append = String(body?.appendSystemPrompt ?? "").trim();
+    if (!append) {
+      return undefined;
+    }
+    if (cacheKey && body.rosterResolved === true) {
+      sessionPromptAppendByCacheKey.set(cacheKey, append);
+    }
+    return append;
+  } catch {
+    return undefined;
+  }
 }
 
 async function injectSessionIdForTool(
@@ -1160,6 +1224,16 @@ export default async function (pi: ExtensionAPI) {
   registerQuestionTool(pi, ownTools);
 
   // -- Permission gate -------------------------------------------------------
+  pi.on("before_agent_start", async (event, ctx) => {
+    const backendSessionId = backendSessionIdFromContext(ctx);
+    if (!backendSessionId) return undefined;
+    const append = await fetchSessionPromptAppend(backendSessionId);
+    if (!append) return undefined;
+    const base = String(event.systemPrompt ?? "").trim();
+    const systemPrompt = base ? `${base}\n\n${append}` : append;
+    return { systemPrompt };
+  });
+
   pi.on("tool_call", async (event, ctx) => {
     if (ownTools.has(event.toolName)) return undefined;
 

--- a/apps/daemon/src/backend/cloud_api/mod.rs
+++ b/apps/daemon/src/backend/cloud_api/mod.rs
@@ -1174,6 +1174,14 @@ impl Backend for CloudApiBackend {
             .collect())
     }
 
+    async fn get_session_roster(
+        &self,
+        session_id: &str,
+    ) -> BackendResult<super::records::SessionRoster> {
+        let path = format!("/v1/sessions/{session_id}/roster");
+        self.get(&path).await
+    }
+
     async fn fetch_session_with_participants(
         &self,
         session_id: &str,
@@ -2730,6 +2738,29 @@ mod tests {
             })))
             .mount(server)
             .await;
+    }
+
+    #[tokio::test]
+    async fn get_session_roster_reads_the_roster_endpoint() {
+        let server = MockServer::start().await;
+        mount_refresh(&server).await;
+        Mock::given(method("GET"))
+            .and(path("/v1/sessions/session-1/roster"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "sessionId": "session-1",
+                "callerActorId": "agent-1",
+                "items": [
+                    { "actorId": "agent-1", "displayName": "MDC", "kind": "agent", "isSelf": true },
+                    { "actorId": "human-1", "displayName": "Alice", "kind": "member", "isSelf": false }
+                ]
+            })))
+            .mount(&server)
+            .await;
+        let backend = CloudApiBackend::new(config(&server));
+        let roster = backend.get_session_roster("session-1").await.unwrap();
+        assert_eq!(roster.session_id, "session-1");
+        assert_eq!(roster.items.len(), 2);
+        assert_eq!(roster.items[0].display_name.as_deref(), Some("MDC"));
     }
 
     #[tokio::test]

--- a/apps/daemon/src/backend/deferred.rs
+++ b/apps/daemon/src/backend/deferred.rs
@@ -327,6 +327,13 @@ impl Backend for DeferredBackend {
             .await
     }
 
+    async fn get_session_roster(
+        &self,
+        session_id: &str,
+    ) -> BackendResult<super::records::SessionRoster> {
+        self.inner()?.get_session_roster(session_id).await
+    }
+
     async fn get_actors_by_ids(&self, ids: &[String]) -> BackendResult<Vec<ActorDirectoryRow>> {
         self.inner()?.get_actors_by_ids(ids).await
     }

--- a/apps/daemon/src/backend/mock.rs
+++ b/apps/daemon/src/backend/mock.rs
@@ -479,6 +479,38 @@ impl Backend for MockBackend {
             .collect())
     }
 
+    async fn get_session_roster(&self, session_id: &str) -> BackendResult<super::SessionRoster> {
+        let st = self.state.lock().unwrap();
+        let snap = st
+            .sessions
+            .get(session_id)
+            .cloned()
+            .ok_or_else(|| BackendError::Provider {
+                provider: "mock",
+                code: Some("404".into()),
+                message: format!("MockBackend: session {session_id} not seeded"),
+            })?;
+        let caller_actor_id = self.actor_id.clone();
+        let items = snap
+            .participants
+            .iter()
+            .map(|seat| {
+                let dir = st.actors_by_id.get(&seat.actor_id);
+                super::SessionRosterEntry {
+                    actor_id: seat.actor_id.clone(),
+                    display_name: dir.and_then(|row| row.display_name.clone()),
+                    kind: dir.and_then(|row| row.kind.clone()),
+                    is_self: seat.actor_id == caller_actor_id,
+                }
+            })
+            .collect();
+        Ok(super::SessionRoster {
+            session_id: session_id.to_string(),
+            caller_actor_id,
+            items,
+        })
+    }
+
     async fn messages_after_cursor(
         &self,
         session_id: &str,

--- a/apps/daemon/src/backend/mod.rs
+++ b/apps/daemon/src/backend/mod.rs
@@ -55,7 +55,8 @@ pub mod deferred;
 pub mod records;
 pub use records::{
     ActorDirectoryRow, BackendParticipantRow, BackendSessionAndParticipants, BackendSessionRow,
-    ClaimResult, GatewaySessionRow, StoredMessage, WorkspaceRow, WorkspaceUpsert,
+    ClaimResult, GatewaySessionRow, SessionRoster, SessionRosterEntry, StoredMessage, WorkspaceRow,
+    WorkspaceUpsert,
 };
 
 /// MQTT settings delivered by `/v1/config/bootstrap`. The full broker URL
@@ -454,6 +455,10 @@ pub trait Backend: Send + Sync {
         &self,
         session_id: &str,
     ) -> BackendResult<BackendSessionAndParticipants>;
+
+    /// Display names for seated session participants via
+    /// `GET /v1/sessions/{sessionId}/roster`.
+    async fn get_session_roster(&self, session_id: &str) -> BackendResult<SessionRoster>;
 
     /// Resolve actor UUIDs to their directory entries (name + actor type).
     ///

--- a/apps/daemon/src/backend/records.rs
+++ b/apps/daemon/src/backend/records.rs
@@ -109,6 +109,25 @@ pub struct BackendSessionAndParticipants {
     pub participants: Vec<BackendParticipantRow>,
 }
 
+/// One seated actor returned by `GET /v1/sessions/{sessionId}/roster`.
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionRosterEntry {
+    pub actor_id: String,
+    pub display_name: Option<String>,
+    pub kind: Option<String>,
+    pub is_self: bool,
+}
+
+/// Session-scoped participant labels from `GET /v1/sessions/{sessionId}/roster`.
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionRoster {
+    pub session_id: String,
+    pub caller_actor_id: String,
+    pub items: Vec<SessionRosterEntry>,
+}
+
 /// A directory entry for one actor, as `POST /v1/actors/by-ids` returns it.
 ///
 /// Only the two fields a roster needs: `session_participants` stores actor ids

--- a/apps/daemon/src/daemon/server.rs
+++ b/apps/daemon/src/daemon/server.rs
@@ -196,6 +196,10 @@ pub struct DaemonServer {
     rpc_client: Arc<AsyncMutex<crate::teamclu::rpc::RpcClient>>,
     team_skill_reconciler: Arc<crate::runtime::team_skills::TeamSkillReconciler>,
     runtime_context: Arc<crate::runtime::RuntimeContextService>,
+    /// HTTP listener handle; shut down before local runtimes so loopback
+    /// `/internal/runtime-context/*` does not outlive the process or serve
+    /// stale Pi generations after restart.
+    http_handle: Option<crate::http::server::HttpHandle>,
     /// Answered capability-management requests, keyed on the authorized
     /// (requester, request_id) pair. Shared rather than owned so the handler
     /// can run on its own task instead of on the message pump.
@@ -821,6 +825,7 @@ impl DaemonServer {
             rpc_client,
             team_skill_reconciler,
             runtime_context,
+            http_handle: None,
             agent_management_results: Arc::new(AsyncMutex::new(HashMap::new())),
             cron_turn_done_tx,
             cron_turn_done_rx: Some(cron_turn_done_rx),
@@ -1091,7 +1096,7 @@ impl DaemonServer {
         // once the sock command channel exists (below).
         let mut supervisor_for_prewarm: Option<Arc<crate::runtime::RuntimeSupervisor>> = None;
         let team_skill_reconciler = self.team_skill_reconciler.clone();
-        let _http_handle = {
+        self.http_handle = {
             let mut meta = crate::http::server::metadata(self.actor_id.clone(), "amuxd");
             // Expose configured backends so the model-catalog endpoint can
             // group models per backend (opencode / pi / cursor / claude-code).
@@ -1156,6 +1161,12 @@ impl DaemonServer {
                     ),
                 )
             });
+            let session_prompt = Some(Arc::new(
+                crate::runtime::session_prompt::SessionPromptService::new(
+                    self.agents.clone(),
+                    self.backend.clone(),
+                ),
+            ));
             match crate::http::spawn(
                 http_cfg,
                 meta,
@@ -1176,6 +1187,7 @@ impl DaemonServer {
                 Some(local_live_ingest_tx),
                 Some(team_skill_reconciler.clone()),
                 Some(self.runtime_context.clone()),
+                session_prompt,
             )
             .await
             {
@@ -3839,6 +3851,7 @@ pub(crate) mod tests {
                     crate::runtime::team_skills::TeamSkillReconciler::new(backend),
                 ),
                 runtime_context: Arc::new(crate::runtime::RuntimeContextService::new()),
+                http_handle: None,
                 agent_management_results: Arc::new(AsyncMutex::new(HashMap::new())),
                 cron_turn_done_tx,
                 cron_turn_done_rx: Some(cron_turn_done_rx),

--- a/apps/daemon/src/daemon/server/channels.rs
+++ b/apps/daemon/src/daemon/server/channels.rs
@@ -898,6 +898,9 @@ impl DaemonServer {
     /// when main returns; `amuxd stop` also calls `finalize_stop` as a safety net.
     pub(crate) async fn shutdown_for_exit(&mut self) {
         info!("daemon shutdown: draining channels and local runtimes");
+        if let Some(handle) = self.http_handle.take() {
+            handle.shutdown().await;
+        }
         self.shutdown_channels().await;
         {
             let mut agents = self.agents.lock().await;

--- a/apps/daemon/src/http/routes.rs
+++ b/apps/daemon/src/http/routes.rs
@@ -37,6 +37,10 @@ pub fn build(state: HttpState) -> Router {
             "/internal/runtime-context/resolve",
             post(crate::http::runtime_context::resolve_runtime_context),
         )
+        .route(
+            "/internal/runtime-context/session-prompt",
+            post(crate::http::runtime_context::session_prompt),
+        )
         .route("/v1/mqtt/recover", post(mqtt_recover))
         // Embedded protocol console. Static zero-dependency HTML inlined into
         // the binary; it drives this same daemon's /v1/sessions API over fetch

--- a/apps/daemon/src/http/runtime_context.rs
+++ b/apps/daemon/src/http/runtime_context.rs
@@ -87,6 +87,74 @@ fn session_context_error_message(err: &ResolveError) -> &'static str {
     }
 }
 
+pub async fn session_prompt(
+    State(state): State<HttpState>,
+    ConnectInfo(peer): ConnectInfo<SocketAddr>,
+    headers: HeaderMap,
+    Json(body): Json<ResolveRuntimeContextRequest>,
+) -> Response {
+    if !runtime_context_peer_allowed(peer) {
+        return problem(
+            StatusCode::FORBIDDEN,
+            "forbidden",
+            "Runtime context resolve is loopback-only",
+        );
+    }
+    let Some(context_service) = state.runtime_context.clone() else {
+        return problem(
+            StatusCode::SERVICE_UNAVAILABLE,
+            "runtime_context_unavailable",
+            "Runtime context service is not configured",
+        );
+    };
+    let Some(prompt_service) = state.session_prompt.clone() else {
+        return problem(
+            StatusCode::SERVICE_UNAVAILABLE,
+            "session_prompt_unavailable",
+            "Session prompt service is not configured",
+        );
+    };
+    let bearer = headers
+        .get(header::AUTHORIZATION)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|v| v.strip_prefix("Bearer "))
+        .unwrap_or("")
+        .trim();
+    let resolved = match context_service.resolve_with_token(bearer, &body) {
+        Ok(resolved) => resolved,
+        Err(err) => {
+            warn!(
+                event = "runtime_context_session_prompt",
+                backend_kind = %body.backend_kind,
+                host_generation_id = %body.host_generation_id,
+                backend_session_id = %body.backend_session_id,
+                result = err.code(),
+                "session prompt resolve failed"
+            );
+            return problem(
+                StatusCode::from_u16(err.http_status()).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR),
+                err.code(),
+                session_context_error_message(&err),
+            );
+        }
+    };
+    let response = prompt_service
+        .build_for_resolved(&resolved.teamclu_session_id, &resolved.runtime_id)
+        .await;
+    tracing::info!(
+        event = "runtime_context_session_prompt",
+        backend_kind = %body.backend_kind,
+        host_generation_id = %body.host_generation_id,
+        backend_session_id = %body.backend_session_id,
+        teamclu_session_id = %response.teamclu_session_id,
+        runtime_id = %response.runtime_id,
+        participant_count = response.participants.len(),
+        result = "built",
+        "session prompt built"
+    );
+    Json(response).into_response()
+}
+
 fn problem(status: StatusCode, code: &str, detail: &str) -> Response {
     (
         status,

--- a/apps/daemon/src/http/server.rs
+++ b/apps/daemon/src/http/server.rs
@@ -113,6 +113,10 @@ async fn spawn_dedicated_runtime_context_listener(
             "/internal/runtime-context/resolve",
             post(crate::http::runtime_context::resolve_runtime_context),
         )
+        .route(
+            "/internal/runtime-context/session-prompt",
+            post(crate::http::runtime_context::session_prompt),
+        )
         .with_state(state);
     let (shutdown_tx, shutdown_rx) = oneshot::channel();
     let join = tokio::spawn(async move {
@@ -160,6 +164,7 @@ pub async fn spawn(
     local_live_ingest_tx: Option<crate::http::state::LocalLiveIngestTx>,
     team_skills: Option<Arc<crate::runtime::team_skills::TeamSkillReconciler>>,
     runtime_context: Option<Arc<crate::runtime::context_service::RuntimeContextService>>,
+    session_prompt: Option<Arc<crate::runtime::session_prompt::SessionPromptService>>,
 ) -> anyhow::Result<HttpHandle> {
     // Resolve token + port files (defaults live in DaemonConfig::config_dir).
     let token_path = http
@@ -233,6 +238,7 @@ pub async fn spawn(
     } else {
         state
     };
+    let state = state.with_session_prompt(session_prompt);
 
     let mut runtime_context_join = None;
     let mut runtime_context_shutdown = None;
@@ -371,6 +377,7 @@ mod tests {
             None,
             None,
             None,
+            None,
         )
         .await
         .unwrap();
@@ -400,6 +407,7 @@ mod tests {
             None,
             None,
             test_dispatcher(),
+            None,
             None,
             None,
             None,
@@ -456,6 +464,7 @@ mod tests {
             None,
             None,
             test_dispatcher(),
+            None,
             None,
             None,
             None,
@@ -661,6 +670,7 @@ mod tests {
             None,
             None,
             None,
+            None,
         )
         .await
         .unwrap();
@@ -735,6 +745,7 @@ mod tests {
             None,
             None,
             test_dispatcher(),
+            None,
             None,
             None,
             None,
@@ -824,6 +835,7 @@ mod tests {
             None,
             None,
             test_dispatcher(),
+            None,
             None,
             None,
             None,
@@ -925,6 +937,7 @@ mod tests {
             None,
             None,
             test_dispatcher(),
+            None,
             None,
             None,
             None,
@@ -1055,6 +1068,7 @@ mod tests {
             None,
             None,
             None,
+            None,
         )
         .await
         .unwrap();
@@ -1174,6 +1188,7 @@ mod tests {
             None,
             Some(reconciler),
             None,
+            None,
         )
         .await
         .unwrap();
@@ -1290,6 +1305,7 @@ mod tests {
             None,
             None,
             Some(Arc::clone(&service)),
+            None,
         )
         .await
         .unwrap();
@@ -1433,6 +1449,326 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(ok["teamcluSessionId"], "teamclu-z");
+
+        let _ = shutdown_tx.send(());
+        let _ = join.await;
+    }
+
+    fn seed_session_prompt_backend(
+        backend: &Arc<crate::backend::mock::MockBackend>,
+        session_id: &str,
+        actors: &[(&str, &str, &str)],
+    ) {
+        use crate::backend::{
+            ActorDirectoryRow, BackendParticipantRow, BackendSessionAndParticipants,
+            BackendSessionRow,
+        };
+        let now = chrono::Utc::now();
+        let mut st = backend.state();
+        st.sessions.insert(
+            session_id.to_string(),
+            BackendSessionAndParticipants {
+                session: BackendSessionRow {
+                    id: session_id.to_string(),
+                    team_id: "team-mock".to_string(),
+                    created_by_actor_id: None,
+                    primary_agent_id: None,
+                    mode: "collab".to_string(),
+                    title: "Test chat".to_string(),
+                    summary: String::new(),
+                    idea_id: None,
+                    created_at: now,
+                },
+                participants: actors
+                    .iter()
+                    .map(|(id, _, _)| BackendParticipantRow {
+                        session_id: session_id.to_string(),
+                        actor_id: id.to_string(),
+                        role: None,
+                        joined_at: now,
+                    })
+                    .collect(),
+            },
+        );
+        for (id, name, kind) in actors {
+            st.actors_by_id.insert(
+                id.to_string(),
+                ActorDirectoryRow {
+                    id: id.to_string(),
+                    display_name: Some(name.to_string()),
+                    kind: Some(kind.to_string()),
+                },
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn runtime_context_session_prompt_returns_roster_and_append_text() {
+        use crate::backend::mock::MockBackend;
+        use crate::proto::amux;
+        use crate::runtime::context_registry::ResolveRuntimeContextRequest;
+        use crate::runtime::context_service::RuntimeContextService;
+        use crate::runtime::session_prompt::SessionPromptService;
+        use crate::runtime::RuntimeManager;
+        use std::sync::Arc;
+        use tokio::sync::Mutex;
+
+        let dir = tempfile::tempdir().unwrap();
+        let cfg = HttpConfig {
+            bind: "127.0.0.1:0".into(),
+            token_file: Some(dir.path().join("token")),
+            port_file: Some(dir.path().join("port")),
+            ..HttpConfig::default()
+        };
+        let service = Arc::new(RuntimeContextService::new());
+        service.register_attached_session(
+            amux::AgentType::Pi,
+            "gen-prompt",
+            "backend-pi",
+            "teamclu-prompt",
+            "runtime-prompt",
+        );
+        let env = service.env_for_generation(amux::AgentType::Pi, "gen-prompt");
+        let token = env
+            .get("TEAMCLU_RUNTIME_CONTEXT_TOKEN")
+            .cloned()
+            .expect("token");
+
+        let backend = Arc::new(MockBackend::default());
+        seed_session_prompt_backend(
+            &backend,
+            "teamclu-prompt",
+            &[
+                ("agent-1", "小助手", "agent"),
+                ("human-1", "Alice", "member"),
+            ],
+        );
+
+        let manager = Arc::new(Mutex::new(RuntimeManager::new(
+            std::collections::HashMap::new(),
+            None,
+        )));
+        {
+            let mut mgr = manager.lock().await;
+            mgr.add_test_runtime("runtime-prompt");
+            mgr.get_handle_mut("runtime-prompt")
+                .unwrap()
+                .owner_actor_id = "agent-1".into();
+        }
+        let prompt_service = Arc::new(SessionPromptService::new(
+            Arc::clone(&manager),
+            backend.clone(),
+        ));
+
+        let meta = metadata("actor-test".into(), "test");
+        let runtime = crate::http::runtime_adapter::StubRuntimeAdapter::new(256);
+        let handle = spawn(
+            cfg,
+            meta,
+            runtime,
+            None,
+            None,
+            None,
+            test_dispatcher(),
+            None,
+            Some(backend),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            Some(Arc::clone(&service)),
+            Some(prompt_service),
+        )
+        .await
+        .unwrap();
+        let base = format!("http://{}", handle.local_addr);
+        let client = reqwest::Client::new();
+        let ok: serde_json::Value = client
+            .post(format!("{base}/internal/runtime-context/session-prompt"))
+            .bearer_auth(&token)
+            .json(&ResolveRuntimeContextRequest {
+                backend_session_id: "backend-pi".into(),
+                host_generation_id: "gen-prompt".into(),
+                backend_kind: "pi".into(),
+            })
+            .send()
+            .await
+            .unwrap()
+            .json()
+            .await
+            .unwrap();
+        assert_eq!(ok["teamcluSessionId"], "teamclu-prompt");
+        assert_eq!(ok["agentDisplayName"], "小助手");
+        assert_eq!(ok["rosterResolved"], true);
+        assert!(ok["appendSystemPrompt"]
+            .as_str()
+            .unwrap()
+            .contains("Your display name is \"小助手\""));
+        let participants = ok["participants"].as_array().unwrap();
+        assert_eq!(participants.len(), 2);
+
+        handle.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn runtime_context_session_prompt_returns_503_when_service_missing() {
+        use crate::proto::amux;
+        use crate::runtime::context_registry::ResolveRuntimeContextRequest;
+        use crate::runtime::context_service::RuntimeContextService;
+
+        let dir = tempfile::tempdir().unwrap();
+        let cfg = HttpConfig {
+            bind: "127.0.0.1:0".into(),
+            token_file: Some(dir.path().join("token")),
+            port_file: Some(dir.path().join("port")),
+            ..HttpConfig::default()
+        };
+        let service = Arc::new(RuntimeContextService::new());
+        service.register_attached_session(
+            amux::AgentType::Pi,
+            "gen-prompt",
+            "backend-pi",
+            "teamclu-prompt",
+            "runtime-prompt",
+        );
+        let env = service.env_for_generation(amux::AgentType::Pi, "gen-prompt");
+        let token = env
+            .get("TEAMCLU_RUNTIME_CONTEXT_TOKEN")
+            .cloned()
+            .expect("token");
+        let meta = metadata("actor-test".into(), "test");
+        let runtime = crate::http::runtime_adapter::StubRuntimeAdapter::new(256);
+        let handle = spawn(
+            cfg,
+            meta,
+            runtime,
+            None,
+            None,
+            None,
+            test_dispatcher(),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            Some(Arc::clone(&service)),
+            None,
+        )
+        .await
+        .unwrap();
+        let base = format!("http://{}", handle.local_addr);
+        let client = reqwest::Client::new();
+        let resp = client
+            .post(format!("{base}/internal/runtime-context/session-prompt"))
+            .bearer_auth(&token)
+            .json(&ResolveRuntimeContextRequest {
+                backend_session_id: "backend-pi".into(),
+                host_generation_id: "gen-prompt".into(),
+                backend_kind: "pi".into(),
+            })
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(resp.status().as_u16(), 503);
+
+        handle.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn dedicated_runtime_context_listener_serves_session_prompt() {
+        use crate::backend::mock::MockBackend;
+        use crate::proto::amux;
+        use crate::runtime::context_registry::ResolveRuntimeContextRequest;
+        use crate::runtime::context_service::RuntimeContextService;
+        use crate::runtime::session_prompt::SessionPromptService;
+        use crate::runtime::RuntimeManager;
+        use std::sync::Arc;
+        use tokio::sync::Mutex;
+
+        let dir = tempfile::tempdir().unwrap();
+        let cfg = HttpConfig {
+            bind: "127.0.0.1:0".into(),
+            token_file: Some(dir.path().join("token")),
+            port_file: Some(dir.path().join("port")),
+            ..HttpConfig::default()
+        };
+        let service = Arc::new(RuntimeContextService::new());
+        service.register_attached_session(
+            amux::AgentType::Pi,
+            "gen-dedicated-prompt",
+            "backend-z",
+            "teamclu-z",
+            "runtime-z",
+        );
+        let env = service.env_for_generation(amux::AgentType::Pi, "gen-dedicated-prompt");
+        let token = env
+            .get("TEAMCLU_RUNTIME_CONTEXT_TOKEN")
+            .cloned()
+            .expect("token");
+
+        let backend = Arc::new(MockBackend::default());
+        seed_session_prompt_backend(
+            &backend,
+            "teamclu-z",
+            &[("agent-z", "Bot", "agent")],
+        );
+        let manager = Arc::new(Mutex::new(RuntimeManager::new(
+            std::collections::HashMap::new(),
+            None,
+        )));
+        {
+            let mut mgr = manager.lock().await;
+            mgr.add_test_runtime("runtime-z");
+            mgr.get_handle_mut("runtime-z")
+                .unwrap()
+                .owner_actor_id = "agent-z".into();
+        }
+        let prompt_service = Arc::new(SessionPromptService::new(
+            Arc::clone(&manager),
+            backend,
+        ));
+
+        let meta = metadata("actor-test".into(), "test");
+        let runtime = crate::http::runtime_adapter::StubRuntimeAdapter::new(256);
+        let state = HttpState::new(
+            cfg,
+            tokens::TokenStore::load_or_init(&dir.path().join("token")).unwrap(),
+            meta,
+            runtime,
+            None,
+            None,
+            None,
+            test_dispatcher(),
+            None,
+        )
+        .with_runtime_context(Arc::clone(&service))
+        .with_session_prompt(Some(prompt_service));
+
+        let (dedicated_base, join, shutdown_tx) =
+            spawn_dedicated_runtime_context_listener(state).await.unwrap();
+        let client = reqwest::Client::new();
+        let ok: serde_json::Value = client
+            .post(format!("{dedicated_base}/internal/runtime-context/session-prompt"))
+            .bearer_auth(&token)
+            .json(&ResolveRuntimeContextRequest {
+                backend_session_id: "backend-z".into(),
+                host_generation_id: "gen-dedicated-prompt".into(),
+                backend_kind: "pi".into(),
+            })
+            .send()
+            .await
+            .unwrap()
+            .json()
+            .await
+            .unwrap();
+        assert_eq!(ok["agentDisplayName"], "Bot");
 
         let _ = shutdown_tx.send(());
         let _ = join.await;

--- a/apps/daemon/src/http/state.rs
+++ b/apps/daemon/src/http/state.rs
@@ -182,6 +182,8 @@ pub struct HttpState {
     pub local_live_ingest_tx: Option<LocalLiveIngestTx>,
     /// Backend session → TeamClu session registry for managed MCP adapters.
     pub runtime_context: Option<Arc<crate::runtime::context_service::RuntimeContextService>>,
+    /// Per-session group-chat system prompt for managed backends (Pi v1).
+    pub session_prompt: Option<Arc<crate::runtime::session_prompt::SessionPromptService>>,
 }
 
 impl HttpState {
@@ -227,6 +229,7 @@ impl HttpState {
             local_rpc_tx: None,
             local_live_ingest_tx: None,
             runtime_context: None,
+            session_prompt: None,
         }
     }
 
@@ -235,6 +238,14 @@ impl HttpState {
         service: Arc<crate::runtime::context_service::RuntimeContextService>,
     ) -> Self {
         self.runtime_context = Some(service);
+        self
+    }
+
+    pub fn with_session_prompt(
+        mut self,
+        service: Option<Arc<crate::runtime::session_prompt::SessionPromptService>>,
+    ) -> Self {
+        self.session_prompt = service;
         self
     }
 

--- a/apps/daemon/src/runtime/mod.rs
+++ b/apps/daemon/src/runtime/mod.rs
@@ -22,6 +22,7 @@ mod manager;
 pub mod permission_policy;
 pub mod prompt_attachments;
 pub mod refresh;
+pub mod session_prompt;
 pub mod sidecar;
 pub mod supervisor;
 pub mod team_cloud_config;
@@ -47,6 +48,7 @@ pub use permission_policy::PermissionPolicy;
 // goes through `AgentBackend`.
 #[allow(unused_imports)]
 pub use opencode_http::OpencodeHost;
+pub use session_prompt::{SessionPromptResponse, SessionPromptService};
 pub use supervisor::RuntimeSupervisor;
 pub use workspace_runtime::{apply_workspace_system_instructions, instruction_plugin_installed};
 

--- a/apps/daemon/src/runtime/session_prompt.rs
+++ b/apps/daemon/src/runtime/session_prompt.rs
@@ -27,8 +27,8 @@ pub struct SessionPromptResponse {
     pub agent_display_name: String,
     pub participants: Vec<SessionPromptParticipant>,
     pub append_system_prompt: String,
-    /// False when the Cloud roster could not be loaded; callers must not cache
-    /// the degraded prompt for the whole host generation.
+    /// False when roster data was unavailable or incomplete; callers must not
+    /// cache or inject a prompt for this host generation.
     pub roster_resolved: bool,
 }
 
@@ -55,6 +55,15 @@ impl SessionPromptService {
         };
         let owner_trimmed = owner_actor_id.trim();
 
+        let base = SessionPromptResponse {
+            teamclu_session_id: teamclu_session_id.to_string(),
+            runtime_id: runtime_id.to_string(),
+            agent_display_name: agent_display_name_fallback(owner_trimmed),
+            participants: Vec::new(),
+            append_system_prompt: String::new(),
+            roster_resolved: false,
+        };
+
         let roster = match self.backend.get_session_roster(teamclu_session_id).await {
             Ok(roster) => roster,
             Err(err) => {
@@ -63,36 +72,46 @@ impl SessionPromptService {
                     teamclu_session_id,
                     runtime_id,
                     error = %err,
-                    "session roster fetch failed; continuing with empty roster"
+                    "session roster fetch failed; skipping session prompt injection"
                 );
-                let agent_display_name = agent_display_name_fallback(owner_trimmed);
-                let append_system_prompt =
-                    build_session_prompt(&agent_display_name, &[]);
-                return SessionPromptResponse {
-                    teamclu_session_id: teamclu_session_id.to_string(),
-                    runtime_id: runtime_id.to_string(),
-                    agent_display_name,
-                    participants: Vec::new(),
-                    append_system_prompt,
-                    roster_resolved: false,
-                };
+                return base;
             }
         };
 
-        let agent_display_name =
-            resolve_agent_display_name_from_roster(&roster, owner_trimmed);
+        let Some(agent_display_name) =
+            resolve_agent_display_name_from_roster(&roster, owner_trimmed)
+        else {
+            warn!(
+                event = "runtime_context_session_prompt",
+                teamclu_session_id,
+                runtime_id,
+                "session roster missing agent display name; skipping session prompt injection"
+            );
+            return base;
+        };
+
         let participants =
             roster_to_participants(&roster, owner_trimmed, &agent_display_name);
+        if participants.is_empty() {
+            warn!(
+                event = "runtime_context_session_prompt",
+                teamclu_session_id,
+                runtime_id,
+                "session roster empty; skipping session prompt injection"
+            );
+            return base;
+        }
+
+        let brand = teamclu_runtime_env::brand_display_name_from_env();
         let append_system_prompt =
-            build_session_prompt(&agent_display_name, &participants);
+            build_session_prompt(&brand, &agent_display_name, &participants);
 
         SessionPromptResponse {
-            teamclu_session_id: teamclu_session_id.to_string(),
-            runtime_id: runtime_id.to_string(),
             agent_display_name,
             participants,
             append_system_prompt,
             roster_resolved: true,
+            ..base
         }
     }
 }
@@ -100,9 +119,9 @@ impl SessionPromptService {
 fn resolve_agent_display_name_from_roster(
     roster: &SessionRoster,
     owner_actor_id: &str,
-) -> String {
+) -> Option<String> {
     if let Some(name) = roster_entry_display_name(roster.items.iter().find(|item| item.is_self)) {
-        return name;
+        return Some(name);
     }
     if !owner_actor_id.is_empty() {
         if let Some(item) = roster
@@ -111,11 +130,11 @@ fn resolve_agent_display_name_from_roster(
             .find(|item| item.actor_id == owner_actor_id)
         {
             if let Some(name) = roster_entry_display_name(Some(item)) {
-                return name;
+                return Some(name);
             }
         }
     }
-    agent_display_name_fallback(owner_actor_id)
+    None
 }
 
 fn roster_to_participants(
@@ -190,41 +209,34 @@ fn kind_label(kind: Option<&str>) -> &str {
 }
 
 pub fn build_session_prompt(
+    brand_name: &str,
     agent_display_name: &str,
     participants: &[SessionPromptParticipant],
 ) -> String {
-    let mut out = String::from(
-        "[TeamClu Session Context]\n\n\
-You are participating in a TeamClu group chat, not a one-to-one private conversation.\n\n\
-Your display name is \"",
-    );
+    let brand = brand_name.trim();
+    let brand = if brand.is_empty() { "this app" } else { brand };
+
+    let mut out = String::from("[");
+    out.push_str(brand);
+    out.push_str(" Session Context]\n\nYou are an AI assistant in a ");
+    out.push_str(brand);
+    out.push_str(" session.\n\nYour display name is \"");
     out.push_str(agent_display_name.trim());
     out.push_str(
         "\". This is the name users assigned you in the UI; when someone @mentions you, \
-they usually use this name or a close variant.\n\n",
+they usually use this name or a close variant.\n\nParticipants:\n",
     );
 
-    if participants.is_empty() {
-        out.push_str("Participants: no roster available.\n\n");
-    } else {
-        out.push_str("Participants:\n");
-        for p in participants {
-            let role = kind_label(p.kind.as_deref());
-            if p.is_self {
-                out.push_str(&format!(
-                    "- {} ({}, you)\n",
-                    p.display_name, role
-                ));
-            } else {
-                out.push_str(&format!("- {} ({})\n", p.display_name, role));
-            }
+    for p in participants {
+        let role = kind_label(p.kind.as_deref());
+        if p.is_self {
+            out.push_str(&format!("- {} ({}, you)\n", p.display_name, role));
+        } else {
+            out.push_str(&format!("- {} ({})\n", p.display_name, role));
         }
-        out.push('\n');
     }
-
-    out.push_str(
-        "@mentions in messages indicate who the sender is addressing.",
-    );
+    out.push('\n');
+    out.push_str("@mentions in messages indicate who the sender is addressing.");
     out
 }
 
@@ -255,14 +267,18 @@ mod tests {
     }
 
     #[test]
-    fn build_session_prompt_includes_agent_name_and_roster() {
+    fn build_session_prompt_uses_brand_and_roster() {
         let text = build_session_prompt(
+            "Copilot361",
             "小助手",
             &[
                 participant("agent-1", "小助手", Some("agent"), true),
                 participant("human-1", "Alice", Some("member"), false),
             ],
         );
+        assert!(text.starts_with("[Copilot361 Session Context]"));
+        assert!(text.contains("You are an AI assistant in a Copilot361 session."));
+        assert!(!text.contains("group chat"));
         assert!(text.contains("Your display name is \"小助手\""));
         assert!(text.contains("- Alice (member)"));
         assert!(text.contains("- 小助手 (agent, you)"));
@@ -294,7 +310,7 @@ mod tests {
         ]);
         assert_eq!(
             resolve_agent_display_name_from_roster(&roster, "agent-mdc"),
-            "MDC"
+            Some("MDC".to_string())
         );
     }
 
@@ -308,16 +324,16 @@ mod tests {
         }]);
         assert_eq!(
             resolve_agent_display_name_from_roster(&roster, "agent-mdc"),
-            "MDC"
+            Some("MDC".to_string())
         );
     }
 
     #[test]
-    fn resolve_agent_display_name_from_roster_falls_back_to_owner_prefix() {
+    fn resolve_agent_display_name_from_roster_returns_none_without_display_name() {
         let roster = roster(vec![]);
         assert_eq!(
             resolve_agent_display_name_from_roster(&roster, "abcdef123456"),
-            "abcdef12"
+            None
         );
     }
 

--- a/apps/daemon/src/runtime/session_prompt.rs
+++ b/apps/daemon/src/runtime/session_prompt.rs
@@ -1,0 +1,328 @@
+//! Per-session group-chat system prompt for managed agent backends (Pi v1).
+
+use std::sync::Arc;
+
+use serde::{Deserialize, Serialize};
+use tracing::warn;
+
+use crate::backend::{Backend, SessionRoster, SessionRosterEntry};
+use crate::runtime::RuntimeManager;
+
+/// One seat in the session roster surfaced to the Pi extension.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionPromptParticipant {
+    pub actor_id: String,
+    pub display_name: String,
+    pub kind: Option<String>,
+    pub is_self: bool,
+}
+
+/// Loopback response for `POST /internal/runtime-context/session-prompt`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionPromptResponse {
+    pub teamclu_session_id: String,
+    pub runtime_id: String,
+    pub agent_display_name: String,
+    pub participants: Vec<SessionPromptParticipant>,
+    pub append_system_prompt: String,
+    /// False when the Cloud roster could not be loaded; callers must not cache
+    /// the degraded prompt for the whole host generation.
+    pub roster_resolved: bool,
+}
+
+pub struct SessionPromptService {
+    manager: Arc<tokio::sync::Mutex<RuntimeManager>>,
+    backend: Arc<dyn Backend>,
+}
+
+impl SessionPromptService {
+    pub fn new(manager: Arc<tokio::sync::Mutex<RuntimeManager>>, backend: Arc<dyn Backend>) -> Self {
+        Self { manager, backend }
+    }
+
+    pub async fn build_for_resolved(
+        &self,
+        teamclu_session_id: &str,
+        runtime_id: &str,
+    ) -> SessionPromptResponse {
+        let owner_actor_id = {
+            let mgr = self.manager.lock().await;
+            mgr.get_handle(runtime_id)
+                .map(|h| h.owner_actor_id.clone())
+                .unwrap_or_default()
+        };
+        let owner_trimmed = owner_actor_id.trim();
+
+        let roster = match self.backend.get_session_roster(teamclu_session_id).await {
+            Ok(roster) => roster,
+            Err(err) => {
+                warn!(
+                    event = "runtime_context_session_prompt",
+                    teamclu_session_id,
+                    runtime_id,
+                    error = %err,
+                    "session roster fetch failed; continuing with empty roster"
+                );
+                let agent_display_name = agent_display_name_fallback(owner_trimmed);
+                let append_system_prompt =
+                    build_session_prompt(&agent_display_name, &[]);
+                return SessionPromptResponse {
+                    teamclu_session_id: teamclu_session_id.to_string(),
+                    runtime_id: runtime_id.to_string(),
+                    agent_display_name,
+                    participants: Vec::new(),
+                    append_system_prompt,
+                    roster_resolved: false,
+                };
+            }
+        };
+
+        let agent_display_name =
+            resolve_agent_display_name_from_roster(&roster, owner_trimmed);
+        let participants =
+            roster_to_participants(&roster, owner_trimmed, &agent_display_name);
+        let append_system_prompt =
+            build_session_prompt(&agent_display_name, &participants);
+
+        SessionPromptResponse {
+            teamclu_session_id: teamclu_session_id.to_string(),
+            runtime_id: runtime_id.to_string(),
+            agent_display_name,
+            participants,
+            append_system_prompt,
+            roster_resolved: true,
+        }
+    }
+}
+
+fn resolve_agent_display_name_from_roster(
+    roster: &SessionRoster,
+    owner_actor_id: &str,
+) -> String {
+    if let Some(name) = roster_entry_display_name(roster.items.iter().find(|item| item.is_self)) {
+        return name;
+    }
+    if !owner_actor_id.is_empty() {
+        if let Some(item) = roster
+            .items
+            .iter()
+            .find(|item| item.actor_id == owner_actor_id)
+        {
+            if let Some(name) = roster_entry_display_name(Some(item)) {
+                return name;
+            }
+        }
+    }
+    agent_display_name_fallback(owner_actor_id)
+}
+
+fn roster_to_participants(
+    roster: &SessionRoster,
+    owner_actor_id: &str,
+    agent_display_name: &str,
+) -> Vec<SessionPromptParticipant> {
+    roster
+        .items
+        .iter()
+        .map(|item| {
+            let is_self = (!owner_actor_id.is_empty() && item.actor_id == owner_actor_id)
+                || item.is_self;
+            SessionPromptParticipant {
+                actor_id: item.actor_id.clone(),
+                display_name: if is_self {
+                    agent_display_name.to_string()
+                } else {
+                    display_label(&item.actor_id, item.display_name.as_deref())
+                },
+                kind: item.kind.clone(),
+                is_self,
+            }
+        })
+        .collect()
+}
+
+fn roster_entry_display_name(item: Option<&SessionRosterEntry>) -> Option<String> {
+    item.and_then(|entry| {
+        entry
+            .display_name
+            .as_deref()
+            .map(str::trim)
+            .filter(|name| !name.is_empty())
+            .map(str::to_string)
+    })
+}
+
+fn agent_display_name_fallback(owner_actor_id: &str) -> String {
+    if owner_actor_id.is_empty() {
+        "this agent".to_string()
+    } else {
+        display_label(owner_actor_id, None)
+    }
+}
+
+fn display_label(actor_id: &str, display_name: Option<&str>) -> String {
+    display_name
+        .map(str::trim)
+        .filter(|name| !name.is_empty())
+        .map(str::to_string)
+        .unwrap_or_else(|| actor_id_short_label(actor_id))
+}
+
+fn actor_id_short_label(actor_id: &str) -> String {
+    let trimmed = actor_id.trim();
+    if trimmed.len() <= 8 {
+        trimmed.to_string()
+    } else {
+        trimmed[..8].to_string()
+    }
+}
+
+fn kind_label(kind: Option<&str>) -> &str {
+    match kind.map(str::trim).filter(|k| !k.is_empty()) {
+        Some("member") => "member",
+        Some("agent") => "agent",
+        Some("external") => "external",
+        Some(other) => other,
+        None => "participant",
+    }
+}
+
+pub fn build_session_prompt(
+    agent_display_name: &str,
+    participants: &[SessionPromptParticipant],
+) -> String {
+    let mut out = String::from(
+        "[TeamClu Session Context]\n\n\
+You are participating in a TeamClu group chat, not a one-to-one private conversation.\n\n\
+Your display name is \"",
+    );
+    out.push_str(agent_display_name.trim());
+    out.push_str(
+        "\". This is the name users assigned you in the UI; when someone @mentions you, \
+they usually use this name or a close variant.\n\n",
+    );
+
+    if participants.is_empty() {
+        out.push_str("Participants: no roster available.\n\n");
+    } else {
+        out.push_str("Participants:\n");
+        for p in participants {
+            let role = kind_label(p.kind.as_deref());
+            if p.is_self {
+                out.push_str(&format!(
+                    "- {} ({}, you)\n",
+                    p.display_name, role
+                ));
+            } else {
+                out.push_str(&format!("- {} ({})\n", p.display_name, role));
+            }
+        }
+        out.push('\n');
+    }
+
+    out.push_str(
+        "@mentions in messages indicate who the sender is addressing.",
+    );
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn participant(
+        actor_id: &str,
+        display_name: &str,
+        kind: Option<&str>,
+        is_self: bool,
+    ) -> SessionPromptParticipant {
+        SessionPromptParticipant {
+            actor_id: actor_id.to_string(),
+            display_name: display_name.to_string(),
+            kind: kind.map(str::to_string),
+            is_self,
+        }
+    }
+
+    fn roster(items: Vec<SessionRosterEntry>) -> SessionRoster {
+        SessionRoster {
+            session_id: "session-1".to_string(),
+            caller_actor_id: "agent-mdc".to_string(),
+            items,
+        }
+    }
+
+    #[test]
+    fn build_session_prompt_includes_agent_name_and_roster() {
+        let text = build_session_prompt(
+            "小助手",
+            &[
+                participant("agent-1", "小助手", Some("agent"), true),
+                participant("human-1", "Alice", Some("member"), false),
+            ],
+        );
+        assert!(text.contains("Your display name is \"小助手\""));
+        assert!(text.contains("- Alice (member)"));
+        assert!(text.contains("- 小助手 (agent, you)"));
+        assert!(text.contains("@mentions in messages indicate who the sender is addressing"));
+    }
+
+    #[test]
+    fn display_label_falls_back_to_actor_id_prefix() {
+        assert_eq!(display_label("abcdef123456", None), "abcdef12");
+        assert_eq!(display_label("short", None), "short");
+        assert_eq!(display_label("id", Some("  Bob  ")), "Bob");
+    }
+
+    #[test]
+    fn resolve_agent_display_name_from_roster_prefers_self_item() {
+        let roster = roster(vec![
+            SessionRosterEntry {
+                actor_id: "agent-mdc".to_string(),
+                display_name: Some("MDC".to_string()),
+                kind: Some("agent".to_string()),
+                is_self: true,
+            },
+            SessionRosterEntry {
+                actor_id: "human-1".to_string(),
+                display_name: Some("Alice".to_string()),
+                kind: Some("member".to_string()),
+                is_self: false,
+            },
+        ]);
+        assert_eq!(
+            resolve_agent_display_name_from_roster(&roster, "agent-mdc"),
+            "MDC"
+        );
+    }
+
+    #[test]
+    fn resolve_agent_display_name_from_roster_uses_owner_when_self_missing() {
+        let roster = roster(vec![SessionRosterEntry {
+            actor_id: "agent-mdc".to_string(),
+            display_name: Some("MDC".to_string()),
+            kind: Some("agent".to_string()),
+            is_self: false,
+        }]);
+        assert_eq!(
+            resolve_agent_display_name_from_roster(&roster, "agent-mdc"),
+            "MDC"
+        );
+    }
+
+    #[test]
+    fn resolve_agent_display_name_from_roster_falls_back_to_owner_prefix() {
+        let roster = roster(vec![]);
+        assert_eq!(
+            resolve_agent_display_name_from_roster(&roster, "abcdef123456"),
+            "abcdef12"
+        );
+    }
+
+    #[test]
+    fn agent_display_name_fallback_defaults_when_owner_missing() {
+        assert_eq!(agent_display_name_fallback(""), "this agent");
+    }
+}

--- a/apps/daemon/tests/http_apps.rs
+++ b/apps/daemon/tests/http_apps.rs
@@ -116,6 +116,7 @@ async fn test_app_inner(backend: Option<Arc<dyn Backend>>) -> (TestApp, tempfile
         None,
         None,
         None,
+        None,
     )
     .await
     .expect("spawn http server");

--- a/apps/daemon/tests/http_default_workspace.rs
+++ b/apps/daemon/tests/http_default_workspace.rs
@@ -63,6 +63,7 @@ async fn test_app(backend: Arc<dyn Backend>, scopes: &[&str]) -> (TestApp, tempf
         None,
         None,
         None,
+        None,
     )
     .await
     .expect("spawn http server");

--- a/apps/daemon/tests/http_sessions_runtime.rs
+++ b/apps/daemon/tests/http_sessions_runtime.rs
@@ -188,6 +188,7 @@ async fn test_app_with_runtime_adapter() -> TestApp {
         None,
         None,
         None,
+        None,
     )
     .await
     .expect("spawn http server");

--- a/apps/daemon/tests/http_workspace_provider_auth.rs
+++ b/apps/daemon/tests/http_workspace_provider_auth.rs
@@ -62,6 +62,7 @@ async fn test_app_with_workspace_store(
         None,
         None,
         None,
+        None,
     )
     .await
     .expect("spawn http server");

--- a/apps/desktop/build.rs
+++ b/apps/desktop/build.rs
@@ -148,6 +148,15 @@ fn main() {
     println!("cargo:rustc-env=APP_SHORT_NAME={}", short_name);
     println!("cargo:warning=Using APP_SHORT_NAME={}", short_name);
 
+    let display_name = config["app"]["displayName"]
+        .as_str()
+        .or_else(|| config["app"]["name"].as_str())
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .unwrap_or("TeamClu");
+    println!("cargo:rustc-env=APP_DISPLAY_NAME={}", display_name);
+    println!("cargo:warning=Using APP_DISPLAY_NAME={}", display_name);
+
     // Resolved by the one brand table, not a second copy of the rule. This file
     // used to carry its own `is_official` list that disagreed with
     // `storage_namespace`'s, which is how a betly build ended up reading secrets

--- a/apps/desktop/src/commands/amuxd_supervisor.rs
+++ b/apps/desktop/src/commands/amuxd_supervisor.rs
@@ -36,6 +36,7 @@ const AMUXD_HOME_ENV: &str = teamclu_runtime_env::AMUXD_HOME_ENV;
 /// Read by the teamclu-introspect sidecar (`export_session_link`), which amuxd
 /// registers as an MCP server and therefore inherits this from.
 const APP_SCHEME_ENV: &str = "TEAMCLU_APP_SCHEME";
+const APP_DISPLAY_NAME_ENV: &str = teamclu_runtime_env::APP_DISPLAY_NAME_ENV;
 const LAUNCHD_LABEL: &str = "cc.ucar.amuxd";
 
 struct SupervisorInner {
@@ -648,6 +649,7 @@ impl AmuxdSupervisor {
         // state under ~/.amuxd-<brand> (official keeps ~/.amuxd).
         let amuxd_home = amuxd_dir();
         cmd.env(BRAND_SHORT_NAME_ENV, super::APP_SHORT_NAME);
+        cmd.env(APP_DISPLAY_NAME_ENV, super::APP_DISPLAY_NAME);
         cmd.env(AMUXD_HOME_ENV, &amuxd_home);
         cmd.env(APP_SCHEME_ENV, super::APP_SCHEME);
         if let Some(introspect) = bundled_introspect_path() {

--- a/apps/desktop/src/commands/mod.rs
+++ b/apps/desktop/src/commands/mod.rs
@@ -66,6 +66,8 @@ pub fn prefers_zh_locale() -> bool {
 
 /// The short application name, injected at compile time via `build.rs`.
 pub const APP_SHORT_NAME: &str = env!("APP_SHORT_NAME");
+/// User-facing product name (`app.displayName` / `app.name` from build config).
+pub const APP_DISPLAY_NAME: &str = env!("APP_DISPLAY_NAME");
 /// Deep-link scheme for this build (`app.scheme`, default `teamclu`).
 /// Independent of `APP_SHORT_NAME` — betly is short name `teamclaw` on scheme
 /// `teamclu`, copilot361 is `copilot361` on both.
@@ -153,6 +155,7 @@ pub fn with_amuxd_brand_env(
 ) -> tauri_plugin_shell::process::Command {
     command
         .env(teamclu_runtime_env::BRAND_SHORT_NAME_ENV, APP_SHORT_NAME)
+        .env(teamclu_runtime_env::APP_DISPLAY_NAME_ENV, APP_DISPLAY_NAME)
         .env(
             teamclu_runtime_env::AMUXD_HOME_ENV,
             amuxd_home_dir().to_string_lossy().as_ref(),

--- a/crates/teamclu-runtime-env/src/lib.rs
+++ b/crates/teamclu-runtime-env/src/lib.rs
@@ -68,14 +68,14 @@ pub use workspace_instructions::{
     claude_md_block_present, load_system_prompt, sync_teamclu_claude_md,
 };
 pub use storage_namespace::{
-    amuxd_home_for_brand, amuxd_home_from_env, brand_home_dir, brand_short_name_from_env,
-    is_official_brand, resolve_amuxd_dir_name, resolve_storage_dir_name,
+    amuxd_home_for_brand, amuxd_home_from_env, brand_display_name_from_env, brand_home_dir,
+    brand_short_name_from_env, is_official_brand, resolve_amuxd_dir_name, resolve_storage_dir_name,
     resolve_workspace_config_path, resolve_workspace_config_path_from_env,
     resolve_workspace_meta_path, resolve_workspace_meta_path_from_env, workspace_config_file_name,
     workspace_config_path, workspace_config_path_from_env, workspace_meta_dir,
     workspace_meta_dir_from_env, workspace_meta_dir_name, workspace_meta_read_roots,
     workspace_meta_write_path, workspace_meta_write_path_from_env, AMUXD_HOME_ENV,
-    BRAND_SHORT_NAME_ENV, LEGACY_BRAND_CONFIG_FILE, LEGACY_BRAND_STORAGE_DIR,
+    APP_DISPLAY_NAME_ENV, BRAND_SHORT_NAME_ENV, LEGACY_BRAND_CONFIG_FILE, LEGACY_BRAND_STORAGE_DIR,
     LEGACY_BRAND_TEAM_SHARED_DIR_NAME, LEGACY_BRAND_WORKSPACE_META_DIR,
     LEGACY_OFFICIAL_DEV_CONFIG_FILE, LEGACY_OFFICIAL_DEV_STORAGE_DIR, OFFICIAL_AMUXD_DIR_NAME,
     OFFICIAL_STORAGE_DIR, REBRAND_NAMESPACE_MIGRATION_MARKER, ROOT_ALLOWLIST,

--- a/crates/teamclu-runtime-env/src/storage_namespace.rs
+++ b/crates/teamclu-runtime-env/src/storage_namespace.rs
@@ -15,6 +15,11 @@ use std::path::{Path, PathBuf};
 /// the same personal secrets store as the brand (`~/.copilot361/secrets`, …).
 pub const BRAND_SHORT_NAME_ENV: &str = "TEAMCLU_BRAND_SHORT_NAME";
 
+/// Human-facing product name for this build (`TeamClu`, `Copilot361`, …).
+/// Set by desktop when it spawns amuxd; used in agent-facing copy such as
+/// session system prompts.
+pub const APP_DISPLAY_NAME_ENV: &str = "TEAMCLU_APP_DISPLAY_NAME";
+
 /// Optional absolute override for the amuxd state directory (`DaemonConfig::config_dir`).
 /// When unset, derived from [`BRAND_SHORT_NAME_ENV`] via [`amuxd_home_from_env`].
 pub const AMUXD_HOME_ENV: &str = "AMUXD_HOME";
@@ -114,6 +119,25 @@ pub fn brand_short_name_from_env() -> String {
         .map(|s| s.trim().to_string())
         .filter(|s| !s.is_empty())
         .unwrap_or_else(|| OFFICIAL_STORAGE_DIR.to_string())
+}
+
+/// Resolve the user-facing product name for the current process.
+///
+/// Precedence: [`APP_DISPLAY_NAME_ENV`] → official brand default (`TeamClu`) →
+/// [`brand_short_name_from_env`] as a last resort for standalone daemon runs.
+pub fn brand_display_name_from_env() -> String {
+    if let Ok(name) = std::env::var(APP_DISPLAY_NAME_ENV) {
+        let trimmed = name.trim();
+        if !trimmed.is_empty() {
+            return trimmed.to_string();
+        }
+    }
+    let short = brand_short_name_from_env();
+    if is_official_brand(&short) {
+        "TeamClu".to_string()
+    } else {
+        short
+    }
 }
 
 /// Local amuxd state folder name under `$HOME` (no leading dot).
@@ -316,6 +340,23 @@ mod tests {
         assert_eq!(LEGACY_BRAND_WORKSPACE_META_DIR, ".teamclaw");
         assert_eq!(LEGACY_BRAND_CONFIG_FILE, "teamclaw.json");
         assert_eq!(LEGACY_BRAND_TEAM_SHARED_DIR_NAME, "teamclaw-team");
+    }
+
+    #[test]
+    fn brand_display_name_from_env_prefers_override() {
+        let _lock = home_env_lock();
+        std::env::remove_var(APP_DISPLAY_NAME_ENV);
+        std::env::remove_var(BRAND_SHORT_NAME_ENV);
+        assert_eq!(brand_display_name_from_env(), "TeamClu");
+
+        std::env::set_var(APP_DISPLAY_NAME_ENV, "Copilot361");
+        assert_eq!(brand_display_name_from_env(), "Copilot361");
+
+        std::env::remove_var(APP_DISPLAY_NAME_ENV);
+        std::env::set_var(BRAND_SHORT_NAME_ENV, "copilot361");
+        assert_eq!(brand_display_name_from_env(), "copilot361");
+
+        std::env::remove_var(BRAND_SHORT_NAME_ENV);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Inject group-chat session context into Pi via `before_agent_start`, appending a system prompt with agent display name and participant roster.
- Resolve names through `GET /v1/sessions/:sessionId/roster` (depends on #1133) instead of `by-ids` / `actor_directory`.
- Add loopback `POST /internal/runtime-context/session-prompt` for the Pi extension, with dedicated runtime-context listener support.
- Only cache resolved rosters (`rosterResolved: true`); degraded prompts refetch on each turn so transient FC failures recover.

## Test plan
- [x] `node --test apps/daemon/assets/pi-extension/session-context.test.mjs` (10/10)
- [x] `cargo test -p amuxd --bin amuxd session_prompt` (9/9)
- [x] Live on accounting: roster returns MDC + 港爷; prompt injection looks correct after daemon restart


Made with [Cursor](https://cursor.com)