### PR TITLE
fix(daemon): pin amuxd home in the cross-entry-point env test

### DIFF
--- a/apps/daemon/src/daemon/server.rs
+++ b/apps/daemon/src/daemon/server.rs
@@ -4291,6 +4291,21 @@ pub(crate) mod tests {
 
     #[tokio::test]
     async fn all_actual_entry_points_propagate_identical_workspace_env_and_revision() {
+        // Each entry point re-derives OPENCODE_CONFIG from the process-global
+        // amuxd home (`global_opencode_config_path` -> `amuxd_home_from_env`),
+        // once per spawn. This test spawns four times across many awaits, so a
+        // concurrent test moving `HOME` between two of them makes those two
+        // disagree on the path and the comparison fails -- the `daemon::server`
+        // race `test_brand_env` documents. Pin the home and take that lock.
+        let amuxd_home = TempDir::new().unwrap();
+        let _home_guard = crate::test_brand_env::BrandEnvGuard::set_amuxd_home(amuxd_home.path());
+        // `env_assembly` only emits OPENCODE_CONFIG when the file is there, so
+        // without this the key is absent from all four captures and they agree
+        // for the wrong reason. Materialise it and the assertion covers it.
+        let global_config = teamclu_runtime_env::opencode_config::global_opencode_config_path();
+        std::fs::create_dir_all(global_config.parent().unwrap()).unwrap();
+        std::fs::write(&global_config, "{}").unwrap();
+
         let workspace = TempDir::new().unwrap();
         let backend = Arc::new(crate::backend::mock::MockBackend::with_identity(
             "team-test",
@@ -4401,6 +4416,13 @@ pub(crate) mod tests {
         let captures = captures.lock().unwrap().clone();
         assert_eq!(captures.len(), 4);
         let desktop = &captures[0];
+        // Guards the setup above: if the device config were missing, every
+        // capture would simply lack this key and the comparison would pass
+        // without ever covering it.
+        assert!(
+            desktop.extra_env.contains_key("OPENCODE_CONFIG"),
+            "OPENCODE_CONFIG absent, so the env comparison below covers nothing"
+        );
         for (entry_point, capture) in [
             ("cron", &captures[1]),
             ("resume", &captures[2]),


### PR DESCRIPTION
`all_actual_entry_points_propagate_identical_workspace_env_and_revision` was the
second failure in `Daemon Unit Tests (Linux)` at f77bec1a, alongside the one
fixed in #1176. Both predate the sqlite link failure in #1175.

## Cause

The test spawns four runtimes across many awaits and compares the env each entry
point assembled. The CI diff showed the two sides differing in the tempdir alone
— every other entry in the map matched:

```
left:  {"OPENCODE_CONFIG": "/tmp/.tmpRa5M4K/.amuxd/teams/_unclaimed/state/opencode.json", ...}
right: {"OPENCODE_CONFIG": "/tmp/.tmpDrjDeN/.amuxd/teams/_unclaimed/state/opencode.json", ...}
```

`env_assembly` derives that value from the process-global amuxd home on every
spawn (`global_opencode_config_path` → `amuxd_home_from_env`), and this test took
no lock. Any concurrently running test that moved `HOME` between two of the four
spawns made those two disagree.

That is the race `test_brand_env` was written for — its module docs name
`daemon::server` tests specifically. This test just never joined it, which is
also why it reproduces under `cargo test` but not under `--test-threads=1`.

## Fix

Take `BrandEnvGuard::set_amuxd_home`, which pins the home and holds
`TEST_HOME_LOCK` for the test's duration.

Pinning it to a bare tempdir would have hidden the assertion rather than fixed
it: `env_assembly` only emits `OPENCODE_CONFIG` when the file exists, so all four
captures would have agreed by all lacking the key. The device config is created
so the key is really there, and a new assertion enforces that — the comparison
now genuinely covers the variable that was drifting.

## Verification

Nine full parallel runs of `cargo test -p amuxd --locked`: this test stayed
green throughout. Remaining failures were only the known load-sensitive flakes,
each green when run serially. The Linux-only appearance is a scheduling
difference, not a platform dependency, so this is verified by construction
rather than by a local repro.

## Note

CI cannot go green here until #1175 lands, since the daemon does not link on
Linux without it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YLHqMLpNb9kbBJm891ooYv