### PR TITLE
fix(desktop): satisfy clippy::unnecessary_sort_by

### DIFF
--- a/apps/desktop/src/commands/team_skills.rs
+++ b/apps/desktop/src/commands/team_skills.rs
@@ -1483,7 +1483,7 @@ pub fn team_skill_list_draft_recoveries(
         .filter(|rec| slug_filter.is_none_or(|s| rec.slug == s))
         .filter(|rec| std::path::Path::new(&rec.path).is_dir())
         .collect();
-    out.sort_by(|a, b| b.at.cmp(&a.at));
+    out.sort_by_key(|a| std::cmp::Reverse(a.at));
     out.truncate(cap);
     Ok(out)
 }


### PR DESCRIPTION
`Rust Format & Clippy` runs formatting *and* clippy. #1178 fixed the formatting,
which uncovered the failure behind it — the job is still red on `main`:

```
error: consider using `sort_by_key`
 --> apps/desktop/src/commands/team_skills.rs:1486:5
     out.sort_by(|a, b| b.at.cmp(&a.at));
note: `-D clippy::unnecessary-sort-by` implied by `-D warnings`
```

Same file as #1178, also from #1173.

Takes the form clippy suggests. `DraftRecoveryRecord::at` is a `u64`, so
`Reverse` copies it — worth checking first, because this rewrite does not
compile when the key field is not `Copy`. Ordering is unchanged: newest first.

## Note

CI could not tell us whether anything else fails clippy further along, since
`-D warnings` stopped at this error. If another lint surfaces once this lands,
it is a separate pre-existing one, not a regression from here.

This is the second of the breakages currently on `main`; #1175, #1176 and #1177
cover the other three and cannot go green until the daemon links again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YLHqMLpNb9kbBJm891ooYv