### PR TITLE
fix(sessions): exclude thread forks from list and sync paths

### DIFF
--- a/services/fc/src/lib/pg-repo/sessions.ts
+++ b/services/fc/src/lib/pg-repo/sessions.ts
@@ -819,7 +819,7 @@ export function makeSessionsRepo(db: DbLike, ctx: SessionsCtx = {}, deps: Sessio
       updatedAfter: string | null,
       { limit = DEFAULT_LIST_LIMIT, cursor = null }: { limit?: number; cursor?: { updatedAt?: string | null; id?: string } | null } = {},
     ) {
-      const conditions = [eq(sessions.teamId, teamId)];
+      const conditions = [eq(sessions.teamId, teamId), isNull(sessions.parentSessionId)];
       if (updatedAfter) conditions.push(gt(sessions.updatedAt, new Date(updatedAfter)));
       if (cursor?.updatedAt) {
         // Keyset: strictly after (updatedAt, id).

--- a/services/fc/src/lib/supabase-repo.ts
+++ b/services/fc/src/lib/supabase-repo.ts
@@ -2303,7 +2303,8 @@ export function createSupabaseBusinessRepository(options) {
       let q = supabase
         .from("sessions")
         .select(SESSION_SYNC_COLUMNS)
-        .eq("team_id", teamId);
+        .eq("team_id", teamId)
+        .is("parent_session_id", null);
       if (updatedAfter) q = q.gt("updated_at", updatedAfter);
       const { data, error } = await applySyncKeyset(q, cursor, limit);
       if (error) throw error;

--- a/services/supabase/migrations/20260831110000_session_list_exclude_threads.sql
+++ b/services/supabase/migrations/20260831110000_session_list_exclude_threads.sql
@@ -1,0 +1,132 @@
+-- Thread fork sessions must not appear in the main session sidebar list.
+-- Predicate is in the RPC WHERE (before ORDER BY / LIMIT) so keyset pagination
+-- stays correct — same pattern as p_kind / p_idea_id narrowing.
+
+DROP FUNCTION IF EXISTS amux.list_current_actor_sessions(
+  uuid, integer, timestamp with time zone, timestamp with time zone, uuid, uuid, text
+);
+
+CREATE FUNCTION amux.list_current_actor_sessions(
+  p_team_id uuid,
+  p_limit integer DEFAULT 50,
+  p_before_last_message_at timestamp with time zone DEFAULT NULL::timestamp with time zone,
+  p_before_created_at timestamp with time zone DEFAULT NULL::timestamp with time zone,
+  p_before_id uuid DEFAULT NULL::uuid,
+  p_idea_id uuid DEFAULT NULL::uuid,
+  p_kind text DEFAULT 'all'
+) RETURNS TABLE(
+  id uuid,
+  title text,
+  team_id uuid,
+  mode text,
+  idea_id uuid,
+  last_message_at timestamp with time zone,
+  last_message_preview text,
+  created_at timestamp with time zone,
+  updated_at timestamp with time zone,
+  has_unread boolean,
+  source text,
+  cron_job_id text,
+  summary text,
+  primary_agent_id uuid,
+  created_by_actor_id uuid,
+  participant_count integer
+)
+LANGUAGE plpgsql
+STABLE
+SET search_path TO 'public', 'app'
+SET plan_cache_mode TO 'force_custom_plan'
+AS $function$
+begin
+  if p_team_id is null then
+    raise exception 'list_current_actor_sessions requires p_team_id'
+      using errcode = '22023';
+  end if;
+  if coalesce(p_kind, 'all') not in ('all', 'regular', 'cron') then
+    raise exception 'list_current_actor_sessions p_kind must be all, regular, or cron'
+      using errcode = '22023';
+  end if;
+
+  return query
+  with current_actor as (
+    select amux.current_actor_id_for_team(p_team_id) as actor_id
+  )
+  select
+    s.id,
+    s.title,
+    s.team_id,
+    s.mode,
+    s.idea_id,
+    s.last_message_at,
+    s.last_message_preview,
+    s.created_at,
+    s.updated_at,
+    (
+      s.last_message_at is not null
+      and s.last_message_at > coalesce(
+            (select srm.last_read_at
+               from amux.session_read_markers srm
+              where srm.session_id = s.id
+                and srm.actor_id = ca.actor_id),
+            '-infinity'::timestamptz)
+    ) as has_unread,
+    s.source,
+    s.cron_job_id,
+    s.summary,
+    s.primary_agent_id,
+    s.created_by_actor_id,
+    (
+      select count(*)
+      from amux.session_participants participant
+      where participant.session_id = s.id
+    )::integer as participant_count
+  from current_actor ca
+  join amux.session_participants membership
+    on membership.actor_id = ca.actor_id
+  join amux.sessions s
+    on s.id = membership.session_id
+  where s.archived_at is null
+    and s.parent_session_id is null
+    and s.team_id = p_team_id
+    and (p_idea_id is null or s.idea_id = p_idea_id)
+    and (
+      coalesce(p_kind, 'all') = 'all'
+      or (p_kind = 'cron' and s.source = 'cron')
+      or (p_kind = 'regular' and coalesce(s.source, 'user') <> 'cron')
+    )
+    and (
+      p_before_id is null
+      or (
+        case
+          when p_before_last_message_at is null then
+            s.last_message_at is not null
+            or (
+              s.last_message_at is null
+              and (
+                s.created_at < p_before_created_at
+                or (s.created_at = p_before_created_at and s.id < p_before_id)
+              )
+            )
+          when s.last_message_at is null then false
+          when s.last_message_at < p_before_last_message_at then true
+          when s.last_message_at = p_before_last_message_at then
+            s.created_at < p_before_created_at
+            or (s.created_at = p_before_created_at and s.id < p_before_id)
+          else false
+        end
+      )
+    )
+  order by
+    s.last_message_at desc nulls first,
+    s.created_at desc,
+    s.id desc
+  limit greatest(1, least(coalesce(p_limit, 50), 101));
+end;
+$function$;
+
+REVOKE ALL ON FUNCTION amux.list_current_actor_sessions(
+  uuid, integer, timestamp with time zone, timestamp with time zone, uuid, uuid, text
+) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION amux.list_current_actor_sessions(
+  uuid, integer, timestamp with time zone, timestamp with time zone, uuid, uuid, text
+) TO authenticated, service_role;


### PR DESCRIPTION
## Summary

Follow-up to #1162 (thread schema + createThread API). Thread child sessions (`parent_session_id IS NOT NULL`) were still returned by:

- `amux.list_current_actor_sessions` RPC → `GET /v1/sessions`
- `listSessionsForTeamSince` → `GET /v1/sync/sessions` (Tauri libsql cache)

This PR adds the filter on all three paths so thread forks never appear in the main session sidebar.

**Scope (server only):**
- Migration `20260831110000_session_list_exclude_threads.sql` — RPC WHERE clause
- FC `pg-repo/sessions.ts` — sync query `isNull(parentSessionId)` (listSessions already had this)
- FC `supabase-repo.ts` — sync query `.is("parent_session_id", null)`

## Backward compatibility (old clients)

| Surface | Change | Impact on old clients |
|---------|--------|----------------------|
| `GET /v1/sessions` (RPC) | Thread rows dropped from list | **Compatible.** Old clients never had thread UI; fewer rows is correct behavior. No API shape change. |
| `GET /v1/sync/sessions` | Thread rows dropped from sync delta | **Compatible.** Same as above for desktop libsql cache. New sync writes skip threads; **already-cached thread rows may linger until next full list refresh** (no client-side filter by design). |
| `GET /v1/sessions/:id`, messages, MQTT | Unchanged | Thread sessions remain addressable by ID if known. Old clients won't create threads (#1162 API unused). |
| Schema (`parent_session_id`) | Already on main (#1162) | Nullable column; old INSERT paths unaffected. |
| Pagination | Filter in WHERE before ORDER BY/LIMIT | **Safe.** Same pattern as `p_kind` / `p_idea_id`; keyset cursors stay valid. |
| iOS / Expo | Use list RPC only, not sync | Migration alone fixes them; FC redeploy optional for sync-only clients. |

**Deploy order:** migration + FC redeploy together (self-host CI applies both on merge to main).

## Test plan

- [ ] Apply migration on self-host; confirm `list_current_actor_sessions` omits rows where `parent_session_id` is set
- [ ] `GET /v1/sessions` — parent sessions only
- [ ] `GET /v1/sync/sessions?teamId=…` — no thread rows in delta
- [ ] Existing session open / message send on non-thread sessions unchanged
- [ ] Thread create + list via `GET /v1/sessions/:id/thread-summaries` still works (not affected)


Made with [Cursor](https://cursor.com)