### PR TITLE
fix(billing): be the merchant of record, not Link

### DIFF
--- a/services/fc/src/lib/stripe.ts
+++ b/services/fc/src/lib/stripe.ts
@@ -135,6 +135,8 @@ export interface CheckoutSessionInput {
   priceId: string;
   /** Who clicked buy — recorded on the Session for support, never trusted for authz. */
   actorId?: string | null;
+  /** Injectable so tests can assert the params we send without a live account. */
+  stripe?: Stripe;
 }
 
 /**
@@ -153,7 +155,7 @@ export interface CheckoutSessionInput {
 export async function createCheckoutSession(
   input: CheckoutSessionInput,
 ): Promise<{ sessionId: string; url: string }> {
-  const stripe = stripeClient();
+  const stripe = input.stripe ?? stripeClient();
   if (!allowedPriceIds().includes(input.priceId)) {
     throw new ApiError(400, "invalid_price", "priceId is not an offered credit package");
   }
@@ -164,6 +166,21 @@ export async function createCheckoutSession(
   const session = await stripe.checkout.sessions.create(
     {
       mode: "payment",
+      // We are the merchant of record, not Link.
+      //
+      // Managed Payments is ON by default on this account and changes who
+      // sells: the hosted page reads "sold through Link — you authorise Link to
+      // charge you", Link owns the tax treatment (a 9% GST line turned an
+      // HK$98 order into HK$106.82), and the payment runs on Link's own rails.
+      // That last part is not cosmetic — a real Apple Pay attempt failed there
+      // and left NO PaymentIntent and no event on our account, so there was
+      // nothing to debug from. Turning it off also switches automatic_tax back
+      // off, which is correct: being the merchant of record means owning the
+      // tax question rather than having one silently answered for us.
+      //
+      // Cast: the API accepts this (its own error message recommends it) but it
+      // is absent from the SDK's typed surface as of v22.6.0.
+      ...({ managed_payments: { enabled: false } } as Record<string, unknown>),
       line_items: [{ price: input.priceId, quantity: 1 }],
       client_reference_id: input.teamId,
       metadata: {

--- a/services/fc/test/stripe.test.ts
+++ b/services/fc/test/stripe.test.ts
@@ -12,7 +12,7 @@ import crypto from "node:crypto";
 import { Hono } from "hono";
 import { createHonoRouterAdapter } from "../src/lib/hono-adapter.js";
 import { aiGateway } from "../src/lib/ai-gateway.js";
-import { allowedPriceIds, creditsForPrice, idempotency } from "../src/lib/stripe.js";
+import { allowedPriceIds, createCheckoutSession, creditsForPrice, idempotency } from "../src/lib/stripe.js";
 import { registerStripe, handleStripeEvent, creditsForSession } from "../src/lib/routes/stripe.js";
 import { stripeReconcileCheckouts } from "../src/lib/stripe-reconcile.js";
 
@@ -144,6 +144,57 @@ test("a session with no stamped credits falls back to the live Price", async () 
     },
   } as any;
   assert.equal(await creditsForSession(stripe, session({ metadata: {} })), 2000);
+});
+
+// --- checkout session params ----------------------------------------------
+
+function captureStripe() {
+  const seen: any = {};
+  return {
+    seen,
+    client: {
+      prices: {
+        retrieve: async (id: string) => ({ id, metadata: { credits: "5000" } }),
+      },
+      checkout: {
+        sessions: {
+          create: async (params: any) => {
+            seen.params = params;
+            return { id: "cs_test_new", url: "https://checkout.stripe.com/c/pay/cs_test_new" };
+          },
+        },
+      },
+    } as any,
+  };
+}
+
+test("checkout opts OUT of Managed Payments — we are the merchant of record", async () => {
+  // Regression guard for a production failure. With Managed Payments on (the
+  // account default), the hosted page sold "through Link", Link owned the tax
+  // treatment (a 9% GST line turned an HK$98 order into HK$106.82), and the
+  // payment ran on Link's rails — where a failed Apple Pay attempt left NO
+  // PaymentIntent and no event on our account, so there was nothing to debug.
+  const { seen, client } = captureStripe();
+  await createCheckoutSession({ teamId: "team-1", priceId: "price_a", stripe: client });
+  assert.deepEqual(seen.params.managed_payments, { enabled: false });
+});
+
+test("the team is stamped where a payment can be attributed by, and nowhere else", async () => {
+  const { seen, client } = captureStripe();
+  await createCheckoutSession({ teamId: "team-1", priceId: "price_b", stripe: client });
+
+  // Both, because the webhook reads client_reference_id first and metadata is
+  // the fallback for Sessions created any other way.
+  assert.equal(seen.params.client_reference_id, "team-1");
+  assert.equal(seen.params.metadata.team_id, "team-1");
+  // Frozen at purchase time: a later price change must not alter an in-flight
+  // order (§4.9.3).
+  assert.equal(seen.params.metadata.credits, "5000");
+  // Copied onto the PaymentIntent -> Charge, the only object a charge.refunded
+  // event carries. Without it a refund has no team to debit.
+  assert.equal(seen.params.payment_intent_data.metadata.team_id, "team-1");
+  assert.equal(seen.params.payment_intent_data.metadata.credits, "5000");
+  assert.equal(seen.params.success_url, "https://api.example.com/v1/stripe/return?status=success");
 });
 
 // --- the webhook route: raw bytes in, signature verified -------------------


### PR DESCRIPTION
A real Apple Pay attempt failed, and **Stripe had recorded nothing** — no PaymentIntent, no failed charge, no event. That absence was the diagnosis: the payment never reached our account's rails.

The account has **Managed Payments** on by default. I had noticed it only as the thing that demanded a `tax_code`. Loading the live hosted page showed what it actually does:

> 提交订单，即表示您同意 **Link 的条款**…并授权 **Link 就此订单向您扣款** — 已通过 Link 销售

Link is the merchant of record, Link owns the tax treatment (a 9% GST line had turned an HK$98 order into **HK$106.82**), and the payment runs on Link's rails — where a failed authorisation leaves nothing on our account to debug from.

## Fix

`managed_payments[enabled]=false` at session creation. Verified against the live account: the footer goes back to "Powered by Stripe", the price back to a flat HK$98, and `automatic_tax` switches off — which is the correct consequence, not a side effect. Being the merchant of record means owning the tax question instead of having one silently answered for us.

The cast is because the API accepts the parameter (its own error message recommends it) but it is absent from the SDK's typed surface as of v22.6.0.

## Tests

`createCheckoutSession` now takes an injectable client, matching the reconcile task, so the params can be asserted without a live account:

- the Managed Payments opt-out
- the team id on `client_reference_id` **and** `metadata` (the webhook reads the first, falls back to the second), the credits frozen at purchase time, and both copied onto `payment_intent_data` — the only place a `charge.refunded` event can find a team to debit

My first draft of that first test asserted an object literal built inside the test and would have passed no matter what the code did. Replaced.

19/19 in `services/fc/test/stripe.test.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018rRCi6g5nDwrhVvC8VHEgk