### PR TITLE
fix(fc): break sessions schema circular FK (deploy hotfix)

### DIFF
--- a/services/fc/src/db/schema/sessions.ts
+++ b/services/fc/src/db/schema/sessions.ts
@@ -1,4 +1,4 @@
-import { pgTable, uuid, text, timestamp, unique } from "drizzle-orm/pg-core";
+import { pgTable, uuid, text, timestamp, unique, foreignKey } from "drizzle-orm/pg-core";
 import { teams } from "./teams.js";
 import { actors } from "./teams.js";
 
@@ -26,9 +26,7 @@ export const sessions = pgTable("sessions", {
   /** How the session was created: 'user' (default) | 'cron' | 'gateway' | 'thread'. */
   source: text("source").notNull().default("user"),
   /** Parent session when source='thread' (forked agent-reply thread). */
-  parentSessionId: uuid("parent_session_id").references((): typeof sessions.id => sessions.id, {
-    onDelete: "cascade",
-  }),
+  parentSessionId: uuid("parent_session_id"),
   /** Anchor agent_reply message when source='thread'. */
   threadRootMessageId: uuid("thread_root_message_id"),
   /** For source='cron': the desktop-local cron job id that created it
@@ -38,6 +36,10 @@ export const sessions = pgTable("sessions", {
   updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
 }, (t) => ({
   teamBindingUniq: unique("sessions_team_binding_uniq").on(t.teamId, t.binding),
+  parentSessionFk: foreignKey({
+    columns: [t.parentSessionId],
+    foreignColumns: [t.id],
+  }).onDelete("cascade"),
 }));
 
 export const sessionParticipants = pgTable("session_participants", {


### PR DESCRIPTION
## Summary

Fixes FC Docker build failure after #1162:

```
src/db/schema/sessions.ts(29,61): error TS2577: Return type annotation circularly references itself.
```

Replace inline `parentSessionId.references((): typeof sessions.id => ...)` with a table-level `foreignKey()` constraint. Runtime/DB behavior unchanged (migration FK unchanged).

## Test plan

- [x] `npm --prefix services/fc ci && npm --prefix services/fc run build` passes locally
- [ ] Merge → SDP / self-host deploy green


Made with [Cursor](https://cursor.com)