### PR TITLE
fix(skills): align hosted publishing and secure session deeplinks

### DIFF
--- a/apps/daemon/assets/pi-extension/session-context.test.mjs
+++ b/apps/daemon/assets/pi-extension/session-context.test.mjs
@@ -104,6 +104,29 @@ test("non allowlist PI tools ignore session identity", async () => {
   assert.equal(called, false);
 });
 
+test("PI injection gate matches production alias rules", async () => {
+  // The PI bridge calls injectSessionIdForTool with the ORIGINAL bare MCP tool
+  // name, so only bare allowlist names should inject. Namespaced ids belong to
+  // other backends and must not resolve on the PI path.
+  let called = 0;
+  const resolve = async (id) => {
+    called += 1;
+    return `teamclu-for-${id}`;
+  };
+  const ctx = { ui: makeUiContext("pi:/tmp/a.json") };
+  const injected = await injectForPiTool("get_session_deeplink", {}, ctx, { resolve });
+  assert.equal(injected.session_id, "teamclu-for-pi:/tmp/a.json");
+  assert.equal(called, 1);
+
+  for (const tool of ["other-server/get_session_deeplink", "browser_manage_participants"]) {
+    // Mirrors production: the base tool of "other-server/get_session_deeplink"
+    // is "get_session_deeplink", which IS allowlisted — but the PI bridge never
+    // passes namespaced names to injectSessionIdForTool (it forwards the bare
+    // MCP tool name), so this case only documents the shared-client contract.
+    assert.equal(typeof tool, "string");
+  }
+});
+
 /** Mirrors session prompt cache key in teamclu.ts */
 function sessionPromptCacheKey(backendSessionId, generationId) {
   const sessionId = backendSessionId?.trim();

--- a/apps/daemon/shared/session-context-client.mjs
+++ b/apps/daemon/shared/session-context-client.mjs
@@ -22,10 +22,10 @@ export function normalizeSessionScopedToolName(name) {
 
   for (const tool of SESSION_SCOPED_TOOL_LIST) {
     if (raw === tool) return tool;
-    if (raw.endsWith(`/${tool}`)) return tool;
-    if (raw.startsWith("mcp__") && raw.endsWith(`__${tool}`)) return tool;
 
     for (const server of MANAGED_INTROSPECT_SERVERS) {
+      if (raw === `${server}/${tool}`) return tool;
+      if (raw === `mcp__${server}__${tool}`) return tool;
       if (raw === `${server}_${tool}`) return tool;
     }
   }

--- a/apps/daemon/shared/session-context-client.test.mjs
+++ b/apps/daemon/shared/session-context-client.test.mjs
@@ -19,10 +19,39 @@ test("normalizeSessionScopedToolName handles slash and mcp__ forms", () => {
     normalizeSessionScopedToolName("mcp__teamclu-introspect__get_session_deeplink"),
     "get_session_deeplink",
   );
-  assert.equal(
-    normalizeSessionScopedToolName("mcp__my_server-with_underscores__archive_session"),
-    "archive_session",
-  );
+});
+
+test("normalizeSessionScopedToolName accepts every managed introspect alias and format", () => {
+  const tools = ["get_session_deeplink", "manage_participants", "archive_session"];
+  const servers = ["teamclu-introspect", "teamclaw-introspect"];
+  for (const tool of tools) {
+    for (const server of servers) {
+      assert.equal(normalizeSessionScopedToolName(tool), tool);
+      assert.equal(normalizeSessionScopedToolName(`${server}/${tool}`), tool);
+      assert.equal(normalizeSessionScopedToolName(`mcp__${server}__${tool}`), tool);
+      assert.equal(normalizeSessionScopedToolName(`${server}_${tool}`), tool);
+    }
+  }
+});
+
+test("normalizeSessionScopedToolName rejects namespaced forms from unmanaged servers", () => {
+  for (const name of [
+    "other-server/get_session_deeplink",
+    "other-server/manage_participants",
+    "other-server/archive_session",
+    "mcp__other-server__get_session_deeplink",
+    "mcp__other-server__manage_participants",
+    "mcp__other-server__archive_session",
+    "mcp__my_server-with_underscores__archive_session",
+    "browser/get_session_deeplink",
+    "mcp__teamclu-introspect__get_session_deeplink_extra",
+    "teamclu-introspect/get_session_deeplink_extra",
+    "teamclu-introspect-extra/get_session_deeplink",
+    "teamclu-introspect-extra_get_session_deeplink",
+  ]) {
+    assert.equal(normalizeSessionScopedToolName(name), name);
+    assert.equal(isSessionScopedTool(name), false);
+  }
 });
 
 test("normalizeSessionScopedToolName handles OpenCode server_tool ids", () => {
@@ -59,6 +88,48 @@ test("isSessionScopedTool recognizes namespaced MCP tool ids", () => {
   assert.equal(isSessionScopedTool("mcp__teamclu-introspect__manage_participants"), true);
   assert.equal(isSessionScopedTool("teamclu-introspect_get_session_deeplink"), true);
   assert.equal(isSessionScopedTool("browser_click"), false);
+});
+
+test("injectSessionIdForTool does not resolve for namespaced ids from unmanaged servers", async () => {
+  let called = false;
+  const deps = {
+    resolveTeamcluSessionId: async () => {
+      called = true;
+      return "teamclu-leaked";
+    },
+  };
+  for (const tool of [
+    "other-server/get_session_deeplink",
+    "mcp__other-server__archive_session",
+    "browser_manage_participants",
+  ]) {
+    const args = { scheme: "copilot361" };
+    const next = await injectSessionIdForTool(tool, args, "backend-a", deps);
+    assert.deepEqual(next, args);
+  }
+  assert.equal(called, false, "resolver must never run for unmanaged server tools");
+});
+
+test("handleToolExecuteBefore ignores namespaced ids from unmanaged servers", async () => {
+  let called = false;
+  for (const tool of [
+    "other-server/get_session_deeplink",
+    "mcp__other-server__archive_session",
+  ]) {
+    const output = { args: { scheme: "copilot361" } };
+    await handleToolExecuteBefore(
+      { tool, sessionID: "backend-a", callID: "c1" },
+      output,
+      {
+        injectSessionIdForTool: async () => {
+          called = true;
+          return { session_id: "teamclu-leaked" };
+        },
+      },
+    );
+    assert.deepEqual(output.args, { scheme: "copilot361" });
+  }
+  assert.equal(called, false);
 });
 
 test("handleToolExecuteBefore injects output.args.session_id using OpenCode hook shape", async () => {

--- a/apps/daemon/src/daemon/server.rs
+++ b/apps/daemon/src/daemon/server.rs
@@ -174,6 +174,8 @@ pub struct DaemonServer {
     refresh_watch_registry:
         Option<std::sync::Arc<crate::runtime::refresh::refresh_watch::RefreshWatchRegistry>>,
     refresh_coordinator: Option<Arc<crate::runtime::refresh::RuntimeRefreshCoordinator>>,
+    /// Applies skills-only refreshes once the workspace becomes idle.
+    refresh_auto_apply_task: Option<tokio::task::JoinHandle<()>>,
     /// Shared flag written by the MQTT event loop and read by `/v1/info`.
     mqtt_connected_flag: Option<Arc<std::sync::atomic::AtomicBool>>,
     /// Recovery signal receiver is installed into the supervisor exactly once.
@@ -811,6 +813,7 @@ impl DaemonServer {
             cron_sessions: cron::CronSessionCache::new(),
             refresh_watch_registry: None,
             refresh_coordinator: None,
+            refresh_auto_apply_task: None,
             mqtt_connected_flag: None,
             managed_llm: Arc::new(crate::runtime::managed_llm::ManagedLlmResolver::new(
                 backend,
@@ -1130,6 +1133,8 @@ impl DaemonServer {
                 let mut manager = self.agents.lock().await;
                 manager.attach_refresh_coordinator(refresh_coordinator.clone());
             }
+            self.refresh_auto_apply_task =
+                Some(runtime_supervisor.clone().start_refresh_auto_applier());
             let runtime: Arc<dyn crate::http::runtime_adapter::RuntimeAdapter> =
                 crate::http::runtime_adapter::RuntimeManagerAdapter::new_with_execution_context_assembler(
                     self.agents.clone(),
@@ -1167,7 +1172,7 @@ impl DaemonServer {
                     self.backend.clone(),
                 ),
             ));
-            match crate::http::spawn(
+            match crate::http::spawn_with_refresh_watch_registry(
                 http_cfg,
                 meta,
                 runtime,
@@ -1186,6 +1191,7 @@ impl DaemonServer {
                 Some(local_rpc_tx),
                 Some(local_live_ingest_tx),
                 Some(team_skill_reconciler.clone()),
+                self.refresh_watch_registry.clone(),
                 Some(self.runtime_context.clone()),
                 session_prompt,
             )
@@ -1518,13 +1524,20 @@ impl DaemonServer {
             let reconciler = team_skill_reconciler.clone();
             let backend = Some(self.backend.clone());
             let refresh = self.refresh_coordinator.clone();
+            let refresh_watch_registry = self.refresh_watch_registry.clone();
             tokio::spawn(async move {
                 // Once at startup so a daemon that was offline while an admin
                 // made a change converges immediately rather than after a full
                 // interval.
                 let outcome = reconciler.reconcile_now(&team_id).await;
-                apply_team_skill_outcome(&team_id, outcome, backend.as_ref(), refresh.as_ref())
-                    .await;
+                apply_team_skill_outcome(
+                    &team_id,
+                    outcome,
+                    backend.as_ref(),
+                    refresh.as_ref(),
+                    refresh_watch_registry.as_ref(),
+                )
+                .await;
                 let mut tick = tokio::time::interval(crate::runtime::team_skills::TEAM_SKILLS_TTL);
                 tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
                 loop {
@@ -1536,8 +1549,14 @@ impl DaemonServer {
                     // every tick lands a few seconds short of the TTL and skips,
                     // silently halving the cadence to 20 minutes.
                     let outcome = reconciler.reconcile_now(&team_id).await;
-                    apply_team_skill_outcome(&team_id, outcome, backend.as_ref(), refresh.as_ref())
-                        .await;
+                    apply_team_skill_outcome(
+                        &team_id,
+                        outcome,
+                        backend.as_ref(),
+                        refresh.as_ref(),
+                        refresh_watch_registry.as_ref(),
+                    )
+                    .await;
                 }
             });
         }
@@ -3826,6 +3845,7 @@ pub(crate) mod tests {
                 cron_sessions: cron::CronSessionCache::new(),
                 refresh_watch_registry: None,
                 refresh_coordinator: None,
+                refresh_auto_apply_task: None,
                 mqtt_connected_flag: None,
                 mqtt_recovery_rx: None,
                 mqtt_recovery_handle: crate::mqtt::MqttRecoveryHandle::channel().0,

--- a/apps/daemon/src/daemon/server/channels.rs
+++ b/apps/daemon/src/daemon/server/channels.rs
@@ -898,6 +898,9 @@ impl DaemonServer {
     /// when main returns; `amuxd stop` also calls `finalize_stop` as a safety net.
     pub(crate) async fn shutdown_for_exit(&mut self) {
         info!("daemon shutdown: draining channels and local runtimes");
+        if let Some(task) = self.refresh_auto_apply_task.take() {
+            task.abort();
+        }
         if let Some(handle) = self.http_handle.take() {
             handle.shutdown().await;
         }

--- a/apps/daemon/src/daemon/server/rpc.rs
+++ b/apps/daemon/src/daemon/server/rpc.rs
@@ -266,6 +266,8 @@ pub(crate) struct AgentManagementCtx {
     backend: Arc<dyn crate::backend::Backend>,
     reconciler: Arc<crate::runtime::team_skills::TeamSkillReconciler>,
     refresh: Option<Arc<crate::runtime::refresh::RuntimeRefreshCoordinator>>,
+    refresh_watch_registry:
+        Option<Arc<crate::runtime::refresh::refresh_watch::RefreshWatchRegistry>>,
     results: Arc<
         AsyncMutex<HashMap<String, (std::time::Instant, crate::proto::teamclu::RpcResponse)>>,
     >,
@@ -386,6 +388,7 @@ impl DaemonServer {
             backend: self.backend.clone(),
             reconciler: self.team_skill_reconciler.clone(),
             refresh: self.refresh_coordinator.clone(),
+            refresh_watch_registry: self.refresh_watch_registry.clone(),
             results: self.agent_management_results.clone(),
         }
     }
@@ -627,6 +630,7 @@ impl DaemonServer {
                         outcome,
                         Some(&ctx.backend),
                         ctx.refresh.as_ref(),
+                        ctx.refresh_watch_registry.as_ref(),
                     )
                     .await;
                 }
@@ -641,6 +645,7 @@ impl DaemonServer {
                         outcome,
                         Some(&ctx.backend),
                         ctx.refresh.as_ref(),
+                        ctx.refresh_watch_registry.as_ref(),
                     )
                     .await;
                 }
@@ -651,6 +656,7 @@ impl DaemonServer {
                         outcome,
                         Some(&ctx.backend),
                         ctx.refresh.as_ref(),
+                        ctx.refresh_watch_registry.as_ref(),
                     )
                     .await;
                 }

--- a/apps/daemon/src/daemon/server/runtime_lifecycle.rs
+++ b/apps/daemon/src/daemon/server/runtime_lifecycle.rs
@@ -237,6 +237,24 @@ impl DaemonServer {
             }
         }
 
+        // RuntimeStart's worktree is the directory OpenCode actually uses and
+        // therefore the authoritative target for cache invalidation.
+        if let Some(registry) = self.refresh_watch_registry.as_ref() {
+            let refresh_workspace_id = if ws_id.is_empty() {
+                crate::runtime::refresh::refresh_watch::workspace_runtime_id(Path::new(
+                    &resolved_worktree,
+                ))
+            } else {
+                ws_id.clone()
+            };
+            registry
+                .upsert_workspace(crate::runtime::refresh::refresh_watch::WatchedWorkspace {
+                    workspace_id: refresh_workspace_id,
+                    workspace_path: PathBuf::from(&resolved_worktree),
+                })
+                .await;
+        }
+
         // Invariant: a conversation has at most one live runtime *on this
         // daemon*. The daemon is a single actor/participant in the session, so
         // it must answer an @mention exactly once. Historically each desktop

--- a/apps/daemon/src/http/mod.rs
+++ b/apps/daemon/src/http/mod.rs
@@ -51,4 +51,4 @@ pub mod workspaces;
 mod routes;
 pub mod server;
 
-pub use server::{spawn, HttpHandle};
+pub use server::{spawn, spawn_with_refresh_watch_registry, HttpHandle};

--- a/apps/daemon/src/http/server.rs
+++ b/apps/daemon/src/http/server.rs
@@ -157,6 +157,51 @@ pub async fn spawn(
     register_workspace_tx: Option<crate::http::state::RegisterWorkspaceTx>,
     backend: Option<Arc<dyn Backend>>,
     live_tee: Option<tokio::sync::broadcast::Sender<super::live_events::LiveTeeEvent>>,
+    config_path: Option<std::path::PathBuf>,
+    channel_reload_tx: Option<tokio::sync::mpsc::Sender<()>>,
+    onboarding: Option<Arc<dyn crate::http::setup::OnboardingService>>,
+    local_rpc_tx: Option<crate::http::state::LocalRpcTx>,
+    local_live_ingest_tx: Option<crate::http::state::LocalLiveIngestTx>,
+    team_skills: Option<Arc<crate::runtime::team_skills::TeamSkillReconciler>>,
+    runtime_context: Option<Arc<crate::runtime::context_service::RuntimeContextService>>,
+    session_prompt: Option<Arc<crate::runtime::session_prompt::SessionPromptService>>,
+) -> anyhow::Result<HttpHandle> {
+    spawn_with_refresh_watch_registry(
+        http,
+        meta,
+        runtime,
+        workspace_control,
+        runtime_supervisor,
+        opencode_settings,
+        sync_dispatcher,
+        register_workspace_tx,
+        backend,
+        live_tee,
+        config_path,
+        channel_reload_tx,
+        onboarding,
+        local_rpc_tx,
+        local_live_ingest_tx,
+        team_skills,
+        None,
+        runtime_context,
+        session_prompt,
+    )
+    .await
+}
+
+#[allow(clippy::too_many_arguments)]
+pub async fn spawn_with_refresh_watch_registry(
+    http: HttpConfig,
+    meta: DaemonMetadata,
+    runtime: Arc<dyn RuntimeAdapter>,
+    workspace_control: Option<Arc<dyn WorkspaceControlStore>>,
+    runtime_supervisor: Option<Arc<crate::runtime::RuntimeSupervisor>>,
+    opencode_settings: Option<Arc<crate::opencode_settings::OpenCodeSettingsService>>,
+    sync_dispatcher: crate::sync::dispatch::SyncDispatcher,
+    register_workspace_tx: Option<crate::http::state::RegisterWorkspaceTx>,
+    backend: Option<Arc<dyn Backend>>,
+    live_tee: Option<tokio::sync::broadcast::Sender<super::live_events::LiveTeeEvent>>,
     // Daemon-level config surface (`/v1/config/*`, `/v1/setup/*`). All three are
     // `None` in focused tests, which makes those routes 503 rather than panic.
     config_path: Option<std::path::PathBuf>,
@@ -165,6 +210,9 @@ pub async fn spawn(
     local_rpc_tx: Option<crate::http::state::LocalRpcTx>,
     local_live_ingest_tx: Option<crate::http::state::LocalLiveIngestTx>,
     team_skills: Option<Arc<crate::runtime::team_skills::TeamSkillReconciler>>,
+    refresh_watch_registry: Option<
+        Arc<crate::runtime::refresh::refresh_watch::RefreshWatchRegistry>,
+    >,
     runtime_context: Option<Arc<crate::runtime::context_service::RuntimeContextService>>,
     session_prompt: Option<Arc<crate::runtime::session_prompt::SessionPromptService>>,
 ) -> anyhow::Result<HttpHandle> {
@@ -237,6 +285,7 @@ pub async fn spawn(
     .with_managed_llm(managed_llm)
     .with_team_cloud(team_cloud)
     .with_team_skills(team_skills)
+    .with_refresh_watch_registry(refresh_watch_registry)
     .with_local_rpc(local_rpc_tx)
     .with_local_live_ingest(local_live_ingest_tx);
     let state = if let Some(service) = runtime_context {

--- a/apps/daemon/src/http/state.rs
+++ b/apps/daemon/src/http/state.rs
@@ -134,6 +134,8 @@ pub struct HttpState {
     pub runtime_supervisor: Option<Arc<crate::runtime::RuntimeSupervisor>>,
     /// Workspace refresh state shared with `/v1/workspaces/:id/runtime*`.
     pub runtime_refresh: Option<Arc<crate::runtime::refresh::RuntimeRefreshCoordinator>>,
+    pub refresh_watch_registry:
+        Option<Arc<crate::runtime::refresh::refresh_watch::RefreshWatchRegistry>>,
     /// Loopback `opencode serve` pool for provider OAuth (settings only).
     pub opencode_settings: Option<Arc<crate::opencode_settings::OpenCodeSettingsService>>,
     /// Daemon-owned team sync dispatcher (drives `/v1/team/sync*`).
@@ -225,6 +227,7 @@ impl HttpState {
             workspace_control,
             runtime_supervisor,
             runtime_refresh,
+            refresh_watch_registry: None,
             opencode_settings,
             sync_dispatcher,
             register_workspace_tx,
@@ -305,6 +308,14 @@ impl HttpState {
         team_skills: Option<Arc<crate::runtime::team_skills::TeamSkillReconciler>>,
     ) -> Self {
         self.team_skills = team_skills;
+        self
+    }
+
+    pub fn with_refresh_watch_registry(
+        mut self,
+        registry: Option<Arc<crate::runtime::refresh::refresh_watch::RefreshWatchRegistry>>,
+    ) -> Self {
+        self.refresh_watch_registry = registry;
         self
     }
 

--- a/apps/daemon/src/http/team_sync.rs
+++ b/apps/daemon/src/http/team_sync.rs
@@ -398,6 +398,7 @@ async fn reconcile_team_skills_for_state(
         outcome,
         state.backend.as_ref(),
         state.runtime_refresh.as_ref(),
+        state.refresh_watch_registry.as_ref(),
     )
     .await;
     Ok(Json(TeamSkillReconcileResponse { team_id, outcome }))

--- a/apps/daemon/src/runtime/refresh_watch.rs
+++ b/apps/daemon/src/runtime/refresh_watch.rs
@@ -98,10 +98,12 @@ impl RefreshWatchRegistry {
     }
 
     pub async fn upsert_workspace(&self, workspace: WatchedWorkspace) {
-        self.workspaces
-            .write()
-            .await
-            .insert(workspace.workspace_path.clone(), workspace);
+        let mut workspaces = self.workspaces.write().await;
+        workspaces.retain(|path, existing| {
+            path == &workspace.workspace_path || existing.workspace_id != workspace.workspace_id
+        });
+        workspaces.insert(workspace.workspace_path.clone(), workspace);
+        drop(workspaces);
         self.changed.notify_one();
     }
 
@@ -110,7 +112,7 @@ impl RefreshWatchRegistry {
         self.changed.notify_one();
     }
 
-    async fn snapshot(&self) -> Vec<WatchedWorkspace> {
+    pub(crate) async fn snapshot(&self) -> Vec<WatchedWorkspace> {
         self.workspaces.read().await.values().cloned().collect()
     }
 
@@ -868,6 +870,22 @@ mod tests {
         assert_eq!(
             registry.workspace_paths().await,
             vec![PathBuf::from("/tmp/ws-2")]
+        );
+    }
+
+    #[tokio::test]
+    async fn watch_registry_replaces_stale_path_for_same_workspace_id() {
+        let registry = RefreshWatchRegistry::new(Vec::new());
+        registry
+            .upsert_workspace(watched_workspace("ws-1", "/tmp/cloud-path"))
+            .await;
+        registry
+            .upsert_workspace(watched_workspace("ws-1", "/tmp/runtime-path"))
+            .await;
+
+        assert_eq!(
+            registry.workspace_paths().await,
+            vec![PathBuf::from("/tmp/runtime-path")]
         );
     }
 

--- a/apps/daemon/src/runtime/team_skills.rs
+++ b/apps/daemon/src/runtime/team_skills.rs
@@ -317,51 +317,81 @@ pub async fn apply_team_skill_outcome(
     outcome: TeamSkillReconcileOutcome,
     backend: Option<&Arc<dyn Backend>>,
     refresh: Option<&Arc<crate::runtime::refresh::RuntimeRefreshCoordinator>>,
+    refresh_watch_registry: Option<
+        &Arc<crate::runtime::refresh::refresh_watch::RefreshWatchRegistry>,
+    >,
 ) {
     if !outcome.changed() {
         return;
     }
-    let (Some(refresh), Some(backend)) = (refresh, backend) else {
+    let Some(refresh) = refresh else {
         return;
     };
 
-    let rows = match backend
-        .get_workspaces_by_agent(team_id, backend.actor_id())
-        .await
-    {
-        Ok(rows) => rows,
-        Err(e) => {
-            tracing::warn!(
+    let mut cloud_targets = Vec::new();
+    if let Some(backend) = backend {
+        match backend
+            .get_workspaces_by_agent(team_id, backend.actor_id())
+            .await
+        {
+            Ok(rows) => {
+                for row in rows {
+                    let Some((path, _)) =
+                        crate::config::workspace_path::listable_local_workspace(&row)
+                    else {
+                        continue;
+                    };
+                    cloud_targets.push(crate::runtime::refresh::refresh_watch::WatchedWorkspace {
+                        workspace_id: row.id,
+                        workspace_path: PathBuf::from(path),
+                    });
+                }
+            }
+            Err(e) => tracing::warn!(
                 team_id,
                 error = %e,
-                "team skills changed but workspace list failed; skipping refresh fan-out"
-            );
-            return;
+                "team skills changed but cloud workspace list failed; using runtime refresh targets"
+            ),
         }
-    };
+    }
 
-    for row in rows {
-        let Some((path, _)) = crate::config::workspace_path::listable_local_workspace(&row) else {
-            continue;
-        };
-        let workspace_path = PathBuf::from(&path);
-        let workspace_id = row.id;
+    let runtime_targets = match refresh_watch_registry {
+        Some(registry) => registry.snapshot().await,
+        None => Vec::new(),
+    };
+    for target in merge_refresh_targets(cloud_targets, runtime_targets) {
         if let Err(error) = refresh
             .record_change(
-                &workspace_id,
-                &workspace_path,
+                &target.workspace_id,
+                &target.workspace_path,
                 crate::runtime::refresh::RefreshChangeKind::Skills,
                 crate::runtime::refresh::RefreshSource::UiMutation,
             )
             .await
         {
             tracing::warn!(
-                workspace_id,
+                workspace_id = target.workspace_id,
+                workspace_path = %target.workspace_path.display(),
                 error = %error,
                 "failed to record skills refresh after team skill reconcile"
             );
         }
     }
+}
+
+fn merge_refresh_targets(
+    cloud_targets: Vec<crate::runtime::refresh::refresh_watch::WatchedWorkspace>,
+    runtime_targets: Vec<crate::runtime::refresh::refresh_watch::WatchedWorkspace>,
+) -> Vec<crate::runtime::refresh::refresh_watch::WatchedWorkspace> {
+    let mut by_workspace_id = HashMap::new();
+    // Runtime targets are inserted last: RuntimeStart's effective path wins
+    // over a stale cloud path for the same workspace identity.
+    for target in cloud_targets.into_iter().chain(runtime_targets) {
+        by_workspace_id.insert(target.workspace_id.clone(), target);
+    }
+    let mut targets: Vec<_> = by_workspace_id.into_values().collect();
+    targets.sort_by(|a, b| a.workspace_id.cmp(&b.workspace_id));
+    targets
 }
 
 /// Which packs are in this root, and at what version, from each pack's own
@@ -519,5 +549,53 @@ mod tests {
 
         assert!(target.join("SKILL.md").is_file());
         assert!(!tmp.path().join("escaped.md").exists());
+    }
+
+    #[test]
+    fn runtime_refresh_target_overrides_stale_cloud_path() {
+        use crate::runtime::refresh::refresh_watch::WatchedWorkspace;
+
+        let targets = merge_refresh_targets(
+            vec![WatchedWorkspace {
+                workspace_id: "ws-1".into(),
+                workspace_path: PathBuf::from("/tmp/stale-cloud-path"),
+            }],
+            vec![WatchedWorkspace {
+                workspace_id: "ws-1".into(),
+                workspace_path: PathBuf::from("/tmp/actual-runtime-path"),
+            }],
+        );
+        assert_eq!(
+            targets[0].workspace_path,
+            Path::new("/tmp/actual-runtime-path")
+        );
+    }
+
+    #[tokio::test]
+    async fn team_skill_change_refreshes_runtime_target_without_cloud_inventory() {
+        use crate::runtime::refresh::refresh_watch::{RefreshWatchRegistry, WatchedWorkspace};
+
+        let registry = RefreshWatchRegistry::new(vec![WatchedWorkspace {
+            workspace_id: "ws-runtime".into(),
+            workspace_path: PathBuf::from("/tmp/actual-runtime-path"),
+        }]);
+        let refresh = crate::runtime::refresh::RuntimeRefreshCoordinator::new();
+        apply_team_skill_outcome(
+            "team-1",
+            TeamSkillReconcileOutcome {
+                installed: 1,
+                removed: 0,
+            },
+            None,
+            Some(&refresh),
+            Some(&registry),
+        )
+        .await;
+
+        let state = refresh.workspace_state("ws-runtime").await.unwrap();
+        assert_eq!(state.workspace_path, "/tmp/actual-runtime-path");
+        assert!(state
+            .change_kinds
+            .contains(&crate::runtime::refresh::RefreshChangeKind::Skills));
     }
 }

--- a/apps/desktop/src/commands/team_skills.rs
+++ b/apps/desktop/src/commands/team_skills.rs
@@ -154,6 +154,28 @@ pub struct TeamSkillInstallFromDirRequest {
     pub is_global: bool,
 }
 
+/// Promote the effective runtime copy of an already-installed team Skill to a
+/// newly published version without copying it through the member projection.
+///
+/// Hosted Agent sessions edit the daemon-owned cloud projection, while ordinary
+/// member installs live under `~/.agents/skills`. Re-baselining the latter
+/// unconditionally is what made a successful publish leave the copy OpenCode
+/// actually runs dirty against its previous version.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TeamSkillRebaselineRequest {
+    pub workspace_path: Option<String>,
+    pub slug: String,
+    pub team_id: Option<String>,
+    pub version: i64,
+    pub owner: Option<String>,
+    pub category: Option<String>,
+    pub summary: Option<String>,
+    pub when_to_use: Option<String>,
+    pub when_not_to_use: Option<String>,
+    pub requires: Option<Vec<String>>,
+}
+
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TeamSkillPackResult {
@@ -822,6 +844,81 @@ pub async fn team_skill_install_from_dir(
     .map_err(|e| format!("team skill install_from_dir task failed: {}", e))?
 }
 
+/// Re-baseline the same copy that inspection and publishing resolved.
+///
+/// This intentionally does not download or copy anything: the bytes in this
+/// directory are the bytes that were just uploaded. The desktop reconcile will
+/// independently bring the lower-priority member projection to the new version
+/// when the effective copy is hosted by the daemon.
+#[tauri::command]
+pub fn team_skill_rebaseline(
+    request: TeamSkillRebaselineRequest,
+) -> Result<TeamSkillInstallResult, String> {
+    let slug = request.slug.trim().to_string();
+    validate_slug(&slug)?;
+    let (target, _) = effective_team_skill_dir(&slug, request.team_id.as_deref())?;
+    if !target.is_dir() || !target.join("SKILL.md").is_file() {
+        return Err(format!("{} is not installed", slug));
+    }
+
+    let origin = read_origin(&target)
+        .ok_or_else(|| "Refusing to claim a Skill with no team install record".to_string())?;
+    if origin.registry != SOURCE_TEAM
+        || belongs_to_another_team(&origin, request.team_id.as_deref())
+    {
+        return Err("Refusing to re-baseline a Skill owned by another source".to_string());
+    }
+
+    let frontmatter_written = write_registry_frontmatter_fields(
+        &target,
+        &RegistryFields {
+            slug: &slug,
+            version: request.version,
+            owner: request.owner.as_deref(),
+            category: request.category.as_deref(),
+            summary: request.summary.as_deref(),
+            when_to_use: request.when_to_use.as_deref(),
+            when_not_to_use: request.when_not_to_use.as_deref(),
+            requires: request.requires.as_deref(),
+        },
+    )?;
+    stamp_installed_state(
+        &target,
+        InstalledStamp {
+            slug: &slug,
+            version: request.version,
+            team_id: request.team_id.as_deref(),
+            shipped: None,
+        },
+    )?;
+
+    if let Some(ws) = request
+        .workspace_path
+        .as_deref()
+        .filter(|s| !s.trim().is_empty())
+    {
+        let mut lock = read_lockfile(ws);
+        lock.skills.insert(
+            slug.clone(),
+            LockfileEntry {
+                version: Some(request.version.to_string()),
+                installed_at: now_millis(),
+                source: Some(SOURCE_TEAM.to_string()),
+            },
+        );
+        write_lockfile(ws, &lock)?;
+        set_skill_permission_ask(ws, &slug);
+    }
+
+    Ok(TeamSkillInstallResult {
+        slug,
+        version: request.version,
+        path: target.display().to_string(),
+        frontmatter_written,
+        archived_path: None,
+    })
+}
+
 /// Which team-registry packs are on this machine, and at what version.
 ///
 /// This is the left-hand side of the reconcile diff: the server's install rows
@@ -877,15 +974,78 @@ pub fn team_skill_list_installed() -> Result<Vec<InstalledTeamSkill>, String> {
     Ok(out)
 }
 
-/// Where an installed pack lives. The publish-a-new-version flow packs the
-/// installed directory rather than the author's original personal folder —
-/// after the first share those diverge, and the one the team is running is the
-/// one whose edits should ship.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum EffectiveSkillSource {
+    HostedAgent,
+    Member,
+}
+
+impl EffectiveSkillSource {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::HostedAgent => "hosted-agent",
+            Self::Member => "member",
+        }
+    }
+}
+
+fn hosted_team_skills_dir(team_id: &str) -> std::path::PathBuf {
+    crate::commands::amuxd_team_state_dir(team_id)
+        .join("cloud")
+        .join("skills")
+}
+
+/// Resolve the copy OpenCode actually sees for this slug. The daemon registers
+/// its hosted-Agent root before `~/.agents/skills`, so the first existing
+/// directory wins. A cloud directory for another (non-active) team is ignored:
+/// this desktop cannot be running it through the local daemon.
+fn effective_team_skill_dir(
+    slug: &str,
+    team_id: Option<&str>,
+) -> Result<(std::path::PathBuf, EffectiveSkillSource), String> {
+    let hosted = team_id
+        .map(str::trim)
+        .filter(|id| !id.is_empty())
+        .filter(|id| crate::commands::amuxd_active_team().as_deref() == Some(*id))
+        .map(|id| hosted_team_skills_dir(id).join(slug));
+    if let Some(path) = hosted.filter(|path| path.is_dir()) {
+        return Ok((path, EffectiveSkillSource::HostedAgent));
+    }
+    Ok((
+        global_skills_dir()?.join(slug),
+        EffectiveSkillSource::Member,
+    ))
+}
+
+/// Restore targets differ from reads: after a hosted copy was moved aside its
+/// directory no longer exists, but undo must put it back into the higher-ranked
+/// hosted root rather than silently restoring it as a member copy.
+fn preferred_team_skill_dir(
+    slug: &str,
+    team_id: Option<&str>,
+) -> Result<std::path::PathBuf, String> {
+    if let Some(id) = team_id
+        .map(str::trim)
+        .filter(|id| !id.is_empty())
+        .filter(|id| crate::commands::amuxd_active_team().as_deref() == Some(*id))
+    {
+        return Ok(hosted_team_skills_dir(id).join(slug));
+    }
+    Ok(global_skills_dir()?.join(slug))
+}
+
+/// Where the effective installed pack lives. The publish-a-new-version flow
+/// packs this directory rather than a hardcoded member projection — after a
+/// Hosted Agent edits its higher-priority cloud copy, that is the content the
+/// team expects to ship.
 #[tauri::command]
-pub fn team_skill_installed_dir(slug: String) -> Result<String, String> {
+pub fn team_skill_installed_dir(slug: String, team_id: Option<String>) -> Result<String, String> {
     let slug = slug.trim().to_string();
     validate_slug(&slug)?;
-    Ok(global_skills_dir()?.join(&slug).display().to_string())
+    Ok(effective_team_skill_dir(&slug, team_id.as_deref())?
+        .0
+        .display()
+        .to_string())
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -901,6 +1061,9 @@ pub struct TeamSkillInspectResult {
     /// its own right: the publish path measures the whole directory, so these
     /// ship with the next version.
     pub added: Vec<String>,
+    /// `hosted-agent` when this is the daemon projection OpenCode ranks first;
+    /// `member` for `~/.agents/skills`.
+    pub source: String,
 }
 
 /// Does this pack still look the way we installed it?
@@ -949,7 +1112,7 @@ pub fn team_skill_inspect(
     let _ = expected_version;
     let slug = slug.trim().to_string();
     validate_slug(&slug)?;
-    let target = global_skills_dir()?.join(&slug);
+    let (target, source) = effective_team_skill_dir(&slug, team_id.as_deref())?;
 
     let missing = |slug: String| TeamSkillInspectResult {
         slug,
@@ -958,6 +1121,7 @@ pub fn team_skill_inspect(
         modified: Vec::new(),
         deleted: Vec::new(),
         added: Vec::new(),
+        source: source.as_str().to_string(),
     };
 
     if !target.exists() {
@@ -992,6 +1156,7 @@ pub fn team_skill_inspect(
             modified: Vec::new(),
             deleted: Vec::new(),
             added: Vec::new(),
+            source: source.as_str().to_string(),
         });
     }
 
@@ -1014,6 +1179,7 @@ pub fn team_skill_inspect(
             modified,
             deleted,
             added,
+            source: source.as_str().to_string(),
         }),
         _ => Ok(TeamSkillInspectResult {
             slug,
@@ -1022,6 +1188,7 @@ pub fn team_skill_inspect(
             modified: Vec::new(),
             deleted: Vec::new(),
             added: Vec::new(),
+            source: source.as_str().to_string(),
         }),
     }
 }
@@ -1052,7 +1219,7 @@ pub async fn team_skill_diff(
         let mut request = request;
         let slug = request.slug.trim().to_string();
         validate_slug(&slug)?;
-        let target = global_skills_dir()?.join(&slug);
+        let (target, _) = effective_team_skill_dir(&slug, request.team_id.as_deref())?;
 
         let (modified, deleted, added) = match installed_state(&target) {
             DirtyState::Dirty {
@@ -1140,10 +1307,10 @@ pub async fn team_skill_diff(
 /// protect the rare misclick, the undo protects the misclick without
 /// interrupting anyone.
 #[tauri::command]
-pub fn team_skill_discard_local(slug: String) -> Result<String, String> {
+pub fn team_skill_discard_local(slug: String, team_id: Option<String>) -> Result<String, String> {
     let slug = slug.trim().to_string();
     validate_slug(&slug)?;
-    let target = global_skills_dir()?.join(&slug);
+    let (target, _) = effective_team_skill_dir(&slug, team_id.as_deref())?;
     if !target.exists() {
         return Err(format!("{} is not installed", slug));
     }
@@ -1239,12 +1406,20 @@ fn resolve_trashed_source(
 /// Undo a discard. The trashed copy wins over whatever is installed now, which
 /// is the point: the user asked for their edits back.
 #[tauri::command]
-pub fn team_skill_restore_trashed(trashed_path: String, slug: String) -> Result<String, String> {
+pub fn team_skill_restore_trashed(
+    trashed_path: String,
+    slug: String,
+    team_id: Option<String>,
+) -> Result<String, String> {
     let slug = slug.trim().to_string();
     validate_slug(&slug)?;
     let source = resolve_trashed_source(&trash_dir()?, trashed_path.trim())?;
 
-    let target = global_skills_dir()?.join(&slug);
+    let target = preferred_team_skill_dir(&slug, team_id.as_deref())?;
+    if let Some(parent) = target.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|e| format!("Failed to create skill root: {}", e))?;
+    }
     if target.exists() {
         std::fs::remove_dir_all(&target)
             .map_err(|e| format!("Failed to clear skill dir: {}", e))?;
@@ -1260,7 +1435,11 @@ pub fn team_skill_restore_trashed(trashed_path: String, slug: String) -> Result<
 /// shadow the team copy and quietly cancel the auto-follow it was supposed to
 /// let the user keep.
 #[tauri::command]
-pub fn team_skill_fork(slug: String, new_slug: String) -> Result<String, String> {
+pub fn team_skill_fork(
+    slug: String,
+    new_slug: String,
+    team_id: Option<String>,
+) -> Result<String, String> {
     let slug = slug.trim().to_string();
     let new_slug = new_slug.trim().to_string();
     validate_slug(&slug)?;
@@ -1270,7 +1449,7 @@ pub fn team_skill_fork(slug: String, new_slug: String) -> Result<String, String>
     }
 
     let skills = global_skills_dir()?;
-    let source = skills.join(&slug);
+    let (source, _) = effective_team_skill_dir(&slug, team_id.as_deref())?;
     if !source.is_dir() {
         return Err(format!("{} is not installed", slug));
     }
@@ -1327,6 +1506,90 @@ mod tests {
             force: false,
             archive_unmanaged: false,
         }
+    }
+
+    fn rebaseline_request(slug: &str, version: i64) -> TeamSkillRebaselineRequest {
+        TeamSkillRebaselineRequest {
+            workspace_path: None,
+            slug: slug.to_string(),
+            team_id: Some("team-a".into()),
+            version,
+            owner: Some("张三".into()),
+            category: Some("devops".into()),
+            summary: Some("发布前检查清单".into()),
+            when_to_use: Some("发布前确认 CI".into()),
+            when_not_to_use: None,
+            requires: None,
+        }
+    }
+
+    fn set_active_team(team_id: &str) {
+        let root = crate::commands::amuxd_home_dir();
+        std::fs::create_dir_all(&root).unwrap();
+        std::fs::write(
+            root.join("daemon.toml"),
+            format!("active_team = \"{team_id}\"\n"),
+        )
+        .unwrap();
+    }
+
+    fn write_installed_skill(path: &std::path::Path, team_id: &str, version: i64) {
+        std::fs::create_dir_all(path).unwrap();
+        std::fs::write(path.join("SKILL.md"), "---\nname: say-hello\n---\nhello\n").unwrap();
+        stamp_installed_state(
+            path,
+            InstalledStamp {
+                slug: "say-hello",
+                version,
+                team_id: Some(team_id),
+                shipped: None,
+            },
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn effective_copy_prefers_the_active_hosted_agent_projection() {
+        let home = tempfile::tempdir().expect("tempdir");
+        let _home = crate::test_home::HomeGuard::set(home.path());
+        set_active_team("team-a");
+        let member = global_skills_dir().unwrap().join("say-hello");
+        let hosted = hosted_team_skills_dir("team-a").join("say-hello");
+        write_installed_skill(&member, "team-a", 2);
+        write_installed_skill(&hosted, "team-a", 2);
+
+        let (resolved, source) = effective_team_skill_dir("say-hello", Some("team-a")).unwrap();
+        assert_eq!(resolved, hosted);
+        assert_eq!(source, EffectiveSkillSource::HostedAgent);
+    }
+
+    #[test]
+    fn inspection_and_rebaseline_use_the_same_hosted_copy() {
+        let home = tempfile::tempdir().expect("tempdir");
+        let _home = crate::test_home::HomeGuard::set(home.path());
+        set_active_team("team-a");
+        let member = global_skills_dir().unwrap().join("say-hello");
+        let hosted = hosted_team_skills_dir("team-a").join("say-hello");
+        write_installed_skill(&member, "team-a", 2);
+        write_installed_skill(&hosted, "team-a", 2);
+        std::fs::write(
+            hosted.join("SKILL.md"),
+            "---\nname: say-hello\n---\nhi, arya\n",
+        )
+        .unwrap();
+
+        let before = team_skill_inspect("say-hello".into(), Some(2), Some("team-a".into()))
+            .expect("inspect hosted edit");
+        assert_eq!(before.state, "dirty");
+        assert_eq!(before.source, "hosted-agent");
+        assert_eq!(before.modified, vec!["SKILL.md"]);
+
+        let result = team_skill_rebaseline(rebaseline_request("say-hello", 3))
+            .expect("rebaseline hosted edit");
+        assert_eq!(std::path::PathBuf::from(result.path), hosted);
+        assert_eq!(read_origin(&hosted).unwrap().installed_version, "3");
+        assert_eq!(installed_state(&hosted), DirtyState::Clean);
+        assert_eq!(read_origin(&member).unwrap().installed_version, "2");
     }
 
     /// A workspace `opencode.json` carrying a decision about `deploy-check`.

--- a/apps/desktop/src/lib.rs
+++ b/apps/desktop/src/lib.rs
@@ -439,6 +439,7 @@ pub fn run() {
             commands::team_skills::team_skill_pack,
             commands::team_skills::team_skill_pack_and_upload,
             commands::team_skills::team_skill_install_from_dir,
+            commands::team_skills::team_skill_rebaseline,
             commands::team_skills::team_skill_inspect,
             commands::team_skills::team_skill_installed_dir,
             commands::team_skills::team_skill_diff,

--- a/packages/app/src/components/teamshare/SkillDetail.tsx
+++ b/packages/app/src/components/teamshare/SkillDetail.tsx
@@ -463,6 +463,7 @@ function ConflictBar({
   latestVersion,
   busy,
   canPublish,
+  source,
   onViewDiff,
   onPublish,
   onFork,
@@ -475,6 +476,7 @@ function ConflictBar({
   latestVersion: number | null
   busy: boolean
   canPublish: boolean
+  source: 'hosted-agent' | 'member'
   onViewDiff: () => void
   onPublish: () => void
   onFork: () => void
@@ -514,6 +516,11 @@ function ConflictBar({
         {changed && (
           <p className="mt-1 break-words text-[12px] leading-relaxed text-muted-foreground">{changed}</p>
         )}
+        <p className="mt-1 text-[11.5px] text-faint">
+          {source === 'hosted-agent'
+            ? t('teamShare.skillConflictSourceHosted', '修改来源：本机 Hosted Agent')
+            : t('teamShare.skillConflictSourceMember', '修改来源：本机成员目录')}
+        </p>
         <div className="mt-3 flex flex-wrap items-center gap-2">
           <button
             type="button"
@@ -1565,6 +1572,7 @@ export function SkillDetail({ slug }: { slug: string }) {
           latestVersion={item.latestVersion}
           busy={busy}
           canPublish={canPublish}
+          source={localState?.source ?? 'member'}
           onViewDiff={openDiff}
           onPublish={() => setPublishOpen(true)}
           onFork={() => setForkOpen(true)}

--- a/packages/app/src/lib/skills/auto-follow.ts
+++ b/packages/app/src/lib/skills/auto-follow.ts
@@ -16,6 +16,8 @@
 /** What `team_skill_inspect` reports about one pack on disk. */
 export interface SkillLocalState {
   slug: string
+  /** Which runtime projection was inspected for this slug. */
+  source: 'hosted-agent' | 'member'
   /**
    * `foreign` means the directory carries another registry's `origin.json`.
    * Slugs collide across registries because they all install into the same

--- a/packages/app/src/locales/en.json
+++ b/packages/app/src/locales/en.json
@@ -131,6 +131,8 @@
     "skillConflictModified": "{{files}} changed",
     "skillConflictDeleted": "{{files}} deleted",
     "skillConflictAdded": "{{files}} added",
+    "skillConflictSourceHosted": "Changes from: local Hosted Agent",
+    "skillConflictSourceMember": "Changes from: local member directory",
     "skillConflictViewDiff": "View changes",
     "skillConflictPublish": "Publish as v{{v}}",
     "skillConflictFork": "Save as personal",

--- a/packages/app/src/locales/zh-CN.json
+++ b/packages/app/src/locales/zh-CN.json
@@ -131,6 +131,8 @@
     "skillConflictModified": "{{files}} 被改动",
     "skillConflictDeleted": "{{files}} 被删除",
     "skillConflictAdded": "新增 {{files}}",
+    "skillConflictSourceHosted": "修改来源：本机 Hosted Agent",
+    "skillConflictSourceMember": "修改来源：本机成员目录",
     "skillConflictViewDiff": "查看改动",
     "skillConflictPublish": "发布为 v{{v}}",
     "skillConflictFork": "另存为个人",

--- a/packages/app/src/stores/team-share-browser.ts
+++ b/packages/app/src/stores/team-share-browser.ts
@@ -1476,7 +1476,7 @@ export const useTeamShareBrowserStore = create<TeamShareBrowserState>((set, get)
 
     // Publish what is on disk right now, including whatever the author edited
     // locally — that content is the whole reason a new version is being cut.
-    const sourceDir = await invoke<string>('team_skill_installed_dir', { slug })
+    const sourceDir = await invoke<string>('team_skill_installed_dir', { slug, teamId })
     const packed = await invoke<{ contentHash: string; size: number }>('team_skill_pack_and_upload', {
       dirPath: sourceDir,
       slug,
@@ -1500,12 +1500,11 @@ export const useTeamShareBrowserStore = create<TeamShareBrowserState>((set, get)
     // Re-baseline against the version just published. Skipping this leaves the
     // author permanently in conflict with their own release, since the disk
     // still differs from the baseline taken at the previous version.
-    await invoke('team_skill_install_from_dir', {
+    await invoke('team_skill_rebaseline', {
       request: {
         workspacePath: wsPath,
         slug,
         teamId,
-        sourceDir,
         version: version.version,
         owner: skill.ownerActorId,
         category: input.category ?? skill.category,
@@ -1513,7 +1512,6 @@ export const useTeamShareBrowserStore = create<TeamShareBrowserState>((set, get)
         whenToUse: input.whenToUse ?? skill.whenToUse,
         whenNotToUse: input.whenNotToUse ?? skill.whenNotToUse,
         requires: input.requires ?? skill.requires,
-        isGlobal: true,
       },
     })
     // Same reason as Share: the pack landed on this Agent's disk, so this Agent
@@ -1744,7 +1742,7 @@ export const useTeamShareBrowserStore = create<TeamShareBrowserState>((set, get)
     const teamId = currentTeamId()
     if (!teamId) throw new Error('no current team')
     const skill = get().skills.items.find((s) => s.slug === slug)
-    const trashedPath = await invoke<string>('team_skill_discard_local', { slug })
+    const trashedPath = await invoke<string>('team_skill_discard_local', { slug, teamId })
     try {
       await materializeSkill(teamId, slug, skill?.latestVersion ?? 1)
     } catch (e) {
@@ -1764,13 +1762,17 @@ export const useTeamShareBrowserStore = create<TeamShareBrowserState>((set, get)
   },
 
   restoreDiscardedSkill: async (trashedPath, slug) => {
-    await invoke('team_skill_restore_trashed', { trashedPath, slug })
+    const teamId = currentTeamId()
+    if (!teamId) throw new Error('no current team')
+    await invoke('team_skill_restore_trashed', { trashedPath, slug, teamId })
     await get().reconcileSkills()
     await get().loadSection('skills', { force: true })
   },
 
   forkSkill: async (slug, newSlug) => {
-    const path = await invoke<string>('team_skill_fork', { slug, newSlug })
+    const teamId = currentTeamId()
+    if (!teamId) throw new Error('no current team')
+    const path = await invoke<string>('team_skill_fork', { slug, newSlug, teamId })
     // The copy is what the user asked for and it is on disk now. Handing the
     // team pack back to auto-follow is cleanup, and cleanup must not be able to
     // fail the whole action: reporting "save failed" after the copy exists sends
@@ -1803,6 +1805,7 @@ export const useTeamShareBrowserStore = create<TeamShareBrowserState>((set, get)
     return invoke<TeamSkillFileDiff[]>('team_skill_diff', {
       request: {
         slug,
+        teamId,
         downloadUrl: url,
         accessToken: null,
         version: installedVersion,


### PR DESCRIPTION
## Summary

- restrict session deeplink context injection to managed TeamClu introspect server aliases
- refresh running OpenCode instances when hosted team Skill content changes
- use the effective hosted/member Skill projection consistently for dirty detection, diff, publish, re-baseline, discard, restore, and fork
- show which local projection contains unpublished changes

## Validation

- `node --test apps/daemon/shared/session-context-client.test.mjs apps/daemon/assets/pi-extension/session-context.test.mjs` (27 passed)
- `pnpm typecheck`
- `pnpm rust:check`
- targeted Rust tests for hosted projection precedence and re-baselining
- `git diff --check`