### PR TITLE
fix(deploy): provision what the AI gateway needs to actually boot

### DIFF
--- a/.github/workflows/self-host-deploy.yml
+++ b/.github/workflows/self-host-deploy.yml
@@ -215,6 +215,50 @@ jobs:
             # New gateway, alongside litellm. Not a replacement yet: clients
             # keep using litellm until their team's llm_base_url is flipped.
             upsert_env AI_GATEWAY_INTERNAL_URL "http://ai-gateway:4001"
+
+            # Shared secret for the gateway's /internal/* routes (FC -> gateway).
+            # Preserved once set: rotating it locks FC out of an already-running
+            # gateway until both restart together.
+            if ! grep -qE '^AI_GATEWAY_SERVICE_TOKEN=.+' .env; then
+              upsert_env AI_GATEWAY_SERVICE_TOKEN "$(openssl rand -hex 32)"
+            fi
+            # Where the gateway asks GoTrue who a token belongs to. In-network;
+            # it never needs the public hostname.
+            grep -qE '^SUPABASE_URL=.+' .env || upsert_env SUPABASE_URL "http://kong:8000"
+
+            # The gateway's own least-privilege database login.
+            #
+            # The migration creates the `ai_gateway` role NOLOGIN on purpose so
+            # no credential lives in git — which means SOMETHING has to grant it
+            # login, and that something is here. Without this the container
+            # crash-loops on "DATABASE_URL is required" and the deploy's health
+            # wait times out.
+            #
+            # Generated once and preserved: regenerating on every deploy would
+            # invalidate the URL already in .env for the running container.
+            if ! grep -qE '^AI_GATEWAY_DB_URL=.+' .env; then
+              GW_PW="$(openssl rand -hex 24)"
+              docker compose exec -T -e PGPASSWORD="$(grep '^POSTGRES_PASSWORD=' .env | cut -d= -f2-)" \
+                db psql -U supabase_admin -d postgres -q \
+                -c "alter role ai_gateway login password '$GW_PW';"
+              upsert_env AI_GATEWAY_DB_URL "postgres://ai_gateway:$GW_PW@db:5432/postgres"
+              echo "  provisioned ai_gateway database login"
+            else
+              echo "  keep AI_GATEWAY_DB_URL (already set)"
+            fi
+
+            # Per-deployment catalog. Deliberately not in git (upstream keys and
+            # prices differ per deployment), so seed it from the example on
+            # first deploy.
+            #
+            # This must run BEFORE `docker compose up`: a missing bind source is
+            # not an error to Docker, it creates a DIRECTORY at that path and
+            # the gateway dies with EISDIR.
+            if [ ! -f ai/catalog.yaml ]; then
+              [ -d ai/catalog.yaml ] && rmdir ai/catalog.yaml
+              cp ai/catalog.example.yaml ai/catalog.yaml
+              echo "  seeded ai/catalog.yaml from the example"
+            fi
             # Admin credential for the gateway. Generated once on the server and then
             # preserved — rotating it would orphan every virtual key already issued
             # to a team in the _litellm database.

--- a/deploy/self-host/ai/catalog.example.yaml
+++ b/deploy/self-host/ai/catalog.example.yaml
@@ -27,10 +27,16 @@ providers:
     #                          when the client did not ask for it.
     # Verified against the live API on 2026-08-28 (§4.4.0.1).
     usage_mode: always
-  openai:
-    api_base: https://api.openai.com/v1
-    api_key_env: OPENAI_API_KEY
-    usage_mode: needs_stream_options
+  # A second provider is opt-in, NOT shipped enabled. Startup validation
+  # requires a key for every provider listed here, so shipping one the
+  # deployment has no key for means the gateway refuses to boot — which is what
+  # happened the first time this file reached production. Uncomment together
+  # with a gpt-4o backend and set OPENAI_API_KEY.
+  #
+  # openai:
+  #   api_base: https://api.openai.com/v1
+  #   api_key_env: OPENAI_API_KEY
+  #   usage_mode: needs_stream_options
 
 # Body keys forwarded upstream. Everything else is dropped with a debug log.
 # Replaces LiteLLM's `litellm_settings.drop_params: true`.
@@ -74,10 +80,10 @@ backend_models:
     upstream_model: deepseek-v4-flash
     default_max_output_tokens: 16000
 
-  gpt-4o:
-    provider: openai
-    upstream_model: gpt-4o
-    default_max_output_tokens: 16000
+  # gpt-4o:
+  #   provider: openai
+  #   upstream_model: gpt-4o
+  #   default_max_output_tokens: 16000
 
 public_models:
   # ── THE public contract: exactly three tiers, and their prices ───────
@@ -116,9 +122,10 @@ public_models:
     routes:
       - backend: ds-v4-pro
 
-  # Failover across two backends whose upstream costs differ by an order of
-  # magnitude — and the customer pays the same either way. That is the whole
-  # point of pricing the tier instead of the backend.
+  # Failover: if the first backend is unavailable the tier still serves, and
+  # the customer pays the same either way — the whole point of pricing the tier
+  # rather than the backend. Point the first route at a second provider once
+  # one is configured above.
   max:
     name: 旗舰
     routing: failover
@@ -126,8 +133,8 @@ public_models:
       input_per_1m_credits: 20000000
       output_per_1m_credits: 80000000
     routes:
-      - backend: gpt-4o
       - backend: ds-v4-pro
+      - backend: ds-v4-flash
 
   # ── transition aliases — REMOVE IN PHASE 3 ───────────────────────────
   # Old clients still send these vendor ids, and they are still sitting in

--- a/deploy/self-host/docker-compose.yml
+++ b/deploy/self-host/docker-compose.yml
@@ -243,6 +243,13 @@ services:
       OPENAI_API_KEY: "${OPENAI_API_KEY:-}"
       ANTHROPIC_API_KEY: "${ANTHROPIC_API_KEY:-}"
     volumes:
+      # ai/catalog.yaml is PER DEPLOYMENT and deliberately not in git; the
+      # deploy creates it from ai/catalog.example.yaml when absent.
+      #
+      # It has to exist before this mount resolves: Docker does not fail on a
+      # missing bind source, it silently creates a DIRECTORY there, and the
+      # gateway then dies with `EISDIR` — an error that names nothing about the
+      # actual cause.
       - ./ai/catalog.yaml:/app/catalog.yaml:ro
     healthcheck:
       test:

--- a/services/ai-gateway/test/catalog.test.ts
+++ b/services/ai-gateway/test/catalog.test.ts
@@ -3,7 +3,7 @@ import assert from "node:assert/strict";
 import { parseCatalog, pickRoute, REQUIRED_TIERS } from "../src/catalog.js";
 import { readFileSync } from "node:fs";
 
-const ENV = { DEEPSEEK_API_KEY: "k1", OPENAI_API_KEY: "k2" } as NodeJS.ProcessEnv;
+const ENV = { DEEPSEEK_API_KEY: "k1" } as NodeJS.ProcessEnv;
 const SHIPPED = readFileSync(
   new URL("../../../deploy/self-host/ai/catalog.example.yaml", import.meta.url),
   "utf8",
@@ -43,8 +43,16 @@ test("refuses a route pointing at an unknown backend", () => {
 });
 
 test("refuses to start when a provider key is absent from the environment", () => {
-  assert.throws(() => parseCatalog(SHIPPED, { DEEPSEEK_API_KEY: "k" } as NodeJS.ProcessEnv),
-    /needs OPENAI_API_KEY/);
+  assert.throws(() => parseCatalog(SHIPPED, {} as NodeJS.ProcessEnv), /needs DEEPSEEK_API_KEY/);
+});
+
+// The shipped example must boot on a deployment that has configured exactly
+// one upstream. It listed a second provider once, and startup validation —
+// correctly — refused to boot for the missing key, which is how the gateway
+// failed on its first real deploy.
+test("the shipped example needs only the keys it actually lists", () => {
+  const cat = parseCatalog(SHIPPED, { DEEPSEEK_API_KEY: "k" } as NodeJS.ProcessEnv);
+  assert.deepEqual(Object.keys(cat.providers), ["deepseek"]);
 });
 
 test("refuses an unknown usage_mode", () => {
@@ -54,10 +62,10 @@ test("refuses an unknown usage_mode", () => {
 
 test("failover walks the route list by attempt", () => {
   const cat = parseCatalog(SHIPPED, ENV);
-  assert.equal(pickRoute(cat, "max", 0)!.backendId, "gpt-4o");
-  assert.equal(pickRoute(cat, "max", 1)!.backendId, "ds-v4-pro");
+  assert.equal(pickRoute(cat, "max", 0)!.backendId, "ds-v4-pro");
+  assert.equal(pickRoute(cat, "max", 1)!.backendId, "ds-v4-flash");
   // Past the end it clamps rather than throwing.
-  assert.equal(pickRoute(cat, "max", 9)!.backendId, "ds-v4-pro");
+  assert.equal(pickRoute(cat, "max", 9)!.backendId, "ds-v4-flash");
 });
 
 test("unknown public id resolves to nothing (caller turns this into 403)", () => {


### PR DESCRIPTION
Three defects found by deploying Phase 0 for real. Each stopped the gateway from starting; none was caught by a test, because they all live in the gap between "the code is right" and "the deployment has what it needs".

| | Symptom |
|---|---|
| Nothing granted the `ai_gateway` database login | crash-loop on `DATABASE_URL is required` |
| `ai/catalog.yaml` absent → **Docker creates a directory** | `EISDIR`, an error naming nothing about the cause |
| Example catalog listed a provider the box has no key for | startup validation correctly refused to boot |

The migration creates the role NOLOGIN on purpose so no credential lives in git — which means *something* has to grant it, and nothing did. The deploy now generates a password once, grants login, and preserves the URL across deploys.

The second one is the nastiest: a missing bind source is not an error to Docker. It creates a directory and the failure surfaces three layers away.

The third means the shipped example could not boot on a DeepSeek-only deployment — which is every deployment today. `max` now fails over between the two DeepSeek backends, so the tier still demonstrates failover, and a test asserts the example needs only the keys it lists.

`AI_GATEWAY_SERVICE_TOKEN` and `SUPABASE_URL` were never seeded either; added.

29 gateway tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)