### PR TITLE
feat(billing): reconcile refunds, not just purchases

### DIFF
--- a/deploy/self-host/docker-compose.yml
+++ b/deploy/self-host/docker-compose.yml
@@ -690,9 +690,12 @@ services:
             -H "x-cron-secret: ${CRON_TRIGGER_SECRET}" \
             -H "content-type: application/json" \
             -d '{"task":"oss-gc-blobs"}' || true
-          # Repairs top-ups whose webhook never arrived. Stripe calls in from
-          # outside the country to a mainland host, so the delivery link is the
-          # weak point; this pass is idempotent and cheap when nothing is wrong.
+          # Repairs top-ups AND refunds whose webhook never arrived. Stripe
+          # calls in from outside the country to a mainland host, so the
+          # delivery link is the weak point; both passes are idempotent and
+          # cheap when nothing is wrong. The refund half matters more than it
+          # looks: a missing top-up gets reported by the customer within
+          # minutes, a missing refund debit is silent.
           curl -fsS -X POST http://fc:9000/internal/cron \
             -H "x-cron-secret: ${CRON_TRIGGER_SECRET}" \
             -H "content-type: application/json" \

--- a/docs/specs/2026-08-28-team-ai-gateway-design.md
+++ b/docs/specs/2026-08-28-team-ai-gateway-design.md
@@ -425,6 +425,10 @@ Stripe 从境外主动回调 `api.<domain>/v1/stripe/webhook`，而该域名解�
 1. Stripe 自身重试最多 3 天。
 2. 一个定时对账任务扫 `stripe.checkout.sessions.list`，把已支付但本地无 ledger 条目的补进来。
 
+⚠️ **退款那一侧同样需要对账，而且更需要。** 第一版只扫 Checkout Session，充值有两层保险（Stripe 重试 + 定时对账），退款只有一层 —— 这个不对称是反的：**一笔没补上的充值，客户几分钟内就会来说；一笔没补上的退款是静默的** —— 钱已经退了，没人在盯他留着的那些额度。
+
+两趟的差别只有一处：webhook 收到的事件本该属于我们，所以 charge 上没有 `team_id` 要**大声报错**；而对账扫的是账号上所有退款，没有 `team_id` 只意味着「这不是我们的单」，按失败计只会把真正的失败淹掉。
+
 #### 4.9.7 客户端
 
 Tauri 内嵌 webview **不要**用来打开 Checkout（3DS 与钱包会出问题，用户也看不到地址栏），走系统浏览器。返回后不阻塞 UI 等 webhook —— 显示「处理中」，让余额自行刷新。
@@ -439,7 +443,7 @@ Tauri 内嵌 webview **不要**用来打开 Checkout（3DS 与钱包会出问题
 |---|---|
 | `GET /v1/teams/:teamId/credits/packages` | 充值卡要显示「买什么、多少钱、给多少积分」。三者都只能来自 Stripe Price + `metadata.credits`（§4.9.3），客户端硬编码价格在调价当天就是错的。**任何成员可读**（看得见但买不了），下单才是 owner-only |
 | `GET /v1/stripe/return` | Checkout 完成后浏览器要有地方落。一张静态 HTML：桌面端本来就不依赖这次跳转（§4.9.7），这页只需要告诉人可以关掉。公网 origin 用**专门的 `STRIPE_RETURN_URL_BASE`** —— 见下方那条 |
-| `stripe-reconcile` cron 任务 | §4.9.6 的第二层兜底。**不查账本**：重复 top-up 靠唯一索引变成空操作，返回的 `applied` 就是「这笔本地是不是缺了」的答案，比自己 join 一次账本少一条会腐化的查询路径 |
+| `stripe-reconcile` cron 任务 | §4.9.6 的第二层兜底，**充值和退款两趟都扫**。**不查账本**：重复写入靠唯一索引变成空操作，返回的 `applied` 就是「这笔本地是不是缺了」的答案，比自己 join 一次账本少一条会腐化的查询路径。退款那趟走的是 webhook 同一个 `refundCharge`，不会漂移 |
 
 ⚠️ **回跳地址不要复用现成变量。** 第一版试过两个，两个都错：
 

--- a/services/fc/src/lib/cron.ts
+++ b/services/fc/src/lib/cron.ts
@@ -17,7 +17,7 @@ import {
 } from "../db/schema/oss-sync.js";
 import { teamSkills, teamSkillVersions } from "../db/schema/team-skills.js";
 import { getTeamBlobStorage, type BlobStorage } from "./team-blob-storage.js";
-import { stripeReconcileCheckouts } from "./stripe-reconcile.js";
+import { stripeReconcile } from "./stripe-reconcile.js";
 
 /** What the cron tasks need injected; everything defaults to the real thing. */
 export interface CronDeps {
@@ -296,7 +296,7 @@ export async function runCronTask(
     // No `db`: the gateway owns the ledger, so this task talks to Stripe and to
     // the gateway's /internal API and never touches a table here.
     case "stripe-reconcile": {
-      const result = await stripeReconcileCheckouts();
+      const result = await stripeReconcile();
       return { task, result };
     }
     default:

--- a/services/fc/src/lib/routes/stripe.ts
+++ b/services/fc/src/lib/routes/stripe.ts
@@ -155,7 +155,7 @@ export async function creditCheckoutSession(
  * fails by doing nothing at all is the worst shape this could take, so it now
  * asks the API rather than trusting the payload's shape.
  */
-async function refundCharge(
+export async function refundCharge(
   stripe: Stripe,
   charge: Stripe.Charge,
 ): Promise<{ handled: boolean; applied?: boolean; reason?: string }> {

--- a/services/fc/src/lib/stripe-reconcile.ts
+++ b/services/fc/src/lib/stripe-reconcile.ts
@@ -14,7 +14,7 @@
 // `applied` flag coming back is the answer to "was this one missing".
 // ---------------------------------------------------------------------------
 import type Stripe from "stripe";
-import { creditCheckoutSession } from "./routes/stripe.js";
+import { creditCheckoutSession, refundCharge } from "./routes/stripe.js";
 import { stripeClient, stripeConfigured } from "./stripe.js";
 
 export interface ReconcileResult extends Record<string, number> {
@@ -82,4 +82,102 @@ export async function stripeReconcileCheckouts(
     }
   }
   return result;
+}
+
+
+// ---------------------------------------------------------------------------
+// Refunds
+// ---------------------------------------------------------------------------
+// The purchase side had two layers of insurance (Stripe's own retries, plus the
+// sweep above) and the refund side had one. That asymmetry is the wrong way
+// round: an unrepaired top-up means a paying customer is missing credits and
+// will say so within minutes. An unrepaired REFUND is silent — the customer has
+// their money back and nobody is watching the balance they kept.
+//
+// Same shape as the checkout pass, and deliberately the same code path:
+// `refundCharge` is what the webhook runs, so this cannot drift from it.
+
+export interface RefundReconcileResult extends Record<string, number> {
+  scanned: number;
+  succeededRefunds: number;
+  /** Charges whose refunds were genuinely missing locally and are now debited. */
+  repaired: number;
+  alreadyRecorded: number;
+  /** Refunds on charges that carry no team id — not ours, and not a problem. */
+  notOurs: number;
+  failed: number;
+}
+
+export async function stripeReconcileRefunds(
+  opts: { lookbackDays?: number; stripe?: Stripe } = {},
+): Promise<RefundReconcileResult> {
+  const result: RefundReconcileResult = {
+    scanned: 0,
+    succeededRefunds: 0,
+    repaired: 0,
+    alreadyRecorded: 0,
+    notOurs: 0,
+    failed: 0,
+  };
+  if (!opts.stripe && !stripeConfigured()) return result;
+
+  const stripe = opts.stripe ?? stripeClient();
+  const days = opts.lookbackDays ?? DEFAULT_LOOKBACK_DAYS;
+  const since = Math.floor(Date.now() / 1000) - days * 86_400;
+
+  // Grouped by charge, because `refundCharge` works per charge and applies
+  // every refund on it. A charge refunded in three parts is one unit of work,
+  // and each part still lands under its own idempotency key.
+  const charges = new Set<string>();
+  for await (const refund of stripe.refunds.list({ created: { gte: since }, limit: 100 })) {
+    result.scanned += 1;
+    if (refund.status !== "succeeded") continue;
+    result.succeededRefunds += 1;
+    const chargeId = typeof refund.charge === "string" ? refund.charge : refund.charge?.id;
+    if (chargeId) charges.add(chargeId);
+  }
+
+  for (const chargeId of charges) {
+    try {
+      const charge = await stripe.charges.retrieve(chargeId);
+      // Unlike the webhook — which receives an event for a charge that SHOULD be
+      // ours and so shouts about a missing team id — this pass walks every
+      // refund on the account. A charge with no team id is simply someone
+      // else's, and treating that as a failure would bury the real ones.
+      if (!(charge.metadata?.team_id ?? "").trim()) {
+        result.notOurs += 1;
+        continue;
+      }
+      const r = await refundCharge(stripe, charge);
+      if (r.applied) {
+        result.repaired += 1;
+        console.warn(
+          `[stripe/reconcile] debited refunds on charge ${chargeId} that the webhook never delivered`,
+        );
+      } else {
+        result.alreadyRecorded += 1;
+      }
+    } catch (err) {
+      // One bad charge must not stop the rest — this IS the recovery path.
+      result.failed += 1;
+      console.error(`[stripe/reconcile] charge ${chargeId} failed:`, err);
+    }
+  }
+  return result;
+}
+
+/** Both passes. What the cron task runs. */
+export async function stripeReconcile(
+  opts: { lookbackDays?: number; stripe?: Stripe } = {},
+): Promise<Record<string, number>> {
+  const checkouts = await stripeReconcileCheckouts(opts);
+  const refunds = await stripeReconcileRefunds(opts);
+  return {
+    ...checkouts,
+    refundsScanned: refunds.scanned,
+    refundsRepaired: refunds.repaired,
+    refundsAlreadyRecorded: refunds.alreadyRecorded,
+    refundsNotOurs: refunds.notOurs,
+    refundsFailed: refunds.failed,
+  };
 }

--- a/services/fc/test/stripe.test.ts
+++ b/services/fc/test/stripe.test.ts
@@ -14,7 +14,7 @@ import { createHonoRouterAdapter } from "../src/lib/hono-adapter.js";
 import { aiGateway } from "../src/lib/ai-gateway.js";
 import { allowedPriceIds, createCheckoutSession, creditsForPrice, idempotency } from "../src/lib/stripe.js";
 import { registerStripe, handleStripeEvent, creditsForSession } from "../src/lib/routes/stripe.js";
-import { stripeReconcileCheckouts } from "../src/lib/stripe-reconcile.js";
+import { stripeReconcile, stripeReconcileCheckouts, stripeReconcileRefunds } from "../src/lib/stripe-reconcile.js";
 
 const WEBHOOK_SECRET = "whsec_test_secret";
 
@@ -359,6 +359,92 @@ test("one unusable session does not abort the rest of the run", async () => {
   });
   assert.equal(result.failed, 1);
   assert.equal(result.repaired + result.alreadyCredited, 1, "the good session still went through");
+});
+
+function fakeStripeWithRefunds(refunds: any[], charges: Record<string, any>) {
+  return {
+    refunds: {
+      list: (opts: any) =>
+        // The webhook path calls refunds.list({charge}); the reconcile pass
+        // calls it with {created} and iterates. One fake serves both.
+        opts?.charge
+          ? Promise.resolve({ data: refunds.filter((r) => r.charge === opts.charge) })
+          : { [Symbol.asyncIterator]: async function* () { for (const r of refunds) yield r; } },
+    },
+    charges: { retrieve: async (id: string) => charges[id] },
+  } as any;
+}
+
+test("reconcile repairs refunds the webhook never delivered", async () => {
+  // The purchase side had two layers of insurance and the refund side had one.
+  // That is the wrong way round: a missing top-up gets reported by the customer
+  // within minutes, a missing refund debit is silent — they have their money
+  // back and nobody is watching the credits they kept.
+  const missing = new Set(["stripe:re:re_missing"]);
+  (aiGateway as any).topUp = async (teamId: string, body: any) => {
+    topUps.push({ teamId, body });
+    return { teamId, applied: missing.has(body.idempotencyKey), balanceCredits: 1 };
+  };
+
+  const stripe = fakeStripeWithRefunds(
+    [
+      { id: "re_present", charge: "ch_a", amount: 500, status: "succeeded" },
+      { id: "re_missing", charge: "ch_b", amount: 500, status: "succeeded" },
+      { id: "re_pending", charge: "ch_c", amount: 500, status: "pending" },
+      { id: "re_other", charge: "ch_other", amount: 500, status: "succeeded" },
+    ],
+    {
+      ch_a: { id: "ch_a", amount: 500, metadata: { team_id: "team-1", credits: "1500000" } },
+      ch_b: { id: "ch_b", amount: 500, metadata: { team_id: "team-1", credits: "1500000" } },
+      // Someone else's charge on the same account: no team id.
+      ch_other: { id: "ch_other", amount: 500, metadata: {} },
+    },
+  );
+
+  const r = await stripeReconcileRefunds({ stripe });
+  assert.equal(r.scanned, 4);
+  assert.equal(r.succeededRefunds, 3, "the pending refund is not counted");
+  assert.equal(r.repaired, 1);
+  assert.equal(r.alreadyRecorded, 1);
+  assert.equal(r.notOurs, 1, "a charge with no team id is someone else's, not a failure");
+  assert.equal(r.failed, 0);
+});
+
+test("a charge that cannot be retrieved does not abort the refund sweep", async () => {
+  const stripe = {
+    refunds: {
+      list: (opts: any) =>
+        opts?.charge
+          ? Promise.resolve({ data: [{ id: "re_ok", charge: "ch_ok", amount: 500, status: "succeeded" }] })
+          : { [Symbol.asyncIterator]: async function* () {
+              yield { id: "re_boom", charge: "ch_boom", amount: 500, status: "succeeded" };
+              yield { id: "re_ok", charge: "ch_ok", amount: 500, status: "succeeded" };
+            } },
+    },
+    charges: {
+      retrieve: async (id: string) => {
+        if (id === "ch_boom") throw new Error("no such charge");
+        return { id, amount: 500, metadata: { team_id: "team-1", credits: "1500000" } };
+      },
+    },
+  } as any;
+  const r = await stripeReconcileRefunds({ stripe });
+  assert.equal(r.failed, 1);
+  assert.equal(r.repaired + r.alreadyRecorded, 1, "the good charge still went through");
+});
+
+test("the cron task runs BOTH passes", async () => {
+  const stripe = {
+    checkout: { sessions: { list: () => ({ [Symbol.asyncIterator]: async function* () {} }) } },
+    refunds: { list: () => ({ [Symbol.asyncIterator]: async function* () {} }) },
+    charges: { retrieve: async () => ({}) },
+  } as any;
+  const r = await stripeReconcile({ stripe });
+  // Checkout counters and refund counters both present — a task that silently
+  // dropped one half would still "succeed" without this.
+  for (const k of ["scanned", "paid", "repaired", "refundsScanned", "refundsRepaired", "refundsFailed"]) {
+    assert.ok(k in r, `${k} missing from the combined result`);
+  }
 });
 
 test("reconcile is a no-op when Stripe is not configured", async () => {


### PR DESCRIPTION
Closing the gap flagged in #1148. The purchase side had two layers of insurance — Stripe's own retries plus the reconciliation sweep — and the refund side had one.

That asymmetry is the wrong way round:

> An unrepaired **top-up** is loud: a paying customer is missing credits and says so within minutes.
> An unrepaired **refund** is silent — they have their money back, and nobody is watching the balance they kept.

The half that needed the second layer more was the half that did not have it. We came within one Stripe retry of finding that out with real money last night.

## Shape

Same as the checkout pass, and deliberately the **same code path**: `refundCharge` is what the webhook runs, so the recovery route cannot drift from the live one. Grouped by charge, because that function applies every refund on a charge, and each part still lands under its own `stripe:re:<id>` key.

One difference from the webhook, and it is the point:

| | missing `team_id` on the charge |
|---|---|
| webhook | **throws** — the event was for a charge that should be ours |
| reconcile | **counted as `notOurs`** — this pass walks every refund on the account, and treating other people's charges as failures would bury the real ones |

## Tests

26/26. Three new: the repaired/already-recorded/not-ours/pending split, one unretrievable charge not aborting the sweep, and an assertion that the cron task's combined result carries **both** sets of counters — a task that silently dropped one half would otherwise still look like it succeeded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018rRCi6g5nDwrhVvC8VHEgk