### PR TITLE
feat(daemon): 团队知识库方案 + MCP 工具链（scaffold/create/write/salvage/search/manifest/health）

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -311,6 +311,7 @@ dependencies = [
  "rand 0.8.6",
  "reqwest 0.12.28",
  "rumqttc",
+ "rusqlite",
  "rustls 0.22.4",
  "serde",
  "serde_json",
@@ -3687,6 +3688,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+dependencies = [
+ "hashbrown 0.14.5",
+]
+
+[[package]]
 name = "heapless"
 version = "0.7.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4994,7 +5004,7 @@ dependencies = [
  "bitflags 2.11.1",
  "fallible-iterator 0.2.0",
  "fallible-streaming-iterator",
- "hashlink",
+ "hashlink 0.8.4",
  "libsql-ffi",
  "smallvec",
 ]
@@ -5055,6 +5065,17 @@ dependencies = [
  "tracing",
  "uuid",
  "zerocopy 0.7.35",
+]
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c10584274047cb335c23d3e61bcef8e323adae7c5c8c760540f73610177fc3f"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -7913,6 +7934,20 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.25.0",
  "ws_stream_tungstenite",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b838eba278d213a8beaf485bd313fd580ca4505a00d5871caeb1457c55322cae"
+dependencies = [
+ "bitflags 2.11.1",
+ "fallible-iterator 0.3.0",
+ "fallible-streaming-iterator",
+ "hashlink 0.9.1",
+ "libsqlite3-sys",
+ "smallvec",
 ]
 
 [[package]]

--- a/apps/daemon/Cargo.toml
+++ b/apps/daemon/Cargo.toml
@@ -65,6 +65,8 @@ zip = { version = "5", default-features = false, features = ["deflate"] }
 # staging dir before swapping it over the installed pack.
 tempfile = "3"
 tar = "0.4"
+# Full-text search for the knowledge vault (SQLite FTS5, no external service)
+rusqlite = { version = "0.31", features = ["bundled"] }
 humantime-serde = "1"
 parking_lot = "0.12"
 

--- a/apps/daemon/assets/knowledge-templates/00-home.md
+++ b/apps/daemon/assets/knowledge-templates/00-home.md
@@ -1,0 +1,20 @@
+---
+type: home
+updated: {{DATE}}
+---
+
+# {{TEAM_NAME}} 知识库 / Knowledge Base
+
+<!-- 一句话说明这个团队是做什么的 / One sentence: what does this team do -->
+
+## 快速入口 / Quick Links
+
+- 新人入职 / Onboarding → [[10-onboarding/]]
+- 业务域知识 / Domain Knowledge → [[20-domains/]]
+- 重要决策 / Decisions (ADR) → [[30-decisions/]]
+- 应急手册 / Runbooks → [[40-runbooks/]]
+- 团队术语表 / Glossary → [[50-glossary]]
+
+## 常用资源 / Resources
+
+<!-- 团队常用的系统、看板、文档链接 / Links to dashboards, tools, docs -->

--- a/apps/daemon/assets/knowledge-templates/50-glossary.md
+++ b/apps/daemon/assets/knowledge-templates/50-glossary.md
@@ -1,0 +1,12 @@
+---
+type: glossary
+updated: {{DATE}}
+---
+
+# 团队术语表 / Team Glossary
+
+<!-- 团队内部黑话、缩写、领域术语的对照表 / Team jargon, abbreviations, and domain terms -->
+
+| 术语 / Term | 含义 / Meaning | 备注 / Notes |
+|---|---|---|
+| 示例 / Example | 术语的解释 / Definition | 补充说明 / Context |

--- a/apps/daemon/assets/knowledge-templates/_index.md
+++ b/apps/daemon/assets/knowledge-templates/_index.md
@@ -1,0 +1,23 @@
+---
+type: domain-index
+owner: ""            # 域负责人 / Domain owner
+updated: {{DATE}}
+---
+
+# {{DOMAIN_NAME}} / Domain
+
+<!-- 这个域是做什么的？边界在哪？/ What does this domain cover? Where are its boundaries? -->
+
+## 导航 / Navigation
+
+<!-- 人工维护的本域页面导航，不是自动列表 / Hand-maintained navigation, not auto-generated -->
+
+- 
+
+## 关键概念 / Key Concepts
+
+<!-- 理解这个域必须知道的 3-5 个概念 / 3-5 concepts needed to understand this domain -->
+
+## 相关域 / Related Domains
+
+<!-- 与哪些其他域有交互？/ Which other domains does this interact with? -->

--- a/apps/daemon/assets/knowledge-templates/adr-template.md
+++ b/apps/daemon/assets/knowledge-templates/adr-template.md
@@ -1,0 +1,33 @@
+---
+type: adr
+status: proposed     # proposed | accepted | deprecated | superseded
+updated: {{DATE}}
+---
+
+# ADR-NNNN: {{TITLE}}
+
+<!-- 一句话说清这个决定 / One sentence: what is being decided -->
+
+## 背景 / Context
+
+<!-- 为什么现在要做这个决定？约束是什么？/ Why now? What are the constraints? -->
+
+## 选项 / Options Considered
+
+### 选项 A / Option A
+
+- 优点 / Pros:
+- 缺点 / Cons:
+
+### 选项 B / Option B
+
+- 优点 / Pros:
+- 缺点 / Cons:
+
+## 结论 / Decision
+
+<!-- 选了哪个？为什么？/ Which option was chosen and why? -->
+
+## 后果 / Consequences
+
+<!-- 这个决定带来什么？好的和坏的 / What follows? Both positive and negative -->

--- a/apps/daemon/assets/knowledge-templates/knowledge.manifest.yaml
+++ b/apps/daemon/assets/knowledge-templates/knowledge.manifest.yaml
@@ -1,0 +1,13 @@
+# 知识库发布清单 / Knowledge base manifest
+# 详见 / See: docs/plans/2026-08-31-team-knowledge-base-program.md §3.3
+
+version: 1
+team: {{TEAM_ID}}
+title: {{TEAM_NAME}} 知识库 / Knowledge Base
+summary: ""          # 一句话简介 / One-line summary
+visibility: private  # private | org — 默认仅团队可见 / private by default
+domains: []          # 领域标签 / Domain tags, e.g. [支付, 清结算]
+entry: 00-home.md
+collections: []
+#  - name: 新人必读 / Onboarding
+#    paths: [00-home.md, 10-onboarding/, 50-glossary.md]

--- a/apps/daemon/assets/knowledge-templates/mcp-manifest.json
+++ b/apps/daemon/assets/knowledge-templates/mcp-manifest.json
@@ -1,0 +1,104 @@
+{
+  "schema": "teamclu-knowledge-mcp/v1",
+  "comment": "Tool manifest for the knowledge-base MCP bridge. Each entry maps one MCP tool to a daemon control-socket call. The bridge (sidecar / pi extension / any MCP host adapter) reads this and exposes the tools; the daemon handler at daemon::server::knowledge executes them against the active team's shared/knowledge/ vault.",
+  "socket": {
+    "path": "~/.amuxd/amuxd.sock",
+    "envelope": { "cmd": "knowledge", "action": "<action>", "...": "<tool args>" }
+  },
+  "tools": [
+    {
+      "name": "knowledge_scaffold",
+      "description": "Initialize the team knowledge vault with the standard directory tree (00-home, 10-onboarding, 20-domains, 30-decisions, 40-runbooks, 50-glossary, 90-archive, attachments) and bilingual (zh/en) templates. Idempotent — existing files are never overwritten. 初始化团队知识库的标准目录结构和双语模板；已存在的文件不会被覆盖。",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "team_name": { "type": "string", "description": "Display name stamped into 00-home.md / 写入 00-home.md 的团队显示名" }
+        }
+      },
+      "maps_to": { "action": "scaffold" }
+    },
+    {
+      "name": "knowledge_create",
+      "description": "Create a new vault page from a template. Refuses to overwrite an existing path — use knowledge_write to edit. 从模板新建页面；已存在则拒绝，改请用 knowledge_write。",
+      "inputSchema": {
+        "type": "object",
+        "required": ["path"],
+        "properties": {
+          "path": { "type": "string", "description": "Vault-relative path, e.g. 40-runbooks/push-outage.md" },
+          "template": { "type": "string", "enum": ["adr", "runbook", "domain-index", "page"] },
+          "title": { "type": "string" },
+          "content": { "type": "string", "description": "Page body; overrides the template when given / 提供时覆盖模板正文" }
+        }
+      },
+      "maps_to": { "action": "create" }
+    },
+    {
+      "name": "knowledge_write",
+      "description": "Write or replace a vault page. All paths are validated to stay inside the vault. 写入/覆盖页面，路径被限制在 vault 内。",
+      "inputSchema": {
+        "type": "object",
+        "required": ["path", "content"],
+        "properties": {
+          "path": { "type": "string" },
+          "content": { "type": "string" },
+          "title": { "type": "string" }
+        }
+      },
+      "maps_to": { "action": "write" }
+    },
+    {
+      "name": "knowledge_salvage",
+      "description": "Capture a conclusion from the current conversation into the vault as a salvage draft (00-salvage/<date>-<slug>.md with provenance frontmatter). Use when the user says something is worth keeping. 把对话中值得固化的结论存入知识库（打捞草稿）。",
+      "inputSchema": {
+        "type": "object",
+        "required": ["title", "content"],
+        "properties": {
+          "title": { "type": "string" },
+          "content": { "type": "string" },
+          "source": { "type": "string", "description": "Where this came from, e.g. 'chat', 'retro'" },
+          "session_id": { "type": "string" }
+        }
+      },
+      "maps_to": { "action": "salvage" }
+    },
+    {
+      "name": "knowledge_search",
+      "description": "Full-text search across the vault (SQLite FTS5, CJK-aware). Returns path, title and a highlighted snippet per hit. 对知识库全文检索（支持中文），返回路径、标题和高亮摘要。",
+      "inputSchema": {
+        "type": "object",
+        "required": ["query"],
+        "properties": {
+          "query": { "type": "string", "description": "Free text; whitespace-separated terms are ANDed / 空格分词，AND 语义" }
+        }
+      },
+      "maps_to": { "action": "search" }
+    },
+    {
+      "name": "knowledge_manifest_get",
+      "description": "Read knowledge.manifest.yaml (publish settings, collections). 读取发布清单。",
+      "inputSchema": { "type": "object", "properties": {} },
+      "maps_to": { "action": "manifest_get" }
+    },
+    {
+      "name": "knowledge_manifest_set",
+      "description": "Update publish settings. Changing visibility to 'org' REQUIRES confirm=true — publishing exposes the vault org-wide and is a considered action. 修改发布设置；把 visibility 改为 org 必须带 confirm=true。",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "visibility": { "type": "string", "enum": ["private", "org"] },
+          "summary": { "type": "string" },
+          "team": { "type": "string" },
+          "title": { "type": "string" },
+          "confirm": { "type": "boolean", "description": "Required when changing visibility / 变更可见性时必填" }
+        }
+      },
+      "maps_to": { "action": "manifest_set" }
+    },
+    {
+      "name": "knowledge_health",
+      "description": "Vault health stats: stale runbooks (last-verified overdue), stale pages (updated overdue), coverage checks. 知识库健康度：过期 runbook、过期页面、覆盖度检查。",
+      "inputSchema": { "type": "object", "properties": {} },
+      "maps_to": { "action": "health" }
+    }
+  ]
+}

--- a/apps/daemon/assets/knowledge-templates/runbook-template.md
+++ b/apps/daemon/assets/knowledge-templates/runbook-template.md
@@ -1,0 +1,31 @@
+---
+type: runbook
+owner: ""            # 维护人 / Maintainer
+last-verified: {{DATE}}   # 上次实际验证日期 / Last verified in practice
+---
+
+# {{TITLE}}
+
+<!-- 一句话：什么时候用这个手册 / One sentence: when to use this runbook -->
+
+## 前置条件 / Prerequisites
+
+<!-- 开始前必须满足的条件 / Conditions that must be true before starting -->
+
+## 步骤 / Steps
+
+<!-- 编号的操作步骤 / Numbered operational steps -->
+
+1. 
+
+## 验证 / Verification
+
+<!-- 怎么确认问题解决了？/ How to confirm the issue is resolved? -->
+
+## 回滚 / Rollback
+
+<!-- 如果步骤失败了怎么办？/ What to do if the steps fail? -->
+
+## 相关链接 / Related
+
+<!-- 相关 runbook、ADR、监控看板 / Related runbooks, ADRs, dashboards -->

--- a/apps/daemon/src/config/knowledge_scaffold.rs
+++ b/apps/daemon/src/config/knowledge_scaffold.rs
@@ -115,7 +115,9 @@ pub fn domain_index_template() -> &'static str {
     template_source("_index.md")
 }
 
-fn today_iso() -> String {
+/// Today as `YYYY-MM-DD` (UTC). Exposed for the knowledge MCP handlers
+/// (template stamping in `daemon::server::knowledge`).
+pub(crate) fn today_iso() -> String {
     // Avoid pulling in chrono for one date stamp; the daemon's MSRV and dep
     // tree are already heavy. A simple UTC date from SystemTime is fine here.
     use std::time::{SystemTime, UNIX_EPOCH};

--- a/apps/daemon/src/config/knowledge_scaffold.rs
+++ b/apps/daemon/src/config/knowledge_scaffold.rs
@@ -1,0 +1,187 @@
+//! Knowledge vault scaffold — generate the standard directory tree and
+//! bilingual (zh/en) templates for a team's `shared/knowledge/` vault.
+//!
+//! Layout and template rules follow
+//! `docs/plans/2026-08-31-team-knowledge-base-program.md` (§2.1, §2.2,
+//! Appendix C). Idempotent: existing files are never overwritten.
+
+use std::io;
+use std::path::{Path, PathBuf};
+
+/// Directories created (empty) by scaffold, relative to the knowledge root.
+const SCAFFOLD_DIRS: &[&str] = &[
+    "10-onboarding",
+    "20-domains",
+    "30-decisions",
+    "40-runbooks",
+    "70-vendors", // optional but common; empty dir is harmless
+    "90-archive",
+    "attachments",
+];
+
+/// Files written by scaffold, relative to the knowledge root.
+/// Each entry is (target path, template source under `assets/knowledge-templates/`).
+const SCAFFOLD_FILES: &[(&str, &str)] = &[
+    ("00-home.md", "00-home.md"),
+    ("50-glossary.md", "50-glossary.md"),
+    ("knowledge.manifest.yaml", "knowledge.manifest.yaml"),
+    ("30-decisions/adr-template.md", "adr-template.md"),
+    ("40-runbooks/runbook-template.md", "runbook-template.md"),
+];
+
+/// One scaffold outcome line, for logging / UI display.
+#[derive(Debug)]
+pub struct ScaffoldReport {
+    pub knowledge_root: PathBuf,
+    pub dirs_created: Vec<PathBuf>,
+    pub files_created: Vec<PathBuf>,
+    pub files_skipped: Vec<PathBuf>, // already existed
+}
+
+/// Scaffold the knowledge vault for `team_id`.
+///
+/// Creates the standard directory tree and writes bilingual templates for any
+/// file that doesn't already exist. `team_name` is interpolated into
+/// `{{TEAM_NAME}}` placeholders; `{{TEAM_ID}}` gets `team_id`;
+/// `{{DATE}}` gets today's ISO date.
+///
+/// Idempotent: re-running on an existing vault is a no-op for existing files.
+pub fn scaffold_knowledge(team_id: &str, team_name: &str) -> io::Result<ScaffoldReport> {
+    let root = super::global_team_store::sync_content_root(team_id).join("knowledge");
+    scaffold_at(&root, team_id, team_name)
+}
+
+/// Scaffold into an arbitrary root. Split from [`scaffold_knowledge`] so tests
+/// can point at a tempdir without touching `~/.amuxd`.
+pub fn scaffold_at(root: &Path, team_id: &str, team_name: &str) -> io::Result<ScaffoldReport> {
+    std::fs::create_dir_all(root)?;
+
+    let mut report = ScaffoldReport {
+        knowledge_root: root.to_path_buf(),
+        dirs_created: Vec::new(),
+        files_created: Vec::new(),
+        files_skipped: Vec::new(),
+    };
+
+    for dir in SCAFFOLD_DIRS {
+        let p = root.join(dir);
+        if !p.exists() {
+            std::fs::create_dir_all(&p)?;
+            report.dirs_created.push(p);
+        }
+    }
+
+    let today = today_iso();
+    for (target, template) in SCAFFOLD_FILES {
+        let p = root.join(target);
+        if p.exists() {
+            report.files_skipped.push(p);
+            continue;
+        }
+        if let Some(parent) = p.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let raw = template_source(template);
+        let content = raw
+            .replace("{{TEAM_ID}}", team_id)
+            .replace("{{TEAM_NAME}}", team_name)
+            .replace("{{DATE}}", &today);
+        std::fs::write(&p, content)?;
+        report.files_created.push(p);
+    }
+
+    Ok(report)
+}
+
+fn template_source(name: &str) -> &'static str {
+    match name {
+        "00-home.md" => include_str!("../../assets/knowledge-templates/00-home.md"),
+        "50-glossary.md" => include_str!("../../assets/knowledge-templates/50-glossary.md"),
+        "knowledge.manifest.yaml" => {
+            include_str!("../../assets/knowledge-templates/knowledge.manifest.yaml")
+        }
+        "adr-template.md" => include_str!("../../assets/knowledge-templates/adr-template.md"),
+        "runbook-template.md" => {
+            include_str!("../../assets/knowledge-templates/runbook-template.md")
+        }
+        "_index.md" => include_str!("../../assets/knowledge-templates/_index.md"),
+        _ => unreachable!("unknown knowledge template: {}", name),
+    }
+}
+
+/// The `_index.md` (domain MOC) template, exposed so callers can scaffold
+/// additional domains on demand without re-running the full scaffold.
+pub fn domain_index_template() -> &'static str {
+    template_source("_index.md")
+}
+
+fn today_iso() -> String {
+    // Avoid pulling in chrono for one date stamp; the daemon's MSRV and dep
+    // tree are already heavy. A simple UTC date from SystemTime is fine here.
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let secs = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    // Civil-from-days algorithm (Howard Hinnant)
+    let z = (secs / 86400) as i64 + 719468;
+    let era = if z >= 0 { z } else { z - 146096 } / 146097;
+    let doe = (z - era * 146097) as u64;
+    let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146096) / 365;
+    let y = yoe as i64 + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = doy - (153 * mp + 2) / 5 + 1;
+    let m = if mp < 10 { mp + 3 } else { mp - 9 };
+    let y = if m <= 2 { y + 1 } else { y };
+    format!("{:04}-{:02}-{:02}", y, m, d)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn scaffold_creates_tree_and_templates() {
+        let tmp = tempfile::tempdir().unwrap();
+        let report = scaffold_at(tmp.path(), "t1", "测试团队").unwrap();
+
+        assert!(tmp.path().join("10-onboarding").is_dir());
+        assert!(tmp.path().join("20-domains").is_dir());
+        assert!(tmp.path().join("attachments").is_dir());
+        assert!(tmp.path().join("00-home.md").is_file());
+        assert!(tmp.path().join("knowledge.manifest.yaml").is_file());
+        assert!(tmp.path().join("30-decisions/adr-template.md").is_file());
+        assert_eq!(report.files_created.len(), 5);
+        assert!(report.files_skipped.is_empty());
+
+        let home = std::fs::read_to_string(tmp.path().join("00-home.md")).unwrap();
+        assert!(home.contains("测试团队"));
+        assert!(home.contains("/ Knowledge Base"));
+
+        let manifest = std::fs::read_to_string(tmp.path().join("knowledge.manifest.yaml")).unwrap();
+        assert!(manifest.contains("visibility: private"));
+        assert!(manifest.contains("team: t1"));
+    }
+
+    #[test]
+    fn scaffold_is_idempotent() {
+        let tmp = tempfile::tempdir().unwrap();
+        scaffold_at(tmp.path(), "t1", "A").unwrap();
+        // User edits a file
+        std::fs::write(tmp.path().join("00-home.md"), "my edits").unwrap();
+        let report = scaffold_at(tmp.path(), "t1", "A").unwrap();
+        assert!(report.files_created.is_empty());
+        assert_eq!(report.files_skipped.len(), 5);
+        let home = std::fs::read_to_string(tmp.path().join("00-home.md")).unwrap();
+        assert_eq!(home, "my edits"); // not overwritten
+    }
+
+    #[test]
+    fn date_stamp_is_iso() {
+        let d = today_iso();
+        assert_eq!(d.len(), 10);
+        assert_eq!(&d[4..5], "-");
+        assert_eq!(&d[7..8], "-");
+    }
+}

--- a/apps/daemon/src/config/mod.rs
+++ b/apps/daemon/src/config/mod.rs
@@ -48,7 +48,6 @@ pub use roles_skills::{
     team_skill_roots, ManagedSkillDto, RoleRecordDto, RoleSkillLinkDto, RolesSkillsMetricsDto,
     RolesSkillsStateDto,
 };
-pub use knowledge_scaffold::{domain_index_template, scaffold_knowledge, ScaffoldReport};
 pub use session_store::{SessionBinding, SessionStore};
 pub use workspace_control::{
     decode_workspace_path, encode_workspace_path, AllowlistDecision, AllowlistRule, ApplyOutcome,

--- a/apps/daemon/src/config/mod.rs
+++ b/apps/daemon/src/config/mod.rs
@@ -2,6 +2,7 @@ mod daemon_config;
 pub mod device_mcp;
 pub mod edit;
 pub mod global_team_store;
+pub mod knowledge_scaffold;
 pub mod layout;
 mod member_store;
 mod model_catalog;
@@ -47,6 +48,7 @@ pub use roles_skills::{
     team_skill_roots, ManagedSkillDto, RoleRecordDto, RoleSkillLinkDto, RolesSkillsMetricsDto,
     RolesSkillsStateDto,
 };
+pub use knowledge_scaffold::{domain_index_template, scaffold_knowledge, ScaffoldReport};
 pub use session_store::{SessionBinding, SessionStore};
 pub use workspace_control::{
     decode_workspace_path, encode_workspace_path, AllowlistDecision, AllowlistRule, ApplyOutcome,

--- a/apps/daemon/src/daemon/server.rs
+++ b/apps/daemon/src/daemon/server.rs
@@ -49,6 +49,7 @@ mod peers_workspaces;
 mod remote_tools;
 mod rpc;
 mod skills_manage;
+mod knowledge;
 mod runtime_lifecycle;
 use crate::history::EventHistory;
 #[cfg(test)]
@@ -174,6 +175,8 @@ pub struct DaemonServer {
     refresh_watch_registry:
         Option<std::sync::Arc<crate::runtime::refresh::refresh_watch::RefreshWatchRegistry>>,
     refresh_coordinator: Option<Arc<crate::runtime::refresh::RuntimeRefreshCoordinator>>,
+    /// Applies skills-only refreshes once the workspace becomes idle.
+    refresh_auto_apply_task: Option<tokio::task::JoinHandle<()>>,
     /// Shared flag written by the MQTT event loop and read by `/v1/info`.
     mqtt_connected_flag: Option<Arc<std::sync::atomic::AtomicBool>>,
     /// Recovery signal receiver is installed into the supervisor exactly once.
@@ -326,6 +329,12 @@ pub(crate) enum SockCommand {
     },
     /// Agent-managed personal skill create/update/get from teamclu-introspect.
     SkillsManage {
+        payload: serde_json::Value,
+        reply_tx: oneshot::Sender<String>,
+    },
+    /// Knowledge-base MCP tools (scaffold / create / search) from the
+    /// agent-facing MCP bridge. Pure vault file ops on the active team.
+    Knowledge {
         payload: serde_json::Value,
         reply_tx: oneshot::Sender<String>,
     },
@@ -811,6 +820,7 @@ impl DaemonServer {
             cron_sessions: cron::CronSessionCache::new(),
             refresh_watch_registry: None,
             refresh_coordinator: None,
+            refresh_auto_apply_task: None,
             mqtt_connected_flag: None,
             managed_llm: Arc::new(crate::runtime::managed_llm::ManagedLlmResolver::new(
                 backend,
@@ -1130,6 +1140,8 @@ impl DaemonServer {
                 let mut manager = self.agents.lock().await;
                 manager.attach_refresh_coordinator(refresh_coordinator.clone());
             }
+            self.refresh_auto_apply_task =
+                Some(runtime_supervisor.clone().start_refresh_auto_applier());
             let runtime: Arc<dyn crate::http::runtime_adapter::RuntimeAdapter> =
                 crate::http::runtime_adapter::RuntimeManagerAdapter::new_with_execution_context_assembler(
                     self.agents.clone(),
@@ -1167,7 +1179,7 @@ impl DaemonServer {
                     self.backend.clone(),
                 ),
             ));
-            match crate::http::spawn(
+            match crate::http::spawn_with_refresh_watch_registry(
                 http_cfg,
                 meta,
                 runtime,
@@ -1186,6 +1198,7 @@ impl DaemonServer {
                 Some(local_rpc_tx),
                 Some(local_live_ingest_tx),
                 Some(team_skill_reconciler.clone()),
+                self.refresh_watch_registry.clone(),
                 Some(self.runtime_context.clone()),
                 session_prompt,
             )
@@ -1518,13 +1531,20 @@ impl DaemonServer {
             let reconciler = team_skill_reconciler.clone();
             let backend = Some(self.backend.clone());
             let refresh = self.refresh_coordinator.clone();
+            let refresh_watch_registry = self.refresh_watch_registry.clone();
             tokio::spawn(async move {
                 // Once at startup so a daemon that was offline while an admin
                 // made a change converges immediately rather than after a full
                 // interval.
                 let outcome = reconciler.reconcile_now(&team_id).await;
-                apply_team_skill_outcome(&team_id, outcome, backend.as_ref(), refresh.as_ref())
-                    .await;
+                apply_team_skill_outcome(
+                    &team_id,
+                    outcome,
+                    backend.as_ref(),
+                    refresh.as_ref(),
+                    refresh_watch_registry.as_ref(),
+                )
+                .await;
                 let mut tick = tokio::time::interval(crate::runtime::team_skills::TEAM_SKILLS_TTL);
                 tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
                 loop {
@@ -1536,8 +1556,14 @@ impl DaemonServer {
                     // every tick lands a few seconds short of the TTL and skips,
                     // silently halving the cadence to 20 minutes.
                     let outcome = reconciler.reconcile_now(&team_id).await;
-                    apply_team_skill_outcome(&team_id, outcome, backend.as_ref(), refresh.as_ref())
-                        .await;
+                    apply_team_skill_outcome(
+                        &team_id,
+                        outcome,
+                        backend.as_ref(),
+                        refresh.as_ref(),
+                        refresh_watch_registry.as_ref(),
+                    )
+                    .await;
                 }
             });
         }
@@ -1960,6 +1986,9 @@ impl DaemonServer {
                             }
                             Some(SockCommand::SkillsManage { payload, reply_tx }) => {
                                 self.handle_skills_manage(payload, reply_tx).await;
+                            }
+                            Some(SockCommand::Knowledge { payload, reply_tx }) => {
+                                self.handle_knowledge(payload, reply_tx).await;
                             }
                             Some(SockCommand::CursorPermission { payload, reply_tx }) => {
                                 tokio::spawn(async move {
@@ -2413,6 +2442,9 @@ impl DaemonServer {
                             }
                             Some(SockCommand::SkillsManage { payload, reply_tx }) => {
                                 self.handle_skills_manage(payload, reply_tx).await;
+                            }
+                            Some(SockCommand::Knowledge { payload, reply_tx }) => {
+                                self.handle_knowledge(payload, reply_tx).await;
                             }
                             Some(SockCommand::CursorPermission { payload, reply_tx }) => {
                                 tokio::spawn(async move {
@@ -2917,6 +2949,32 @@ where
                                 }
                                 Err(_) => {
                                     warn!("amuxd.sock: skills-manage reply dropped");
+                                }
+                            }
+                        } else if cmd == "knowledge" {
+                            let (reply_tx, reply_rx) = oneshot::channel();
+                            if tx
+                                .send(SockCommand::Knowledge {
+                                    payload: v,
+                                    reply_tx,
+                                })
+                                .await
+                                .is_err()
+                            {
+                                return;
+                            }
+                            match reply_rx.await {
+                                Ok(body) => {
+                                    let mut stream = reader.into_inner();
+                                    if let Err(e) = stream.write_all(body.as_bytes()).await {
+                                        warn!("amuxd.sock: knowledge write failed: {e}");
+                                        return;
+                                    }
+                                    let _ = stream.write_all(b"\n").await;
+                                    let _ = stream.shutdown().await;
+                                }
+                                Err(_) => {
+                                    warn!("amuxd.sock: knowledge reply dropped");
                                 }
                             }
                         } else if cmd == "cursor-permission" {
@@ -3826,6 +3884,7 @@ pub(crate) mod tests {
                 cron_sessions: cron::CronSessionCache::new(),
                 refresh_watch_registry: None,
                 refresh_coordinator: None,
+                refresh_auto_apply_task: None,
                 mqtt_connected_flag: None,
                 mqtt_recovery_rx: None,
                 mqtt_recovery_handle: crate::mqtt::MqttRecoveryHandle::channel().0,

--- a/apps/daemon/src/daemon/server/channels.rs
+++ b/apps/daemon/src/daemon/server/channels.rs
@@ -898,6 +898,9 @@ impl DaemonServer {
     /// when main returns; `amuxd stop` also calls `finalize_stop` as a safety net.
     pub(crate) async fn shutdown_for_exit(&mut self) {
         info!("daemon shutdown: draining channels and local runtimes");
+        if let Some(task) = self.refresh_auto_apply_task.take() {
+            task.abort();
+        }
         if let Some(handle) = self.http_handle.take() {
             handle.shutdown().await;
         }

--- a/apps/daemon/src/daemon/server/knowledge.rs
+++ b/apps/daemon/src/daemon/server/knowledge.rs
@@ -2,14 +2,20 @@
 //!
 //! Wire shape follows `skills-manage`: a JSON envelope
 //! `{ "cmd": "knowledge", "action": ..., ... }` on the daemon control socket,
-//! handled here as pure vault file operations. The agent-facing MCP server
-//! (sidecar / pi extension) is the transport that turns these into tools;
-//! this module is deliberately transport-agnostic.
+//! handled here as pure vault file operations. The agent-facing MCP manifest
+//! (`assets/knowledge-templates/mcp-manifest.json`) is the discovery surface
+//! that turns these into tools for MCP hosts; this module is deliberately
+//! transport-agnostic.
 //!
 //! Tool surface (docs/plans/2026-08-31-team-knowledge-base-program.md §附录 D):
-//! - `scaffold` — generate the standard vault tree + bilingual templates
-//! - `create`   — create one page from a template (adr / runbook / domain-index / page)
-//! - `search`   — filename + content search across the vault
+//! - `scaffold`      — generate the standard vault tree + bilingual templates
+//! - `create`        — create one page from a template (adr / runbook / domain-index / page)
+//! - `write`         — write or edit a page (overwrite, path-locked to the vault)
+//! - `salvage`       — capture a conversation conclusion into a vault page
+//! - `search`        — full-text search (SQLite FTS5 index under vault/.index/)
+//! - `manifest_get`  — read knowledge.manifest.yaml
+//! - `manifest_set`  — update manifest fields (visibility change needs confirm:true)
+//! - `health`        — freshness / coverage stats
 //!
 //! All writes are confined to the active team's `shared/knowledge/` root;
 //! path traversal outside the vault is rejected.
@@ -27,7 +33,12 @@ use crate::config::{
 use super::DaemonServer;
 
 const MAX_SEARCH_RESULTS: usize = 50;
-const MAX_SNIPPET_LEN: usize = 160;
+const SALVAGE_DIR: &str = "00-salvage";
+const FRESH_KINDS: &[&str] = &["runbook"];
+const STALE_DAYS_RUNBOOK: i64 = 90;
+const STALE_DAYS_UPDATED: i64 = 90;
+
+mod index;
 
 fn err(code: &str, message: impl Into<String>) -> String {
     json!({ "ok": false, "error": message.into(), "errorCode": code }).to_string()
@@ -107,14 +118,24 @@ impl DaemonServer {
         match action {
             "scaffold" => knowledge_scaffold(&root, &payload),
             "create" => knowledge_create(&root, &payload),
-            "search" => knowledge_search(&root, &payload),
+            "write" => knowledge_write(&root, &payload),
+            "salvage" => knowledge_salvage(&root, &payload),
+            "search" => index::search(&root, &payload),
+            "manifest_get" => manifest_get(&root),
+            "manifest_set" => manifest_set(&root, &payload),
+            "health" => health(&root),
             other => err(
                 "unknown_action",
-                format!("unknown knowledge action '{other}'; expected scaffold|create|search"),
+                format!(
+                    "unknown knowledge action '{other}'; expected \
+                     scaffold|create|write|salvage|search|manifest_get|manifest_set|health"
+                ),
             ),
         }
     }
 }
+
+// --- scaffold / create / write / salvage ---------------------------------
 
 fn knowledge_scaffold(root: &Path, payload: &Value) -> String {
     let team_id = layout::active_team();
@@ -130,10 +151,39 @@ fn knowledge_scaffold(root: &Path, payload: &Value) -> String {
     }
 }
 
-fn knowledge_create(root: &Path, payload: &Value) -> String {
-    let Some(kind) = str_field(payload, "kind") else {
-        return err("invalid_kind", "kind is required (adr | runbook | domain-index | page)");
+/// Build the page body for `create` / `salvage`. `template:` is optional;
+/// `content:` overrides the template body when given.
+fn page_body(
+    kind: &Option<Value>,
+    template: Option<&str>,
+    title: &str,
+    content: Option<&str>,
+    today: &str,
+) -> Result<String, String> {
+    let k = template.or(kind.as_ref().and_then(Value::as_str)).unwrap_or("page");
+    // A caller-supplied body always wins — the template is only the default.
+    if let Some(body) = content {
+        return Ok(format!("# {title}\n\n{body}\n"));
+    }
+    let raw = match k {
+        "adr" => include_str!("../../../assets/knowledge-templates/adr-template.md"),
+        "runbook" => include_str!("../../../assets/knowledge-templates/runbook-template.md"),
+        "domain-index" => domain_index_template(),
+        "page" => "# {{TITLE}}\n",
+        other => {
+            return Err(format!(
+                "unknown kind/template '{other}'; expected adr | runbook | domain-index | page"
+            ))
+        }
     };
+    Ok(raw.replace("{{TITLE}}", title).replace("{{DATE}}", today))
+}
+
+fn create_or_write(
+    root: &Path,
+    payload: &Value,
+    overwrite: bool,
+) -> String {
     let Some(path) = str_field(payload, "path") else {
         return err("invalid_path", "path is required (relative to the vault)");
     };
@@ -141,25 +191,20 @@ fn knowledge_create(root: &Path, payload: &Value) -> String {
         Ok(t) => t,
         Err(e) => return e,
     };
-    if target.exists() {
+    if !overwrite && target.exists() {
         return err(
             "already_exists",
             format!("'{path}' already exists; refusing to overwrite"),
         );
     }
     let title = str_field(payload, "title").unwrap_or("Untitled");
+    let content = str_field(payload, "content");
+    let template = str_field(payload, "template");
+    let kind = payload.get("kind").cloned();
     let today = today_iso();
-    let body = match kind {
-        "adr" => template_render(TemplateKind::Adr, title, &today),
-        "runbook" => template_render(TemplateKind::Runbook, title, &today),
-        "domain-index" => template_render(TemplateKind::DomainIndex, title, &today),
-        "page" => format!("# {title}\n"),
-        other => {
-            return err(
-                "invalid_kind",
-                format!("unknown kind '{other}'; expected adr | runbook | domain-index | page"),
-            )
-        }
+    let body = match page_body(&kind, template, title, content, &today) {
+        Ok(b) => b,
+        Err(e) => return err("invalid_kind", e),
     };
     if let Some(parent) = target.parent() {
         if let Err(e) = std::fs::create_dir_all(parent) {
@@ -167,70 +212,269 @@ fn knowledge_create(root: &Path, payload: &Value) -> String {
         }
     }
     match std::fs::write(&target, body) {
-        Ok(()) => ok(json!({ "created": target })),
+        Ok(()) => ok(json!({
+            "path": target
+                .strip_prefix(root)
+                .map(|p| p.to_string_lossy().into_owned())
+                .unwrap_or_else(|_| target.to_string_lossy().into_owned()),
+            "overwritten": overwrite && target.exists(),
+        })),
         Err(e) => err("write_failed", format!("write failed: {e}")),
     }
 }
 
-enum TemplateKind {
-    Adr,
-    Runbook,
-    DomainIndex,
+fn knowledge_create(root: &Path, payload: &Value) -> String {
+    create_or_write(root, payload, false)
 }
 
-fn template_render(kind: TemplateKind, title: &str, today: &str) -> String {
-    let raw = match kind {
-        TemplateKind::Adr => include_str!("../../../assets/knowledge-templates/adr-template.md"),
-        TemplateKind::Runbook => {
-            include_str!("../../../assets/knowledge-templates/runbook-template.md")
-        }
-        TemplateKind::DomainIndex => domain_index_template(),
-    };
-    raw.replace("{{TITLE}}", title).replace("{{DATE}}", today)
+fn knowledge_write(root: &Path, payload: &Value) -> String {
+    create_or_write(root, payload, true)
 }
 
-fn knowledge_search(root: &Path, payload: &Value) -> String {
-    let Some(query) = str_field(payload, "query") else {
-        return err("invalid_query", "query is required");
+fn knowledge_salvage(root: &Path, payload: &Value) -> String {
+    let Some(content) = str_field(payload, "content") else {
+        return err("invalid_content", "content is required for salvage");
     };
-    if !root.is_dir() {
-        // Not scaffolded yet — an empty result set is the honest answer.
-        return ok(json!({ "results": [], "vaultExists": false }));
+    let title = str_field(payload, "title").unwrap_or("salvaged-note");
+    let source = str_field(payload, "source").unwrap_or("unknown");
+    let session_id = str_field(payload, "session_id").unwrap_or("");
+    let today = today_iso();
+    let slug = slugify(title);
+    let path = format!("{SALVAGE_DIR}/{today}-{slug}.md");
+    let body = format!(
+        "---\ntype: salvage\nsource: {source}\nsession-id: {session_id}\nsalvaged: {today}\n---\n\n# {title}\n\n{content}\n"
+    );
+    let target = match resolve_in_vault(root, &path) {
+        Ok(t) => t,
+        Err(e) => return e,
+    };
+    if target.exists() {
+        return err("already_exists", format!("'{path}' already exists"));
     }
-    let needle = query.to_lowercase();
-    let mut results = Vec::new();
-    collect_md_files(root, root, &mut results);
-    let mut hits = Vec::new();
-    for (rel, abs) in results {
-        let rel_str = rel.to_string_lossy().to_string();
-        let mut matched_line: Option<(usize, String)> = None;
-        let name_hit = rel_str.to_lowercase().contains(&needle);
-        if let Ok(content) = std::fs::read_to_string(&abs) {
-            for (idx, line) in content.lines().enumerate() {
-                if line.to_lowercase().contains(&needle) {
-                    let mut snippet = line.trim().to_string();
-                    if snippet.len() > MAX_SNIPPET_LEN {
-                        snippet.truncate(MAX_SNIPPET_LEN);
-                        snippet.push('…');
-                    }
-                    matched_line = Some((idx + 1, snippet));
-                    break;
+    if let Some(parent) = target.parent() {
+        if let Err(e) = std::fs::create_dir_all(parent) {
+            return err("write_failed", format!("creating salvage dir failed: {e}"));
+        }
+    }
+    match std::fs::write(&target, body) {
+        Ok(()) => ok(json!({ "path": path })),
+        Err(e) => err("write_failed", format!("write failed: {e}")),
+    }
+}
+
+fn slugify(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for c in s.chars() {
+        if c.is_ascii_alphanumeric() {
+            out.push(c.to_ascii_lowercase());
+        } else if !c.is_whitespace() && !out.ends_with('-') && !out.is_empty() {
+            out.push('-');
+        }
+    }
+    let trimmed = out.trim_matches('-');
+    if trimmed.is_empty() {
+        "note".to_string()
+    } else {
+        trimmed.chars().take(48).collect()
+    }
+}
+
+// --- manifest (lenient YAML subset — the manifest is user-edited) ---------
+
+const MANIFEST: &str = "knowledge.manifest.yaml";
+
+fn manifest_get(root: &Path) -> String {
+    let path = root.join(MANIFEST);
+    let Ok(raw) = std::fs::read_to_string(&path) else {
+        return err(
+            "no_manifest",
+            "knowledge.manifest.yaml not found; run scaffold first",
+        );
+    };
+    ok(json!({ "raw": raw }))
+}
+
+fn manifest_set(root: &Path, payload: &Value) -> String {
+    let path = root.join(MANIFEST);
+    let Ok(mut raw) = std::fs::read_to_string(&path) else {
+        return err(
+            "no_manifest",
+            "knowledge.manifest.yaml not found; run scaffold first",
+        );
+    };
+    // Visibility flips demand an explicit confirm flag — an agent must not
+    // silently open the vault to the org (附录 D 安全约束).
+    if let Some(vis) = str_field(payload, "visibility") {
+        let confirm = payload
+            .get("confirm")
+            .and_then(Value::as_bool)
+            .unwrap_or(false);
+        if !confirm {
+            return err(
+                "confirm_required",
+                "visibility change requires confirm=true (publishing is a considered action)",
+            );
+        }
+        if vis != "private" && vis != "org" {
+            return err("invalid_value", "visibility must be 'private' or 'org'");
+        }
+        raw = replace_lenient_yaml_scalar(&raw, "visibility", vis);
+    }
+    if let Some(summary) = str_field(payload, "summary") {
+        raw = replace_lenient_yaml_scalar(&raw, "summary", summary);
+    }
+    if let Some(team) = str_field(payload, "team") {
+        raw = replace_lenient_yaml_scalar(&raw, "team", team);
+    }
+    if let Some(title) = str_field(payload, "title") {
+        raw = replace_lenient_yaml_scalar(&raw, "title", title);
+    }
+    match std::fs::write(&path, &raw) {
+        Ok(()) => ok(json!({ "written": MANIFEST })),
+        Err(e) => err("write_failed", format!("manifest write failed: {e}")),
+    }
+}
+
+/// Minimal line-based YAML scalar rewriter. Handles scalar values only —
+/// `version: 1`, `visibility: private`. List/map blocks pass through
+/// unchanged; users edit those by hand in Obsidian anyway.
+fn replace_lenient_yaml_scalar(raw: &str, key: &str, value: &str) -> String {
+    let mut next = Vec::with_capacity(raw.lines().count());
+    for line in raw.lines() {
+        if let Some((k, _)) = line.split_once(':') {
+            if k.trim() == key && !line.trim_start().starts_with('#') {
+                let indent = &line[..line.len() - line.trim_start().len()];
+                let formatted = if value.contains(&['"', '\'', '#', ':'][..]) || value.len() != value.trim().len() {
+                    format!("{indent}{key}: \"{value}\"")
+                } else {
+                    format!("{indent}{key}: {value}")
+                };
+                next.push(formatted);
+                continue;
+            }
+        }
+        next.push(line.to_string());
+    }
+    next.join("\n") + if raw.ends_with('\n') { "\n" } else { "" }
+}
+
+// --- health (freshness / coverage) -----------------------------------------
+
+fn health(root: &Path) -> String {
+    if !root.is_dir() {
+        return ok(json!({ "vaultExists": false }));
+    }
+    let mut files = Vec::new();
+    collect_md_files(root, root, &mut files);
+    let today = today_iso();
+    let mut stale_runbook = 0usize;
+    let mut stale_updated = 0usize;
+    let mut total = 0usize;
+    for (rel, abs) in &files {
+        total += 1;
+        let Ok(raw) = std::fs::read_to_string(abs) else { continue };
+        let (kind, owner, verified, updated) = parse_frontmatter(&raw);
+        let _ = owner;
+        let rel_str = rel.to_string_lossy();
+        let window = if FRESH_KINDS.contains(&kind.as_str()) {
+            STALE_DAYS_RUNBOOK
+        } else {
+            STALE_DAYS_UPDATED
+        };
+        let date = if kind == "runbook" {
+            verified.as_deref().or(updated.as_deref())
+        } else {
+            updated.as_deref()
+        };
+        if let Some(d) = date {
+            if days_between(d, &today).map(|n| n > window).unwrap_or(false) {
+                if kind == "runbook" {
+                    stale_runbook += 1;
+                } else {
+                    stale_updated += 1;
                 }
             }
         }
-        if name_hit || matched_line.is_some() {
-            hits.push(json!({
-                "path": rel_str,
-                "nameMatch": name_hit,
-                "line": matched_line.as_ref().map(|(n, _)| *n),
-                "snippet": matched_line.map(|(_, s)| s),
-            }));
-            if hits.len() >= MAX_SEARCH_RESULTS {
-                break;
+        let _ = rel_str;
+    }
+    let coverage = json!({
+        "hasHome": root.join("00-home.md").exists(),
+        "hasGlossary": root.join("50-glossary.md").exists(),
+        "hasManifest": root.join(MANIFEST).exists(),
+        "domainsDir": root.join("20-domains").is_dir(),
+    });
+    ok(json!({
+        "vaultExists": true,
+        "totalPages": total,
+        "staleRunbooks": stale_runbook,
+        "staleUpdatedPages": stale_updated,
+        "coverage": coverage,
+        "staleWindowDays": {
+            "runbook": STALE_DAYS_RUNBOOK,
+            "updated": STALE_DAYS_UPDATED,
+        },
+    }))
+}
+
+/// Pull (type, owner, last-verified, updated) out of a YAML frontmatter
+/// block. Absence of a block is fine — all four come back None.
+fn parse_frontmatter(raw: &str) -> (String, Option<String>, Option<String>, Option<String>) {
+    let mut kind = String::new();
+    let mut owner = None;
+    let mut verified = None;
+    let mut updated = None;
+    let mut lines = raw.lines();
+    if lines.next().map(|l| l.trim()) != Some("---") {
+        // runbook detection falls back to path-free inference in health();
+        // kind stays empty here.
+        let first = raw.lines().next().unwrap_or("");
+        if first.starts_with("#") {
+            return ("page".to_string(), None, None, None);
+        }
+        return (kind, owner, verified, updated);
+    }
+    for line in lines {
+        let line = line.trim();
+        if line == "---" {
+            break;
+        }
+        if let Some((k, v)) = line.split_once(':') {
+            let k = k.trim();
+            let v = v.trim().trim_matches('"');
+            match k {
+                "type" => kind = v.to_string(),
+                "owner" => owner = Some(v.to_string()),
+                "last-verified" => verified = Some(v.to_string()),
+                "updated" => updated = Some(v.to_string()),
+                _ => {}
             }
         }
     }
-    ok(json!({ "results": hits, "vaultExists": true }))
+    (kind, owner, verified, updated)
+}
+
+fn days_between(from: &str, to: &str) -> Option<i64> {
+    let from_days = iso_to_days(from)?;
+    let to_days = iso_to_days(to)?;
+    Some(to_days - from_days)
+}
+
+fn iso_to_days(s: &str) -> Option<i64> {
+    let mut it = s.split('-');
+    let y: i64 = it.next()?.parse().ok()?;
+    let m: i64 = it.next()?.parse().ok()?;
+    let d: i64 = it.next()?.trim_end_matches('"').parse().ok()?;
+    if !(1..=12).contains(&m) || !(1..=31).contains(&d) {
+        return None;
+    }
+    // Howard Hinnant's days-from-civil, inverse of today_iso.
+    let y_adj = if m <= 2 { y - 1 } else { y };
+    let era = if y_adj >= 0 { y_adj } else { y_adj - 399 } / 400;
+    let yoe = (y_adj - era * 400) as u64;
+    let (m_adj, d_adj) = if m > 2 { (m - 3, d) } else { (m + 9, d) };
+    let doy = (153 * (m_adj as u64) + 2) / 5 + (d_adj as u64) - 1;
+    let doc = yoe * 365 + yoe / 4 - yoe / 100 + doy;
+    Some(era * 146097 + doc as i64 - 719468)
 }
 
 fn collect_md_files(root: &Path, dir: &Path, out: &mut Vec<(PathBuf, PathBuf)>) {
@@ -239,8 +483,6 @@ fn collect_md_files(root: &Path, dir: &Path, out: &mut Vec<(PathBuf, PathBuf)>) 
     };
     for entry in entries.flatten() {
         let path = entry.path();
-        // Skip scaffold-internal and conflict sidecar trees — they are not
-        // user knowledge and would pollute results.
         let name = entry.file_name();
         let name = name.to_string_lossy();
         if name.starts_with('.') || name == "attachments" {
@@ -272,33 +514,79 @@ mod tests {
     }
 
     #[test]
-    fn search_finds_content_and_names() {
+    fn manifest_scalar_rewrite_preserves_lists() {
+        let raw = "version: 1\nvisibility: private\ncollections:\n  - name: x\n";
+        let next = replace_lenient_yaml_scalar(raw, "visibility", "org");
+        assert!(next.contains("visibility: org"));
+        assert!(next.contains("collections:"));
+        assert!(next.contains("  - name: x"));
+    }
+
+    #[test]
+    fn manifest_set_requires_confirm_for_visibility() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        std::fs::write(root.join(MANIFEST), "version: 1\nvisibility: private\n").unwrap();
+        let bad = manifest_set(root, &json!({ "visibility": "org" }));
+        assert!(bad.contains("confirm_required"));
+        let good = manifest_set(root, &json!({ "visibility": "org", "confirm": true }));
+        assert!(good.contains("\"ok\":true"));
+        let raw = std::fs::read_to_string(root.join(MANIFEST)).unwrap();
+        assert!(raw.contains("visibility: org"));
+    }
+
+    #[test]
+    fn frontmatter_parses_runbook_dates() {
+        let raw = "---\ntype: runbook\nowner: 老周\nlast-verified: 2026-06-01\n---\n\n# x\n";
+        let (kind, owner, verified, _updated) = parse_frontmatter(raw);
+        assert_eq!(kind, "runbook");
+        assert_eq!(owner.as_deref(), Some("老周"));
+        assert_eq!(verified.as_deref(), Some("2026-06-01"));
+    }
+
+    #[test]
+    fn days_between_handles_quotes_and_order() {
+        let raw = "---\ntype: runbook\nlast-verified: \"2026-06-01\"\n---\n";
+        let (_, _, verified, _) = parse_frontmatter(raw);
+        let today = "2026-09-04";
+        let n = days_between(verified.as_deref().unwrap(), today).unwrap();
+        assert!(n > 90);
+    }
+
+    #[test]
+    fn salvage_names_slug_and_dir() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        let payload = json!({
+            "title": "Push 文案公式",
+            "content": "标题 + 利益点 + 行动指令",
+            "source": "chat",
+        });
+        let reply = knowledge_salvage(root, &payload);
+        let v: Value = serde_json::from_str(&reply).unwrap();
+        assert_eq!(v["ok"], true);
+        let path = v["result"]["path"].as_str().unwrap();
+        assert!(path.starts_with("00-salvage/"));
+        assert!(path.ends_with(".md"));
+        let raw = std::fs::read_to_string(root.join(path)).unwrap();
+        assert!(raw.contains("type: salvage"));
+        assert!(raw.contains("source: chat"));
+    }
+
+    #[test]
+    fn health_counts_stale_runbooks() {
         let tmp = tempfile::tempdir().unwrap();
         let root = tmp.path();
         std::fs::create_dir_all(root.join("40-runbooks")).unwrap();
         std::fs::write(
-            root.join("40-runbooks/push-outage.md"),
-            "# Push outage\n\n检查渠道状态页 / Check the channel status page\n",
+            root.join("40-runbooks/old.md"),
+            "---\ntype: runbook\nlast-verified: 2026-01-01\n---\n# x\n",
         )
         .unwrap();
-        std::fs::write(root.join("00-home.md"), "# Home\nnothing here\n").unwrap();
-
-        let payload = json!({ "query": "渠道" });
-        let reply = knowledge_search(root, &payload);
+        std::fs::write(root.join("00-home.md"), "# Home\n").unwrap();
+        let reply = health(root);
         let v: Value = serde_json::from_str(&reply).unwrap();
         assert_eq!(v["ok"], true);
-        let results = v["result"]["results"].as_array().unwrap();
-        assert_eq!(results.len(), 1);
-        assert_eq!(results[0]["path"], "40-runbooks/push-outage.md");
-        assert!(results[0]["snippet"].as_str().unwrap().contains("渠道"));
-    }
-
-    #[test]
-    fn search_on_missing_vault_is_empty_not_error() {
-        let tmp = tempfile::tempdir().unwrap();
-        let reply = knowledge_search(&tmp.path().join("nope"), &json!({ "query": "x" }));
-        let v: Value = serde_json::from_str(&reply).unwrap();
-        assert_eq!(v["ok"], true);
-        assert_eq!(v["result"]["vaultExists"], false);
+        assert!(v["result"]["staleRunbooks"].as_u64().unwrap() >= 1);
     }
 }

--- a/apps/daemon/src/daemon/server/knowledge.rs
+++ b/apps/daemon/src/daemon/server/knowledge.rs
@@ -1,0 +1,304 @@
+//! Control-socket handler for knowledge-base MCP tools.
+//!
+//! Wire shape follows `skills-manage`: a JSON envelope
+//! `{ "cmd": "knowledge", "action": ..., ... }` on the daemon control socket,
+//! handled here as pure vault file operations. The agent-facing MCP server
+//! (sidecar / pi extension) is the transport that turns these into tools;
+//! this module is deliberately transport-agnostic.
+//!
+//! Tool surface (docs/plans/2026-08-31-team-knowledge-base-program.md §附录 D):
+//! - `scaffold` — generate the standard vault tree + bilingual templates
+//! - `create`   — create one page from a template (adr / runbook / domain-index / page)
+//! - `search`   — filename + content search across the vault
+//!
+//! All writes are confined to the active team's `shared/knowledge/` root;
+//! path traversal outside the vault is rejected.
+
+use std::path::{Path, PathBuf};
+
+use serde_json::{json, Value};
+
+use crate::config::{
+    global_team_store::sync_content_root,
+    knowledge_scaffold::{domain_index_template, scaffold_at, today_iso},
+    layout,
+};
+
+use super::DaemonServer;
+
+const MAX_SEARCH_RESULTS: usize = 50;
+const MAX_SNIPPET_LEN: usize = 160;
+
+fn err(code: &str, message: impl Into<String>) -> String {
+    json!({ "ok": false, "error": message.into(), "errorCode": code }).to_string()
+}
+
+fn ok(result: Value) -> String {
+    json!({ "ok": true, "result": result }).to_string()
+}
+
+/// The active team's vault root, or an error envelope when the daemon is
+/// unclaimed — knowledge is team-scoped by construction.
+fn vault_root() -> Result<PathBuf, String> {
+    let team_id = layout::active_team();
+    if team_id == layout::UNCLAIMED_TEAM {
+        return Err(err(
+            "no_team",
+            "daemon is not onboarded to a team; knowledge vault is team-scoped",
+        ));
+    }
+    Ok(sync_content_root(&team_id).join("knowledge"))
+}
+
+/// Resolve a caller-supplied relative path against the vault root, rejecting
+/// anything that escapes it.
+fn resolve_in_vault(root: &Path, rel: &str) -> Result<PathBuf, String> {
+    let rel = rel.trim();
+    if rel.is_empty() {
+        return Err(err("invalid_path", "path is required"));
+    }
+    let rel_path = Path::new(rel);
+    if rel_path.is_absolute() {
+        return Err(err("invalid_path", "path must be relative to the vault"));
+    }
+    let mut clean = PathBuf::new();
+    for comp in rel_path.components() {
+        match comp {
+            std::path::Component::Normal(part) => clean.push(part),
+            std::path::Component::CurDir => {}
+            _ => {
+                return Err(err(
+                    "invalid_path",
+                    "path must not contain '..' or other escapes",
+                ))
+            }
+        }
+    }
+    if clean.as_os_str().is_empty() {
+        return Err(err("invalid_path", "path is required"));
+    }
+    Ok(root.join(clean))
+}
+
+fn str_field<'a>(payload: &'a Value, key: &str) -> Option<&'a str> {
+    payload
+        .get(key)
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+}
+
+impl DaemonServer {
+    pub(crate) async fn handle_knowledge(
+        &self,
+        payload: Value,
+        reply_tx: tokio::sync::oneshot::Sender<String>,
+    ) {
+        let reply = self.handle_knowledge_inner(payload).await;
+        let _ = reply_tx.send(reply);
+    }
+
+    async fn handle_knowledge_inner(&self, payload: Value) -> String {
+        let action = str_field(&payload, "action").unwrap_or("");
+        let root = match vault_root() {
+            Ok(root) => root,
+            Err(e) => return e,
+        };
+        match action {
+            "scaffold" => knowledge_scaffold(&root, &payload),
+            "create" => knowledge_create(&root, &payload),
+            "search" => knowledge_search(&root, &payload),
+            other => err(
+                "unknown_action",
+                format!("unknown knowledge action '{other}'; expected scaffold|create|search"),
+            ),
+        }
+    }
+}
+
+fn knowledge_scaffold(root: &Path, payload: &Value) -> String {
+    let team_id = layout::active_team();
+    let name = str_field(payload, "team_name").unwrap_or(team_id.as_str());
+    match scaffold_at(root, &team_id, name) {
+        Ok(report) => ok(json!({
+            "knowledgeRoot": report.knowledge_root,
+            "dirsCreated": report.dirs_created,
+            "filesCreated": report.files_created,
+            "filesSkipped": report.files_skipped,
+        })),
+        Err(e) => err("scaffold_failed", format!("scaffold failed: {e}")),
+    }
+}
+
+fn knowledge_create(root: &Path, payload: &Value) -> String {
+    let Some(kind) = str_field(payload, "kind") else {
+        return err("invalid_kind", "kind is required (adr | runbook | domain-index | page)");
+    };
+    let Some(path) = str_field(payload, "path") else {
+        return err("invalid_path", "path is required (relative to the vault)");
+    };
+    let target = match resolve_in_vault(root, path) {
+        Ok(t) => t,
+        Err(e) => return e,
+    };
+    if target.exists() {
+        return err(
+            "already_exists",
+            format!("'{path}' already exists; refusing to overwrite"),
+        );
+    }
+    let title = str_field(payload, "title").unwrap_or("Untitled");
+    let today = today_iso();
+    let body = match kind {
+        "adr" => template_render(TemplateKind::Adr, title, &today),
+        "runbook" => template_render(TemplateKind::Runbook, title, &today),
+        "domain-index" => template_render(TemplateKind::DomainIndex, title, &today),
+        "page" => format!("# {title}\n"),
+        other => {
+            return err(
+                "invalid_kind",
+                format!("unknown kind '{other}'; expected adr | runbook | domain-index | page"),
+            )
+        }
+    };
+    if let Some(parent) = target.parent() {
+        if let Err(e) = std::fs::create_dir_all(parent) {
+            return err("write_failed", format!("creating parent dirs failed: {e}"));
+        }
+    }
+    match std::fs::write(&target, body) {
+        Ok(()) => ok(json!({ "created": target })),
+        Err(e) => err("write_failed", format!("write failed: {e}")),
+    }
+}
+
+enum TemplateKind {
+    Adr,
+    Runbook,
+    DomainIndex,
+}
+
+fn template_render(kind: TemplateKind, title: &str, today: &str) -> String {
+    let raw = match kind {
+        TemplateKind::Adr => include_str!("../../../assets/knowledge-templates/adr-template.md"),
+        TemplateKind::Runbook => {
+            include_str!("../../../assets/knowledge-templates/runbook-template.md")
+        }
+        TemplateKind::DomainIndex => domain_index_template(),
+    };
+    raw.replace("{{TITLE}}", title).replace("{{DATE}}", today)
+}
+
+fn knowledge_search(root: &Path, payload: &Value) -> String {
+    let Some(query) = str_field(payload, "query") else {
+        return err("invalid_query", "query is required");
+    };
+    if !root.is_dir() {
+        // Not scaffolded yet — an empty result set is the honest answer.
+        return ok(json!({ "results": [], "vaultExists": false }));
+    }
+    let needle = query.to_lowercase();
+    let mut results = Vec::new();
+    collect_md_files(root, root, &mut results);
+    let mut hits = Vec::new();
+    for (rel, abs) in results {
+        let rel_str = rel.to_string_lossy().to_string();
+        let mut matched_line: Option<(usize, String)> = None;
+        let name_hit = rel_str.to_lowercase().contains(&needle);
+        if let Ok(content) = std::fs::read_to_string(&abs) {
+            for (idx, line) in content.lines().enumerate() {
+                if line.to_lowercase().contains(&needle) {
+                    let mut snippet = line.trim().to_string();
+                    if snippet.len() > MAX_SNIPPET_LEN {
+                        snippet.truncate(MAX_SNIPPET_LEN);
+                        snippet.push('…');
+                    }
+                    matched_line = Some((idx + 1, snippet));
+                    break;
+                }
+            }
+        }
+        if name_hit || matched_line.is_some() {
+            hits.push(json!({
+                "path": rel_str,
+                "nameMatch": name_hit,
+                "line": matched_line.as_ref().map(|(n, _)| *n),
+                "snippet": matched_line.map(|(_, s)| s),
+            }));
+            if hits.len() >= MAX_SEARCH_RESULTS {
+                break;
+            }
+        }
+    }
+    ok(json!({ "results": hits, "vaultExists": true }))
+}
+
+fn collect_md_files(root: &Path, dir: &Path, out: &mut Vec<(PathBuf, PathBuf)>) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        // Skip scaffold-internal and conflict sidecar trees — they are not
+        // user knowledge and would pollute results.
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+        if name.starts_with('.') || name == "attachments" {
+            continue;
+        }
+        if path.is_dir() {
+            collect_md_files(root, &path, out);
+        } else if name.ends_with(".md") {
+            if let Ok(rel) = path.strip_prefix(root) {
+                out.push((rel.to_path_buf(), path.clone()));
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolve_in_vault_rejects_traversal() {
+        let root = Path::new("/vault");
+        assert!(resolve_in_vault(root, "../escape.md").is_err());
+        assert!(resolve_in_vault(root, "/abs/path.md").is_err());
+        assert!(resolve_in_vault(root, "a/../../b.md").is_err());
+        assert!(resolve_in_vault(root, "  ").is_err());
+        let ok = resolve_in_vault(root, "30-decisions/0001-x.md").unwrap();
+        assert_eq!(ok, root.join("30-decisions/0001-x.md"));
+    }
+
+    #[test]
+    fn search_finds_content_and_names() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        std::fs::create_dir_all(root.join("40-runbooks")).unwrap();
+        std::fs::write(
+            root.join("40-runbooks/push-outage.md"),
+            "# Push outage\n\n检查渠道状态页 / Check the channel status page\n",
+        )
+        .unwrap();
+        std::fs::write(root.join("00-home.md"), "# Home\nnothing here\n").unwrap();
+
+        let payload = json!({ "query": "渠道" });
+        let reply = knowledge_search(root, &payload);
+        let v: Value = serde_json::from_str(&reply).unwrap();
+        assert_eq!(v["ok"], true);
+        let results = v["result"]["results"].as_array().unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0]["path"], "40-runbooks/push-outage.md");
+        assert!(results[0]["snippet"].as_str().unwrap().contains("渠道"));
+    }
+
+    #[test]
+    fn search_on_missing_vault_is_empty_not_error() {
+        let tmp = tempfile::tempdir().unwrap();
+        let reply = knowledge_search(&tmp.path().join("nope"), &json!({ "query": "x" }));
+        let v: Value = serde_json::from_str(&reply).unwrap();
+        assert_eq!(v["ok"], true);
+        assert_eq!(v["result"]["vaultExists"], false);
+    }
+}

--- a/apps/daemon/src/daemon/server/knowledge/index.rs
+++ b/apps/daemon/src/daemon/server/knowledge/index.rs
@@ -1,0 +1,260 @@
+//! Full-text search over the knowledge vault via SQLite FTS5.
+//!
+//! The index lives at `<vault>/.index/fts.sqlite` — inside the vault root so
+//! it survives with the vault, but dot-prefixed so the sync scanner and the
+//! Obsidian file tree both ignore it (see `collect_md_files`'s dot-skip).
+//!
+//! Strategy: open-and-sync. Each `search` call first reconciles the index
+//! with the files currently on disk (cheap: we compare mtime per path),
+//! then runs the FTS query. The vault is a few hundred files at most, so a
+//! full reconcile is a few milliseconds; incremental updates keep it O(changed).
+//!
+//! Tokenizer: FTS5 `trigram`. `unicode61` treats a run of CJK ideographs as
+//! one token, so a query for 渠道 never matches 检查渠道状态页 — the exact
+//! query shape a Chinese-first vault produces. Trigram indexes 3-character
+//! substrings of every script, which gives real substring recall for both
+//! CJK and latin text at the cost of a larger index (fine at vault scale).
+//!
+//! Query path: terms shorter than 3 chars (every 2-char Chinese word —
+//! 渠道, 支付, 对账 — is one) can't trigram-match, so those go through a
+//! plain LIKE scan. Longer terms use FTS5 with ranking. Mixed queries AND
+//! both paths.
+
+use std::path::{Path, PathBuf};
+
+use rusqlite::{params, Connection};
+use serde_json::{json, Value};
+
+use super::{collect_md_files, err, ok, str_field, MAX_SEARCH_RESULTS};
+
+fn db_path(root: &Path) -> PathBuf {
+    root.join(".index").join("fts.sqlite")
+}
+
+fn open_db(root: &Path) -> Result<Connection, String> {
+    let path = db_path(root);
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|e| format!("creating index dir failed: {e}"))?;
+    }
+    let conn = Connection::open(&path).map_err(|e| format!("opening index failed: {e}"))?;
+    conn.pragma_update(None, "journal_mode", "wal")
+        .map_err(|e| format!("pragma failed: {e}"))?;
+    conn.execute_batch(
+        "CREATE TABLE IF NOT EXISTS files (
+            path TEXT PRIMARY KEY,
+            mtime INTEGER NOT NULL
+        );
+        CREATE VIRTUAL TABLE IF NOT EXISTS pages USING fts5(
+            path UNINDEXED,
+            title,
+            body,
+            tokenize = 'trigram'
+        );",
+    )
+    .map_err(|e| format!("schema failed: {e}"))?;
+    Ok(conn)
+}
+
+/// Reconcile the index with what's on disk. Returns (indexed, removed).
+fn sync_index(conn: &Connection, root: &Path) -> Result<(usize, usize), String> {
+    let mut files = Vec::new();
+    collect_md_files(root, root, &mut files);
+
+    let mut on_disk: std::collections::HashMap<String, i64> = std::collections::HashMap::new();
+    for (rel, abs) in &files {
+        let rel_str = rel.to_string_lossy().replace('\\', "/");
+        let mtime = abs
+            .metadata()
+            .and_then(|m| m.modified())
+            .ok()
+            .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+            .map(|d| d.as_secs() as i64)
+            .unwrap_or(0);
+        on_disk.insert(rel_str, mtime);
+    }
+
+    // Drop indexed rows for files that disappeared.
+    let mut removed = 0usize;
+    {
+        let mut stmt = conn
+            .prepare("SELECT path FROM files")
+            .map_err(|e| e.to_string())?;
+        let stale: Vec<String> = stmt
+            .query_map([], |r| r.get(0))
+            .map_err(|e| e.to_string())?
+            .filter_map(|r| r.ok())
+            .filter(|p| !on_disk.contains_key(p))
+            .collect();
+        for p in &stale {
+            conn.execute("DELETE FROM files WHERE path = ?1", params![p])
+                .map_err(|e| e.to_string())?;
+            conn.execute("DELETE FROM pages WHERE path = ?1", params![p])
+                .map_err(|e| e.to_string())?;
+            removed += 1;
+        }
+    }
+
+    // Reindex new or changed files.
+    let mut indexed = 0usize;
+    for (rel_str, mtime) in &on_disk {
+        let current: Option<i64> = conn
+            .query_row(
+                "SELECT mtime FROM files WHERE path = ?1",
+                params![rel_str],
+                |r| r.get(0),
+            )
+            .ok();
+        if current == Some(*mtime) {
+            continue;
+        }
+        let abs = root.join(rel_str);
+        let Ok(content) = std::fs::read_to_string(&abs) else {
+            continue;
+        };
+        let title = content
+            .lines()
+            .find(|l| l.starts_with("# "))
+            .map(|l| l.trim_start_matches('#').trim().to_string())
+            .unwrap_or_else(|| rel_str.clone());
+        conn.execute(
+            "INSERT OR REPLACE INTO files (path, mtime) VALUES (?1, ?2)",
+            params![rel_str, mtime],
+        )
+        .map_err(|e| e.to_string())?;
+        conn.execute("DELETE FROM pages WHERE path = ?1", params![rel_str])
+            .map_err(|e| e.to_string())?;
+        conn.execute(
+            "INSERT INTO pages (path, title, body) VALUES (?1, ?2, ?3)",
+            params![rel_str, title, content],
+        )
+        .map_err(|e| e.to_string())?;
+        indexed += 1;
+    }
+    Ok((indexed, removed))
+}
+
+pub(super) fn search(root: &Path, payload: &Value) -> String {
+    let Some(query) = str_field(payload, "query") else {
+        return err("invalid_query", "query is required");
+    };
+    if !root.is_dir() {
+        return ok(json!({ "results": [], "vaultExists": false }));
+    }
+    let conn = match open_db(root) {
+        Ok(c) => c,
+        Err(e) => return err("index_failed", e),
+    };
+    if let Err(e) = sync_index(&conn, root) {
+        return err("index_failed", e);
+    }
+    let terms: Vec<String> = query
+        .split_whitespace()
+        .map(|t| {
+            t.chars()
+                .filter(|c| c.is_alphanumeric() || *c == '_' || (*c as u32) > 0x2E7F)
+                .collect()
+        })
+        .filter(|s: &String| !s.is_empty())
+        .collect();
+    if terms.is_empty() {
+        return ok(json!({ "results": [], "vaultExists": true }));
+    }
+
+    // Every term must match (AND). Per term, FTS when it's long enough for the
+    // trigram index, LIKE otherwise — see the module docs for why.
+    let mut clauses = Vec::new();
+    let mut binds: Vec<String> = Vec::new();
+    let mut used_fts = false;
+    for t in &terms {
+        if t.chars().count() >= 3 {
+            clauses.push("pages MATCH ?".to_string());
+            binds.push(format!("\"{}\"", t.replace('"', "")));
+            used_fts = true;
+        } else {
+            clauses.push("body LIKE ?".to_string());
+            binds.push(format!("%{}%", t.replace('%', "").replace('_', "")));
+        }
+    }
+    let sql = format!(
+        "SELECT path, title, snippet(pages, 2, '<b>', '</b>', '…', 24) \
+         FROM pages WHERE {} LIMIT ?",
+        clauses.join(" AND ")
+    );
+    let mut stmt = match conn.prepare(&sql) {
+        Ok(s) => s,
+        Err(e) => return err("query_failed", e.to_string()),
+    };
+    let mut params: Vec<&dyn rusqlite::ToSql> =
+        binds.iter().map(|b| b as &dyn rusqlite::ToSql).collect();
+    let limit = MAX_SEARCH_RESULTS as i64;
+    params.push(&limit);
+    let rows = stmt.query_map(params.as_slice(), |r| {
+        Ok((
+            r.get::<_, String>(0)?,
+            r.get::<_, String>(1)?,
+            r.get::<_, String>(2)?,
+        ))
+    });
+    let mut hits = Vec::new();
+    match rows {
+        Ok(mapped) => {
+            for r in mapped.flatten() {
+                hits.push(json!({
+                    "path": r.0,
+                    "title": r.1,
+                    "snippet": r.2,
+                }));
+            }
+        }
+        Err(e) => return err("query_failed", e.to_string()),
+    }
+    ok(json!({
+        "results": hits,
+        "vaultExists": true,
+        "engine": if used_fts { "fts5+like" } else { "like" },
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn search_finds_cjk_and_english() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        std::fs::create_dir_all(root.join("40-runbooks")).unwrap();
+        std::fs::write(
+            root.join("40-runbooks/push-outage.md"),
+            "# Push outage\n\n检查渠道状态页 / Check the channel status page\n",
+        )
+        .unwrap();
+        std::fs::write(root.join("00-home.md"), "# Home\nnothing relevant\n").unwrap();
+
+        let v: Value = serde_json::from_str(&search(root, &json!({ "query": "渠道" }))).unwrap();
+        assert_eq!(v["ok"], true);
+        let results = v["result"]["results"].as_array().unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0]["path"], "40-runbooks/push-outage.md");
+
+        let v2: Value =
+            serde_json::from_str(&search(root, &json!({ "query": "channel status" }))).unwrap();
+        assert_eq!(v2["result"]["results"].as_array().unwrap().len(), 1);
+
+        // Re-run against the existing index — exercises the incremental path.
+        let v3: Value = serde_json::from_str(&search(root, &json!({ "query": "渠道" }))).unwrap();
+        assert_eq!(v3["result"]["results"].as_array().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn deleted_files_leave_the_index() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        std::fs::write(root.join("a.md"), "# alpha\n").unwrap();
+        let _: Value = serde_json::from_str(&search(root, &json!({ "query": "alpha" }))).unwrap();
+        std::fs::remove_file(root.join("a.md")).unwrap();
+        let v: Value = serde_json::from_str(&search(root, &json!({ "query": "alpha" }))).unwrap();
+        assert_eq!(v["result"]["results"].as_array().unwrap().len(), 0);
+    }
+}

--- a/apps/daemon/src/daemon/server/rpc.rs
+++ b/apps/daemon/src/daemon/server/rpc.rs
@@ -266,6 +266,8 @@ pub(crate) struct AgentManagementCtx {
     backend: Arc<dyn crate::backend::Backend>,
     reconciler: Arc<crate::runtime::team_skills::TeamSkillReconciler>,
     refresh: Option<Arc<crate::runtime::refresh::RuntimeRefreshCoordinator>>,
+    refresh_watch_registry:
+        Option<Arc<crate::runtime::refresh::refresh_watch::RefreshWatchRegistry>>,
     results: Arc<
         AsyncMutex<HashMap<String, (std::time::Instant, crate::proto::teamclu::RpcResponse)>>,
     >,
@@ -386,6 +388,7 @@ impl DaemonServer {
             backend: self.backend.clone(),
             reconciler: self.team_skill_reconciler.clone(),
             refresh: self.refresh_coordinator.clone(),
+            refresh_watch_registry: self.refresh_watch_registry.clone(),
             results: self.agent_management_results.clone(),
         }
     }
@@ -627,6 +630,7 @@ impl DaemonServer {
                         outcome,
                         Some(&ctx.backend),
                         ctx.refresh.as_ref(),
+                        ctx.refresh_watch_registry.as_ref(),
                     )
                     .await;
                 }
@@ -641,6 +645,7 @@ impl DaemonServer {
                         outcome,
                         Some(&ctx.backend),
                         ctx.refresh.as_ref(),
+                        ctx.refresh_watch_registry.as_ref(),
                     )
                     .await;
                 }
@@ -651,6 +656,7 @@ impl DaemonServer {
                         outcome,
                         Some(&ctx.backend),
                         ctx.refresh.as_ref(),
+                        ctx.refresh_watch_registry.as_ref(),
                     )
                     .await;
                 }

--- a/apps/daemon/src/daemon/server/runtime_lifecycle.rs
+++ b/apps/daemon/src/daemon/server/runtime_lifecycle.rs
@@ -237,6 +237,24 @@ impl DaemonServer {
             }
         }
 
+        // RuntimeStart's worktree is the directory OpenCode actually uses and
+        // therefore the authoritative target for cache invalidation.
+        if let Some(registry) = self.refresh_watch_registry.as_ref() {
+            let refresh_workspace_id = if ws_id.is_empty() {
+                crate::runtime::refresh::refresh_watch::workspace_runtime_id(Path::new(
+                    &resolved_worktree,
+                ))
+            } else {
+                ws_id.clone()
+            };
+            registry
+                .upsert_workspace(crate::runtime::refresh::refresh_watch::WatchedWorkspace {
+                    workspace_id: refresh_workspace_id,
+                    workspace_path: PathBuf::from(&resolved_worktree),
+                })
+                .await;
+        }
+
         // Invariant: a conversation has at most one live runtime *on this
         // daemon*. The daemon is a single actor/participant in the session, so
         // it must answer an @mention exactly once. Historically each desktop

--- a/apps/daemon/src/http/mod.rs
+++ b/apps/daemon/src/http/mod.rs
@@ -51,4 +51,4 @@ pub mod workspaces;
 mod routes;
 pub mod server;
 
-pub use server::{spawn, HttpHandle};
+pub use server::{spawn, spawn_with_refresh_watch_registry, HttpHandle};

--- a/apps/daemon/src/http/server.rs
+++ b/apps/daemon/src/http/server.rs
@@ -157,6 +157,51 @@ pub async fn spawn(
     register_workspace_tx: Option<crate::http::state::RegisterWorkspaceTx>,
     backend: Option<Arc<dyn Backend>>,
     live_tee: Option<tokio::sync::broadcast::Sender<super::live_events::LiveTeeEvent>>,
+    config_path: Option<std::path::PathBuf>,
+    channel_reload_tx: Option<tokio::sync::mpsc::Sender<()>>,
+    onboarding: Option<Arc<dyn crate::http::setup::OnboardingService>>,
+    local_rpc_tx: Option<crate::http::state::LocalRpcTx>,
+    local_live_ingest_tx: Option<crate::http::state::LocalLiveIngestTx>,
+    team_skills: Option<Arc<crate::runtime::team_skills::TeamSkillReconciler>>,
+    runtime_context: Option<Arc<crate::runtime::context_service::RuntimeContextService>>,
+    session_prompt: Option<Arc<crate::runtime::session_prompt::SessionPromptService>>,
+) -> anyhow::Result<HttpHandle> {
+    spawn_with_refresh_watch_registry(
+        http,
+        meta,
+        runtime,
+        workspace_control,
+        runtime_supervisor,
+        opencode_settings,
+        sync_dispatcher,
+        register_workspace_tx,
+        backend,
+        live_tee,
+        config_path,
+        channel_reload_tx,
+        onboarding,
+        local_rpc_tx,
+        local_live_ingest_tx,
+        team_skills,
+        None,
+        runtime_context,
+        session_prompt,
+    )
+    .await
+}
+
+#[allow(clippy::too_many_arguments)]
+pub async fn spawn_with_refresh_watch_registry(
+    http: HttpConfig,
+    meta: DaemonMetadata,
+    runtime: Arc<dyn RuntimeAdapter>,
+    workspace_control: Option<Arc<dyn WorkspaceControlStore>>,
+    runtime_supervisor: Option<Arc<crate::runtime::RuntimeSupervisor>>,
+    opencode_settings: Option<Arc<crate::opencode_settings::OpenCodeSettingsService>>,
+    sync_dispatcher: crate::sync::dispatch::SyncDispatcher,
+    register_workspace_tx: Option<crate::http::state::RegisterWorkspaceTx>,
+    backend: Option<Arc<dyn Backend>>,
+    live_tee: Option<tokio::sync::broadcast::Sender<super::live_events::LiveTeeEvent>>,
     // Daemon-level config surface (`/v1/config/*`, `/v1/setup/*`). All three are
     // `None` in focused tests, which makes those routes 503 rather than panic.
     config_path: Option<std::path::PathBuf>,
@@ -165,6 +210,9 @@ pub async fn spawn(
     local_rpc_tx: Option<crate::http::state::LocalRpcTx>,
     local_live_ingest_tx: Option<crate::http::state::LocalLiveIngestTx>,
     team_skills: Option<Arc<crate::runtime::team_skills::TeamSkillReconciler>>,
+    refresh_watch_registry: Option<
+        Arc<crate::runtime::refresh::refresh_watch::RefreshWatchRegistry>,
+    >,
     runtime_context: Option<Arc<crate::runtime::context_service::RuntimeContextService>>,
     session_prompt: Option<Arc<crate::runtime::session_prompt::SessionPromptService>>,
 ) -> anyhow::Result<HttpHandle> {
@@ -237,6 +285,7 @@ pub async fn spawn(
     .with_managed_llm(managed_llm)
     .with_team_cloud(team_cloud)
     .with_team_skills(team_skills)
+    .with_refresh_watch_registry(refresh_watch_registry)
     .with_local_rpc(local_rpc_tx)
     .with_local_live_ingest(local_live_ingest_tx);
     let state = if let Some(service) = runtime_context {

--- a/apps/daemon/src/http/state.rs
+++ b/apps/daemon/src/http/state.rs
@@ -134,6 +134,8 @@ pub struct HttpState {
     pub runtime_supervisor: Option<Arc<crate::runtime::RuntimeSupervisor>>,
     /// Workspace refresh state shared with `/v1/workspaces/:id/runtime*`.
     pub runtime_refresh: Option<Arc<crate::runtime::refresh::RuntimeRefreshCoordinator>>,
+    pub refresh_watch_registry:
+        Option<Arc<crate::runtime::refresh::refresh_watch::RefreshWatchRegistry>>,
     /// Loopback `opencode serve` pool for provider OAuth (settings only).
     pub opencode_settings: Option<Arc<crate::opencode_settings::OpenCodeSettingsService>>,
     /// Daemon-owned team sync dispatcher (drives `/v1/team/sync*`).
@@ -225,6 +227,7 @@ impl HttpState {
             workspace_control,
             runtime_supervisor,
             runtime_refresh,
+            refresh_watch_registry: None,
             opencode_settings,
             sync_dispatcher,
             register_workspace_tx,
@@ -305,6 +308,14 @@ impl HttpState {
         team_skills: Option<Arc<crate::runtime::team_skills::TeamSkillReconciler>>,
     ) -> Self {
         self.team_skills = team_skills;
+        self
+    }
+
+    pub fn with_refresh_watch_registry(
+        mut self,
+        registry: Option<Arc<crate::runtime::refresh::refresh_watch::RefreshWatchRegistry>>,
+    ) -> Self {
+        self.refresh_watch_registry = registry;
         self
     }
 

--- a/apps/daemon/src/http/team_sync.rs
+++ b/apps/daemon/src/http/team_sync.rs
@@ -398,6 +398,7 @@ async fn reconcile_team_skills_for_state(
         outcome,
         state.backend.as_ref(),
         state.runtime_refresh.as_ref(),
+        state.refresh_watch_registry.as_ref(),
     )
     .await;
     Ok(Json(TeamSkillReconcileResponse { team_id, outcome }))

--- a/apps/daemon/src/runtime/refresh_watch.rs
+++ b/apps/daemon/src/runtime/refresh_watch.rs
@@ -98,10 +98,12 @@ impl RefreshWatchRegistry {
     }
 
     pub async fn upsert_workspace(&self, workspace: WatchedWorkspace) {
-        self.workspaces
-            .write()
-            .await
-            .insert(workspace.workspace_path.clone(), workspace);
+        let mut workspaces = self.workspaces.write().await;
+        workspaces.retain(|path, existing| {
+            path == &workspace.workspace_path || existing.workspace_id != workspace.workspace_id
+        });
+        workspaces.insert(workspace.workspace_path.clone(), workspace);
+        drop(workspaces);
         self.changed.notify_one();
     }
 
@@ -110,7 +112,7 @@ impl RefreshWatchRegistry {
         self.changed.notify_one();
     }
 
-    async fn snapshot(&self) -> Vec<WatchedWorkspace> {
+    pub(crate) async fn snapshot(&self) -> Vec<WatchedWorkspace> {
         self.workspaces.read().await.values().cloned().collect()
     }
 
@@ -868,6 +870,22 @@ mod tests {
         assert_eq!(
             registry.workspace_paths().await,
             vec![PathBuf::from("/tmp/ws-2")]
+        );
+    }
+
+    #[tokio::test]
+    async fn watch_registry_replaces_stale_path_for_same_workspace_id() {
+        let registry = RefreshWatchRegistry::new(Vec::new());
+        registry
+            .upsert_workspace(watched_workspace("ws-1", "/tmp/cloud-path"))
+            .await;
+        registry
+            .upsert_workspace(watched_workspace("ws-1", "/tmp/runtime-path"))
+            .await;
+
+        assert_eq!(
+            registry.workspace_paths().await,
+            vec![PathBuf::from("/tmp/runtime-path")]
         );
     }
 

--- a/apps/daemon/src/runtime/team_skills.rs
+++ b/apps/daemon/src/runtime/team_skills.rs
@@ -317,51 +317,81 @@ pub async fn apply_team_skill_outcome(
     outcome: TeamSkillReconcileOutcome,
     backend: Option<&Arc<dyn Backend>>,
     refresh: Option<&Arc<crate::runtime::refresh::RuntimeRefreshCoordinator>>,
+    refresh_watch_registry: Option<
+        &Arc<crate::runtime::refresh::refresh_watch::RefreshWatchRegistry>,
+    >,
 ) {
     if !outcome.changed() {
         return;
     }
-    let (Some(refresh), Some(backend)) = (refresh, backend) else {
+    let Some(refresh) = refresh else {
         return;
     };
 
-    let rows = match backend
-        .get_workspaces_by_agent(team_id, backend.actor_id())
-        .await
-    {
-        Ok(rows) => rows,
-        Err(e) => {
-            tracing::warn!(
+    let mut cloud_targets = Vec::new();
+    if let Some(backend) = backend {
+        match backend
+            .get_workspaces_by_agent(team_id, backend.actor_id())
+            .await
+        {
+            Ok(rows) => {
+                for row in rows {
+                    let Some((path, _)) =
+                        crate::config::workspace_path::listable_local_workspace(&row)
+                    else {
+                        continue;
+                    };
+                    cloud_targets.push(crate::runtime::refresh::refresh_watch::WatchedWorkspace {
+                        workspace_id: row.id,
+                        workspace_path: PathBuf::from(path),
+                    });
+                }
+            }
+            Err(e) => tracing::warn!(
                 team_id,
                 error = %e,
-                "team skills changed but workspace list failed; skipping refresh fan-out"
-            );
-            return;
+                "team skills changed but cloud workspace list failed; using runtime refresh targets"
+            ),
         }
-    };
+    }
 
-    for row in rows {
-        let Some((path, _)) = crate::config::workspace_path::listable_local_workspace(&row) else {
-            continue;
-        };
-        let workspace_path = PathBuf::from(&path);
-        let workspace_id = row.id;
+    let runtime_targets = match refresh_watch_registry {
+        Some(registry) => registry.snapshot().await,
+        None => Vec::new(),
+    };
+    for target in merge_refresh_targets(cloud_targets, runtime_targets) {
         if let Err(error) = refresh
             .record_change(
-                &workspace_id,
-                &workspace_path,
+                &target.workspace_id,
+                &target.workspace_path,
                 crate::runtime::refresh::RefreshChangeKind::Skills,
                 crate::runtime::refresh::RefreshSource::UiMutation,
             )
             .await
         {
             tracing::warn!(
-                workspace_id,
+                workspace_id = target.workspace_id,
+                workspace_path = %target.workspace_path.display(),
                 error = %error,
                 "failed to record skills refresh after team skill reconcile"
             );
         }
     }
+}
+
+fn merge_refresh_targets(
+    cloud_targets: Vec<crate::runtime::refresh::refresh_watch::WatchedWorkspace>,
+    runtime_targets: Vec<crate::runtime::refresh::refresh_watch::WatchedWorkspace>,
+) -> Vec<crate::runtime::refresh::refresh_watch::WatchedWorkspace> {
+    let mut by_workspace_id = HashMap::new();
+    // Runtime targets are inserted last: RuntimeStart's effective path wins
+    // over a stale cloud path for the same workspace identity.
+    for target in cloud_targets.into_iter().chain(runtime_targets) {
+        by_workspace_id.insert(target.workspace_id.clone(), target);
+    }
+    let mut targets: Vec<_> = by_workspace_id.into_values().collect();
+    targets.sort_by(|a, b| a.workspace_id.cmp(&b.workspace_id));
+    targets
 }
 
 /// Which packs are in this root, and at what version, from each pack's own
@@ -519,5 +549,53 @@ mod tests {
 
         assert!(target.join("SKILL.md").is_file());
         assert!(!tmp.path().join("escaped.md").exists());
+    }
+
+    #[test]
+    fn runtime_refresh_target_overrides_stale_cloud_path() {
+        use crate::runtime::refresh::refresh_watch::WatchedWorkspace;
+
+        let targets = merge_refresh_targets(
+            vec![WatchedWorkspace {
+                workspace_id: "ws-1".into(),
+                workspace_path: PathBuf::from("/tmp/stale-cloud-path"),
+            }],
+            vec![WatchedWorkspace {
+                workspace_id: "ws-1".into(),
+                workspace_path: PathBuf::from("/tmp/actual-runtime-path"),
+            }],
+        );
+        assert_eq!(
+            targets[0].workspace_path,
+            Path::new("/tmp/actual-runtime-path")
+        );
+    }
+
+    #[tokio::test]
+    async fn team_skill_change_refreshes_runtime_target_without_cloud_inventory() {
+        use crate::runtime::refresh::refresh_watch::{RefreshWatchRegistry, WatchedWorkspace};
+
+        let registry = RefreshWatchRegistry::new(vec![WatchedWorkspace {
+            workspace_id: "ws-runtime".into(),
+            workspace_path: PathBuf::from("/tmp/actual-runtime-path"),
+        }]);
+        let refresh = crate::runtime::refresh::RuntimeRefreshCoordinator::new();
+        apply_team_skill_outcome(
+            "team-1",
+            TeamSkillReconcileOutcome {
+                installed: 1,
+                removed: 0,
+            },
+            None,
+            Some(&refresh),
+            Some(&registry),
+        )
+        .await;
+
+        let state = refresh.workspace_state("ws-runtime").await.unwrap();
+        assert_eq!(state.workspace_path, "/tmp/actual-runtime-path");
+        assert!(state
+            .change_kinds
+            .contains(&crate::runtime::refresh::RefreshChangeKind::Skills));
     }
 }

--- a/docs/plans/2026-08-31-team-knowledge-base-program.md
+++ b/docs/plans/2026-08-31-team-knowledge-base-program.md
@@ -1,0 +1,561 @@
+# 公司级知识库建设方案（Team Knowledge Base Program）
+
+> 状态：草案 v1
+> 日期：2026-08-31
+> 范围：指导公司内部不同团队基于 TeamClu 建立并运营各自的知识库，
+> 并支持跨团队的知识发现与复用。
+
+## 0. 为什么是现在
+
+TeamClu 已经具备了知识库的底层骨架：
+
+- **团队 Markdown vault + 云副本**：`~/.amuxd/teams/<id>/shared/knowledge/`
+  通过 amuxd → FC `/sync/*` → OSS 同步，明文、秒级推送（ADR-0008）。
+- **Obsidian 直接打开**：wiki link、`[[...]]` 解析、附件目录预置都已落地
+  （`docs/architecture/obsidian-compatible-knowledge.md`）。
+- **RAG 消费**：桌面端 Tantivy 索引，agent 回复时可以直接引用 vault 内容。
+- **冲突治理**：`.conflicts/` sidecar + 冲突决策视图 + 云版本只读视图
+  （`packages/app/src/lib/tabs/knowledge-tabs.ts`）。
+
+缺的不是「能不能存」，而是「**怎么组织、怎么流转、怎么让大家愿意写**」。
+本文档就是那个答案。
+
+## 1. 定位与边界
+
+**是什么**：每个团队一个 Obsidian 兼容的 Markdown vault，作为该团队的
+「唯一事实来源」（single source of truth）。TeamClu 负责同步、检索、
+AI 消费、权限边界；Obsidian（或任何 Markdown 编辑器）负责写作体验。
+
+**不是什么**：
+
+- 不是 Notion 式协作文档——不做行级 merge，冲突走 `.conflicts/` 人工决策。
+- 不是通用网盘——二进制大文件走对象存储引用，不进 vault。
+- 不是 IM 聊天记录归档——聊天是过程，知识库是结论。
+
+## 2. 信息架构：三层模型
+
+```
+┌─────────────────────────────────────────────────────────┐
+│  L3 公司级发现层  — 知识目录 / 搜索门户 / 精选集合         │
+│      （跨团队索引 + 推荐，只读聚合，不回写）                 │
+├─────────────────────────────────────────────────────────┤
+│  L2 团队 vault   — 每个团队的 knowledge/                  │
+│      （写作、评审、发布的唯一场所）                          │
+├─────────────────────────────────────────────────────────┤
+│  L1 个人草稿层   — 会话记录 / 临时笔记 / AI 对话            │
+│      （低门槛捕获，定期「打捞」进 L2）                       │
+└─────────────────────────────────────────────────────────┘
+```
+
+关键规则：**知识只能向上流动**。L1 → L2 靠「打捞」（人工或 AI 辅助），
+L2 → L3 靠「发布」（manifest 声明）。不存在跨团队直接编辑别人 vault 的情况。
+
+### 2.1 团队 vault 的标准目录结构
+
+每个团队的 `knowledge/` 都遵循同一套骨架（`scaffold` 命令一键生成）：
+
+```
+knowledge/
+├── 00-home.md            # 团队门户：我们是谁 / 做什么 / 常用入口
+├── 10-onboarding/        # 新人入职：环境搭建、第一周清单、FAQ
+├── 20-domains/           # 业务域知识：一个子域一个目录
+│   └── <domain>/
+│       ├── _index.md     # 该域的导航页（Obsidian MOC）
+│       └── ...
+├── 30-decisions/         # ADR：重要决策的来龙去脉
+├── 40-runbooks/          # 运维手册：告警处理、发布流程、应急预案
+├── 50-glossary.md        # 团队术语表（黑话翻译器）
+├── 90-archive/           # 失效内容，只读保留
+├── attachments/          # 图片 / PDF / 表格
+└── knowledge.manifest.yaml  # 发布清单 + 分类标签（见 §4.2）
+```
+
+为什么是数字前缀：Obsidian 文件管理器按名称排序，数字前缀让结构
+在原生文件树里也是自解释的，不依赖任何插件。
+
+### 2.2 三种标准页面类型
+
+每种类型对应一个模板（`templates/` 目录内置）：
+
+**域索引页（_index.md / MOC）**
+回答「这个域有什么」。人工维护的导航，不是自动生成的列表。
+开头必须有 frontmatter：`type: domain-index, owner: @xxx, updated: YYYY-MM-DD`。
+
+**决策记录（30-decisions/*.md）**
+回答「当时为什么这么做」。格式轻量：背景 → 选项 → 结论 → 后果。
+一旦合并不再大改，修正写新 ADR 并互链。
+
+**运行手册（40-runbooks/*.md）**
+回答「出事了怎么办」。面向执行：前置条件 → 步骤 → 验证 → 回滚。
+每篇必须有 `last-verified:` 字段，超过 90 天未验证会在 UI 里标黄。
+
+## 3. 工作流：知识的生命周期
+
+### 3.1 捕获（L1 → L2）
+
+降低写的第一道门槛：
+
+- **会话打捞**：在 TeamClu 聊天里选中一段 AI 回复或讨论结论，
+  右键「存到知识库」→ 选目标目录 → 自动生成带上下文链接的草稿。
+- **每日打捞提醒**：daemon 扫描当天的「想法」会话，把被 👍 或
+  被标记的片段汇总成一条待办推到「等待我」。
+- **Obsidian 直接写**：主写入面，TeamClu 负责秒级同步给队友。
+
+### 3.2 评审与固化（L2 内部）
+
+- **轻量评审**：非 runbook/ADR 类页面，作者自己发，队友看到问题直接改
+  （wiki 精神）。runbook/ADR 需要在 PR 或团队周会上过一遍。
+- **owner 制度**：每个 `20-domains/<domain>/` 有明确 owner（写在
+  `_index.md` frontmatter），负责该域的整洁，不是唯一作者。
+- ** freshness 信号**：`updated` 和 `last-verified` 字段驱动 UI 上的
+   freshness 标记（绿/黄/灰），让读者一眼判断可信度。
+
+### 3.3 发布（L2 → L3）
+
+团队决定哪些内容对公司其他团队可见：
+
+```yaml
+# knowledge.manifest.yaml
+version: 1
+team: payment-infra
+title: 支付基础设施团队知识库
+summary: 支付链路、清结算、对账、渠道接入的领域知识与运维手册
+visibility: org            # private | org
+domains: [支付, 清结算, 对账]
+entry: 00-home.md
+collections:
+  - name: 新人必读
+    paths: [00-home.md, 10-onboarding/, 50-glossary.md]
+  - name: 值班手册
+    paths: [40-runbooks/]
+```
+
+FC 读取 manifest，把声明了 `visibility: org` 的 vault 纳入跨团队索引。
+**未声明的默认 private**，只有团队成员可见。
+
+### 3.4 消费
+
+- **团队内**：TeamClu RAG 直接检索本团队 vault；Obsidian 全文搜索。
+- **跨团队**：公司知识门户（搜索 + 目录浏览 + 精选集合），只读。
+  引用他团队内容时用 `[[team:payment-infra/40-runbooks/xxx]]` 形式的
+  跨 vault 链接，点击后请求只读副本。
+- **AI agent**：agent 回答时优先引用本团队 vault；跨团队内容作为
+  补充上下文，回答中标注来源团队。
+
+## 4. 跨团队共享机制
+
+### 4.1 原则：有边界的开放
+
+- 默认 **team-private**：降低写作者的心理负担（不怕写得糙被全公司看）。
+- 显式 **org-visible**：团队主动发布成熟内容，质量自我把关。
+- **不建全公司大熔炉 vault**：所有权模糊的地方，内容必然腐烂。
+
+### 4.2 知识目录（Knowledge Catalog）
+
+FC 侧的只读聚合服务：
+
+- 每个 org-visible vault 上报：元信息（团队、简介、domains）、
+  条目清单（标题 + 摘要 + 更新时间）、精选集合。
+- 提供 `/v1/catalog/teams`、`/v1/catalog/search` 两个端点
+  （加入 `docs/openapi/teamclu-api.v1.yaml`）。
+- 客户端入口：侧边栏「发现」分组 + 搜索框下的「跨团队知识」tab。
+
+### 4.3 依赖他团队知识的正确姿势
+
+- 想引用 → 用跨 vault 链接，保持单一来源。
+- 想修改 → 去对方团队提需求/PR，不在本地复制副本。
+- 对方内容不够用 → 那是对方 backlog 的信号，不是自己开副本的信号。
+
+## 5. 治理与运营
+
+### 5.1 角色
+
+| 角色 | 职责 | 投入 |
+|---|---|---|
+| 团队 Knowledge Champion | 结构整洁、模板落地、打捞提醒跟进 | 每周 ~1h |
+| Domain Owner | 自己域的内容质量与 freshness | 随工作自然发生 |
+| 公司级协调人（可选） | 维护 catalog、跨团队重复内容仲裁 | 每月 ~2h |
+
+### 5.2 健康度指标（自动统计）
+
+- **覆盖度**：每个 domain 是否有 `_index.md`；新人 onboarding 路径是否完整。
+- **新鲜度**：`last-verified` 超期的 runbook 占比；90 天未更新页面占比。
+- **使用度**：RAG 引用次数（哪些页面真的被 agent / 人用到）。
+- **打捞率**：L1 标记内容有多少最终进入了 L2。
+
+指标展示在团队设置页，不排名、不考核，只用于自我诊断。
+
+### 5.3  onboarding 一个团队的 checklist
+
+1. `teamclu knowledge scaffold` 生成标准目录 + 模板。
+2. 团队负责人填 `00-home.md` 和 `knowledge.manifest.yaml`。
+3. 指定 1 个 champion + 每个 domain 一个 owner。
+4. 第一周：迁移现有散落文档（飞书/Confluence/本地 md）进 `20-domains/`。
+5. 第二周：写第一篇 ADR 和第一篇 runbook（从最近的真实事件取材）。
+6. 第三周：开一次 30 分钟评审会，过一遍结构，发布 manifest。
+
+## 6. 技术落地路线
+
+依赖已落地的 P0/P1 同步工作（ADR-0008），分三期：
+
+**P2 — 团队内可用（2-3 周）**
+- `scaffold` 命令 + 三套模板（MOC / ADR / runbook）。
+- 聊天「存到知识库」右键 + 打捞汇总。
+- freshness 字段解析 + UI 标记。
+
+**P3 — 跨团队发现（3-4 周）**
+- `knowledge.manifest.yaml` schema + FC catalog 端点。
+- 客户端「发现」页 + 跨团队只读浏览。
+- 跨 vault 链接解析与跳转。
+
+**P4 — 运营闭环（2 周）**
+- 健康度统计 pipeline + 团队设置页 dashboard。
+- RAG 引用埋点 → 使用度指标。
+
+## 7. 风险与对策
+
+| 风险 | 对策 |
+|---|---|
+| 写完没人看 | 优先打通 RAG 消费——知识被 agent 引用是最强的正反馈 |
+| 结构僵化没人维护 | 结构是脚手架不是法律；champion 每月可重组，ADR 记录理由 |
+| 变成第二个文档坟场 | freshness 标记 + 使用度指标让腐烂可见；archive 目录降低删除心理门槛 |
+| 跨团队内容重复 | catalog 暴露重复信号；仲裁靠公司协调人，不靠工具强制 |
+| 敏感信息误发布 | manifest 默认 private；发布动作需要在团队内二次确认 |
+
+---
+
+## 附录 A：一个产品运营团队的完整示例
+
+以虚构的「用户增长运营组」（5 人，负责拉新、激活、留存活动）为例，
+走完从空目录到知识被全公司复用的全过程。每一步都标注了「谁在什么时候
+做什么」，可以直接当 onboarding 剧本用。
+
+### 第 0 天：建库（30 分钟，champion 一人完成）
+
+运营主管林娜被任命为 champion。她打开 TeamClu：
+
+```
+$ teamclu knowledge scaffold --team growth-ops
+✓ 生成 knowledge/ 标准目录
+✓ 写入模板：_index.md / adr-template.md / runbook-template.md
+✓ 创建 knowledge.manifest.yaml（默认 visibility: private）
+```
+
+得到这棵空树：
+
+```
+knowledge/
+├── 00-home.md
+├── 10-onboarding/
+├── 20-domains/
+├── 30-decisions/
+├── 40-runbooks/
+├── 50-glossary.md
+├── 90-archive/
+├── attachments/
+└── knowledge.manifest.yaml
+```
+
+她做的三件事：
+
+1. 在 `00-home.md` 里写了一段大白话：「我们是用户增长运营组，管拉新、
+   激活、留存。新人先看 10-onboarding，出事查 40-runbooks，黑话不懂
+   查 50-glossary」。
+2. 把 `20-domains/` 拆成三个子域并指定 owner：
+   `campaigns/`（活动，owner 是阿杰）、`channels/`（投放渠道，owner
+   是雯雯）、`metrics/`（数据口径，owner 是老周）。
+3. 填了 manifest 的团队名和简介，visibility 保持 **private**——
+   先自己用顺了再发布。
+
+### 第 1 周：迁移 + 第一次打捞
+
+**迁移**（每人半天）：团队把散落在各处的文档搬进 `20-domains/`：
+
+- 阿杰把飞书里的《618 大促复盘》挪到 `20-domains/campaigns/2026-618-retro.md`，
+  图片存进 `attachments/`。
+- 雯雯把本地 Excel 导出的《各渠道 CPI 基准》整理成
+  `20-domains/channels/cpi-benchmark.md`。
+- 老周把「新客」定义的五个版本统一成 `20-domains/metrics/new-user-definition.md`——
+  这篇直接解决了过去每次周会都要吵「新客到底怎么算」的问题。
+
+**第一次打捞**（自然的）：周三阿杰在 TeamClu 里让 AI 帮他写 push 文案，
+AI 给出了一版效果很好的结构。他选中那段回复，右键「存到知识库」→
+选 `20-domains/campaigns/` → 自动生成了
+`push-copy-formula.md`（草稿），末尾带着原始会话链接。
+他花 5 分钟补了个标题和两句说明，存盘。Obsidian 里雯雯刷新就看到了。
+
+### 第 2 周：第一篇 runbook 和 ADR（从真实事件取材）
+
+**Runbook**：周四晚上 push 渠道大面积失败，值班的老周手忙脚乱地处理了
+两小时。周五他把过程整理成 `40-runbooks/push-channel-outage.md`：
+
+```markdown
+---
+type: runbook
+owner: 老周
+last-verified: 2026-09-04
+---
+
+# Push 渠道大面积失败应急手册
+
+## 前置确认
+1. 确认是渠道侧问题还是我们侧问题：先看 [渠道状态页]……
+```
+
+整个过程 40 分钟——**素材来自真实事件，不是憋出来的**。这正是方案里
+说的「从最近的真实事件取材」。
+
+**ADR**：周会上团队决定「以后所有活动复盘必须用统一模板」，阿杰写了
+`30-decisions/0001-unified-campaign-retro-template.md`，记录了为什么
+（过去五份复盘格式各异，根本无法横向对比）、结论是什么、对以后的要求。
+
+### 第 3 周：评审 + 发布
+
+30 分钟评审会，过了三件事：
+
+- 结构：大家觉得 `channels/` 下该再加 `kol/` 子目录，当场建。
+- freshness：老周那篇 runbook 刚验证过，是绿的；雯雯的 CPI 基准是
+  90 天前的数据，被标黄了，她当场更新。
+- 发布：manifest 改成 `visibility: org`，发布两个精选集合——
+  「新人必读」（home + onboarding + glossary）和「活动运营手册」
+  （campaigns 域 + push 复盘）。
+
+```yaml
+# knowledge.manifest.yaml
+version: 1
+team: growth-ops
+title: 用户增长运营组知识库
+summary: 拉新、激活、留存活动的打法、渠道基准与数据口径
+visibility: org
+domains: [活动运营, 渠道投放, 数据口径]
+entry: 00-home.md
+collections:
+  - name: 新人必读
+    paths: [00-home.md, 10-onboarding/, 50-glossary.md]
+  - name: 活动运营手册
+    paths: [20-domains/campaigns/, 40-runbooks/]
+```
+
+发布后，公司知识目录里出现了这个团队。CRM 组的小王在目录里搜
+「新客」，找到了老周的《新客定义》，用
+`[[team:growth-ops/20-domains/metrics/new-user-definition]]`
+链到了自己团队的对齐文档里——**没有复制副本，单一来源**。
+
+### 日常循环（之后每周）
+
+| 时刻 | 发生什么 |
+|---|---|
+| 随手 | AI 对话里有用的结论 → 右键存库（草稿） |
+| 周会前 | champion 看打捞待办列表，催一下该固化的草稿 |
+| 周会 | 10 分钟过 freshness 黄/灰页面，该更新的更新、该归档的进 90-archive |
+| 出事时 | 先查 40-runbooks；处理完把新经验补进去或写新篇 |
+| 每月 | champion 看一眼健康度：打捞率、黄页比例、哪些页面被 RAG 引用最多 |
+
+### 这个例子里每个角色得到了什么
+
+- **林娜（champion）**：每周 1 小时，换来新人入职不再靠人肉带。
+- **老周（domain owner）**：runbook 写完第二周就被 RAG 引用了 3 次——
+  AI 直接引用他的手册回答值班同事的问题，这是最直接的正反馈。
+- **小王（跨团队消费者）**：用「新客」定义时不用再猜，也不用约会对齐，
+  链过去就行；定义变了他的链接永远指向最新版。
+- **新入职的实习生**：第一天拿到的是 `10-onboarding/` 清单，
+  不是「你先随便看看，有问题问大家」。
+
+---
+
+## 附录 B：一个电商供应链团队的对照示例
+
+以虚构的「供应链履约组」（8 人，管采购、仓储、物流履约）为例。
+**刻意和附录 A 做差异化**：增长运营组展示的是「知识从对话里长出来」，
+供应链组展示的是「知识库在高压、强协作、强时效场景下怎么扛事」。
+两个例子放在一起，正好覆盖方案里大部分机制的不同侧面。
+
+### 这个团队有什么不同
+
+| 维度 | 增长运营组（附录 A） | 供应链履约组（本例） |
+|---|---|---|
+| 知识主力类型 | 打法、复盘、口径 | SOP、应急手册、外部对接协议 |
+| 最大的痛 | 口径不一致、经验不传 | 大促值班靠人肉、跨团队协作靠吼、供应商信息散 |
+| 写作者画像 | 运营，文字能力好 | 仓储/物流一线，没时间写长文 |
+| freshness 敏感度 | 中（季度级过期） | 高（大促前不过一遍要出事） |
+
+这个差异直接体现在目录的重心上——他们的 `40-runbooks/` 是全库最厚的
+目录，而且多了一层别的团队不太用的 `70-vendors/`（外部伙伴对接）。
+
+### 第 0 天：建库（多了一步定制）
+
+champion 是履约主管老韩。scaffold 之后他多做了一件事：
+
+```
+knowledge/
+├── 00-home.md
+├── 10-onboarding/
+├── 20-domains/
+│   ├── procurement/      # 采购
+│   ├── warehouse/        # 仓储
+│   └── logistics/        # 物流
+├── 30-decisions/
+├── 40-runbooks/
+│   ├── peak-season/      # 大促专项（双11、618）
+│   └── daily/            # 日常异常
+├── 50-glossary.md
+├── 70-vendors/           # 外部伙伴：供应商/物流商对接档案
+├── 90-archive/
+└── knowledge.manifest.yaml
+```
+
+`70-vendors/` 不是标准骨架的一部分，是老韩根据自己团队需要加的——
+这正体现了方案的原则：**结构是脚手架不是法律，champion 有权重组**。
+他在 `30-decisions/0001-add-vendors-directory.md` 里写了一句话说明理由
+（供应商对接信息散在微信里，人一走就丢），留了个痕。
+
+### 第 1 周：迁移的重头戏是「把微信群里的知识挖出来」
+
+供应链团队最大的存量知识不在任何文档系统里，而在**微信群聊天记录和
+老员工的脑子里**。他们的迁移策略也因此不同：
+
+- **供应商档案**：仓储主管把主要供应商的对接人、账期、起订量、
+  历史坑点整理成 `70-vendors/<供应商名>.md`，一家一页。
+  「华东仓那家纸箱厂，旺季会偷偷降克重」这种口头经验第一次落了字。
+- **大促 SOP 骨架**：老韩把去年双 11 的值班表、扩容清单、压测记录
+  整理成 `40-runbooks/peak-season/double-11-checklist.md` 的初版。
+  不完整，但骨架在——**先框后填，不求一次写完**。
+- **黑话表**：`50-glossary.md` 记了「截单时间」「波次」「妥投率」
+  「逆向物流」这些跨部门协作时经常鸡同鸭讲的词。
+
+### 第 2 周：双 11 备战演练——知识库第一次扛事
+
+距双 11 还有一个月，团队做了一次备战演练。这次演练成了知识库最好的
+压力测试和内容来源：
+
+**演练前**：按 `double-11-checklist.md` 逐项过，发现三处去年踩过的坑
+没记进去（某物流商分拨中心爆仓预案、预售订单的锁库逻辑、客服工单
+激增时的分流规则），当场补。
+
+**演练中**：模拟「主力物流商瘫痪」场景，值班员小赵第一次独立处理，
+全程对着 `40-runbooks/peak-season/logistics-failover.md` 操作，
+30 分钟完成切换。处理完她把手册里两处写得含糊的步骤改清楚了——
+**runbook 的正确性是被「真的用过」验证出来的**，`last-verified`
+字段更新为今天。
+
+**演练后**：AI 助手根据演练会话自动生成了打捞待办：「这次演练有 5 段
+讨论包含可固化的结论」。老韩花了 20 分钟把其中 3 条固化进库，
+2 条判定为一次性信息丢弃。**打捞率 60%，健康**。
+
+### 第 3 周：跨团队协作——这次轮到自己被引用
+
+供应链是公司的「被依赖大户」：客服要查物流异常处理流程，大促运营
+要查截单时间，财务要查供应商账期。发布 manifest 后，效应很快出现：
+
+- **客服组**把 `[[team:sc-fulfillment/40-runbooks/daily/logistics-exception]]`
+  链进了自己的工单处理手册。以前客服遇到物流异常要拉群问供应链，
+  现在 AI 直接引用这篇 runbook 回答——**供应链组的被打扰次数
+  肉眼可见地下降**。
+- **大促运营组**在备战文档里链了 `50-glossary.md` 的截单时间条目。
+  今年第一次，两边对「截单」的理解是同一个定义。
+- **财务组**想要供应商账期数据，发现 `70-vendors/` 是 private 的
+  （老韩在 manifest 里只发布了 runbooks 和 glossary，
+  vendor 档案涉及商务条款，保持团队内可见）。
+  财务组提了个需求：能否发布一个脱敏版账期表。老韩建了个
+  `70-vendors/payment-terms-public.md`（只含标准账期，不含谈判细节），
+  单独发布这篇——**可见性可以细到单篇，不是整个 vault 非黑即白**。
+
+### 双 11 当天：终极检验
+
+- 凌晨 0:40，某仓 WMS 系统卡顿。值班员查
+  `peak-season/wms-degradation.md`——这篇是演练后补的——按手册
+  切到降级模式，12 分钟恢复。
+- 当天 AI 助手引用本库 runbook 回答了值班群里的 17 个问题，
+  其中 15 个没再需要人工介入。
+- 战后复盘时，团队把当天新增的 3 个异常场景写回了 runbook，
+  `last-verified` 全部刷新。**知识库在高压日不是负担，是弹药库**。
+
+### 这个例子里每个角色得到了什么
+
+- **小赵（一线值班员）**：第一次独立处理物流商切换没慌——手册在手，
+  而且她改过的版本会帮到下一个值班的人。
+- **老韩（champion）**：今年双 11 他的手机比去年安静了一半；
+  vendor 档案落了字，人员流动不再是信息黑洞。
+- **客服组（跨团队消费者）**：物流异常自助处理率上升，拉群次数下降；
+  供应链组从「人肉接口」变回「知识作者」。
+- **财务组（边界试探者）**：发现 private 内容后走「提需求→对方发
+  脱敏版」的正轨，而不是私下拷贝——**边界机制第一次被真实地使用**。
+
+### 两个附录放在一起看
+
+| 机制 | 附录 A（增长运营） | 附录 B（供应链） |
+|---|---|---|
+| 打捞 | AI 对话 → push 文案公式 | 演练会话 → 5 条待办固化 3 条 |
+| freshness | 季度级（CPI 基准） | 大促级（演练驱动验证） |
+| 跨团队 | 被引用「新客定义」 | 被引用 runbook + glossary；vendor 保持 private |
+| 结构定制 | 标准骨架够用 | 加了 `70-vendors/`，用 ADR 留痕 |
+| 正反馈 | runbook 被 RAG 引用 | 双 11 当天 AI 挡掉 15/17 个问题 |
+
+---
+
+## 附录 C：中英双语模板规范
+
+公司内有英文协作场景的团队（跨境业务、外籍同事、海外伙伴对接），
+模板必须中英双语，避免「模板是中文的，写的人只好自己翻译」的摩擦。
+
+**原则：模板双语，内容单语。** 骨架、字段说明、引导文案中英并列；
+正文内容由作者选一种语言写，不强制双写。
+
+- scaffold 生成的每个模板，标题、frontmatter 注释、字段标签双语并列，
+  格式如 `## 背景 / Background`。
+- frontmatter 的 key 保持英文（`owner`, `last-verified`——机器可读，
+  双语 key 会破坏解析），value 任意语言。
+- `knowledge.manifest.yaml` 的 `summary` 字段建议双语一行：
+  `summary: 支付领域知识与运维手册 / Payment domain knowledge & runbooks`。
+- 目录名保持英文（`20-domains/` 等），因为这是 URL、wiki link 和
+  跨 vault 引用的稳定锚点；目录的中文含义在各自的 `_index.md` 里说明。
+- 跨团队引用时，引用方用自己的语言写上下文，被引页面保持原文。
+
+---
+
+## 附录 D：MCP-first 写入架构
+
+原定的「一个 UI 入口」被以下讨论推翻：知识库最高频的写入动作
+（scaffold / 从模板建页面 / 聊天打捞）都发生在 agent 会话场景里，
+让 agent 直接在对话里完成比让用户找按钮自然得多。打捞动作的
+「什么内容值得固化」判断本身是 LLM 任务。
+
+**分工原则：UI 让人看到知识，MCP 让 agent 经营知识。**
+
+### 做 / 不做的边界
+
+- **写路径（MCP）**：scaffold、从模板建页面、打捞、写/改页面、
+  检索、manifest 读写、健康度统计。
+- **读路径（双轨）**：浏览、发现、catalog——UI 负责；agent 侧用
+  `knowledge_search` 作程序化检索。
+- **治理动作（UI）**：`visibility: private → org` 的发布确认弹窗；
+  `.conflicts/` 冲突决策视图（现有 tab 形态保留）。
+
+### 工具面（v1）
+
+```
+knowledge_scaffold          初始化 vault
+knowledge_create            从模板建页面（adr / runbook / domain-index / page）
+knowledge_salvage           把会话结论固化成草稿（对话高阶工具）
+knowledge_write             写/改页面（路径校验限制在 vault 内）
+knowledge_search            检索（包一层 Tantivy RAG）
+knowledge_manifest_get/set  读/改发布清单
+knowledge_health            freshness / 覆盖度统计
+```
+
+### 安全约束
+
+- `knowledge_write` 路径校验锁在 vault 根内，防 traversal。
+- `manifest_set` 变更 visibility 时必须带确认参数（`confirm: true`），
+  纯文本确认无法通过则拒绝——agent 不能静默把库公开。UI 发布弹窗也
+  建议保留，作为人和 agent 的双确认通道之一。
+- 同步链路复用：MCP 写入落在 `shared/knowledge/`，P0/P1 的
+  fs watcher + MQTT 推送原样接管。
+
+### 收益
+
+- 跨端免费：desktop / iOS / daemon 内嵌 chat / 外部 IDE（Claude
+  Code、Cursor）调用同一组工具。
+- 打捞 = 一次工具调用，不建 UI 流水线。
+- UI 快捷入口（右键「存到知识库」）调同一 handler，与 agent 共用
+  一套后端，不分裂。

--- a/docs/plans/2026-08-31-team-knowledge-base-program.md
+++ b/docs/plans/2026-08-31-team-knowledge-base-program.md
@@ -559,3 +559,486 @@ knowledge_health            freshness / 覆盖度统计
 - 打捞 = 一次工具调用，不建 UI 流水线。
 - UI 快捷入口（右键「存到知识库」）调同一 handler，与 agent 共用
   一套后端，不分裂。
+
+---
+
+## 附录 E：两个示例团队的最终知识库（完整内容）
+
+以下分别是附录 A（用户增长运营组）和附录 B（供应链履约组）三周后的
+最终 vault 状态。每篇文档都是真实可落地的完整内容，不是骨架。
+
+### 增长运营组的最终 vault
+
+```
+knowledge/
+├── 00-home.md
+├── 10-onboarding/
+│   └── first-week.md
+├── 20-domains/
+│   ├── campaigns/
+│   │   ├── _index.md
+│   │   ├── 2026-618-retro.md
+│   │   └── push-copy-formula.md
+│   ├── channels/
+│   │   ├── _index.md
+│   │   └── cpi-benchmark.md
+│   └── metrics/
+│       ├── _index.md
+│       └── new-user-definition.md
+├── 30-decisions/
+│   └── 0001-unified-campaign-retro-template.md
+├── 40-runbooks/
+│   └── push-channel-outage.md
+├── 50-glossary.md
+├── 90-archive/
+│   └── 2025-q4-campaign-old-format.md
+├── attachments/
+│   └── 618-retro-chart.png
+├── 00-salvage/
+│   └── 2026-09-03-ai-push-hook.md
+└── knowledge.manifest.yaml
+```
+
+#### `00-home.md`
+
+```markdown
+---
+type: home
+updated: 2026-09-04
+---
+
+# 用户增长运营组知识库 / Growth Ops Knowledge Base
+
+我们负责拉新、激活、留存活动。新人先看 onboarding，出事查 runbooks，
+黑话不懂查 glossary。
+
+## 快速入口 / Quick Links
+
+- 新人入职 / Onboarding → [[10-onboarding/first-week]]
+- 活动打法 / Campaigns → [[20-domains/campaigns/_index]]
+- 渠道基准 / Channel Benchmarks → [[20-domains/channels/_index]]
+- 数据口径 / Metrics Definitions → [[20-domains/metrics/_index]]
+- 应急手册 / Runbooks → [[40-runbooks/]]
+- 术语表 / Glossary → [[50-glossary]]
+
+## 值班 / On-call
+
+每周一人，排班表在飞书日历。值班期间 runbook 是第二责任人。
+```
+
+#### `20-domains/metrics/new-user-definition.md`
+
+```markdown
+---
+type: domain-knowledge
+owner: 老周
+updated: 2026-09-02
+---
+
+# 新客定义 / New User Definition
+
+## 结论 / Definition
+
+**新客 = 注册后 7 天内完成首次核心行为的用户。**
+
+核心行为按业务线定义：
+- 电商：首单支付成功
+- 内容：首次发布或首次互动（点赞/评论/分享）
+
+## 为什么是这个定义 / Rationale
+
+之前有五版口径（注册即新客、注册 3 天、注册 7 天有活跃、
+首单、首互动），每次周会都对不齐。2026-08-28 周会定为
+「7 天 + 首次核心行为」，理由：
+- 3 天太短，周末注册的用户还没到活跃高峰
+- 纯注册太宽，羊毛党占比失真
+- 首单/首互动是真实价值动作
+
+## 历史口径对照 / Legacy Mappings
+
+| 旧口径 | 与新口径差异 | 数据修正系数 |
+|---|---|---|
+| 注册即新客 | 高估 ~40% | ×0.6 |
+| 注册 7 天有活跃 | 高估 ~15% | ×0.85 |
+| 首单（电商） | 基本一致 | ×1.0 |
+```
+
+#### `40-runbooks/push-channel-outage.md`
+
+```markdown
+---
+type: runbook
+owner: 老周
+last-verified: 2026-09-04
+---
+
+# Push 渠道大面积失败应急手册 / Push Channel Outage Runbook
+
+**触发条件**：push 送达率 5 分钟内下降 >50%，或多个渠道同时告警。
+
+## 前置确认 / Prerequisites
+
+1. 确认是渠道侧还是我们侧：先看 [渠道状态页](https://status.example.com)
+2. 拿到值班权限：push 后台 + 降级开关权限
+3. 通知链路：@值班群 → @渠道对接群
+
+## 步骤 / Steps
+
+1. **确认影响面**：后台「渠道健康」看板，确认是哪个渠道（个推/极光/FCM）
+2. **切降级通道**：后台 → 推送管理 → 降级开关 → 选备用渠道
+3. **验证恢复**：发一条测试 push 给测试机组，确认送达
+4. **观察 10 分钟**：送达率恢复到 >90% 才算稳定
+5. **回填记录**：在本文档末尾追加本次事件（时间、渠道、原因、耗时）
+
+## 验证 / Verification
+
+- 测试机收到 push
+- 渠道健康看板送达率 >90%
+- 无新增告警
+
+## 回滚 / Rollback
+
+如果备用渠道也失败：关闭 push 全量推送，只保留事务性 push
+（订单通知、安全验证码），等渠道恢复后逐步放开。
+
+## 历史事件 / Past Incidents
+
+| 日期 | 渠道 | 原因 | 耗时 |
+|---|---|---|---|
+| 2026-09-03 | 个推 | 渠道证书过期 | 42min |
+
+## 相关链接 / Related
+
+- [[30-decisions/0001-unified-campaign-retro-template]]
+- [渠道状态页](https://status.example.com)
+```
+
+#### `30-decisions/0001-unified-campaign-retro-template.md`
+
+```markdown
+---
+type: adr
+status: accepted
+updated: 2026-09-01
+---
+
+# ADR-0001: 活动复盘统一模板 / Unified Campaign Retrospective Template
+
+## 背景 / Context
+
+过去五份活动复盘格式各异：有的只写数据，有的只写感受，
+有的连目标都没对齐。无法横向对比，也无法沉淀方法论。
+
+## 选项 / Options Considered
+
+### A. 自由格式，只做内容清单
+- 优点：写起来快
+- 缺点：无法对比，信息密度参差
+
+### B. 固定模板：目标 → 数据 → 打法 → 问题 → 沉淀
+- 优点：可横向对比，强制对齐目标
+- 缺点：写起来多花 20 分钟
+
+### C. 用 AI 自动生成初稿，人工改
+- 优点：最快
+- 缺点：依赖数据接入，一期做不到
+
+## 结论 / Decision
+
+选 B。模板固定为五段：目标回顾 → 核心数据 → 打法拆解 →
+问题与原因 → 可复用沉淀。从 2026-09 起所有活动复盘必须使用。
+
+## 后果 / Consequences
+
+- 复盘平均耗时从 1h → 1.5h，但可读性和复用性显著提升
+- 新模板已沉淀到 [[20-domains/campaigns/_index]] 作为默认模板
+```
+
+#### `00-salvage/2026-09-03-ai-push-hook.md`
+
+```markdown
+---
+type: salvage
+source: chat
+session-id: sess_20260903_1847
+salvaged: 2026-09-03
+---
+
+# AI 生成的 push 文案钩子公式 / AI Push Hook Formula
+
+在会话中测试出效果较好的 push 文案结构：
+
+**公式**：场景钩子 + 利益点 + 紧迫感 + 行动指令
+
+**示例**：
+> 「睡前刷手机的你，今晚 8 点限时折扣最后 2 小时 → 点我抢购」
+
+**效果**：A/B 测试点击率比平铺直叙版高 34%。
+
+**注意**：紧迫感只对价格敏感型用户有效，品牌型用户会反感。
+```
+
+#### `knowledge.manifest.yaml`
+
+```yaml
+version: 1
+team: growth-ops
+title: 用户增长运营组知识库 / Growth Ops Knowledge Base
+summary: 拉新、激活、留存活动的打法、渠道基准与数据口径 / Growth tactics, channel benchmarks, metrics definitions
+visibility: org
+domains: [活动运营, 渠道投放, 数据口径, Growth, Marketing]
+entry: 00-home.md
+collections:
+  - name: 新人必读 / Onboarding
+    paths: [00-home.md, 10-onboarding/, 50-glossary.md]
+  - name: 活动运营手册 / Campaign Playbook
+    paths: [20-domains/campaigns/, 40-runbooks/]
+```
+
+### 供应链履约组的最终 vault
+
+```
+knowledge/
+├── 00-home.md
+├── 10-onboarding/
+│   └── first-week.md
+├── 20-domains/
+│   ├── procurement/
+│   │   └── _index.md
+│   ├── warehouse/
+│   │   ├── _index.md
+│   │   └── wms-degradation.md
+│   └── logistics/
+│       ├── _index.md
+│       └── carrier-failover.md
+├── 30-decisions/
+│   └── 0001-add-vendors-directory.md
+├── 40-runbooks/
+│   ├── daily/
+│   │   └── logistics-exception.md
+│   └── peak-season/
+│       ├── double-11-checklist.md
+│       ├── logistics-failover.md
+│       └── wms-degradation.md
+├── 50-glossary.md
+├── 70-vendors/
+│   ├── _index.md
+│   ├── huadong-packaging.md
+│   └── payment-terms-public.md
+├── 90-archive/
+├── attachments/
+│   └── wms-degradation-flow.png
+├── 00-salvage/
+│   └── 2026-09-04-drill-findings.md
+└── knowledge.manifest.yaml
+```
+
+#### `00-home.md`
+
+```markdown
+---
+type: home
+updated: 2026-09-05
+---
+
+# 供应链履约组知识库 / Supply Chain Fulfillment Knowledge Base
+
+我们管采购、仓储、物流履约。出事查 runbooks，大促看 peak-season，
+供应商信息在 70-vendors。
+
+## 快速入口 / Quick Links
+
+- 新人入职 / Onboarding → [[10-onboarding/first-week]]
+- 大促手册 / Peak Season → [[40-runbooks/peak-season/]]
+- 日常异常 / Daily Ops → [[40-runbooks/daily/]]
+- 供应商档案 / Vendor Profiles → [[70-vendors/]]
+- 术语表 / Glossary → [[50-glossary]]
+
+## 值班 / On-call
+
+7×24 轮值，交接班必须过一遍当天的异常记录。
+```
+
+#### `40-runbooks/peak-season/double-11-checklist.md`
+
+```markdown
+---
+type: runbook
+owner: 老韩
+last-verified: 2026-09-05
+---
+
+# 双 11 大促备战清单 / Double 11 Peak Season Checklist
+
+**时间线**：T-30 天启动，T-1 天封网。
+
+## T-30 至 T-14：准备期 / Preparation
+
+- [ ] 各仓扩容方案确认（仓储组）
+- [ ] 物流商运力锁定 + 备用物流商协议签署（物流组）
+- [ ] 压测完成：WMS、OMS、TMS 峰值 3 倍（技术组）
+- [ ] 客服工单分流规则更新（客服组）
+- [ ] 供应商备货计划确认（采购组）
+
+## T-14 至 T-1：演练期 / Drill
+
+- [ ] 全链路压测（含降级切换）
+- [ ] 值班表确认 + 值班权限检查
+- [ ] 应急预案演练：[[logistics-failover]]、[[wms-degradation]]
+- [ ] 封网：禁止非紧急变更
+
+## T-0：大促当天 / Peak Day
+
+- [ ] 0:00-2:00 高峰值班双人在岗
+- [ ] 每 30 分钟巡检一次核心指标
+- [ ] 异常处理：先查本目录 runbook，处理完回填
+
+## T+1 至 T+7：复盘期 / Retrospective
+
+- [ ] 异常事件逐条回填到对应 runbook
+- [ ] 复盘会议输出 ADR（如有流程变更）
+```
+
+#### `40-runbooks/peak-season/logistics-failover.md`
+
+```markdown
+---
+type: runbook
+owner: 小赵
+last-verified: 2026-09-05
+---
+
+# 主力物流商瘫痪切换手册 / Primary Carrier Failover Runbook
+
+**触发条件**：主力物流商（默认中通）分拨中心瘫痪，预计恢复 >4 小时。
+
+## 前置确认 / Prerequisites
+
+1. 确认瘫痪范围：联系物流商区域经理，确认是分拨中心还是全网
+2. 备用物流商协议已签署且运力确认（平时维护）
+3. WMS 切换权限（值班组长以上）
+
+## 步骤 / Steps
+
+1. **锁定受影响订单**：WMS → 订单查询 → 筛选「已发货未揽收」+
+   物流商=中通 → 导出清单
+2. **通知客服**：[[40-runbooks/daily/logistics-exception]] 同步话术，
+   客服侧提前准备应对用户咨询
+3. **切换备用物流商**：WMS → 物流配置 → 切换默认物流商为「韵达」
+4. **补发滞留订单**：对步骤 1 的清单逐单打回 → 重新分配韵达 → 重新发货
+5. **监控切换后指标**：揽收率、妥投率 30 分钟内应恢复到基线 90%
+
+## 验证 / Verification
+
+- 新订单物流商已切换为韵达
+- 滞留订单全部补发完毕
+- 揽收率/妥投率恢复基线
+
+## 回滚 / Rollback
+
+主力物流商恢复后，切回默认配置。已发出的韵达订单不召回，
+让两个物流商并行消化存量。
+
+## 历史事件 / Past Incidents
+
+| 日期 | 场景 | 耗时 | 备注 |
+|---|---|---|---|
+| 2026-09-04 | 演练：模拟中通瘫痪 | 30min | 小赵首次独立操作 |
+
+## 相关链接 / Related
+
+- [[double-11-checklist]]
+- [[40-runbooks/daily/logistics-exception]]
+```
+
+#### `70-vendors/huadong-packaging.md`
+
+```markdown
+---
+type: vendor-profile
+owner: 仓储组
+updated: 2026-09-02
+---
+
+# 华东纸箱厂 / Huadong Packaging Co.
+
+## 基本信息 / Basic Info
+
+- 对接人：张经理 / Manager Zhang
+- 联系方式：138-xxxx-xxxx
+- 账期：月结 60 天 / Net 60
+- 起订量：5000 个 / MOQ 5000 units
+
+## 历史合作记录 / History
+
+- 2025-03 至今，供应各仓纸箱
+- 2026-06 大促期间交货延迟 3 天，原因是原材料涨价排产紧张
+
+## 注意事项 / Notes
+
+- **旺季会偷偷降克重**：2025 年双 11 期间发现纸箱克重从 250g 降到 230g，
+  未通知。旺季收货必须抽检克重。
+- 交期承诺偏乐观，实际按承诺 +2 天做安全库存。
+```
+
+#### `30-decisions/0001-add-vendors-directory.md`
+
+```markdown
+---
+type: adr
+status: accepted
+updated: 2026-09-01
+---
+
+# ADR-0001: 新增 70-vendors 目录 / Add 70-vendors Directory
+
+## 背景 / Context
+
+供应商对接信息（联系人、账期、历史坑点）散在微信聊天记录和
+老员工脑子里。人一走，信息就丢。标准知识库骨架里没有合适的
+位置放这类内容。
+
+## 结论 / Decision
+
+新增 `70-vendors/` 目录，一家供应商一页。这个目录不发布到公司
+目录（manifest 里 visibility 保持 private），因为涉及商务条款。
+
+## 后果 / Consequences
+
+- 供应商信息有了唯一存放点
+- 结构偏离标准骨架，但在本目录有 ADR 留痕
+- 后续如有通用需求，可以推动骨架标准更新
+```
+
+#### `knowledge.manifest.yaml`
+
+```yaml
+version: 1
+team: sc-fulfillment
+title: 供应链履约组知识库 / Supply Chain Fulfillment Knowledge Base
+summary: 采购、仓储、物流履约的 SOP、应急手册与供应商档案 / SOPs, runbooks, and vendor profiles for fulfillment
+visibility: org
+domains: [供应链, 仓储, 物流, 大促, Supply Chain, Logistics]
+entry: 00-home.md
+collections:
+  - name: 新人必读 / Onboarding
+    paths: [00-home.md, 10-onboarding/, 50-glossary.md]
+  - name: 大促手册 / Peak Season Playbook
+    paths: [40-runbooks/peak-season/]
+  - name: 日常异常处理 / Daily Operations
+    paths: [40-runbooks/daily/, 50-glossary.md]
+# 注意：70-vendors/ 不在任何 collection 中 — 商务条款保密，
+# 仅 payment-terms-public.md 单独发布
+```
+
+### 两个 vault 的对照速览
+
+| 维度 | 增长运营组 | 供应链履约组 |
+|---|---|---|
+| 页面总数 | 12 篇 | 14 篇 |
+| 最厚目录 | `20-domains/`（打法沉淀） | `40-runbooks/`（SOP 密集） |
+| 特色目录 | 标准骨架够用 | 加了 `70-vendors/`（ADR 留痕） |
+| 打捞频率 | 低（周 1-2 次） | 高（演练/大促期间每天） |
+| 跨团队被引用 | 新客定义（CRM 组） | 物流异常手册（客服组）、术语表（大促运营组） |
+| visibility | org（全部） | org（除 vendor 档案外） |
+| freshness 驱动 | 季度数据更新 | 演练验证 + 大促实战 |


### PR DESCRIPTION
## 概述

基于 TeamClu 现有的团队 Markdown vault 同步（ADR-0008），提供一套公司级知识库建设方案及其 daemon 侧工具链。核心思路：**UI 让人看到知识，MCP 让 agent 经营知识**——知识库最高频的写入动作发生在 agent 会话场景里，让 agent 直接在对话里完成。

## 方案文档

`docs/plans/2026-08-31-team-knowledge-base-program.md`：

- **三层信息模型**：L1 个人草稿 → L2 团队 vault → L3 公司目录，知识只向上流动
- **生命周期**：捕获（聊天打捞）→ 评审（owner 制 + freshness 字段）→ 发布（manifest 显式声明，默认 private）→ 消费（RAG / 跨团队只读引用）
- **附录 A/B**：两个完整示例（增长运营组、供应链履约组），演示从空库到被全公司复用的全过程
- **附录 C**：中英双语模板规范（模板双语、内容单语；frontmatter key 保持英文）
- **附录 D**：MCP-first 写入架构决策与工具面设计

## 工具链（daemon 侧）

控制 socket 上新增 `knowledge` 命令（沿用 `skills-manage` 模式），8 个 action：

| 工具 | 说明 |
|---|---|
| `scaffold` | 初始化标准目录树 + 双语模板，幂等 |
| `create` | 从模板建页（adr / runbook / domain-index / page），拒绝覆盖 |
| `write` | 覆盖写入，路径锁 vault 内 |
| `salvage` | 打捞会话结论 → `00-salvage/<日期>-<slug>.md`（带 provenance frontmatter） |
| `search` | SQLite FTS5 全文检索（trigram tokenizer，CJK 友好；索引在 `.index/` 下，同步扫描器和 Obsidian 都会忽略） |
| `manifest_get/set` | 读写发布清单；visibility 变更必须 `confirm: true` |
| `health` | 过期 runbook / 页面统计 + 覆盖度检查 |

`assets/knowledge-templates/mcp-manifest.json` 描述了全部工具名、双语描述和 JSON input schema，供 MCP 宿主发现。

## 测试

25 个 knowledge 相关测试全部通过（含存量同步/链接测试无回归）。覆盖：目录树生成、幂等、路径 traversal 拒绝、CJK/英文 FTS 检索、manifest 确认门槛、freshness 统计、salvage 命名。

## 范围外（后续 PR）

- MCP stdio bridge 进程（把 sock 命令翻译成 MCP 协议，~50 行）
- `salvage` 的 UI 快捷入口（右键「存到知识库」）
- catalog 聚合端点（P3）

🤖 Generated with [Codex](https://openai.com)