### PR TITLE
fix(fc): /internal/cron needed a database for every task, including the ones that don't

### DIFF
--- a/services/fc/src/index.ts
+++ b/services/fc/src/index.ts
@@ -326,7 +326,7 @@ const app = createApp({
   createRepository: makeBusinessRepoFactory(resolveBackendKind()),
   createAuthRepository: makeAuthRepoFactory(resolveBackendKind()),
   createSystemRepository: makeSystemRepoFactory(resolveBackendKind()),
-  runCron: (task: string) => runCronTask(getDb(), task),
+  runCron: (task: string) => runCronTask(getDb, task),
   lookupVanityApp: vanityLookup(),
 });
 
@@ -380,7 +380,7 @@ export async function handler(event: any, context: any) {
     if (!payload.task) {
       return { error: "missing_task", message: "Timer payload must include a task field" };
     }
-    return runCronTask(getDb(), payload.task);
+    return runCronTask(getDb, payload.task);
   }
 
   normalizeFcEvent(event);

--- a/services/fc/src/lib/cron.ts
+++ b/services/fc/src/lib/cron.ts
@@ -279,18 +279,28 @@ export async function ossSyncGcOrphanBlobs(
 // ---------------------------------------------------------------------------
 export type CronTask = "oss-abandon-sessions" | "oss-gc-blobs" | "stripe-reconcile";
 
+/**
+ * `db` is a THUNK, not a connection.
+ *
+ * It used to be the connection, resolved by the caller as `runCronTask(getDb(),
+ * task)` — which called `getDb()` before dispatch, so every task needed a
+ * database whether or not it touched one. `getDb()` throws when DATABASE_URL is
+ * unset, and it IS unset on the supabase backend path, so `/internal/cron`
+ * answered 500 for EVERY task on the only deployment that runs. Nobody noticed
+ * because the cron compose profile has never been enabled there.
+ */
 export async function runCronTask(
-  db: Db,
+  db: () => Db,
   task: string,
   deps: CronDeps = {}
 ): Promise<{ task: string; result: Record<string, number> }> {
   switch (task) {
     case "oss-abandon-sessions": {
-      const result = await ossSyncAbandonExpiredSessions(db);
+      const result = await ossSyncAbandonExpiredSessions(db());
       return { task, result };
     }
     case "oss-gc-blobs": {
-      const result = await ossSyncGcOrphanBlobs(db, deps);
+      const result = await ossSyncGcOrphanBlobs(db(), deps);
       return { task, result };
     }
     // No `db`: the gateway owns the ledger, so this task talks to Stripe and to

--- a/services/fc/src/server.ts
+++ b/services/fc/src/server.ts
@@ -18,7 +18,7 @@ const app = createApp({
   // Marketplace admin (shared-secret) — same wiring as the Aliyun FC handler
   // in index.ts. Without this, POST /v1/admin/marketplace/* returns 503.
   createSystemRepository: makeSystemRepoFactory(kind),
-  runCron: (task: string) => runCronTask(getDb(), task),
+  runCron: (task: string) => runCronTask(getDb, task),
   // This entry — not the FC handler — is what serves apps on their own
   // hostnames, because the reverse proxy in front of it is the self-host one.
   lookupVanityApp: vanityLookup(),

--- a/services/fc/test/cron.test.ts
+++ b/services/fc/test/cron.test.ts
@@ -489,7 +489,7 @@ test("ossSyncGcOrphanBlobs: a run is capped, and the backlog survives it", async
 
 test("runCronTask: dispatches oss-abandon-sessions", async () => {
   const { db } = await makeTestDb();
-  const result = await runCronTask(db, "oss-abandon-sessions");
+  const result = await runCronTask(() => db, "oss-abandon-sessions");
   assert.equal(result.task, "oss-abandon-sessions");
   assert.ok("abandoned" in result.result);
   assert.ok("deleted" in result.result);
@@ -497,15 +497,31 @@ test("runCronTask: dispatches oss-abandon-sessions", async () => {
 
 test("runCronTask: dispatches oss-gc-blobs", async () => {
   const { db } = await makeTestDb();
-  const result = await runCronTask(db, "oss-gc-blobs");
+  const result = await runCronTask(() => db, "oss-gc-blobs");
   assert.equal(result.task, "oss-gc-blobs");
   assert.ok("deleted" in result.result);
+});
+
+test("a task that needs no database never asks for one", async () => {
+  // `runCronTask(getDb(), task)` resolved the connection BEFORE dispatch, so
+  // every task needed a database whether or not it touched one. getDb() throws
+  // when DATABASE_URL is unset — and it is unset on the supabase backend path —
+  // so /internal/cron answered 500 for EVERY task on the only deployment that
+  // runs. Unnoticed because the cron compose profile was never enabled there.
+  let asked = false;
+  const boom = () => {
+    asked = true;
+    throw new Error("DATABASE_URL is not set");
+  };
+  const result = await runCronTask(boom, "stripe-reconcile");
+  assert.equal(result.task, "stripe-reconcile");
+  assert.equal(asked, false, "stripe-reconcile talks to Stripe and the gateway, never to a table here");
 });
 
 test("runCronTask: throws on unknown task", async () => {
   const { db } = await makeTestDb();
   await assert.rejects(
-    () => runCronTask(db, "unknown-task"),
+    () => runCronTask(() => db, "unknown-task"),
     /Unknown cron task/
   );
 });


### PR DESCRIPTION
Found by running the reconcile task from #1164 against production. It answered `500`, and the log said:

```
[fc] unhandled: DATABASE_URL is not set
```

## What was wrong

`runCron` was wired as `runCronTask(getDb(), task)` — the connection resolved **before** dispatch, so every task required a database whether or not it touched one. `getDb()` throws when `DATABASE_URL` is unset, and it **is** unset on the `supabase` backend path, which is what the only running deployment uses.

So `/internal/cron` has been answering 500 for **every** task there, not just the new one — `oss-abandon-sessions` and `oss-gc-blobs` included. It went unnoticed because the `cron` compose profile has never been enabled on that box: the endpoint existed, was reachable, was authenticated, and could not have worked.

## Fix

`db` is a thunk, called only in the branches that need it. `stripe-reconcile` talks to Stripe and to the gateway's `/internal` API and never touches a table in FC, so it now runs on a deployment with no direct database access at all.

The regression test passes a thunk that **throws if called**, so a future task cannot quietly reintroduce the coupling.

42/42 across the cron and Stripe suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018rRCi6g5nDwrhVvC8VHEgk