### PR TITLE
fix(ai-gateway): let a refund be negative

### DIFF
--- a/services/ai-gateway/src/app.ts
+++ b/services/ai-gateway/src/app.ts
@@ -311,17 +311,33 @@ export function createApp(deps: Deps) {
       note?: string;
     } | null;
     const amount = Number(body?.amountCredits);
-    if (!Number.isSafeInteger(amount) || amount <= 0) {
-      return c.json(err("invalid_request", "amountCredits must be a positive integer", 400), 400);
+    if (!Number.isSafeInteger(amount) || amount === 0) {
+      return c.json(err("invalid_request", "amountCredits must be a non-zero integer", 400), 400);
     }
     // Required, not optional: without it a retried delivery credits twice, and
     // a payment provider retrying is normal rather than exceptional.
     if (!body?.idempotencyKey) {
       return c.json(err("invalid_request", "idempotencyKey is required", 400), 400);
     }
-    const kind = (body.kind ?? "top_up") as "top_up" | "grant" | "adjustment" | "refund";
+    const kind = (body?.kind ?? "top_up") as "top_up" | "grant" | "adjustment" | "refund";
     if (!["top_up", "grant", "adjustment", "refund"].includes(kind)) {
       return c.json(err("invalid_request", `unknown kind "${kind}"`, 400), 400);
+    }
+    // The SIGN belongs to the kind, and this endpoint used to demand a positive
+    // amount for every one of them — which made §4.9.5 unreachable: the design
+    // says a refund is a negative ledger row and a balance may legally go
+    // below zero (which is why the table carries no non-negative CHECK), but
+    // the only writer refused to write one. A real refund webhook 400'd here,
+    // threw in FC, and had Stripe retrying for three days.
+    //
+    // Checked per kind rather than dropped entirely: a POSITIVE refund, or a
+    // negative top_up, is a bug in the caller, and money paths should not
+    // quietly accept a sign they cannot mean.
+    if ((kind === "top_up" || kind === "grant") && amount < 0) {
+      return c.json(err("invalid_request", `${kind} must be positive`, 400), 400);
+    }
+    if (kind === "refund" && amount > 0) {
+      return c.json(err("invalid_request", "refund must be negative", 400), 400);
     }
     const result = await topUp(sql, {
       teamId,

--- a/services/ai-gateway/test/e2e.test.ts
+++ b/services/ai-gateway/test/e2e.test.ts
@@ -146,6 +146,48 @@ test("internal routes reject an end-user token and accept the service token", { 
   assert.ok((await ok.json() as any).data.length >= 3);
 });
 
+test("a refund is accepted as a NEGATIVE amount and may drive the balance below zero", { skip: !DB }, async () => {
+  // §4.9.5 says a refund is a negative ledger row and that a balance is allowed
+  // to go negative — which is why the table carries no non-negative CHECK. This
+  // endpoint used to demand `amount > 0` for every kind, so that design was
+  // unreachable through the only writer: a real Stripe refund 400'd here and
+  // had the webhook retrying for three days while the customer kept the credits.
+  const svc = { Authorization: `Bearer ${SERVICE_TOKEN}`, "Content-Type": "application/json" };
+  const key = `refund-test-${Date.now()}`;
+  await admin`delete from amux.credit_ledger where team_id = ${teamId}::uuid`;
+  await admin`update amux.team_credit_balance set balance_credits = 1000 where team_id = ${teamId}::uuid`;
+
+  const r = await req(`/internal/teams/${teamId}/credits/top-up`, {
+    method: "POST",
+    headers: svc,
+    body: JSON.stringify({ amountCredits: -5000, kind: "refund", idempotencyKey: key }),
+  });
+  assert.equal(r.status, 200, await r.text());
+  const body = await r.json() as any;
+  assert.equal(body.applied, true);
+  assert.equal(body.balanceCredits, -4000, "the spend gate refuses at a negative balance; the ledger still records the truth");
+});
+
+test("the sign has to match the kind", { skip: !DB }, async () => {
+  // Dropping the check entirely would let a positive refund or a negative
+  // top_up through, and a money path should not silently accept a sign the
+  // caller cannot have meant.
+  const svc = { Authorization: `Bearer ${SERVICE_TOKEN}`, "Content-Type": "application/json" };
+  const post = (b: unknown) =>
+    req(`/internal/teams/${teamId}/credits/top-up`, { method: "POST", headers: svc, body: JSON.stringify(b) });
+
+  const positiveRefund = await post({ amountCredits: 500, kind: "refund", idempotencyKey: `x-${Date.now()}` });
+  assert.equal(positiveRefund.status, 400);
+  assert.match((await positiveRefund.json() as any).error.message, /refund must be negative/);
+
+  const negativeTopUp = await post({ amountCredits: -500, kind: "top_up", idempotencyKey: `y-${Date.now()}` });
+  assert.equal(negativeTopUp.status, 400);
+  assert.match((await negativeTopUp.json() as any).error.message, /top_up must be positive/);
+
+  const zero = await post({ amountCredits: 0, kind: "adjustment", idempotencyKey: `z-${Date.now()}` });
+  assert.equal(zero.status, 400);
+});
+
 test("non-streaming completion round-trips and writes a usage row", { skip: !DB || !KEY }, async () => {
   const before = await sql`select count(*)::int as n from amux.ai_usage_logs where team_id = ${teamId}::uuid`;
   const r = await req(`/v1/teams/${teamId}/chat/completions`, {

--- a/services/ai-gateway/test/e2e.test.ts
+++ b/services/ai-gateway/test/e2e.test.ts
@@ -162,8 +162,11 @@ test("a refund is accepted as a NEGATIVE amount and may drive the balance below 
     headers: svc,
     body: JSON.stringify({ amountCredits: -5000, kind: "refund", idempotencyKey: key }),
   });
-  assert.equal(r.status, 200, await r.text());
+  // Read the body ONCE: passing `await r.text()` as the assertion message
+  // consumes it even when the assertion passes, and the next read throws
+  // "Body has already been read".
   const body = await r.json() as any;
+  assert.equal(r.status, 200, JSON.stringify(body));
   assert.equal(body.applied, true);
   assert.equal(body.balanceCredits, -4000, "the spend gate refuses at a negative balance; the ledger still records the truth");
 });


### PR DESCRIPTION
A real HK$5 refund exposed this. The purchase half works end to end; the refund half could not work at all.

## The contradiction

§4.9.5 argues at length that a refund is a negative ledger row, that a balance may legally go below zero, and that this is exactly why the balance table carries **no** non-negative `CHECK`. The gateway's top-up endpoint then demanded `amount > 0` for **every** kind — so that design was unreachable through the only writer that exists.

What actually happened: the gateway answered `400`, FC's webhook handler threw, Stripe got a `500` and kept retrying (`pending_webhooks=1` for minutes), the ledger recorded nothing — and the customer had their money back **and** kept the credits.

## The fix

The sign belongs to the kind:

| kind | sign |
|---|---|
| `top_up`, `grant` | must be positive |
| `refund` | must be negative |
| `adjustment` | either, never zero |

Checked per kind rather than dropped altogether: a positive refund, or a negative top-up, is a bug in the caller, and a money path should not quietly accept a sign nobody could have meant.

Nothing changes in the schema — the column was always `bigint` carrying the comment `-- signed: usage is negative`.

## Tests

Three, against the real database and the real Hono app (CI runs the gateway suite with Postgres): a refund driving the balance to **-4000**, and both wrong-sign rejections. 68 tests, 0 failures.

## Note for later

`stripe-reconcile` scans Checkout Sessions only, so a **lost refund webhook has no reconciliation path** — the asymmetry is worth closing, but it is a separate change from making the write possible at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018rRCi6g5nDwrhVvC8VHEgk