### PR TITLE
fix(billing): fetch refunds instead of reading them off the event

### DIFF
--- a/services/fc/src/lib/routes/stripe.ts
+++ b/services/fc/src/lib/routes/stripe.ts
@@ -105,7 +105,7 @@ export async function handleStripeEvent(
 
     case "charge.refunded": {
       const charge = event.data.object as Stripe.Charge;
-      return refundCharge(charge);
+      return refundCharge(stripe, charge);
     }
 
     default:
@@ -144,17 +144,50 @@ export async function creditCheckoutSession(
   return { handled: true, applied: Boolean(res?.applied) };
 }
 
-async function refundCharge(charge: Stripe.Charge): Promise<{ handled: boolean; applied?: boolean; reason?: string }> {
+/**
+ * Debit a team for the refunds on a charge.
+ *
+ * The refunds are FETCHED, not read off the event. `charge.refunds` is absent
+ * from the charge object on current API versions, so `charge.refunds?.data ??
+ * []` — which is what this did first — silently yielded an empty list: the loop
+ * never ran, the handler answered 200, Stripe stopped retrying, and the
+ * customer got their money back while keeping the credits. A refund path that
+ * fails by doing nothing at all is the worst shape this could take, so it now
+ * asks the API rather than trusting the payload's shape.
+ */
+async function refundCharge(
+  stripe: Stripe,
+  charge: Stripe.Charge,
+): Promise<{ handled: boolean; applied?: boolean; reason?: string }> {
   const teamId = (charge.metadata?.team_id ?? "").trim();
-  if (!teamId) return { handled: false, reason: "refund carries no team id" };
+  if (!teamId) {
+    // Loud: the charge came from a Session we created, so it should carry one.
+    throw new ApiError(
+      500,
+      "stripe_refund_unattributed",
+      `Stripe charge ${charge.id} carries no team id — refund cannot be applied`,
+    );
+  }
 
-  // One event per refund, but a charge can be refunded in parts. Key on the
-  // individual refund so each part lands exactly once.
-  const refunds = charge.refunds?.data ?? [];
+  const chargedCredits = Number(charge.metadata?.credits ?? 0);
+  if (!Number.isSafeInteger(chargedCredits) || chargedCredits <= 0) {
+    throw new ApiError(
+      500,
+      "stripe_refund_unpriced",
+      `Stripe charge ${charge.id} carries no usable metadata.credits`,
+    );
+  }
+
+  const refunds = await stripe.refunds.list({ charge: charge.id, limit: 100 });
   let applied = false;
-  for (const refund of refunds) {
-    const credits = Number(refund.metadata?.credits ?? charge.metadata?.credits ?? 0);
-    if (!Number.isSafeInteger(credits) || credits <= 0) continue;
+  let debited = 0;
+  for (const refund of refunds.data) {
+    if (refund.status !== "succeeded") continue;
+    // Pro-rata, so a PARTIAL refund debits a proportional share rather than the
+    // whole purchase. Rounding up is deliberate: the rounding error should not
+    // be a way to keep credits that were paid for and then refunded.
+    const credits = Math.ceil((chargedCredits * refund.amount) / charge.amount);
+    if (credits <= 0) continue;
     const res = await aiGateway.topUp(teamId, {
       // Negative: the ledger is the truth and a refund is allowed to drive the
       // balance below zero (§4.9.5). The spend gate is `balance - reserved >=
@@ -164,9 +197,15 @@ async function refundCharge(charge: Stripe.Charge): Promise<{ handled: boolean; 
       idempotencyKey: idempotency.refund(refund.id),
       note: `stripe refund ${refund.id}`,
     });
-    applied = applied || Boolean(res?.applied);
+    if (res?.applied) {
+      applied = true;
+      debited += credits;
+    }
   }
-  return { handled: true, applied };
+  if (refunds.data.length === 0) {
+    return { handled: false, reason: `charge ${charge.id} has no refunds to apply` };
+  }
+  return { handled: true, applied, reason: applied ? `debited ${debited}` : "already recorded" };
 }
 
 /** `client_reference_id` is what we set at creation; metadata is the fallback

--- a/services/fc/test/stripe.test.ts
+++ b/services/fc/test/stripe.test.ts
@@ -110,18 +110,64 @@ test("an unhandled event type is reported, not thrown", async () => {
   assert.match(String(r.reason), /customer\.created/);
 });
 
-test("a refund debits the team and is keyed by refund id", async () => {
-  const charge = {
+/** A charge as the live API actually returns it: NO `refunds` key. */
+function charge(over: Record<string, any> = {}) {
+  return {
     id: "ch_1",
-    metadata: { team_id: "team-1", credits: "5000000" },
-    refunds: { data: [{ id: "re_1", metadata: { credits: "2000000" } }] },
-  };
-  const r = await handleStripeEvent({} as any, event("charge.refunded", charge));
+    amount: 500,
+    metadata: { team_id: "team-1", credits: "1500000" },
+    ...over,
+  } as any;
+}
+
+function stripeWithRefunds(data: any[]) {
+  return { refunds: { list: async () => ({ data }) } } as any;
+}
+
+test("a refund debits the team and is keyed by refund id", async () => {
+  const stripe = stripeWithRefunds([{ id: "re_1", amount: 500, status: "succeeded" }]);
+  const r = await handleStripeEvent(stripe, event("charge.refunded", charge()));
   assert.equal(r.handled, true);
   assert.equal(topUps.length, 1);
-  assert.equal(topUps[0].body.amountCredits, -2000000, "refunds are negative — the balance may legally go below zero");
+  assert.equal(topUps[0].body.amountCredits, -1500000, "refunds are negative — the balance may legally go below zero");
   assert.equal(topUps[0].body.kind, "refund");
   assert.equal(topUps[0].body.idempotencyKey, idempotency.refund("re_1"));
+});
+
+test("refunds are FETCHED, not read off the event payload", async () => {
+  // Regression guard for a silent-loss bug. `charge.refunds` is absent from the
+  // charge object on current API versions, so reading `charge.refunds?.data ??
+  // []` produced an empty list: the loop never ran, the handler answered 200,
+  // Stripe stopped retrying, and the customer kept the credits they had been
+  // refunded for. Verified against the live API — a retrieved charge has no
+  // `refunds` key at all.
+  assert.equal("refunds" in charge(), false, "the fixture must match the live shape");
+  const stripe = stripeWithRefunds([{ id: "re_1", amount: 500, status: "succeeded" }]);
+  await handleStripeEvent(stripe, event("charge.refunded", charge()));
+  assert.equal(topUps.length, 1, "the refund must be applied even though the event carried no refunds list");
+});
+
+test("a PARTIAL refund debits a proportional share, rounded against the customer", async () => {
+  const stripe = stripeWithRefunds([{ id: "re_partial", amount: 200, status: "succeeded" }]);
+  await handleStripeEvent(stripe, event("charge.refunded", charge()));
+  // 1,500,000 credits * 200/500 = 600,000 — not the whole purchase.
+  assert.equal(topUps[0].body.amountCredits, -600000);
+});
+
+test("a pending refund is not debited yet", async () => {
+  const stripe = stripeWithRefunds([{ id: "re_pending", amount: 500, status: "pending" }]);
+  const r = await handleStripeEvent(stripe, event("charge.refunded", charge()));
+  assert.equal(topUps.length, 0);
+  assert.equal(r.applied, false);
+});
+
+test("a charge with no team id fails loudly rather than dropping the refund", async () => {
+  const stripe = stripeWithRefunds([{ id: "re_1", amount: 500, status: "succeeded" }]);
+  await assert.rejects(
+    () => handleStripeEvent(stripe, event("charge.refunded", charge({ metadata: {} }))),
+    (err: any) => err?.code === "stripe_refund_unattributed",
+  );
+  assert.equal(topUps.length, 0);
 });
 
 // --- credits resolution ----------------------------------------------------


### PR DESCRIPTION
Found by inspecting a real charge **before** testing a refund — not by the refund failing. That distinction is the whole point: this bug's failure mode is doing nothing at all.

## The bug

`refundCharge` read `charge.refunds?.data ?? []`. On current API versions the charge object has **no `refunds` key** — verified against the live charge from the first real payment:

```
metadata     : {"credits": "1500000", "team_id": "e84103ca-…"}
refunded     : False
refunds key  : ABSENT
```

So that expression yielded an empty list. The loop never ran, the handler answered **200**, Stripe stopped retrying, and the customer would have had their money back while keeping the credits — with nothing, anywhere, saying so.

## The fix

Ask the API (`refunds.list({ charge })`) instead of trusting the payload's shape. Along the way:

- skip refunds not yet `succeeded`
- debit **pro rata**, so a partial refund takes a proportional share rather than the whole purchase, rounded up so the rounding error is never a way to keep credits that were paid for and then refunded
- **throw** on a charge with no `team_id` or no usable `metadata.credits`, rather than returning "handled" — an unattributable refund is something a human has to see, the same rule that already governs unattributed sessions

## Tests

23/23 in `services/fc/test/stripe.test.ts`. Five cover this path, including a fixture that asserts `"refunds" in charge === false` so the regression cannot return via someone "restoring" the field, plus partial-refund proration, pending refunds, and the unattributed-charge throw.

## Context

The full purchase path is now verified in production end to end: HK$5 paid → cross-border webhook delivered first try (`pending_webhooks=0`) → ledger row keyed `stripe:cs:…` → balance 1000 → 1150 points, all within one second. The refund half is what this PR makes trustworthy before it is exercised with real money.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018rRCi6g5nDwrhVvC8VHEgk