### PR TITLE
fix(billing): give the Stripe return URL its own variable

### DIFF
--- a/deploy/self-host/.env.example
+++ b/deploy/self-host/.env.example
@@ -392,6 +392,14 @@ STRIPE_WEBHOOK_SECRET=
 # business use). Do NOT work around it with managed_payments[enabled]=false:
 # that silently changes who is on the hook for tax.
 STRIPE_PRICE_IDS=
+# This deployment's own public origin -- Stripe sends the browser back here
+# after checkout. Its own variable rather than a reused one: AUTH_BASE_URL is
+# the Better-Auth issuer and sits EMPTY whenever BACKEND_KIND=supabase, and
+# API_EXTERNAL_URL belongs to GoTrue (its value here is the Cloud API host,
+# which is already a surprising local choice -- anyone "correcting" it would
+# silently repoint these URLs).
+#   e.g. https://api.example.com
+STRIPE_RETURN_URL_BASE=
 # Where the gateway asks GoTrue who a token belongs to (BACKEND_KIND=supabase).
 # In-network default; it never needs the public hostname.
 SUPABASE_URL=http://kong:8000

--- a/deploy/self-host/docker-compose.yml
+++ b/deploy/self-host/docker-compose.yml
@@ -504,6 +504,10 @@ services:
       STRIPE_SECRET_KEY: "${STRIPE_SECRET_KEY:-}"
       STRIPE_WEBHOOK_SECRET: "${STRIPE_WEBHOOK_SECRET:-}"
       STRIPE_PRICE_IDS: "${STRIPE_PRICE_IDS:-}"
+      # This deployment's own public origin, for the post-checkout landing page.
+      # Its own variable on purpose: AUTH_BASE_URL is empty on the supabase
+      # backend path, and API_EXTERNAL_URL belongs to GoTrue.
+      STRIPE_RETURN_URL_BASE: "${STRIPE_RETURN_URL_BASE:-}"
       LITELLM_URL: "${LITELLM_URL:-http://litellm:4000}"
       LITELLM_MASTER_KEY: "${LITELLM_MASTER_KEY:-}"
       # Per-team spend cap written at /team/new. Blank = no cap. This was absent

--- a/docs/specs/2026-08-28-team-ai-gateway-design.md
+++ b/docs/specs/2026-08-28-team-ai-gateway-design.md
@@ -438,8 +438,15 @@ Tauri 内嵌 webview **不要**用来打开 Checkout（3DS 与钱包会出问题
 | 补充 | 为什么 |
 |---|---|
 | `GET /v1/teams/:teamId/credits/packages` | 充值卡要显示「买什么、多少钱、给多少积分」。三者都只能来自 Stripe Price + `metadata.credits`（§4.9.3），客户端硬编码价格在调价当天就是错的。**任何成员可读**（看得见但买不了），下单才是 owner-only |
-| `GET /v1/stripe/return` | Checkout 完成后浏览器要有地方落。一张静态 HTML：桌面端本来就不依赖这次跳转（§4.9.7），这页只需要告诉人可以关掉。复用 `AUTH_BASE_URL` 作公网 origin，不为同一个含义再引入一个变量 |
+| `GET /v1/stripe/return` | Checkout 完成后浏览器要有地方落。一张静态 HTML：桌面端本来就不依赖这次跳转（§4.9.7），这页只需要告诉人可以关掉。公网 origin 用**专门的 `STRIPE_RETURN_URL_BASE`** —— 见下方那条 |
 | `stripe-reconcile` cron 任务 | §4.9.6 的第二层兜底。**不查账本**：重复 top-up 靠唯一索引变成空操作，返回的 `applied` 就是「这笔本地是不是缺了」的答案，比自己 join 一次账本少一条会腐化的查询路径 |
+
+⚠️ **回跳地址不要复用现成变量。** 第一版试过两个，两个都错：
+
+- `AUTH_BASE_URL` 是 Better-Auth 的 issuer / JWKS origin。`BACKEND_KIND=supabase` 这条路上没人调它，所以它在**唯一真正在跑的部署上是空的** —— 上线后点「购买」直接报 `AUTH_BASE_URL is not set`。而且为了喂 Stripe 把它填上，等于在 BACKEND_KIND 哪天切到 postgres 时，悄悄把它变成了 JWT 的签发者。
+- `API_EXTERNAL_URL` 是 **GoTrue 的**变量（`deploy/self-host/supabase/docker-compose.yml`）。它在这台机器上碰巧是 Cloud API 的地址 —— 这本身就是个反直觉的本地配置；谁哪天按名字把它「修正」成 Supabase 的地址，回跳地址就静默指错了。
+
+教训不是「少加变量」，是**别把语义挂在自己不拥有的变量上**。桌面端不依赖这次跳转，不等于它的 origin 可以含糊。
 
 对账任务的 Stripe client 是**可注入的**。第一版不是，于是 `npm test` 直接打到了 api.stripe.com —— 一个测试套件能对着生产支付账号发请求，这本身就是缺陷。
 

--- a/services/fc/s.yaml
+++ b/services/fc/s.yaml
@@ -66,6 +66,7 @@ resources:
         STRIPE_SECRET_KEY: ${env('STRIPE_SECRET_KEY', '')}
         STRIPE_WEBHOOK_SECRET: ${env('STRIPE_WEBHOOK_SECRET', '')}
         STRIPE_PRICE_IDS: ${env('STRIPE_PRICE_IDS', '')}
+        STRIPE_RETURN_URL_BASE: ${env('STRIPE_RETURN_URL_BASE', '')}
         LITELLM_URL: ${env('LITELLM_URL', 'https://ai.ucar.cc')}
         LITELLM_MASTER_KEY: ${env('LITELLM_MASTER_KEY', '')}
         # Blank = no cap, matching the compose default. Keep the two targets in

--- a/services/fc/src/lib/stripe.ts
+++ b/services/fc/src/lib/stripe.ts
@@ -198,19 +198,30 @@ export async function createCheckoutSession(
 /**
  * Public origin for the post-checkout landing pages.
  *
- * Reuses `AUTH_BASE_URL` — FC's own public origin, already declared on both
- * deploy targets — rather than introducing a second variable that means the
- * same thing and can drift from it. The desktop never depends on this redirect:
- * it shows "processing" and lets the balance refresh (§4.9.7), so the page only
- * has to tell a human they can close the tab.
+ * Its OWN variable, deliberately, after the first version tried to reuse an
+ * existing one twice and was wrong both times:
+ *
+ * - `AUTH_BASE_URL` is the Better-Auth issuer/JWKS origin. On the supabase
+ *   backend path nothing calls it, so it sits EMPTY on the deployment that
+ *   actually runs — checkout failed with "AUTH_BASE_URL is not set". Filling it
+ *   in to please Stripe would also quietly become the JWT issuer the day
+ *   BACKEND_KIND flips to postgres.
+ * - `API_EXTERNAL_URL` belongs to GoTrue (deploy/self-host/supabase/
+ *   docker-compose.yml). It happens to hold the Cloud API host here, which is
+ *   itself a surprising local choice; anyone "correcting" it to the Supabase
+ *   host would silently repoint these return URLs.
+ *
+ * The desktop never depends on this redirect — it shows "processing" and lets
+ * the balance refresh (§4.9.7) — so the page only has to tell a human they can
+ * close the tab. That is not a reason to let its origin be ambiguous.
  */
 function returnUrlBase(): string {
-  const base = process.env.AUTH_BASE_URL?.trim();
+  const base = process.env.STRIPE_RETURN_URL_BASE?.trim();
   if (!base) {
     throw new ApiError(
       503,
       "stripe_unavailable",
-      "AUTH_BASE_URL is not set — Stripe checkout needs a public origin for its return URLs",
+      "STRIPE_RETURN_URL_BASE is not set — Stripe checkout needs this deployment's public origin for its return URLs",
     );
   }
   return base.replace(/\/+$/, "");

--- a/services/fc/test/stripe.test.ts
+++ b/services/fc/test/stripe.test.ts
@@ -27,7 +27,7 @@ beforeEach(() => {
   process.env.STRIPE_SECRET_KEY = "sk_test_placeholder";
   process.env.STRIPE_WEBHOOK_SECRET = WEBHOOK_SECRET;
   process.env.STRIPE_PRICE_IDS = "price_a, price_b";
-  process.env.AUTH_BASE_URL = "https://api.example.com";
+  process.env.STRIPE_RETURN_URL_BASE = "https://api.example.com";
   // The gateway is the ledger's only writer, so intercepting this one call is
   // the whole surface between Stripe and the money.
   (aiGateway as any).topUp = async (teamId: string, body: any) => {


### PR DESCRIPTION
Follow-up to #1143, caught in production the moment the top-up card was first clicked.

The card listed all three packages correctly; **Buy** answered `AUTH_BASE_URL is not set`.

## What I got wrong

I reused `AUTH_BASE_URL` for the checkout return URLs on the grounds that it is "FC's own public origin, already declared on both deploy targets". I had verified it was *declared*, and took that for *set*.

It is not. `AUTH_BASE_URL` is the Better-Auth issuer / JWKS origin, and on the `BACKEND_KIND=supabase` path nothing calls `authBaseURL()` — so it sits **empty on the only deployment that actually runs**. Filling it in to satisfy Stripe would also have quietly made it the JWT issuer the day `BACKEND_KIND` flips to `postgres`.

The obvious next candidate is worse. `API_EXTERNAL_URL` belongs to **GoTrue** (`deploy/self-host/supabase/docker-compose.yml:107`). It happens to hold the Cloud API host on this box — itself a surprising local choice this repo has already been bitten by — so anyone "correcting" it to the Supabase host would silently repoint every checkout return URL.

## The fix

`STRIPE_RETURN_URL_BASE`: owned by this feature, declared on both deploy targets, documented in `.env.example`, fail-closed with a message that names itself. Already set on the self-host box.

The lesson recorded in §4.9.8 is not "add fewer variables" — it is **do not hang your meaning on a variable you do not own**. That the desktop never depends on this redirect (§4.9.7) is no reason for its origin to be ambiguous.

## Tests

`services/fc` Stripe + deploy-env-parity: 21/21. Frontend suite unchanged and green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018rRCi6g5nDwrhVvC8VHEgk