### PR TITLE
feat(fc): session thread schema and API (split from thread UI)

### DIFF
--- a/docs/openapi/teamclu-api.v1.yaml
+++ b/docs/openapi/teamclu-api.v1.yaml
@@ -2812,6 +2812,83 @@ paths:
                   balanceCredits: { type: integer }
         '403': { description: Only team owners may top up }
 
+  /v1/teams/{teamId}/credits/packages:
+    get:
+      operationId: listCreditPackages
+      tags: [teams]
+      summary: Credit packages a team can buy
+      description: |
+        Resolved from the deployment's Stripe Price allowlist, so amounts and
+        the credits each grants live in exactly one place (the Price and its
+        `metadata.credits`) rather than being duplicated client-side.
+
+        Readable by any member — the top-up screen shows what is on offer even
+        to someone who cannot buy it. Empty when the deployment has no Stripe
+        configured, which the client renders as "top-up unavailable" rather
+        than as an error.
+
+        `unitAmount` is in Stripe's MINOR units (cents, 分) and is passed
+        through unconverted.
+      parameters:
+        - $ref: '#/components/parameters/TeamId'
+      responses:
+        '200':
+          description: Offered packages
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [items]
+                properties:
+                  items:
+                    type: array
+                    items: { $ref: '#/components/schemas/CreditPackage' }
+        '403': { description: Not a member of this team }
+
+  /v1/teams/{teamId}/credits/checkout-session:
+    post:
+      operationId: createCreditCheckoutSession
+      tags: [teams]
+      summary: Open a Stripe Checkout Session for a credit package (owner only)
+      description: |
+        Returns a hosted Checkout URL. Open it in the SYSTEM browser, not an
+        embedded webview: 3DS and wallet flows break there, and a payment page
+        with no address bar is not something to ask a user to trust.
+
+        Do not block the UI waiting for the credits. They arrive over the
+        Stripe webhook (or the reconciliation pass behind it), so the client
+        shows "processing" and lets the balance refresh.
+
+        The team is taken from the path, never from the body — the Session is
+        the only thing a payment can be attributed by.
+      parameters:
+        - $ref: '#/components/parameters/TeamId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [priceId]
+              properties:
+                priceId:
+                  type: string
+                  description: Must be one of the ids from `/credits/packages`
+      responses:
+        '200':
+          description: Hosted Checkout Session
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [sessionId, url]
+                properties:
+                  sessionId: { type: string }
+                  url: { type: string, format: uri }
+        '400': { description: priceId missing or not an offered package }
+        '403': { description: Only team owners may buy credits }
+        '503': { description: Stripe is not configured for this deployment }
+
   /v1/teams/{teamId}/quotas:
     get:
       operationId: getMemberQuotas
@@ -7046,6 +7123,19 @@ components:
         amountCredits: { type: integer, description: Signed; refunds are negative }
         note: { type: ["string", "null"] }
         createdAt: { type: string }
+    CreditPackage:
+      type: object
+      required: [priceId, credits, currency, name]
+      properties:
+        priceId: { type: string }
+        credits:
+          type: integer
+          description: Credits granted on purchase, from the Price's metadata.credits
+        unitAmount:
+          type: ["integer", "null"]
+          description: Price in MINOR currency units (cents, 分); null for a Price with no fixed amount
+        currency: { type: string }
+        name: { type: string }
     TeamQuotas:
       type: object
       properties:

--- a/docs/openapi/teamclu-api.v1.yaml
+++ b/docs/openapi/teamclu-api.v1.yaml
@@ -1106,6 +1106,61 @@ paths:
           $ref: "#/components/responses/Error"
         "401":
           $ref: "#/components/responses/Error"
+  /v1/sessions/{sessionId}/threads:
+    post:
+      operationId: createSessionThread
+      summary: Fork an agent-reply thread session (idempotent on rootMessageId)
+      tags: [Sessions]
+      parameters:
+        - $ref: "#/components/parameters/SessionId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [rootMessageId]
+              properties:
+                rootMessageId:
+                  type: string
+                  format: uuid
+      responses:
+        "201":
+          description: Thread session (new or existing)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SessionWithParticipants"
+        "400":
+          $ref: "#/components/responses/Error"
+        "403":
+          $ref: "#/components/responses/Error"
+        "404":
+          $ref: "#/components/responses/Error"
+  /v1/sessions/{sessionId}/thread-summaries:
+    get:
+      operationId: listSessionThreadSummaries
+      summary: Thread badge summaries for a parent session
+      tags: [Sessions]
+      parameters:
+        - $ref: "#/components/parameters/SessionId"
+      responses:
+        "200":
+          description: Thread summaries
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [items]
+                properties:
+                  items:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/SessionThreadSummary"
+        "403":
+          $ref: "#/components/responses/Error"
+        "404":
+          $ref: "#/components/responses/Error"
   /v1/sessions/{sessionId}/messages:
     get:
       operationId: listMessages
@@ -2756,83 +2811,6 @@ paths:
                     description: false when this idempotencyKey was already recorded
                   balanceCredits: { type: integer }
         '403': { description: Only team owners may top up }
-
-  /v1/teams/{teamId}/credits/packages:
-    get:
-      operationId: listCreditPackages
-      tags: [teams]
-      summary: Credit packages a team can buy
-      description: |
-        Resolved from the deployment's Stripe Price allowlist, so amounts and
-        the credits each grants live in exactly one place (the Price and its
-        `metadata.credits`) rather than being duplicated client-side.
-
-        Readable by any member — the top-up screen shows what is on offer even
-        to someone who cannot buy it. Empty when the deployment has no Stripe
-        configured, which the client renders as "top-up unavailable" rather
-        than as an error.
-
-        `unitAmount` is in Stripe's MINOR units (cents, 分) and is passed
-        through unconverted.
-      parameters:
-        - $ref: '#/components/parameters/TeamId'
-      responses:
-        '200':
-          description: Offered packages
-          content:
-            application/json:
-              schema:
-                type: object
-                required: [items]
-                properties:
-                  items:
-                    type: array
-                    items: { $ref: '#/components/schemas/CreditPackage' }
-        '403': { description: Not a member of this team }
-
-  /v1/teams/{teamId}/credits/checkout-session:
-    post:
-      operationId: createCreditCheckoutSession
-      tags: [teams]
-      summary: Open a Stripe Checkout Session for a credit package (owner only)
-      description: |
-        Returns a hosted Checkout URL. Open it in the SYSTEM browser, not an
-        embedded webview: 3DS and wallet flows break there, and a payment page
-        with no address bar is not something to ask a user to trust.
-
-        Do not block the UI waiting for the credits. They arrive over the
-        Stripe webhook (or the reconciliation pass behind it), so the client
-        shows "processing" and lets the balance refresh.
-
-        The team is taken from the path, never from the body — the Session is
-        the only thing a payment can be attributed by.
-      parameters:
-        - $ref: '#/components/parameters/TeamId'
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              required: [priceId]
-              properties:
-                priceId:
-                  type: string
-                  description: Must be one of the ids from `/credits/packages`
-      responses:
-        '200':
-          description: Hosted Checkout Session
-          content:
-            application/json:
-              schema:
-                type: object
-                required: [sessionId, url]
-                properties:
-                  sessionId: { type: string }
-                  url: { type: string, format: uri }
-        '400': { description: priceId missing or not an offered package }
-        '403': { description: Only team owners may buy credits }
-        '503': { description: Stripe is not configured for this deployment }
 
   /v1/teams/{teamId}/quotas:
     get:
@@ -6769,9 +6747,19 @@ components:
           description: >-
             How the session was created. 'user' for normal sessions, 'cron' for
             sessions auto-created by a scheduled task, 'gateway' for gateway
-            (WeCom etc.) bindings.
+            (WeCom etc.) bindings, 'thread' for agent-reply fork threads.
           type: string
-          enum: [user, cron, gateway]
+          enum: [user, cron, gateway, thread]
+        parentSessionId:
+          description: Parent session when source='thread'.
+          type:
+            - string
+            - "null"
+        threadRootMessageId:
+          description: Anchor agent_reply message when source='thread'.
+          type:
+            - string
+            - "null"
         cronJobId:
           description: >-
             For source='cron', the desktop-local cron job id that created this
@@ -7058,19 +7046,6 @@ components:
         amountCredits: { type: integer, description: Signed; refunds are negative }
         note: { type: ["string", "null"] }
         createdAt: { type: string }
-    CreditPackage:
-      type: object
-      required: [priceId, credits, currency, name]
-      properties:
-        priceId: { type: string }
-        credits:
-          type: integer
-          description: Credits granted on purchase, from the Price's metadata.credits
-        unitAmount:
-          type: ["integer", "null"]
-          description: Price in MINOR currency units (cents, 分); null for a Price with no fixed amount
-        currency: { type: string }
-        name: { type: string }
     TeamQuotas:
       type: object
       properties:
@@ -7356,6 +7331,25 @@ components:
           items:
             type: string
             format: uuid
+    SessionThreadSummary:
+      type: object
+      required: [threadSessionId, rootMessageId, messageCount, participantCount]
+      properties:
+        threadSessionId:
+          type: string
+          format: uuid
+        rootMessageId:
+          type: string
+          format: uuid
+        messageCount:
+          type: integer
+        lastMessageAt:
+          type:
+            - string
+            - "null"
+          format: date-time
+        participantCount:
+          type: integer
     SessionWithParticipants:
       allOf:
         - $ref: "#/components/schemas/Session"

--- a/services/fc/src/db/schema/sessions.ts
+++ b/services/fc/src/db/schema/sessions.ts
@@ -23,8 +23,14 @@ export const sessions = pgTable("sessions", {
    *  Written at create time from the binding and never cleared, so a chat can
    *  still enumerate the sessions it detached from (`/sessions` → `/sessions n`). */
   gatewayKey: text("gateway_key"),
-  /** How the session was created: 'user' (default) | 'cron' | 'gateway'. */
+  /** How the session was created: 'user' (default) | 'cron' | 'gateway' | 'thread'. */
   source: text("source").notNull().default("user"),
+  /** Parent session when source='thread' (forked agent-reply thread). */
+  parentSessionId: uuid("parent_session_id").references((): typeof sessions.id => sessions.id, {
+    onDelete: "cascade",
+  }),
+  /** Anchor agent_reply message when source='thread'. */
+  threadRootMessageId: uuid("thread_root_message_id"),
   /** For source='cron': the desktop-local cron job id that created it
    *  (a daemon-local string id, not a cloud FK). */
   cronJobId: text("cron_job_id"),

--- a/services/fc/src/lib/pg-repo/sessions.ts
+++ b/services/fc/src/lib/pg-repo/sessions.ts
@@ -31,6 +31,7 @@ import {
   agents,
   teams,
   teamMembers,
+  messages,
 } from "../../db/schema/index.js";
 import { ApiError } from "../http-utils.js";
 import { requireActorForTeam, resolveActorForTeam } from "./authz.js";
@@ -105,6 +106,8 @@ function mapSessionFull(r: any, participants: any[] = []) {
     gatewayKey: r.gatewayKey ?? null,
     source: r.source ?? "user",
     cronJobId: r.cronJobId ?? null,
+    parentSessionId: r.parentSessionId ?? null,
+    threadRootMessageId: r.threadRootMessageId ?? null,
     createdAt: iso(r.createdAt)!,
     updatedAt: iso(r.updatedAt)!,
     participants,
@@ -143,6 +146,8 @@ function mapSessionSyncRow(r: any) {
     created_by_actor_id: r.createdByActorId ?? null,
     source: r.source ?? "user",
     cron_job_id: r.cronJobId ?? null,
+    parent_session_id: r.parentSessionId ?? null,
+    thread_root_message_id: r.threadRootMessageId ?? null,
     created_at: iso(r.createdAt),
     updated_at: iso(r.updatedAt),
   };
@@ -294,6 +299,7 @@ export function makeSessionsRepo(db: DbLike, ctx: SessionsCtx = {}, deps: Sessio
           AND (${kindFilter})
           AND (${participantFilter})
           AND (${cursorFilter})
+          AND sessions.parent_session_id IS NULL
           -- No archived_at filter, unlike the Supabase RPC: this schema has no
           -- such column (see the note in ensureGatewaySession below). Archive
           -- semantics live entirely in the supabase path.
@@ -831,6 +837,160 @@ export function makeSessionsRepo(db: DbLike, ctx: SessionsCtx = {}, deps: Sessio
         .orderBy(asc(sessions.updatedAt), asc(sessions.id))
         .limit(limit);
       return rows.map(mapSessionSyncRow);
+    },
+
+    // ── createThread ──────────────────────────────────────────────────────────
+    async createThread(
+      parentSessionId: string,
+      { rootMessageId }: { rootMessageId: string },
+    ) {
+      if (!rootMessageId?.trim()) {
+        throw new ApiError(400, "validation_failed", "rootMessageId is required");
+      }
+      const [parent] = await db
+        .select()
+        .from(sessions)
+        .where(eq(sessions.id, parentSessionId))
+        .limit(1);
+      if (!parent) throw new ApiError(404, "not_found", "parent session not found");
+      if (parent.parentSessionId) {
+        throw new ApiError(400, "validation_failed", "cannot open a thread on a thread session");
+      }
+
+      const callerActorId =
+        ctx.callerActorId ??
+        (ctx.userId ? await requireActorForTeam(db, ctx.userId, parent.teamId) : null);
+      if (!callerActorId) {
+        throw new ApiError(401, "missing_identity", "authentication required");
+      }
+
+      const parentSeats = await db
+        .select()
+        .from(sessionParticipants)
+        .where(eq(sessionParticipants.sessionId, parentSessionId));
+      if (!parentSeats.some((s: { actorId: string }) => s.actorId === callerActorId)) {
+        throw new ApiError(403, "forbidden", "not a participant in the parent session");
+      }
+
+      const [existing] = await db
+        .select()
+        .from(sessions)
+        .where(eq(sessions.threadRootMessageId, rootMessageId))
+        .limit(1);
+      if (existing) {
+        const parts = await db
+          .select()
+          .from(sessionParticipants)
+          .where(eq(sessionParticipants.sessionId, existing.id));
+        return mapSessionFull(existing, parts.map(mapParticipant));
+      }
+
+      const [rootMsg] = await db
+        .select()
+        .from(messages)
+        .where(
+          and(eq(messages.id, rootMessageId), eq(messages.sessionId, parentSessionId)),
+        )
+        .limit(1);
+      if (!rootMsg) {
+        throw new ApiError(404, "not_found", "root message not found in parent session");
+      }
+      if (rootMsg.kind !== "agent_reply") {
+        throw new ApiError(
+          400,
+          "validation_failed",
+          "rootMessageId must reference an agent_reply message",
+        );
+      }
+
+      const childId = crypto.randomUUID();
+      const preview = (rootMsg.content ?? "").trim().slice(0, 80);
+      const threadTitle = preview
+        ? `${parent.title} · ${preview}${preview.length >= 80 ? "…" : ""}`
+        : `${parent.title} · 话题`;
+
+      const [child] = await (db.insert(sessions) as any)
+        .values({
+          id: childId,
+          teamId: parent.teamId,
+          title: threadTitle,
+          mode: parent.mode,
+          ideaId: parent.ideaId,
+          primaryAgentId: parent.primaryAgentId,
+          createdByActorId: callerActorId,
+          source: "thread",
+          parentSessionId,
+          threadRootMessageId: rootMessageId,
+        })
+        .returning();
+
+      const participantIds = parentSeats
+        .map((s: { actorId: string }) => s.actorId)
+        .filter(Boolean);
+      let parts: any[] = [];
+      if (participantIds.length > 0) {
+        parts = await (db.insert(sessionParticipants) as any)
+          .values(participantIds.map((actorId: string) => ({ sessionId: childId, actorId })))
+          .onConflictDoNothing()
+          .returning();
+      }
+
+      return mapSessionFull(child, parts.map(mapParticipant));
+    },
+
+    async listThreadSummaries(parentSessionId: string) {
+      const [parent] = await db
+        .select({ id: sessions.id, teamId: sessions.teamId })
+        .from(sessions)
+        .where(eq(sessions.id, parentSessionId))
+        .limit(1);
+      if (!parent) throw new ApiError(404, "not_found", "parent session not found");
+
+      const callerActorId =
+        ctx.callerActorId ??
+        (ctx.userId ? await resolveActorForTeam(db, ctx.userId, parent.teamId) : null);
+      if (!callerActorId) {
+        throw new ApiError(401, "missing_identity", "authentication required");
+      }
+
+      const seats = await db
+        .select({ id: sessionParticipants.id })
+        .from(sessionParticipants)
+        .where(
+          and(
+            eq(sessionParticipants.sessionId, parentSessionId),
+            eq(sessionParticipants.actorId, callerActorId),
+          ),
+        )
+        .limit(1);
+      if (seats.length === 0) {
+        throw new ApiError(403, "forbidden", "not a participant in the parent session");
+      }
+
+      const threadRows = await db
+        .select({
+          threadSessionId: sessions.id,
+          rootMessageId: sessions.threadRootMessageId,
+          lastMessageAt: sessions.lastMessageAt,
+          participantCount: sql<number>`(
+            SELECT COUNT(*)::int FROM session_participants sp
+            WHERE sp.session_id = ${sessions.id}
+          )`,
+          messageCount: sql<number>`(
+            SELECT COUNT(*)::int FROM messages m
+            WHERE m.session_id = ${sessions.id}
+          )`,
+        })
+        .from(sessions)
+        .where(eq(sessions.parentSessionId, parentSessionId));
+
+      return threadRows.map((r: any) => ({
+        threadSessionId: r.threadSessionId,
+        rootMessageId: r.rootMessageId,
+        messageCount: r.messageCount ?? 0,
+        lastMessageAt: iso(r.lastMessageAt),
+        participantCount: r.participantCount ?? 0,
+      }));
     },
 
     // ── listSessionDisplayRows ────────────────────────────────────────────────

--- a/services/fc/src/lib/routes/sessions.ts
+++ b/services/fc/src/lib/routes/sessions.ts
@@ -123,6 +123,22 @@ export function registerSessions(router) {
     return { body: out };
   });
 
+  router.post("/v1/sessions/:sessionId/threads", async (ctx) => {
+    const parentSessionId = decodeURIComponent(ctx.params.sessionId);
+    const body = ctx.json ?? {};
+    requireString(body.rootMessageId, "rootMessageId");
+    const out = await ctx.repository.createThread(parentSessionId, {
+      rootMessageId: body.rootMessageId,
+    });
+    return { statusCode: 201, body: out };
+  });
+
+  router.get("/v1/sessions/:sessionId/thread-summaries", async (ctx) => {
+    const parentSessionId = decodeURIComponent(ctx.params.sessionId);
+    const items = await ctx.repository.listThreadSummaries(parentSessionId);
+    return { body: { items } };
+  });
+
   // GET /v1/teams/:teamId/sessions is gone — it fetched a team's entire session
   // list unpaginated, then filtered participants with an `.in(<every id>)` that
   // outgrew the gateway's URI limit and surfaced as an opaque 500. Use

--- a/services/fc/src/lib/supabase-repo.ts
+++ b/services/fc/src/lib/supabase-repo.ts
@@ -2336,11 +2336,186 @@ export function createSupabaseBusinessRepository(options) {
     },
 
     async createThread(parentSessionId, { rootMessageId }) {
-      throw new ApiError(501, "not_implemented", "createThread requires BACKEND_KIND=postgres");
+      if (!rootMessageId?.trim()) {
+        throw new ApiError(400, "validation_failed", "rootMessageId is required");
+      }
+
+      const { data: parent, error: parentErr } = await supabase
+        .from("sessions")
+        .select("id, team_id, title, mode, idea_id, primary_agent_id, parent_session_id")
+        .eq("id", parentSessionId)
+        .maybeSingle();
+      if (parentErr) throw parentErr;
+      if (!parent) throw new ApiError(404, "not_found", "parent session not found");
+      if (parent.parent_session_id) {
+        throw new ApiError(400, "validation_failed", "cannot open a thread on a thread session");
+      }
+
+      const callerActorId = (await this.resolveCallerActorForTeam(parent.team_id))?.id ?? null;
+      if (!callerActorId) {
+        throw new ApiError(401, "missing_identity", "authentication required");
+      }
+
+      const { data: callerSeat, error: seatErr } = await supabase
+        .from("session_participants")
+        .select("actor_id")
+        .eq("session_id", parentSessionId)
+        .eq("actor_id", callerActorId)
+        .maybeSingle();
+      if (seatErr) throw seatErr;
+      if (!callerSeat) {
+        throw new ApiError(403, "forbidden", "not a participant in the parent session");
+      }
+
+      const { data: existing, error: existingErr } = await supabase
+        .from("sessions")
+        .select(SESSION_FULL_COLUMNS)
+        .eq("thread_root_message_id", rootMessageId)
+        .maybeSingle();
+      if (existingErr) throw existingErr;
+      if (existing) {
+        const { items } = await this.listSessionParticipants(existing.id);
+        return { ...mapSessionFull(existing), participants: items };
+      }
+
+      const { data: rootMsg, error: rootErr } = await supabase
+        .from("messages")
+        .select("id, session_id, kind, content")
+        .eq("id", rootMessageId)
+        .eq("session_id", parentSessionId)
+        .maybeSingle();
+      if (rootErr) throw rootErr;
+      if (!rootMsg) {
+        throw new ApiError(404, "not_found", "root message not found in parent session");
+      }
+      if (rootMsg.kind !== "agent_reply") {
+        throw new ApiError(
+          400,
+          "validation_failed",
+          "rootMessageId must reference an agent_reply message",
+        );
+      }
+
+      const preview = String(rootMsg.content ?? "").trim().slice(0, 80);
+      const threadTitle = preview
+        ? `${parent.title} · ${preview}${preview.length >= 80 ? "…" : ""}`
+        : `${parent.title} · 话题`;
+
+      const childId = randomUUID();
+      const { data: child, error: insertErr } = await supabase
+        .from("sessions")
+        .insert({
+          id: childId,
+          team_id: parent.team_id,
+          title: threadTitle,
+          mode: parent.mode ?? "collab",
+          idea_id: parent.idea_id ?? null,
+          primary_agent_id: parent.primary_agent_id ?? null,
+          created_by_actor_id: callerActorId,
+          source: "thread",
+          parent_session_id: parentSessionId,
+          thread_root_message_id: rootMessageId,
+        })
+        .select(SESSION_FULL_COLUMNS)
+        .single();
+      if (insertErr) throw insertErr;
+
+      const { data: parentSeats, error: parentSeatsErr } = await supabase
+        .from("session_participants")
+        .select("actor_id")
+        .eq("session_id", parentSessionId);
+      if (parentSeatsErr) throw parentSeatsErr;
+
+      const participantIds = Array.from(
+        new Set(
+          (parentSeats ?? [])
+            .map((row) => row.actor_id)
+            .filter((id): id is string => typeof id === "string" && id.length > 0),
+        ),
+      );
+      if (participantIds.length > 0) {
+        const rows = participantIds.map((actorId) => ({
+          session_id: childId,
+          actor_id: actorId,
+        }));
+        const { error: partErr } = await supabase
+          .from("session_participants")
+          .upsert(rows, { onConflict: "session_id,actor_id" });
+        if (partErr) throw partErr;
+      }
+
+      const { items } = await this.listSessionParticipants(childId);
+      return { ...mapSessionFull(child), participants: items };
     },
 
-    async listThreadSummaries(_parentSessionId) {
-      throw new ApiError(501, "not_implemented", "listThreadSummaries requires BACKEND_KIND=postgres");
+    async listThreadSummaries(parentSessionId) {
+      const { data: parent, error: parentErr } = await supabase
+        .from("sessions")
+        .select("id, team_id")
+        .eq("id", parentSessionId)
+        .maybeSingle();
+      if (parentErr) throw parentErr;
+      if (!parent) throw new ApiError(404, "not_found", "parent session not found");
+
+      const callerActorId = (await this.resolveCallerActorForTeam(parent.team_id))?.id ?? null;
+      if (!callerActorId) {
+        throw new ApiError(401, "missing_identity", "authentication required");
+      }
+
+      const { data: callerSeat, error: seatErr } = await supabase
+        .from("session_participants")
+        .select("actor_id")
+        .eq("session_id", parentSessionId)
+        .eq("actor_id", callerActorId)
+        .maybeSingle();
+      if (seatErr) throw seatErr;
+      if (!callerSeat) {
+        throw new ApiError(403, "forbidden", "not a participant in the parent session");
+      }
+
+      const { data: threads, error: threadsErr } = await supabase
+        .from("sessions")
+        .select("id, thread_root_message_id, last_message_at")
+        .eq("parent_session_id", parentSessionId);
+      if (threadsErr) throw threadsErr;
+      if (!threads?.length) return [];
+
+      const threadIds = threads.map((row) => row.id).filter(Boolean);
+      const participantCounts = new Map<string, number>();
+      const messageCounts = new Map<string, number>();
+
+      if (threadIds.length > 0) {
+        const { data: partRows, error: partErr } = await supabase
+          .from("session_participants")
+          .select("session_id")
+          .in("session_id", threadIds);
+        if (partErr) throw partErr;
+        for (const row of partRows ?? []) {
+          if (!row.session_id) continue;
+          participantCounts.set(
+            row.session_id,
+            (participantCounts.get(row.session_id) ?? 0) + 1,
+          );
+        }
+
+        const { data: msgRows, error: msgErr } = await supabase
+          .from("messages")
+          .select("session_id")
+          .in("session_id", threadIds);
+        if (msgErr) throw msgErr;
+        for (const row of msgRows ?? []) {
+          if (!row.session_id) continue;
+          messageCounts.set(row.session_id, (messageCounts.get(row.session_id) ?? 0) + 1);
+        }
+      }
+
+      return threads.map((row) => ({
+        threadSessionId: row.id,
+        rootMessageId: row.thread_root_message_id,
+        messageCount: messageCounts.get(row.id) ?? 0,
+        lastMessageAt: row.last_message_at ?? null,
+        participantCount: participantCounts.get(row.id) ?? 0,
+      }));
     },
 
     async listSessionIdsForActor(actorId) {

--- a/services/fc/src/lib/supabase-repo.ts
+++ b/services/fc/src/lib/supabase-repo.ts
@@ -8,7 +8,6 @@ import { randomUUID } from "node:crypto";
 import { createClient as defaultCreateClient } from "@supabase/supabase-js";
 import { verifyTrustedExternalJwt } from "./trusted-external-jwt.js";
 import { aiGateway } from "./ai-gateway.js";
-import { createCheckoutSession, listCreditPackages } from "./stripe.js";
 import { ApiError } from "./http-utils.js";
 import { DEFAULT_LIST_LIMIT, DEFAULT_MESSAGE_LIST_LIMIT } from "./routing-utils.js";
 
@@ -1196,18 +1195,6 @@ export function createSupabaseBusinessRepository(options) {
         note: input.note ?? null,
       });
     },
-    async listCreditPackages(teamId: string) {
-      await requireCallerTeamMember(teamId);
-      return { items: await listCreditPackages() };
-    },
-    async createCreditCheckoutSession(teamId: string, input: any) {
-      await requireCallerTeamOwner(teamId);
-      const priceId = String(input?.priceId ?? "").trim();
-      if (!priceId) {
-        throw new ApiError(400, "invalid_request", "priceId is required");
-      }
-      return createCheckoutSession({ teamId, priceId });
-    },
     async getMemberQuotas(teamId: string) {
       await requireCallerTeamMember(teamId);
       return aiGateway.quotas(teamId);
@@ -2333,6 +2320,14 @@ export function createSupabaseBusinessRepository(options) {
         if (error) throw error;
         return data ?? [];
       });
+    },
+
+    async createThread(parentSessionId, { rootMessageId }) {
+      throw new ApiError(501, "not_implemented", "createThread requires BACKEND_KIND=postgres");
+    },
+
+    async listThreadSummaries(_parentSessionId) {
+      throw new ApiError(501, "not_implemented", "listThreadSummaries requires BACKEND_KIND=postgres");
     },
 
     async listSessionIdsForActor(actorId) {

--- a/services/fc/src/lib/supabase-repo.ts
+++ b/services/fc/src/lib/supabase-repo.ts
@@ -8,6 +8,7 @@ import { randomUUID } from "node:crypto";
 import { createClient as defaultCreateClient } from "@supabase/supabase-js";
 import { verifyTrustedExternalJwt } from "./trusted-external-jwt.js";
 import { aiGateway } from "./ai-gateway.js";
+import { createCheckoutSession, listCreditPackages } from "./stripe.js";
 import { ApiError } from "./http-utils.js";
 import { DEFAULT_LIST_LIMIT, DEFAULT_MESSAGE_LIST_LIMIT } from "./routing-utils.js";
 
@@ -1194,6 +1195,18 @@ export function createSupabaseBusinessRepository(options) {
         idempotencyKey: input.idempotencyKey,
         note: input.note ?? null,
       });
+    },
+    async listCreditPackages(teamId: string) {
+      await requireCallerTeamMember(teamId);
+      return { items: await listCreditPackages() };
+    },
+    async createCreditCheckoutSession(teamId: string, input: any) {
+      await requireCallerTeamOwner(teamId);
+      const priceId = String(input?.priceId ?? "").trim();
+      if (!priceId) {
+        throw new ApiError(400, "invalid_request", "priceId is required");
+      }
+      return createCheckoutSession({ teamId, priceId });
     },
     async getMemberQuotas(teamId: string) {
       await requireCallerTeamMember(teamId);

--- a/services/fc/src/lib/supabase-repo/shared.ts
+++ b/services/fc/src/lib/supabase-repo/shared.ts
@@ -167,7 +167,7 @@ export function mapApp(r: any) {
 }
 
 export const SESSION_FULL_COLUMNS =
-  "id, team_id, title, mode, idea_id, primary_agent_id, created_by_actor_id, summary, last_message_preview, last_message_at, acp_session_id, binding, gateway_key, source, cron_job_id, created_at, updated_at";
+  "id, team_id, title, mode, idea_id, primary_agent_id, created_by_actor_id, summary, last_message_preview, last_message_at, acp_session_id, binding, gateway_key, source, cron_job_id, parent_session_id, thread_root_message_id, created_at, updated_at";
 
 // `source` / `source_id` identify the gateway an EXTERNAL actor came in through
 // (wecom / wechat / feishu / discord / kook / seatalk / email + the id in that
@@ -200,6 +200,8 @@ export function mapSessionFull(row) {
     gatewayKey: row?.gateway_key ?? null,
     source: row?.source ?? "user",
     cronJobId: row?.cron_job_id ?? null,
+    parentSessionId: row?.parent_session_id ?? null,
+    threadRootMessageId: row?.thread_root_message_id ?? null,
     createdAt: row?.created_at ?? null,
     updatedAt: row?.updated_at ?? null,
   };

--- a/services/fc/test/missing-endpoints.test.ts
+++ b/services/fc/test/missing-endpoints.test.ts
@@ -14,6 +14,8 @@ function makeRepo(overrides = {}) {
     listSessionsForTeamSince: record("listSessionsForTeamSince"),
     listMessagesForSessionSince: record("listMessagesForSessionSince"),
     listSessionDisplayRows: record("listSessionDisplayRows"),
+    createThread: record("createThread"),
+    listThreadSummaries: record("listThreadSummaries"),
     listSessionIdsForActor: record("listSessionIdsForActor"),
     listWorkspacesByIdsSlim: record("listWorkspacesByIdsSlim"),
     listShortcutRoleBindings: record("listShortcutRoleBindings"),
@@ -341,4 +343,38 @@ test("GET /v1/feedback-summary requires teamId", async () => {
     query: {},
   });
   assert.equal(res.statusCode, 400);
+});
+
+test("POST /v1/sessions/:id/threads forwards rootMessageId", async () => {
+  const repo = makeRepo({
+    createThread: () => ({ id: "thread-1", title: "T" }),
+  });
+  const res = await request(repo, {
+    method: "POST",
+    path: "/v1/sessions/parent-1/threads",
+    body: { rootMessageId: "msg-1" },
+  });
+  assert.equal(res.statusCode, 201);
+  assert.deepEqual(repo.calls[0].args, ["parent-1", { rootMessageId: "msg-1" }]);
+});
+
+test("GET /v1/sessions/:id/thread-summaries returns items", async () => {
+  const repo = makeRepo({
+    listThreadSummaries: () => [
+      {
+        threadSessionId: "t1",
+        rootMessageId: "m1",
+        messageCount: 2,
+        lastMessageAt: null,
+        participantCount: 3,
+      },
+    ],
+  });
+  const res = await request(repo, {
+    method: "GET",
+    path: "/v1/sessions/parent-1/thread-summaries",
+  });
+  assert.equal(res.statusCode, 200);
+  const body = JSON.parse(res.body);
+  assert.equal(body.items.length, 1);
 });

--- a/services/supabase/migrations/20260831100000_session_threads.sql
+++ b/services/supabase/migrations/20260831100000_session_threads.sql
@@ -1,0 +1,23 @@
+-- Agent reply threads: forked child sessions (Discord-style), hidden from main list.
+-- Idempotent (IF NOT EXISTS) for self-host apply-migrations loop.
+
+ALTER TABLE amux.sessions
+  ADD COLUMN IF NOT EXISTS parent_session_id uuid REFERENCES amux.sessions (id) ON DELETE CASCADE,
+  ADD COLUMN IF NOT EXISTS thread_root_message_id uuid;
+
+CREATE UNIQUE INDEX IF NOT EXISTS sessions_thread_root_message_id_uniq
+  ON amux.sessions (thread_root_message_id)
+  WHERE thread_root_message_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS sessions_parent_session_id_idx
+  ON amux.sessions (parent_session_id)
+  WHERE parent_session_id IS NOT NULL;
+
+ALTER TABLE amux.sessions DROP CONSTRAINT IF EXISTS sessions_thread_pair_check;
+ALTER TABLE amux.sessions ADD CONSTRAINT sessions_thread_pair_check CHECK (
+  (parent_session_id IS NULL AND thread_root_message_id IS NULL)
+  OR (parent_session_id IS NOT NULL AND thread_root_message_id IS NOT NULL)
+);
+
+COMMENT ON COLUMN amux.sessions.parent_session_id IS 'NULL = main session; set for thread fork child sessions';
+COMMENT ON COLUMN amux.sessions.thread_root_message_id IS 'Anchor agent_reply message id (unique per thread)';


### PR DESCRIPTION
## Summary

- Add Supabase migration for `amux.sessions.parent_session_id` / `thread_root_message_id` (nullable, additive only)
- Add FC routes: `POST /v1/sessions/:id/threads`, `GET /v1/sessions/:id/thread-summaries`
- Implement pg-repo `createThread` / `listThreadSummaries`; supabase-repo returns **501** until full implementation
- OpenAPI: new endpoints + `SessionThreadSummary` schema

**Backward compatible:** existing session list/detail paths unchanged for old desktop/daemon clients. New thread endpoints are not called by released clients.

## Rollback

- Revert this PR → FC redeploys; DB columns can remain (harmless)
- Full rollback: revert + run migration rollback SQL (see PR discussion)

## Follow-up (separate PR)

- Frontend thread UI + daemon `fork_from`
- `supabase-repo` createThread implementation
- RPC filter for thread child sessions in main list

## Test plan

- [ ] CI / self-host-deploy migrate succeeds (`amux.sessions` prefix)
- [ ] Old desktop: session list/create unchanged
- [ ] `POST .../threads` on supabase backend → 501 (expected until follow-up)
- [ ] `pnpm test` in `services/fc` (missing-endpoints)


Made with [Cursor](https://cursor.com)