### PR TITLE
fix(daemon): link one sqlite, not two

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -302,6 +302,7 @@ dependencies = [
  "image",
  "include_dir",
  "libc",
+ "libsql-rusqlite",
  "mime",
  "notify",
  "openssl",
@@ -311,7 +312,6 @@ dependencies = [
  "rand 0.8.6",
  "reqwest 0.12.28",
  "rumqttc",
- "rusqlite",
  "rustls 0.22.4",
  "serde",
  "serde_json",
@@ -3688,15 +3688,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hashlink"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
-dependencies = [
- "hashbrown 0.14.5",
-]
-
-[[package]]
 name = "heapless"
 version = "0.7.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5004,7 +4995,7 @@ dependencies = [
  "bitflags 2.11.1",
  "fallible-iterator 0.2.0",
  "fallible-streaming-iterator",
- "hashlink 0.8.4",
+ "hashlink",
  "libsql-ffi",
  "smallvec",
 ]
@@ -5065,17 +5056,6 @@ dependencies = [
  "tracing",
  "uuid",
  "zerocopy 0.7.35",
-]
-
-[[package]]
-name = "libsqlite3-sys"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c10584274047cb335c23d3e61bcef8e323adae7c5c8c760540f73610177fc3f"
-dependencies = [
- "cc",
- "pkg-config",
- "vcpkg",
 ]
 
 [[package]]
@@ -7934,20 +7914,6 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.25.0",
  "ws_stream_tungstenite",
-]
-
-[[package]]
-name = "rusqlite"
-version = "0.31.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b838eba278d213a8beaf485bd313fd580ca4505a00d5871caeb1457c55322cae"
-dependencies = [
- "bitflags 2.11.1",
- "fallible-iterator 0.3.0",
- "fallible-streaming-iterator",
- "hashlink 0.9.1",
- "libsqlite3-sys",
- "smallvec",
 ]
 
 [[package]]

--- a/apps/daemon/Cargo.toml
+++ b/apps/daemon/Cargo.toml
@@ -66,7 +66,15 @@ zip = { version = "5", default-features = false, features = ["deflate"] }
 tempfile = "3"
 tar = "0.4"
 # Full-text search for the knowledge vault (SQLite FTS5, no external service)
-rusqlite = { version = "0.31", features = ["bundled"] }
+# The libsql fork of rusqlite, not rusqlite itself. It keeps the crate name
+# `rusqlite` and the same API, so callers need no change — but it links
+# libsql-ffi's sqlite, which teamclu-gateway already pulls in via `libsql`.
+#
+# Plain `rusqlite` with `bundled` compiles a SECOND copy of sqlite3.c into this
+# binary, and both copies define the same symbols. Apple's linker tolerates
+# that, so it builds fine on macOS; rust-lld does not, so Linux and Windows
+# fail with `duplicate symbol: sqlite3_*`. Keep this on the libsql fork.
+rusqlite = { package = "libsql-rusqlite", version = "0.9", features = ["bundled"] }
 humantime-serde = "1"
 parking_lot = "0.12"
 


### PR DESCRIPTION
`main` does not build for Linux or Windows. `rust-lld` reports
`duplicate symbol: sqlite3_result_text` and friends, from
`sqlite3/sqlite3.c` and `bundled/src/sqlite3.c`.

## Cause

#1171 added `rusqlite` with the `bundled` feature, which compiles its own copy
of `sqlite3.c`. amuxd already links a sqlite:

```
libsql-ffi v0.9.30 <- libsql v0.9.30 <- teamclu-gateway <- amuxd
```

So the binary ended up with two copies, both exporting `sqlite3_*`. Apple's
linker tolerates the duplicates, which is why this built fine on macOS during
development and only failed once CI reached Linux and Windows.

## Fix

Switch to `libsql-rusqlite`, the libsql fork of rusqlite. It keeps the crate
name `rusqlite` and the same API, so the only consumer
(`daemon/server/knowledge/index.rs`) is unchanged — but it links libsql-ffi's
sqlite, leaving exactly one copy in the binary.

## Verification

- `cargo tree -p amuxd -i libsqlite3-sys` → `did not match any packages`; the
  second copy is gone from the tree, and `libsql-ffi` now serves both amuxd and
  the gateway.
- FTS5 with the `trigram` tokenizer, which the CJK search path in `index.rs`
  depends on, is present in libsql's sqlite — both index tests pass.
- `cargo metadata --locked` is consistent (CI builds the daemon with `--locked`).

## Note

This unblocks the build; it does not make `main` green on its own. Two test
failures predate #1171 and are fixed separately in #1176 and
#1177.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YLHqMLpNb9kbBJm891ooYv
