### PR TITLE
fix(deploy): build ai-gateway, not just fc

### DIFF
--- a/.github/workflows/self-host-deploy.yml
+++ b/.github/workflows/self-host-deploy.yml
@@ -305,8 +305,21 @@ jobs:
             done
             upsert_env ADDITIONAL_REDIRECT_URLS "$redirects"
 
-            echo "=== build fc ==="
-            docker compose build fc
+            echo "=== build fc + ai-gateway ==="
+            # BOTH locally-built services. `up` runs with --pull never and no
+            # --build, so anything omitted here keeps whatever image it was
+            # first created from — silently, and forever.
+            #
+            # ai-gateway was missing from this line when it was introduced, so
+            # every gateway change after the first deploy ran against stale
+            # code. The symptom is a 404 on a route that demonstrably exists in
+            # the repo, which sends you looking at routing rather than at the
+            # image. Add any new locally-built service here.
+            #
+            # amuxd also has a `build:` in compose but is deliberately NOT here:
+            # that build is for local dev, while this box receives amuxd as a
+            # prebuilt image via daemon-deploy.yml's `docker load`.
+            docker compose build fc ai-gateway
 
             echo "=== pull litellm (up --pull never will not fetch it) ==="
             # Same flaky path to ghcr.io as the git fetch above; the image is

--- a/services/ai-gateway/src/credits.ts
+++ b/services/ai-gateway/src/credits.ts
@@ -247,7 +247,7 @@ export async function topUp(sql: Sql, input: TopUpInput): Promise<TopUpResult> {
   });
 }
 
-export type BackfillResult = { scanned: number; granted: number };
+export type BackfillResult = { scanned: number; granted: number; vanished: number };
 
 /**
  * Give every team that has never been credited its signup grant.
@@ -270,17 +270,31 @@ export async function backfillSignupGrants(
   const teams = await sql<{ team_id: string }[]>`
     select team_id from amux.ai_gateway_teams_missing_signup_grant()`;
   let granted = 0;
+  let vanished = 0;
   for (const t of teams) {
-    const r = await topUp(sql, {
-      teamId: t.team_id,
-      amountCredits,
-      kind: "grant",
-      idempotencyKey: `signup_grant:${t.team_id}`,
-      note: "signup grant (backfill)",
-    });
-    if (r.applied) granted += 1;
+    try {
+      const r = await topUp(sql, {
+        teamId: t.team_id,
+        amountCredits,
+        kind: "grant",
+        idempotencyKey: `signup_grant:${t.team_id}`,
+        note: "signup grant (backfill)",
+      });
+      if (r.applied) granted += 1;
+    } catch (err) {
+      // The team list is a snapshot; a team deleted between the scan and its
+      // grant fails the ledger's foreign key. Skip it and keep going — this
+      // runs over every team on the deployment, and one deletion mid-run must
+      // not abort the rest. It is the gate on enabling enforcement, so a
+      // partial backfill that reports success is the dangerous outcome.
+      if ((err as { code?: string })?.code === "23503") {
+        vanished += 1;
+        continue;
+      }
+      throw err;
+    }
   }
-  return { scanned: teams.length, granted };
+  return { scanned: teams.length, granted, vanished };
 }
 
 export type ReconcileRow = {

--- a/services/ai-gateway/test/credits.test.ts
+++ b/services/ai-gateway/test/credits.test.ts
@@ -290,12 +290,31 @@ test("concurrent deliveries of the same purchase credit once", { skip: !DB }, as
 test("backfill grants every team that has never been credited", { skip: !DB }, async () => {
   await admin`delete from amux.credit_ledger where team_id = ${teamId}::uuid`;
   await admin`delete from amux.team_credit_balance where team_id = ${teamId}::uuid`;
-  const first = await backfillSignupGrants(sql, 777);
-  assert.ok(first.granted >= 1, "the un-credited team was granted");
+  await backfillSignupGrants(sql, 777);
 
+  // Asserts THIS team, not a global count: the backfill sweeps every team on
+  // the deployment, and other suites create and delete their own concurrently.
   const [bal] = await sql<{ balance_credits: string }[]>`
     select balance_credits from amux.team_credit_balance where team_id = ${teamId}::uuid`;
-  assert.equal(Number(bal.balance_credits), 777);
+  assert.equal(Number(bal.balance_credits), 777, "the un-credited team was granted");
+});
+
+test("a team deleted mid-backfill is skipped, not fatal", { skip: !DB }, async () => {
+  // The list is a snapshot. In production the sweep covers every team on the
+  // deployment, so a deletion during the run is ordinary — and aborting would
+  // leave a PARTIAL backfill right before enforcement is switched on, which is
+  // the one outcome that must not happen quietly.
+  const [{ id: doomed }] = await admin<{ id: string }[]>`
+    insert into amux.teams (slug, name) values (${`doomed-${Date.now()}`}, 'doomed') returning id`;
+  await admin`delete from amux.teams where id = ${doomed}::uuid`;
+
+  await admin`delete from amux.credit_ledger where team_id = ${teamId}::uuid`;
+  await admin`delete from amux.team_credit_balance where team_id = ${teamId}::uuid`;
+  // Does not throw, and our team is still granted.
+  await backfillSignupGrants(sql, 555);
+  const [bal] = await sql<{ balance_credits: string }[]>`
+    select balance_credits from amux.team_credit_balance where team_id = ${teamId}::uuid`;
+  assert.equal(Number(bal.balance_credits), 555);
 });
 
 test("backfill is safe to re-run", { skip: !DB }, async () => {


### PR DESCRIPTION
**Every gateway change after the first deploy has been running against stale code.**

`up` runs with `--pull never` and no `--build`, so a locally-built service omitted from `docker compose build` keeps whatever image it was first created from — silently, and forever.

Found by calling `POST /internal/credits/backfill` on production and getting a **404 for a route that plainly exists in the repo**. The running image was built at the Phase 0 deploy:

```
镜像创建于: 2026-08-31T03:26:47Z
grep -c 'credits/backfill' /app/dist/app.js  →  0
```

So it has none of Phase 1's `pricing` field, none of Phase 2's credits enforcement, and none of the operator endpoints. Nothing errored — it just served old code.

Worth the comment because **the symptom points away from the cause**: a 404 sends you looking at routing, not at the image.

`amuxd` also has a `build:` in compose and is deliberately still absent — that build is for local dev; this box receives amuxd as a prebuilt image via `daemon-deploy.yml`'s `docker load`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)