### PR TITLE
fix(smoke): reach the AI gateway the way it is actually exposed

### DIFF
--- a/deploy/self-host/smoke/ai-gateway-smoke.sh
+++ b/deploy/self-host/smoke/ai-gateway-smoke.sh
@@ -1,43 +1,63 @@
 #!/bin/sh
 # Post-deploy smoke for services/ai-gateway. Runs alongside litellm-smoke.sh --
-# both gateways are live until Phase 3 (design §11.5).
+# both gateways are live until Phase 3.
 #
-# Deliberately does NOT spend upstream tokens: a completion needs a real member
-# JWT, which this script has no way to mint. What it proves is that the service
-# is up, its catalog validated at boot, and the authorization gate is closed.
-# The completion path is covered by services/ai-gateway/test/e2e.test.ts.
+# Reached two ways, on purpose:
+#   * in-network, by exec'ing into the container — the gateway publishes NO host
+#     port (unlike litellm on 127.0.0.1:4000), so curling the host would only
+#     ever prove that nothing listens there. It did, the first time this ran.
+#   * through Caddy on the public path, which is what clients actually dial and
+#     the only check that covers the /ai/* route mapping.
+#
+# Deliberately spends no upstream tokens: a completion needs a real member JWT,
+# which this script cannot mint. What it proves is that the service is up, its
+# catalog validated at boot, and the authorization gate is closed. The
+# completion path is covered by services/ai-gateway/test/e2e.test.ts.
 set -eu
 
-BASE="${AI_GATEWAY_BASE:-http://127.0.0.1:4001}"
+SVC=ai-gateway
 fail() { echo "ai-gateway-smoke: FAIL — $1" >&2; exit 1; }
-code() { curl -s -o /dev/null -w '%{http_code}' --max-time 10 "$@"; }
 
-echo "ai-gateway-smoke: base=$BASE"
+# One exec, all in-network assertions: the image ships node, not curl.
+echo "ai-gateway-smoke: in-network checks"
+docker compose exec -T "$SVC" node -e '
+const B = "http://127.0.0.1:" + (process.env.PORT || 4001);
+const T = "00000000-0000-4000-8000-000000000000";
+const code = async (p, h) => (await fetch(B + p, { headers: h || {} })).status;
+const want = async (p, exp, label, h) => {
+  const got = await code(p, h);
+  if (got !== exp) { console.error(`  FAIL ${label}: got ${got}, want ${exp}`); process.exit(1); }
+  console.log(`  ok  ${label}`);
+};
+(async () => {
+  await want("/healthz", 200, "healthz");
+  // A booted gateway has already validated its catalog (missing tier, dangling
+  // backend reference, or absent provider key all abort startup), so reaching
+  // this point means the catalog is coherent.
+  await want(`/v1/teams/${T}/models`, 401, "unauthenticated request rejected");
+  await want(`/v1/teams/${T}/models`, 401, "invalid token rejected",
+             { Authorization: "Bearer not-a-real-token" });
+  // The internal surface must never accept an end-user credential.
+  await want("/internal/models", 401, "internal routes gated by the service token",
+             { Authorization: "Bearer not-a-real-token" });
+  const svc = process.env.AI_GATEWAY_SERVICE_TOKEN;
+  if (svc) {
+    await want("/internal/models", 200, "internal /models serves the tier catalogue",
+               { Authorization: "Bearer " + svc });
+  }
+})().catch((e) => { console.error("  FAIL", e.message); process.exit(1); });
+' || fail "in-network checks"
 
-[ "$(code "$BASE/healthz")" = "200" ] || fail "/healthz not 200"
-echo "  ok  healthz"
-
-# A booted gateway has already validated the catalog (missing tier, dangling
-# backend reference, or absent provider key all abort startup), so reaching this
-# point means the catalog is coherent.
-
-T="00000000-0000-4000-8000-000000000000"
-[ "$(code "$BASE/v1/teams/$T/models")" = "401" ] || fail "unauthenticated /models should be 401"
-echo "  ok  unauthenticated request rejected"
-
-[ "$(code -H 'Authorization: Bearer not-a-real-token' "$BASE/v1/teams/$T/models")" = "401" ] \
-  || fail "garbage bearer token should be 401"
-echo "  ok  invalid token rejected"
-
-# The internal surface must never accept an end-user credential.
-[ "$(code -H 'Authorization: Bearer not-a-real-token' "$BASE/internal/models")" = "401" ] \
-  || fail "internal routes should reject a non-service token"
-echo "  ok  internal routes gated by the service token"
-
-if [ -n "${AI_GATEWAY_SERVICE_TOKEN:-}" ]; then
-  [ "$(code -H "Authorization: Bearer $AI_GATEWAY_SERVICE_TOKEN" "$BASE/internal/models")" = "200" ] \
-    || fail "internal /models should accept the service token"
-  echo "  ok  internal /models serves the tier catalogue"
+# Public path. Catches a Caddy /ai/* misroute, which the in-network checks
+# cannot see and which would break every client while the service looks fine.
+DOMAIN="${FC_DOMAIN:-$(grep '^FC_DOMAIN=' .env 2>/dev/null | cut -d= -f2- || true)}"
+if [ -n "$DOMAIN" ]; then
+  PUB="https://$DOMAIN/ai/healthz"
+  c=$(curl -s -o /dev/null -w '%{http_code}' --max-time 15 "$PUB" || echo 000)
+  [ "$c" = "200" ] || fail "public $PUB -> $c (Caddy /ai/* route)"
+  echo "  ok  public $PUB -> 200"
+else
+  echo "  skip public check (FC_DOMAIN unset)"
 fi
 
 echo "ai-gateway-smoke: PASS"


### PR DESCRIPTION
The deploy failed with `ai-gateway-smoke: FAIL — /healthz not 200` while the gateway was healthy the entire time.

The smoke curled `http://127.0.0.1:4001` **on the host**. The gateway publishes no host port — deliberately. It is reached in-network at `ai-gateway:4001` and publicly through Caddy at `/ai/*`. `litellm-smoke.sh` works because litellm *does* publish `127.0.0.1:4000`, and copying its shape carried over an assumption that was never true for this service.

Now checked two ways:

- **In-network**, by exec'ing into the container. One exec runs every assertion in node, since the image ships node and not curl.
- **Through Caddy on the public path** — the only check covering the `/ai/*` route mapping. An in-network check cannot see a Caddy misroute, and that failure would break every client while the service itself looks perfectly healthy.

Verified against production, all six pass:

```
  ok  healthz
  ok  unauthenticated request rejected
  ok  invalid token rejected
  ok  internal routes gated by the service token
  ok  internal /models serves the tier catalogue
  ok  public https://api.teamclu-dev.ucar.cc/ai/healthz -> 200
ai-gateway-smoke: PASS
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)