### PR TITLE
fix(team-skills): Phase 3 review round 4 — v1 category snapshot and fail-closed recovery

### DIFF
--- a/apps/desktop/src/commands/team_skills.rs
+++ b/apps/desktop/src/commands/team_skills.rs
@@ -1464,6 +1464,14 @@ pub fn team_skill_read_draft_metadata(
 }
 
 fn recovery_record_for_path(source: &std::path::Path) -> Option<DraftRecoveryRecord> {
+    let sidecar = source.join(".clawhub").join("recovery.json");
+    if sidecar.is_file() {
+        if let Ok(text) = std::fs::read_to_string(&sidecar) {
+            if let Ok(rec) = serde_json::from_str::<DraftRecoveryRecord>(&text) {
+                return Some(rec);
+            }
+        }
+    }
     let trash = trash_dir().ok()?;
     let log = trash.join("recovery.jsonl");
     if !log.is_file() {
@@ -1551,14 +1559,15 @@ fn move_to_trash(
     let dest = trash.join(format!("{}-{}", slug, now_millis()));
     std::fs::rename(target, &dest).map_err(|e| format!("Failed to move skill aside: {}", e))?;
     if let Some(ctx) = recovery {
-        record_draft_recovery(&DraftRecoveryRecord {
+        let rec = DraftRecoveryRecord {
             slug: slug.to_string(),
             path: dest.display().to_string(),
             at: now_millis(),
             reason: ctx.reason,
             base_version: ctx.base_version,
             team_id: ctx.team_id,
-        });
+        };
+        record_draft_recovery(&dest, &rec)?;
     }
     // Swept here rather than on a timer: this is the only thing that ever adds
     // to the directory, so it is the only place that can let it grow.
@@ -1584,22 +1593,27 @@ pub struct DraftRecoveryRecord {
     pub team_id: Option<String>,
 }
 
-fn record_draft_recovery(rec: &DraftRecoveryRecord) {
-    let Ok(trash) = trash_dir() else {
-        return;
-    };
+fn record_draft_recovery(dest: &std::path::Path, rec: &DraftRecoveryRecord) -> Result<(), String> {
+    let sidecar_dir = dest.join(".clawhub");
+    std::fs::create_dir_all(&sidecar_dir)
+        .map_err(|e| format!("Failed to write recovery metadata: {}", e))?;
+    let line = serde_json::to_string(rec)
+        .map_err(|e| format!("Failed to serialize recovery metadata: {}", e))?;
+    std::fs::write(sidecar_dir.join("recovery.json"), &line)
+        .map_err(|e| format!("Failed to write recovery metadata: {}", e))?;
+
+    let trash = trash_dir()?;
     let log = trash.join("recovery.jsonl");
-    let Ok(line) = serde_json::to_string(rec) else {
-        return;
-    };
-    let _ = std::fs::OpenOptions::new()
+    std::fs::OpenOptions::new()
         .create(true)
         .append(true)
         .open(&log)
         .and_then(|mut f| {
             use std::io::Write;
             writeln!(f, "{line}")
-        });
+        })
+        .map_err(|e| format!("Failed to append recovery log: {}", e))?;
+    Ok(())
 }
 
 fn draft_recovery_context(
@@ -1697,21 +1711,25 @@ pub fn team_skill_restore_trashed(
     let source = resolve_trashed_source(&trash_dir()?, trashed_path.trim())?;
 
     if let Some(expected_team) = team_id.as_deref().map(str::trim).filter(|s| !s.is_empty()) {
-        if let Some(rec) = recovery_record_for_path(&source) {
-            match rec.team_id.as_deref() {
-                Some(rec_team) if rec_team != expected_team => {
-                    return Err(
-                        "This recovery belongs to another team and cannot be restored here"
-                            .to_string(),
-                    );
-                }
-                None => {
-                    return Err(
-                        "This recovery has no team context and cannot be restored here".to_string(),
-                    );
-                }
-                _ => {}
+        let rec = recovery_record_for_path(&source).ok_or_else(|| {
+            "This backup has no recovery record and cannot be restored into a team skill"
+                .to_string()
+        })?;
+        match rec.team_id.as_deref() {
+            Some(rec_team) if rec_team == expected_team => {}
+            Some(_) => {
+                return Err(
+                    "This recovery belongs to another team and cannot be restored here".to_string(),
+                );
             }
+            None => {
+                return Err(
+                    "This recovery has no team context and cannot be restored here".to_string(),
+                );
+            }
+        }
+        if rec.slug != slug {
+            return Err("This recovery belongs to a different skill".to_string());
         }
     }
 
@@ -2321,20 +2339,58 @@ mod tests {
     }
 
     #[test]
-    fn reqwest_error_includes_source_chain() {
-        let err = build_cloud_api_client()
-            .unwrap()
-            .get("https://127.0.0.1:1/")
-            .send()
-            .expect_err("refused");
-        let formatted = format_reqwest_error(&err);
-        assert!(
-            formatted.contains("error sending request"),
-            "top-level: {formatted}"
-        );
-        assert!(
-            formatted.contains("Connection refused") || formatted.contains("connect"),
-            "source chain must surface: {formatted}"
-        );
+    fn restore_into_a_team_requires_a_matching_recovery_record() {
+        let home = tempfile::tempdir().expect("tempdir");
+        let _home = crate::test_home::HomeGuard::set(home.path());
+        set_active_team("team-a");
+
+        let source = global_skills_dir().unwrap().join("say-hello");
+        write_installed_skill(&source, "team-a", 1);
+
+        let trashed = team_skill_discard_local("say-hello".into(), Some("team-a".into()))
+            .expect("discard writes recovery metadata");
+        assert!(std::path::Path::new(&trashed)
+            .join(".clawhub/recovery.json")
+            .is_file());
+
+        let restored =
+            team_skill_restore_trashed(trashed.clone(), "say-hello".into(), Some("team-a".into()))
+                .expect("same team + slug restores");
+        assert!(std::path::Path::new(&restored).is_dir());
+    }
+
+    #[test]
+    fn restore_into_a_team_rejects_missing_or_mismatched_recovery() {
+        let home = tempfile::tempdir().expect("tempdir");
+        let _home = crate::test_home::HomeGuard::set(home.path());
+        set_active_team("team-a");
+
+        let trash = trash_dir().unwrap();
+        std::fs::create_dir_all(&trash).unwrap();
+        let orphan = trash.join(format!("say-hello-{}", now_millis()));
+        write_installed_skill(&orphan, "team-a", 1);
+
+        let err = team_skill_restore_trashed(
+            orphan.display().to_string(),
+            "say-hello".into(),
+            Some("team-a".into()),
+        )
+        .expect_err("no recovery record");
+        assert!(err.contains("no recovery record"), "{err}");
+
+        let source = global_skills_dir().unwrap().join("say-hello");
+        write_installed_skill(&source, "team-a", 1);
+        let trashed =
+            team_skill_discard_local("say-hello".into(), Some("team-a".into())).expect("discard");
+
+        let wrong_team =
+            team_skill_restore_trashed(trashed.clone(), "say-hello".into(), Some("team-b".into()))
+                .expect_err("other team");
+        assert!(wrong_team.contains("another team"), "{wrong_team}");
+
+        let wrong_slug =
+            team_skill_restore_trashed(trashed, "other-skill".into(), Some("team-a".into()))
+                .expect_err("other slug");
+        assert!(wrong_slug.contains("different skill"), "{wrong_slug}");
     }
 }

--- a/docs/openapi/teamclu-api.v1.yaml
+++ b/docs/openapi/teamclu-api.v1.yaml
@@ -2120,10 +2120,11 @@ paths:
       operationId: publishTeamSkill
       summary: Publish a skill (version 1)
       description: >
-        The publish gate. summary / category / whenToUse / whenNotToUse /
-        changelog are all required — the registry exists so those stop living
-        inside one free-text description. The package zip is uploaded
-        separately via the amuxc blob path; only its contentHash arrives here.
+        The publish gate. `summary`, `category`, and `changelog` are required —
+        they are the list subtitle, filter, and version note. `whenToUse` and
+        `whenNotToUse` are optional: empty is a real answer, not a missing field.
+        The package zip is uploaded separately via the amuxc blob path; only
+        its contentHash arrives here.
       tags: [TeamSkills]
       parameters:
         - $ref: "#/components/parameters/TeamId"
@@ -2440,12 +2441,10 @@ paths:
         "403": { $ref: "#/components/responses/Error" }
         "404": { $ref: "#/components/responses/Error" }
         "409":
-          description: Registry moved since the caller loaded it (`stale_team_skill_base`).
-          content:
-            application/json:
-              schema: { $ref: "#/components/schemas/Error" }
-        "409":
-          description: That version is already the latest.
+          description: >
+            Conflict. Either the registry moved since the caller loaded it
+            (`stale_team_skill_base`), or the target version is already the
+            latest (`conflict`).
           content:
             application/json:
               schema: { $ref: "#/components/schemas/Error" }
@@ -6478,7 +6477,7 @@ components:
         hasUpdate: { type: boolean }
     TeamSkillPublish:
       type: object
-      required: [slug, summary, category, whenToUse, whenNotToUse, changelog, contentHash]
+      required: [slug, summary, category, changelog, contentHash]
       properties:
         slug: { type: string, pattern: "^[a-z0-9][a-z0-9-]{1,63}$" }
         summary: { type: string, maxLength: 200 }

--- a/packages/app/src/stores/team-share-browser.ts
+++ b/packages/app/src/stores/team-share-browser.ts
@@ -1852,12 +1852,12 @@ export const useTeamShareBrowserStore = create<TeamShareBrowserState>((set, get)
       // the part only they can ask for.
       throw new SkillDiscardIncompleteError(trashedPath, e)
     } finally {
+      set((s) => ({ draftRecoveryRevision: s.draftRecoveryRevision + 1 }))
       await get().reconcileSkills().catch(() => {})
       await get()
         .loadSection('skills', { force: true })
         .catch(() => {})
     }
-    set((s) => ({ draftRecoveryRevision: s.draftRecoveryRevision + 1 }))
     return trashedPath
   },
 

--- a/services/fc/src/lib/pg-repo/team-skills.ts
+++ b/services/fc/src/lib/pg-repo/team-skills.ts
@@ -415,6 +415,7 @@ export function makeTeamSkillsRepo(db: DbLike, ctx: TeamSkillsCtx) {
         size: Number(body.size ?? 0),
         changelog,
         summary: fields.summary as string,
+        category: fields.category as string,
         whenToUse: fields.whenToUse as string,
         whenNotToUse: fields.whenNotToUse as string,
         requires: (fields.requires as any) ?? null,

--- a/services/fc/src/lib/supabase-repo.ts
+++ b/services/fc/src/lib/supabase-repo.ts
@@ -4298,6 +4298,7 @@ export function createSupabaseBusinessRepository(options) {
         size: Number(body.size ?? 0),
         changelog,
         summary: fields.summary,
+        category: fields.category,
         when_to_use: fields.whenToUse,
         when_not_to_use: fields.whenNotToUse,
         requires: fields.requires ?? null,

--- a/services/fc/test/db/team-skills-bootstrap.ts
+++ b/services/fc/test/db/team-skills-bootstrap.ts
@@ -47,6 +47,7 @@ create table if not exists team_skill_versions (
   size bigint not null default 0,
   changelog text not null,
   summary text not null,
+  category text,
   when_to_use text not null,
   when_not_to_use text not null,
   requires jsonb,

--- a/services/fc/test/pg-repo-team-skills-authz.test.ts
+++ b/services/fc/test/pg-repo-team-skills-authz.test.ts
@@ -225,6 +225,32 @@ test("a plain member can revert to an earlier version", async () => {
   assert.equal(reverted.contentHash, "a".repeat(64));
 });
 
+test("revert to v1 restores the original category snapshot", async () => {
+  const { team, memberRepo } = await scenario();
+
+  const v1 = await memberRepo.getTeamSkill(team.id, "deploy-check");
+  assert.equal(v1.category, "devops");
+  const snap = v1.versions.find((v: { version: number }) => v.version === 1);
+  assert.equal(snap?.category, "devops");
+
+  await memberRepo.createTeamSkillVersion(team.id, "deploy-check", {
+    changelog: "retarget as coding",
+    contentHash: "b".repeat(64),
+    expectedLatestVersion: 1,
+    category: "coding",
+  });
+
+  const reverted = await memberRepo.revertTeamSkillVersion(team.id, "deploy-check", 1, {
+    expectedLatestVersion: 2,
+  });
+  assert.equal(reverted.version, 3);
+  assert.equal(reverted.category, "devops");
+
+  const after = await memberRepo.getTeamSkill(team.id, "deploy-check");
+  assert.equal(after.category, "devops");
+  assert.equal(after.latestVersion, 3);
+});
+
 test("a plain member can edit metadata and deprecate", async () => {
   const { team, memberRepo } = await scenario();
 


### PR DESCRIPTION
## Summary

Follow-up to #1179. Addresses the fourth review blockers on `main` (`736c952c`):

- **v1 category snapshot (P1)** — first publish writes `category` onto the version row (pg + Supabase); revert to v1 restores the original category
- **Discard recovery refresh (P2)** — `draftRecoveryRevision` bumps in `finally` after move-to-trash, even when reinstall fails
- **Fail-closed restore (P2)** — recovery metadata written beside the trash copy (`.clawhub/recovery.json`); restore with `teamId` requires matching `team_id` + `slug`
- **OpenAPI (P2)** — merge duplicate `409` on revert; first-publish required fields drop optional `whenToUse` / `whenNotToUse`

## Test plan

- [x] `pnpm typecheck`
- [x] desktop `team_skills` unit tests (23/23), including restore ownership cases
- [x] pg-repo test: v1 → change category → revert v1 restores original
- [ ] Manual: publish v1 as devops, publish v2 as coding, revert to v1 → category is devops
- [ ] Manual: discard with reinstall failure → recovery banner still appears
- [ ] Manual: restore with wrong team/slug → rejected


Made with [Cursor](https://cursor.com)