### PR TITLE
fix(skills): stop watching skill roots nothing scans

### DIFF
--- a/apps/daemon/src/runtime/refresh_watch.rs
+++ b/apps/daemon/src/runtime/refresh_watch.rs
@@ -188,8 +188,6 @@ pub fn classify_change_path(
         {
             Some(RefreshChangeKind::EnvVars)
         } else if path.starts_with(workspace.workspace_path.join(".claude/skills"))
-            || path.starts_with(workspace.workspace_path.join(".opencode/skills"))
-            || path.starts_with(workspace.workspace_path.join(".pi/skills"))
             || path.starts_with(workspace.workspace_path.join(".agents/skills"))
             || is_team_skills_path(path, &workspace.workspace_path)
             || is_global_skill_path
@@ -240,16 +238,13 @@ fn watch_roots(workspaces: &[WatchedWorkspace], home: Option<&Path>) -> Vec<Watc
                 recursive: false,
             });
         }
+        // `.opencode/skills` and `.pi/skills` are deliberately absent, here and
+        // in `classify_change_path`. `native_skill_fallback_guard` does watch
+        // those directories, but it reads them itself at turn open and turn
+        // close (`scan_native_skills`) and never consults this watcher, so
+        // subscribing here buys it nothing and breaks the mirror above.
         roots.push(WatchRoot {
             path: workspace.workspace_path.join(".claude/skills"),
-            recursive: true,
-        });
-        roots.push(WatchRoot {
-            path: workspace.workspace_path.join(".opencode/skills"),
-            recursive: true,
-        });
-        roots.push(WatchRoot {
-            path: workspace.workspace_path.join(".pi/skills"),
             recursive: true,
         });
         roots.push(WatchRoot {
@@ -570,6 +565,7 @@ mod tests {
         for retired in [
             Path::new("/tmp/ws-1/.teamclu/skills/demo-skill/SKILL.md"),
             Path::new("/tmp/ws-1/.opencode/skills/demo-skill/SKILL.md"),
+            Path::new("/tmp/ws-1/.pi/skills/demo-skill/SKILL.md"),
             Path::new("/Users/tester/.config/teamclu/skills/global-skill/SKILL.md"),
             Path::new("/Users/tester/.config/opencode/skills/global-skill/SKILL.md"),
         ] {


### PR DESCRIPTION
`skill_path_change_maps_to_skills_kind` has been failing on `main`, independently
of the sqlite link failure in #1175. It is the reason
`Daemon Unit Tests (Linux)` was already red at f77bec1a, before #1171 landed.

## Cause

#1066 converged skill scanning onto `.claude/skills`, `.agents/skills`
(workspace and home) and the team roots, and left an invariant on the watcher —
stated in the comment above `classify_change_path` — that it must mirror
`config::roles_skills::skill_dir_specs`. A root that is watched but not scanned
only fires refreshes nothing can load.

#1126 then added `.opencode/skills` and `.pi/skills` back, to both
`classify_change_path` and the watch roots, alongside its native directory
fallback guard.

The guard does not need them. `native_skill_fallback_guard` reads those
directories itself, via `scan_native_skills` at turn open and turn close, and
never consults this watcher — it contains no reference to `refresh_watch`. So
the subscription bought the guard nothing and broke the mirror, which is exactly
what the test asserts.

## Fix

Drop both roots from both places, and record why they are absent so the next
change in this area does not re-add them.

The test only asserted `.opencode/skills`, which is how `.pi/skills` slipped in
unnoticed, so it now asserts that one too.

## Verification

`cargo test -p amuxd --locked --no-fail-fast` — all targets, not just `--bin`.
The 27 `refresh_watch` tests and the fallback guard's own tests pass; the failure
is gone. Remaining failures across nine full runs were only the known
load-sensitive flakes (`catalog_probe`, `ask_policy`, `resolve_workdir`), each
green when run serially.

## Note

CI cannot go green here until #1175 lands, since the daemon does not link on
Linux without it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YLHqMLpNb9kbBJm891ooYv