### PR TITLE
fix(daemon): make the team gateway actually usable from a runtime

### DIFF
--- a/apps/daemon/src/channels/agent_handle.rs
+++ b/apps/daemon/src/channels/agent_handle.rs
@@ -334,7 +334,11 @@ impl AmuxdAgentHandle {
             let map = self.logical_to_acp.lock().await;
             map.get(session).map(|s| s.binding.clone())
         }
-        .unwrap_or_default();
+        .unwrap_or_default(
+            // Channels spawn the same runtimes; the team provider needs its
+            // credential binding here too.
+            None,
+        );
         let (workspace_dir, _) = self.resolve_spawn_target(session, &binding).await?;
         let Some(dir) = workspace_dir else {
             // No resolvable workspace — a spawn would run in a throwaway

--- a/apps/daemon/src/channels/agent_handle.rs
+++ b/apps/daemon/src/channels/agent_handle.rs
@@ -302,6 +302,11 @@ impl AmuxdAgentHandle {
             &self.spawn_env.actor_name,
             cloud_token_file.as_deref(),
             &managed_llm,
+            // Channels spawn the same runtimes as everything else, so the team
+            // provider needs its credential binding here too. None until this
+            // path has a token source of its own — the gateway runtime does not
+            // hold one, and a wrong token is worse than an absent provider.
+            None,
         )
         .map(|env| SpawnRuntimeEnv {
             is_gateway: true,
@@ -334,11 +339,7 @@ impl AmuxdAgentHandle {
             let map = self.logical_to_acp.lock().await;
             map.get(session).map(|s| s.binding.clone())
         }
-        .unwrap_or_default(
-            // Channels spawn the same runtimes; the team provider needs its
-            // credential binding here too.
-            None,
-        );
+        .unwrap_or_default();
         let (workspace_dir, _) = self.resolve_spawn_target(session, &binding).await?;
         let Some(dir) = workspace_dir else {
             // No resolvable workspace — a spawn would run in a throwaway

--- a/apps/daemon/src/channels/agent_handle.rs
+++ b/apps/daemon/src/channels/agent_handle.rs
@@ -307,6 +307,7 @@ impl AmuxdAgentHandle {
             // path has a token source of its own — the gateway runtime does not
             // hold one, and a wrong token is worse than an absent provider.
             None,
+            None,
         )
         .map(|env| SpawnRuntimeEnv {
             is_gateway: true,

--- a/apps/daemon/src/daemon/runtime_env.rs
+++ b/apps/daemon/src/daemon/runtime_env.rs
@@ -562,26 +562,6 @@ impl ExecutionContextAssembler {
             Some(team_id) => self.managed_llm.resolve(team_id).await,
             None => ManagedLlmState::Unknown,
         };
-        // Diagnostic: the team gateway reaches opencode through the ACTIVE-TEAM
-        // global config, but reaches pi (and any other runtime) only through the
-        // env assembled here, off the WORKSPACE's team. When those two disagree
-        // the picker silently differs per runtime, and nothing on either side
-        // says so. Logged at INFO because the only way to see it otherwise is a
-        // process environment macOS will not show you.
-        tracing::info!(
-            target: "amuxd::team_provider_probe",
-            workspace_team = ?workspace.team_id,
-            configured_team = ?self.configured_team_id(),
-            effective_team = ?team_id,
-            managed_llm = match &managed_llm {
-                ManagedLlmState::Enabled(p) => format!("Enabled({}, {} models)", p.base_url, p.models.len()),
-                ManagedLlmState::Disabled => "Disabled".to_string(),
-                ManagedLlmState::Unknown => "Unknown".to_string(),
-            },
-            workspace_root = %workspace.workspace_root.display(),
-            working_directory = %working_directory.display(),
-            "resolving spawn env"
-        );
         let cloud_token_file = self
             .backend
             .cloud_auth_health()

--- a/apps/daemon/src/daemon/runtime_env.rs
+++ b/apps/daemon/src/daemon/runtime_env.rs
@@ -607,6 +607,9 @@ impl ExecutionContextAssembler {
             cloud_token_file.as_deref(),
             &managed_llm,
             self.managed_llm.gateway_token().as_deref(),
+            team_id
+                .and_then(|id| self.managed_llm.ai_proxy_base(id))
+                .as_deref(),
         )
         .map_err(|e| format!("assemble_runtime_env failed: {e}"))
     }
@@ -813,6 +816,10 @@ impl DaemonServer {
             cloud_token_file.as_deref(),
             &managed_llm,
             self.managed_llm.gateway_token().as_deref(),
+            team_id
+                .as_deref()
+                .and_then(|id| self.managed_llm.ai_proxy_base(id))
+                .as_deref(),
         )
         .map_err(|e| e.to_string())
     }

--- a/apps/daemon/src/daemon/runtime_env.rs
+++ b/apps/daemon/src/daemon/runtime_env.rs
@@ -606,6 +606,7 @@ impl ExecutionContextAssembler {
             &self.actor_name,
             cloud_token_file.as_deref(),
             &managed_llm,
+            self.managed_llm.gateway_token().as_deref(),
         )
         .map_err(|e| format!("assemble_runtime_env failed: {e}"))
     }
@@ -811,6 +812,7 @@ impl DaemonServer {
             &self.config.actor.name,
             cloud_token_file.as_deref(),
             &managed_llm,
+            self.managed_llm.gateway_token().as_deref(),
         )
         .map_err(|e| e.to_string())
     }

--- a/apps/daemon/src/daemon/runtime_env.rs
+++ b/apps/daemon/src/daemon/runtime_env.rs
@@ -562,6 +562,26 @@ impl ExecutionContextAssembler {
             Some(team_id) => self.managed_llm.resolve(team_id).await,
             None => ManagedLlmState::Unknown,
         };
+        // Diagnostic: the team gateway reaches opencode through the ACTIVE-TEAM
+        // global config, but reaches pi (and any other runtime) only through the
+        // env assembled here, off the WORKSPACE's team. When those two disagree
+        // the picker silently differs per runtime, and nothing on either side
+        // says so. Logged at INFO because the only way to see it otherwise is a
+        // process environment macOS will not show you.
+        tracing::info!(
+            target: "amuxd::team_provider_probe",
+            workspace_team = ?workspace.team_id,
+            configured_team = ?self.configured_team_id(),
+            effective_team = ?team_id,
+            managed_llm = match &managed_llm {
+                ManagedLlmState::Enabled(p) => format!("Enabled({}, {} models)", p.base_url, p.models.len()),
+                ManagedLlmState::Disabled => "Disabled".to_string(),
+                ManagedLlmState::Unknown => "Unknown".to_string(),
+            },
+            workspace_root = %workspace.workspace_root.display(),
+            working_directory = %working_directory.display(),
+            "resolving spawn env"
+        );
         let cloud_token_file = self
             .backend
             .cloud_auth_health()

--- a/apps/daemon/src/daemon/server.rs
+++ b/apps/daemon/src/daemon/server.rs
@@ -1222,6 +1222,13 @@ impl DaemonServer {
                     self.managed_llm.set_tokens(
                         crate::runtime::gateway_token::GatewayTokenSource::new(h.tokens.clone()),
                     );
+                    // ...and where to reach that proxy. Runtimes are pointed
+                    // here, not at the cloud gateway: the token above is only
+                    // valid locally, and this hop is what refreshes the cloud
+                    // credential per request so a multi-day agent never meets
+                    // its expiry.
+                    self.managed_llm
+                        .set_local_http_base(format!("http://{}", h.local_addr));
                     if let Err(err) = self
                         .runtime_context
                         .validate_managed_setup(&self.config.agents.local_agent)

--- a/apps/daemon/src/daemon/server.rs
+++ b/apps/daemon/src/daemon/server.rs
@@ -822,9 +822,29 @@ impl DaemonServer {
             refresh_coordinator: None,
             refresh_auto_apply_task: None,
             mqtt_connected_flag: None,
-            managed_llm: Arc::new(crate::runtime::managed_llm::ManagedLlmResolver::new(
-                backend,
-            )),
+            // With a token source, not bare.
+            //
+            // There are two resolvers: this one, on the SPAWN path, and the
+            // HTTP layer's, which reconciles `provider.team` and resolves its
+            // apiKey into the file opencode reads. Only the second had a token
+            // source, which was sufficient for exactly as long as opencode was
+            // the only consumer. Every other runtime is handed
+            // `TEAMCLU_TEAM_PROVIDER` and looks its credential up from the env
+            // by the name in `apiKeyEnv` — so this resolver has to be able to
+            // mint one too, or `tc_gateway_token` is never bound and pi hides
+            // every team model behind an unresolvable credential.
+            //
+            // The store is file-backed and shared, so a token minted here is
+            // the same secret the HTTP layer validates against.
+            managed_llm: Arc::new(
+                crate::runtime::managed_llm::ManagedLlmResolver::new(backend).with_tokens(
+                    crate::http::tokens::TokenStore::load_or_init(
+                        &crate::config::DaemonConfig::http_token_path(),
+                    )
+                    .ok()
+                    .map(crate::runtime::gateway_token::GatewayTokenSource::new),
+                ),
+            ),
             live_tee,
             session_remote_targets: Arc::new(AsyncMutex::new(
                 crate::remote_tools::SessionRemoteTargetStore::default(),

--- a/apps/daemon/src/daemon/server.rs
+++ b/apps/daemon/src/daemon/server.rs
@@ -822,29 +822,12 @@ impl DaemonServer {
             refresh_coordinator: None,
             refresh_auto_apply_task: None,
             mqtt_connected_flag: None,
-            // With a token source, not bare.
-            //
-            // There are two resolvers: this one, on the SPAWN path, and the
-            // HTTP layer's, which reconciles `provider.team` and resolves its
-            // apiKey into the file opencode reads. Only the second had a token
-            // source, which was sufficient for exactly as long as opencode was
-            // the only consumer. Every other runtime is handed
-            // `TEAMCLU_TEAM_PROVIDER` and looks its credential up from the env
-            // by the name in `apiKeyEnv` — so this resolver has to be able to
-            // mint one too, or `tc_gateway_token` is never bound and pi hides
-            // every team model behind an unresolvable credential.
-            //
-            // The store is file-backed and shared, so a token minted here is
-            // the same secret the HTTP layer validates against.
-            managed_llm: Arc::new(
-                crate::runtime::managed_llm::ManagedLlmResolver::new(backend).with_tokens(
-                    crate::http::tokens::TokenStore::load_or_init(
-                        &crate::config::DaemonConfig::http_token_path(),
-                    )
-                    .ok()
-                    .map(crate::runtime::gateway_token::GatewayTokenSource::new),
-                ),
-            ),
+            // Built without a token source: the HTTP layer owns the TokenStore
+            // and has not started yet. It is injected below, once that store
+            // exists — see the `set_tokens` call after the http spawn.
+            managed_llm: Arc::new(crate::runtime::managed_llm::ManagedLlmResolver::new(
+                backend,
+            )),
             live_tee,
             session_remote_targets: Arc::new(AsyncMutex::new(
                 crate::remote_tools::SessionRemoteTargetStore::default(),
@@ -1226,6 +1209,19 @@ impl DaemonServer {
             {
                 Ok(h) => {
                     info!(addr = %h.local_addr, "http listener bound");
+                    // Hand the spawn-path resolver the SAME TokenStore the HTTP
+                    // layer authenticates against. Loading a second store from
+                    // the same file is not equivalent: the file holds only the
+                    // root token, while minted session tokens live in the
+                    // instance that minted them — so a token from any other
+                    // store is rejected as "invalid or expired".
+                    //
+                    // Without this the runtimes that read their credential from
+                    // `TEAMCLU_TEAM_PROVIDER` (pi, and anything after it) get a
+                    // token nothing accepts, and every team-model call 401s.
+                    self.managed_llm.set_tokens(
+                        crate::runtime::gateway_token::GatewayTokenSource::new(h.tokens.clone()),
+                    );
                     if let Err(err) = self
                         .runtime_context
                         .validate_managed_setup(&self.config.agents.local_agent)

--- a/apps/daemon/src/runtime/env_assembly.rs
+++ b/apps/daemon/src/runtime/env_assembly.rs
@@ -105,36 +105,21 @@ pub fn assemble_spawn_runtime_env_for_execution(
         }));
     let mut extra_env = bundle.extra_env;
     // Backend-neutral team-provider handoff. opencode consumes the team gateway
-    // via `provider.team` in the active team's opencode.json;
-    // other local runtimes (pi, …) that can't read opencode.json instead read
-    // this `TEAMCLU_TEAM_PROVIDER` env and register the provider themselves.
-    // The secret is NOT embedded — the payload references `${tc_api_key}`, the
-    // same env-interpolated key opencode uses, which is already in `extra_env`.
+    // via `provider.team` in the active team's opencode.json; other local
+    // runtimes (pi, …) cannot read that file and instead register the provider
+    // themselves from this payload.
+    //
+    // The secret is NOT embedded: the payload carries `apiKeyEnv`, naming the
+    // binding to read it from — `tc_gateway_token`, bound above. That binding
+    // has to exist, or the provider registers and every model on it silently
+    // becomes unavailable, which looks exactly like it never registered.
     if let ManagedLlmState::Enabled(provider) = &managed_llm {
         extra_env.insert(
             "TEAMCLU_TEAM_PROVIDER".to_string(),
             teamclu_runtime_env::team_provider_env_payload(provider, ai_proxy_base),
         );
-        tracing::info!(
-            target: "amuxd::team_provider_probe",
-            base_url = %provider.base_url,
-            models = provider.models.len(),
-            "injected TEAMCLU_TEAM_PROVIDER"
-        );
-    } else {
-        // The state AFTER stabilize_managed_llm_for_spawn, so this also says
-        // whether the on-disk provider.team fallback fired.
-        tracing::info!(
-            target: "amuxd::team_provider_probe",
-            state = match &managed_llm {
-                ManagedLlmState::Disabled => "Disabled",
-                ManagedLlmState::Unknown => "Unknown",
-                ManagedLlmState::Enabled(_) => unreachable!(),
-            },
-            disk_fallback_present = disk_team.is_some(),
-            "NOT injecting TEAMCLU_TEAM_PROVIDER"
-        );
     }
+
     // #742: point opencode at the daemon-owned device-level config, which is
     // where user-configured providers now live. `OPENCODE_CONFIG` loads it as an
     // *additional* global-scope config after the standard global chain, so these

--- a/apps/daemon/src/runtime/env_assembly.rs
+++ b/apps/daemon/src/runtime/env_assembly.rs
@@ -22,6 +22,7 @@ pub fn assemble_spawn_runtime_env(
     cloud_token_file: Option<&str>,
     managed_llm: &ManagedLlmState,
     gateway_token: Option<&str>,
+    ai_proxy_base: Option<&str>,
 ) -> anyhow::Result<SpawnRuntimeEnv> {
     assemble_spawn_runtime_env_for_execution(
         workspace_root,
@@ -32,6 +33,7 @@ pub fn assemble_spawn_runtime_env(
         cloud_token_file,
         managed_llm,
         gateway_token,
+        ai_proxy_base,
     )
 }
 
@@ -47,6 +49,7 @@ pub fn assemble_spawn_runtime_env_for_execution(
     cloud_token_file: Option<&str>,
     managed_llm: &ManagedLlmState,
     gateway_token: Option<&str>,
+    ai_proxy_base: Option<&str>,
 ) -> anyhow::Result<SpawnRuntimeEnv> {
     // Cold ManagedLlm cache often yields Unknown and omits TEAMCLU_TEAM_PROVIDER;
     // reconstruct Enabled from on-disk provider.team so the spawn fingerprint
@@ -76,6 +79,7 @@ pub fn assemble_spawn_runtime_env_for_execution(
             // never having been registered. Verified by A/B — same payload, the
             // only difference being this variable.
             gateway_token: gateway_token.map(str::to_string),
+            ai_proxy_base: ai_proxy_base.map(str::to_string),
         },
         &managed_llm,
     )?;
@@ -109,7 +113,7 @@ pub fn assemble_spawn_runtime_env_for_execution(
     if let ManagedLlmState::Enabled(provider) = &managed_llm {
         extra_env.insert(
             "TEAMCLU_TEAM_PROVIDER".to_string(),
-            teamclu_runtime_env::team_provider_env_payload(provider),
+            teamclu_runtime_env::team_provider_env_payload(provider, ai_proxy_base),
         );
         tracing::info!(
             target: "amuxd::team_provider_probe",

--- a/apps/daemon/src/runtime/env_assembly.rs
+++ b/apps/daemon/src/runtime/env_assembly.rs
@@ -21,6 +21,7 @@ pub fn assemble_spawn_runtime_env(
     display_name: &str,
     cloud_token_file: Option<&str>,
     managed_llm: &ManagedLlmState,
+    gateway_token: Option<&str>,
 ) -> anyhow::Result<SpawnRuntimeEnv> {
     assemble_spawn_runtime_env_for_execution(
         workspace_root,
@@ -30,6 +31,7 @@ pub fn assemble_spawn_runtime_env(
         display_name,
         cloud_token_file,
         managed_llm,
+        gateway_token,
     )
 }
 
@@ -44,6 +46,7 @@ pub fn assemble_spawn_runtime_env_for_execution(
     display_name: &str,
     cloud_token_file: Option<&str>,
     managed_llm: &ManagedLlmState,
+    gateway_token: Option<&str>,
 ) -> anyhow::Result<SpawnRuntimeEnv> {
     // Cold ManagedLlm cache often yields Unknown and omits TEAMCLU_TEAM_PROVIDER;
     // reconstruct Enabled from on-disk provider.team so the spawn fingerprint
@@ -59,13 +62,20 @@ pub fn assemble_spawn_runtime_env_for_execution(
             actor_id: actor_id.to_string(),
             display_name: display_name.to_string(),
             cloud_token_file: cloud_token_file.map(str::to_string),
-            // Not supplied on the spawn path, and not needed there: since #941
-            // `provider.team` is written to the ACTIVE-TEAM GLOBAL config, and
-            // its apiKey is resolved by `sync_global_team_provider` during
-            // reconcile (which runs on every provider read). This context only
-            // feeds workspace-scoped `${...}` resolution, where nothing in the
-            // product references the gateway token.
-            gateway_token: None,
+            // Binds `tc_gateway_token`, which `TEAMCLU_TEAM_PROVIDER` names as
+            // its `apiKeyEnv`.
+            //
+            // This used to be None, on the reasoning that `provider.team` is
+            // written to the active-team global config and its apiKey resolved
+            // during reconcile — true, and true only for opencode, which reads
+            // that file. Every other runtime registers the provider itself from
+            // the env payload and looks the credential up by name. With the
+            // binding missing, pi registered the team provider and then showed
+            // none of its models: a provider with no resolvable credential is
+            // "loaded but unavailable" in pi, which is indistinguishable from
+            // never having been registered. Verified by A/B — same payload, the
+            // only difference being this variable.
+            gateway_token: gateway_token.map(str::to_string),
         },
         &managed_llm,
     )?;
@@ -228,6 +238,7 @@ mod tests {
             "Env Test Agent",
             None,
             &ManagedLlmState::Unknown,
+            None,
         )
         .unwrap();
 
@@ -311,6 +322,7 @@ mod tests {
             "Cron Agent",
             None,
             &managed,
+            None,
         )
         .unwrap();
 
@@ -391,6 +403,7 @@ mod tests {
             "FP Agent",
             None,
             &ManagedLlmState::Unknown,
+            None,
         )
         .unwrap();
         let from_enabled = assemble_spawn_runtime_env(
@@ -400,6 +413,7 @@ mod tests {
             "FP Agent",
             None,
             &enabled,
+            None,
         )
         .unwrap();
 

--- a/apps/daemon/src/runtime/env_assembly.rs
+++ b/apps/daemon/src/runtime/env_assembly.rs
@@ -101,6 +101,25 @@ pub fn assemble_spawn_runtime_env_for_execution(
             "TEAMCLU_TEAM_PROVIDER".to_string(),
             teamclu_runtime_env::team_provider_env_payload(provider),
         );
+        tracing::info!(
+            target: "amuxd::team_provider_probe",
+            base_url = %provider.base_url,
+            models = provider.models.len(),
+            "injected TEAMCLU_TEAM_PROVIDER"
+        );
+    } else {
+        // The state AFTER stabilize_managed_llm_for_spawn, so this also says
+        // whether the on-disk provider.team fallback fired.
+        tracing::info!(
+            target: "amuxd::team_provider_probe",
+            state = match &managed_llm {
+                ManagedLlmState::Disabled => "Disabled",
+                ManagedLlmState::Unknown => "Unknown",
+                ManagedLlmState::Enabled(_) => unreachable!(),
+            },
+            disk_fallback_present = disk_team.is_some(),
+            "NOT injecting TEAMCLU_TEAM_PROVIDER"
+        );
     }
     // #742: point opencode at the daemon-owned device-level config, which is
     // where user-configured providers now live. `OPENCODE_CONFIG` loads it as an

--- a/apps/daemon/src/runtime/managed_llm.rs
+++ b/apps/daemon/src/runtime/managed_llm.rs
@@ -44,7 +44,12 @@ pub struct ManagedLlmResolver {
     /// resolves to. `None` in focused tests and wherever no HTTP layer exists —
     /// the provider is then written with the placeholder left in place, which
     /// is correct: there is no local proxy to authenticate against either.
-    tokens: Option<super::gateway_token::GatewayTokenSource>,
+    /// Interior-mutable because the HTTP layer owns the TokenStore and starts
+    /// AFTER this resolver is built. Two stores loaded from the same file are
+    /// NOT interchangeable — the root token is on disk, but minted session
+    /// tokens live only in the instance that minted them, so a token from a
+    /// second store authenticates against nothing.
+    tokens: parking_lot::RwLock<Option<super::gateway_token::GatewayTokenSource>>,
     cache: AsyncMutex<HashMap<String, CachedManagedLlm>>,
     member_key_kicked: AsyncMutex<HashSet<String>>,
 }
@@ -53,7 +58,7 @@ impl ManagedLlmResolver {
     pub fn new(backend: Arc<dyn Backend>) -> Self {
         Self {
             backend,
-            tokens: None,
+            tokens: parking_lot::RwLock::new(None),
             cache: AsyncMutex::new(HashMap::new()),
             member_key_kicked: AsyncMutex::new(HashSet::new()),
         }
@@ -62,9 +67,15 @@ impl ManagedLlmResolver {
     /// Attach the token source so reconciles can resolve
     /// `provider.team.options.apiKey`. Chained after `new()` because most call
     /// sites (tests, the channel manager) have no HTTP layer to mint from.
-    pub fn with_tokens(mut self, tokens: Option<super::gateway_token::GatewayTokenSource>) -> Self {
-        self.tokens = tokens;
+    pub fn with_tokens(self, tokens: Option<super::gateway_token::GatewayTokenSource>) -> Self {
+        *self.tokens.write() = tokens;
         self
+    }
+
+    /// Attach the token source after construction, for the resolver the daemon
+    /// builds before its HTTP layer exists.
+    pub fn set_tokens(&self, tokens: super::gateway_token::GatewayTokenSource) {
+        *self.tokens.write() = Some(tokens);
     }
 
     /// The `ai:invoke` token `provider.team`'s apiKey resolves to.
@@ -77,7 +88,7 @@ impl ManagedLlmResolver {
     /// credential is "loaded but unavailable" — which looks exactly like the
     /// provider never having been registered at all.
     pub fn gateway_token(&self) -> Option<String> {
-        self.tokens.as_ref().map(|t| t.get_or_mint())
+        self.tokens.read().as_ref().map(|t| t.get_or_mint())
     }
 
     /// Resolve the team's managed (shared) LLM directly from the cloud API, with
@@ -158,6 +169,7 @@ impl ManagedLlmResolver {
         // (and leak a token into the store) on every provider read.
         let token = self
             .tokens
+            .read()
             .as_ref()
             .map(|t| t.get_or_mint())
             .unwrap_or_default();

--- a/apps/daemon/src/runtime/managed_llm.rs
+++ b/apps/daemon/src/runtime/managed_llm.rs
@@ -50,6 +50,10 @@ pub struct ManagedLlmResolver {
     /// tokens live only in the instance that minted them, so a token from a
     /// second store authenticates against nothing.
     tokens: parking_lot::RwLock<Option<super::gateway_token::GatewayTokenSource>>,
+    /// `http://127.0.0.1:<port>` for this daemon's own listener, set once the
+    /// HTTP layer is up. Runtimes are pointed at `<base>/v1/ai/teams/<id>`
+    /// rather than at the cloud gateway — see `runtime_facing_base_url`.
+    local_http_base: parking_lot::RwLock<Option<String>>,
     cache: AsyncMutex<HashMap<String, CachedManagedLlm>>,
     member_key_kicked: AsyncMutex<HashSet<String>>,
 }
@@ -59,6 +63,7 @@ impl ManagedLlmResolver {
         Self {
             backend,
             tokens: parking_lot::RwLock::new(None),
+            local_http_base: parking_lot::RwLock::new(None),
             cache: AsyncMutex::new(HashMap::new()),
             member_key_kicked: AsyncMutex::new(HashSet::new()),
         }
@@ -76,6 +81,20 @@ impl ManagedLlmResolver {
     /// builds before its HTTP layer exists.
     pub fn set_tokens(&self, tokens: super::gateway_token::GatewayTokenSource) {
         *self.tokens.write() = Some(tokens);
+    }
+
+    /// Record this daemon's own HTTP origin, once its listener has an address.
+    pub fn set_local_http_base(&self, base: String) {
+        *self.local_http_base.write() = Some(base);
+    }
+
+    /// The AI proxy URL a runtime should call for `team_id`, or None when this
+    /// daemon has no listener to offer (tests, headless paths).
+    pub fn ai_proxy_base(&self, team_id: &str) -> Option<String> {
+        self.local_http_base
+            .read()
+            .as_ref()
+            .map(|base| format!("{}/v1/ai/teams/{}", base.trim_end_matches('/'), team_id))
     }
 
     /// The `ai:invoke` token `provider.team`'s apiKey resolves to.
@@ -174,7 +193,10 @@ impl ManagedLlmResolver {
             .map(|t| t.get_or_mint())
             .unwrap_or_default();
         let secrets = teamclu_runtime_env::secrets_for_team_provider(&token);
-        if let Err(e) = teamclu_runtime_env::sync_global_team_provider(&state, &secrets) {
+        let proxy_base = self.ai_proxy_base(team_id);
+        if let Err(e) =
+            teamclu_runtime_env::sync_global_team_provider(&state, &secrets, proxy_base.as_deref())
+        {
             tracing::warn!(
                 team_id,
                 error = %e,

--- a/apps/daemon/src/runtime/managed_llm.rs
+++ b/apps/daemon/src/runtime/managed_llm.rs
@@ -67,6 +67,19 @@ impl ManagedLlmResolver {
         self
     }
 
+    /// The `ai:invoke` token `provider.team`'s apiKey resolves to.
+    ///
+    /// Needed on the SPAWN path, not just during reconcile: opencode reads the
+    /// resolved key out of `provider.team` in the global config, but every other
+    /// runtime is handed `TEAMCLU_TEAM_PROVIDER`, whose `apiKeyEnv` names an env
+    /// binding it expects to find. Without the binding pi registers the provider
+    /// and then hides every model on it, because a provider with no resolvable
+    /// credential is "loaded but unavailable" — which looks exactly like the
+    /// provider never having been registered at all.
+    pub fn gateway_token(&self) -> Option<String> {
+        self.tokens.as_ref().map(|t| t.get_or_mint())
+    }
+
     /// Resolve the team's managed (shared) LLM directly from the cloud API, with
     /// a short-TTL in-memory cache. Replaces the old disk-mirrored
     /// `_meta/provider.json` read, which raced the first-install git clone and

--- a/apps/daemon/src/runtime/pi_rpc/process.rs
+++ b/apps/daemon/src/runtime/pi_rpc/process.rs
@@ -487,11 +487,32 @@ impl PiProcessPool {
                 dirs::home_dir().as_deref(),
             ),
         );
+        let mut applied_team_provider = false;
+        let mut skipped: Vec<&str> = Vec::new();
         for (k, v) in env.extra_env.iter() {
             if env.force_env_override || std::env::var_os(k).is_none() {
                 cmd.env(k, v);
+                if k == "TEAMCLU_TEAM_PROVIDER" {
+                    applied_team_provider = true;
+                }
+            } else {
+                // Silently dropped today: a key already present in the daemon's
+                // OWN environment wins over the assembled one unless the caller
+                // asked to override. Worth naming, because the symptom is a
+                // runtime that simply never sees a variable that was assembled
+                // for it.
+                skipped.push(k.as_str());
             }
         }
+        info!(
+            target: "amuxd::team_provider_probe",
+            extra_env_keys = env.extra_env.len(),
+            has_team_provider_in_extra_env = env.extra_env.contains_key("TEAMCLU_TEAM_PROVIDER"),
+            applied_team_provider,
+            force_env_override = env.force_env_override,
+            skipped = ?skipped,
+            "pi spawn env"
+        );
         cmd.stdin(std::process::Stdio::piped())
             .stdout(std::process::Stdio::piped())
             .stderr(std::process::Stdio::piped())

--- a/apps/daemon/src/runtime/pi_rpc/process.rs
+++ b/apps/daemon/src/runtime/pi_rpc/process.rs
@@ -487,32 +487,11 @@ impl PiProcessPool {
                 dirs::home_dir().as_deref(),
             ),
         );
-        let mut applied_team_provider = false;
-        let mut skipped: Vec<&str> = Vec::new();
         for (k, v) in env.extra_env.iter() {
             if env.force_env_override || std::env::var_os(k).is_none() {
                 cmd.env(k, v);
-                if k == "TEAMCLU_TEAM_PROVIDER" {
-                    applied_team_provider = true;
-                }
-            } else {
-                // Silently dropped today: a key already present in the daemon's
-                // OWN environment wins over the assembled one unless the caller
-                // asked to override. Worth naming, because the symptom is a
-                // runtime that simply never sees a variable that was assembled
-                // for it.
-                skipped.push(k.as_str());
             }
         }
-        info!(
-            target: "amuxd::team_provider_probe",
-            extra_env_keys = env.extra_env.len(),
-            has_team_provider_in_extra_env = env.extra_env.contains_key("TEAMCLU_TEAM_PROVIDER"),
-            applied_team_provider,
-            force_env_override = env.force_env_override,
-            skipped = ?skipped,
-            "pi spawn env"
-        );
         cmd.stdin(std::process::Stdio::piped())
             .stdout(std::process::Stdio::piped())
             .stderr(std::process::Stdio::piped())

--- a/apps/daemon/src/runtime/supervisor.rs
+++ b/apps/daemon/src/runtime/supervisor.rs
@@ -1293,12 +1293,16 @@ impl RuntimeSupervisor {
                     .unwrap_or_default(),
                 cloud_token_file: snapshot.bindings.get("TC_ACCESS_TOKEN_FILE").cloned(),
                 gateway_token: None,
+                // Not a spawn path with a listener behind it.
+                ai_proxy_base: None,
             })
             .unwrap_or(teamclu_runtime_env::SystemEnvContext {
                 actor_id: String::new(),
                 display_name: String::new(),
                 cloud_token_file: None,
                 gateway_token: None,
+                // Not a spawn path with a listener behind it.
+                ai_proxy_base: None,
             });
         let resolved = teamclu_runtime_env::resolve_runtime_env(
             personal_env.clone(),
@@ -1722,6 +1726,8 @@ impl RuntimeSupervisor {
                     .unwrap_or_default(),
                 cloud_token_file: previous.bindings.get("TC_ACCESS_TOKEN_FILE").cloned(),
                 gateway_token: None,
+                // Not a spawn path with a listener behind it.
+                ai_proxy_base: None,
             },
         );
         current.fingerprint == previous.fingerprint
@@ -2333,6 +2339,8 @@ mod tests {
                 display_name: "Agent Test".to_string(),
                 cloud_token_file: None,
                 gateway_token: None,
+                // Not a spawn path with a listener behind it.
+                ai_proxy_base: None,
             },
         );
         {

--- a/crates/teamclu-runtime-env/src/env_activation.rs
+++ b/crates/teamclu-runtime-env/src/env_activation.rs
@@ -352,6 +352,7 @@ mod tests {
                         display_name: "Test".to_string(),
                         cloud_token_file: None,
                 gateway_token: None,
+                        ai_proxy_base: None,
                     },
                 ),
             }

--- a/crates/teamclu-runtime-env/src/lib.rs
+++ b/crates/teamclu-runtime-env/src/lib.rs
@@ -115,6 +115,19 @@ pub struct SystemEnvContext {
     /// it is a daemon-lifetime credential — it dies with the process that
     /// minted it, so it cannot go stale while a runtime is alive.
     pub gateway_token: Option<String>,
+    /// The daemon's own loopback AI proxy for this team
+    /// (`http://127.0.0.1:<port>/v1/ai/teams/<id>`), written as the base URL
+    /// every runtime calls.
+    ///
+    /// It is NOT the cloud gateway. The credential above is a daemon token, and
+    /// the gateway verifies GoTrue tokens — a runtime pointed straight at the
+    /// gateway gets `invalid_token` on every call. The hop also buys the same
+    /// thing `cloud_token_file` buys: the daemon refreshes the cloud token per
+    /// request, so a multi-day agent never meets its expiry.
+    ///
+    /// `None` leaves the cloud URL in place, for callers with no listener to
+    /// offer.
+    pub ai_proxy_base: Option<String>,
 }
 
 pub fn assemble_runtime_env(
@@ -125,9 +138,10 @@ pub fn assemble_runtime_env(
 ) -> anyhow::Result<RuntimeEnvBundle> {
     opencode_db::maybe_migrate_legacy_opencode_db(workspace)?;
 
+    let ai_proxy_base = system.ai_proxy_base.clone();
     let personal = personal_secrets::load_personal_env()?;
     let resolved_env = resolved_env::resolve_runtime_env(personal, team_env, system);
-    sync_global_team_provider(managed_llm, &resolved_env.bindings)?;
+    sync_global_team_provider(managed_llm, &resolved_env.bindings, ai_proxy_base.as_deref())?;
     let sync = resolve_workspace_runtime_config(
         workspace,
         &resolved_env.bindings,

--- a/crates/teamclu-runtime-env/src/lib.rs
+++ b/crates/teamclu-runtime-env/src/lib.rs
@@ -193,6 +193,7 @@ mod tests {
                 // credential this replaced (a LiteLLM `sk-tc-*` virtual key)
                 // was guessable precisely because it was derived.
                 gateway_token: Some("tok_spawn_actor".to_string()),
+                ai_proxy_base: None,
             },
             &managed,
         )

--- a/crates/teamclu-runtime-env/src/merge.rs
+++ b/crates/teamclu-runtime-env/src/merge.rs
@@ -67,6 +67,7 @@ mod tests {
             display_name: display_name.to_string(),
             cloud_token_file: None,
             gateway_token: None,
+            ai_proxy_base: None,
         }
     }
 

--- a/crates/teamclu-runtime-env/src/resolved_env.rs
+++ b/crates/teamclu-runtime-env/src/resolved_env.rs
@@ -387,6 +387,7 @@ mod tests {
             display_name: "Agent".to_string(),
             cloud_token_file: Some("/tmp/cloud-token".to_string()),
             gateway_token: None,
+            ai_proxy_base: None,
         }
     }
 

--- a/crates/teamclu-runtime-env/src/team_provider.rs
+++ b/crates/teamclu-runtime-env/src/team_provider.rs
@@ -20,6 +20,26 @@ use crate::DEFAULT_TEAM_REPO_DIR;
 pub const TEAM_MODEL_TIERS: [(&str, &str); 3] =
     [("default", "标准"), ("pro", "高级"), ("max", "旗舰")];
 
+/// The base URL a RUNTIME should call, which is not the one the daemon calls.
+///
+/// `provider.base_url` is the cloud `llm_base_url` — the gateway, and the
+/// cutover lever the daemon's own proxy forwards to. A runtime must not use it
+/// directly: the credential it is handed is a daemon `ai:invoke` token, which
+/// the gateway (a GoTrue verifier) rejects. Pointing a runtime there produced
+/// exactly that — `invalid_token` on every team-model call.
+///
+/// The daemon supplies its own loopback proxy URL instead, and that indirection
+/// is what survives a long run: the runtime's token is good for a year, while
+/// the cloud access token behind it expires hourly and is refreshed per request
+/// on the daemon side. Baking a cloud token into a config file cannot do that —
+/// a long-lived agent would simply start failing an hour in.
+///
+/// `None` leaves the cloud URL in place, which is right for callers that have
+/// no proxy to offer (tests, and any process without an HTTP listener).
+fn runtime_facing_base_url<'a>(provider: &'a ManagedLlmProvider, proxy_base: Option<&'a str>) -> &'a str {
+    proxy_base.unwrap_or(&provider.base_url)
+}
+
 /// One model exposed by the team's managed LLM gateway.
 #[derive(Debug, Clone)]
 pub struct ManagedLlmModel {
@@ -83,6 +103,7 @@ fn map_mutate_err(e: anyhow::Error) -> crate::opencode_config::OpencodeConfigErr
 pub fn mutate_team_provider(
     config: &mut serde_json::Value,
     state: &ManagedLlmState,
+    proxy_base: Option<&str>,
 ) -> anyhow::Result<bool> {
     if matches!(state, ManagedLlmState::Unknown) {
         return Ok(false);
@@ -147,7 +168,7 @@ pub fn mutate_team_provider(
             let team_entry = serde_json::json!({
                 "npm": "@ai-sdk/openai-compatible",
                 "name": name,
-                "options": { "baseURL": provider.base_url, "apiKey": api_key },
+                "options": { "baseURL": runtime_facing_base_url(provider, proxy_base), "apiKey": api_key },
                 "models": models_out,
             });
 
@@ -252,7 +273,10 @@ pub fn stabilize_managed_llm_for_spawn(
 }
 
 /// JSON payload for the `TEAMCLU_TEAM_PROVIDER` spawn env (no secret embedded).
-pub fn team_provider_env_payload(provider: &ManagedLlmProvider) -> String {
+pub fn team_provider_env_payload(
+    provider: &ManagedLlmProvider,
+    proxy_base: Option<&str>,
+) -> String {
     let models: Vec<serde_json::Value> = provider
         .models
         .iter()
@@ -271,7 +295,7 @@ pub fn team_provider_env_payload(provider: &ManagedLlmProvider) -> String {
     };
     serde_json::json!({
         "name": name,
-        "baseUrl": provider.base_url,
+        "baseUrl": runtime_facing_base_url(provider, proxy_base),
         // Names the env binding a runtime that registers the provider
         // itself (pi) should read the credential from. Must track the key
         // bound in resolved_env.rs — a stale name here is a silent 401.
@@ -287,12 +311,15 @@ pub fn team_provider_env_payload(provider: &ManagedLlmProvider) -> String {
 /// Returns whether the on-disk config was rewritten. External callers should prefer
 /// [`crate::team_provider_sync::sync_global_team_provider`] so materialization and secret resolution
 /// stay aligned across spawn and reconcile paths.
-pub fn ensure_global_team_provider(state: &ManagedLlmState) -> anyhow::Result<bool> {
+pub fn ensure_global_team_provider(
+    state: &ManagedLlmState,
+    proxy_base: Option<&str>,
+) -> anyhow::Result<bool> {
     if matches!(state, ManagedLlmState::Unknown) {
         return Ok(false);
     }
     OpencodeConfigStore::apply_global(|config| {
-        mutate_team_provider(config, state).map_err(map_mutate_err)
+        mutate_team_provider(config, state, proxy_base).map_err(map_mutate_err)
     })
     .map_err(map_store_err)
 }

--- a/crates/teamclu-runtime-env/src/team_provider.rs
+++ b/crates/teamclu-runtime-env/src/team_provider.rs
@@ -419,7 +419,7 @@ mod tests {
             }],
         });
         let mut config = serde_json::json!({});
-        assert!(mutate_team_provider(&mut config, &state).unwrap());
+        assert!(mutate_team_provider(&mut config, &state, None).unwrap());
 
         let models = config["provider"]["team"]["models"].as_object().unwrap();
         assert_eq!(models.len(), 3);
@@ -441,7 +441,7 @@ mod tests {
     #[test]
     fn ensure_global_team_provider_adds_team_when_enabled() {
         let (_lock, dir, _home) = global_config_dir();
-        ensure_global_team_provider(&ManagedLlmState::Enabled(sample_provider())).unwrap();
+        ensure_global_team_provider(&ManagedLlmState::Enabled(sample_provider()), None).unwrap();
         let parsed: serde_json::Value =
             serde_json::from_str(&fs::read_to_string(global_config_path(&dir)).unwrap()).unwrap();
         assert!(parsed["provider"]["team"].is_object());
@@ -455,7 +455,7 @@ mod tests {
         let (_lock, dir, _home) = global_config_dir();
         let resolved = "tok_live_session";
         write_team_provider_with_key(&dir, resolved);
-        ensure_global_team_provider(&ManagedLlmState::Enabled(sample_provider())).unwrap();
+        ensure_global_team_provider(&ManagedLlmState::Enabled(sample_provider()), None).unwrap();
         assert_eq!(
             read_team_api_key(&dir).as_deref(),
             Some(resolved),
@@ -473,7 +473,7 @@ mod tests {
         // no amount of reconciling clears.
         let (_lock, dir, _home) = global_config_dir();
         write_team_provider_with_key(&dir, "sk-tc-actor-123");
-        ensure_global_team_provider(&ManagedLlmState::Enabled(sample_provider())).unwrap();
+        ensure_global_team_provider(&ManagedLlmState::Enabled(sample_provider()), None).unwrap();
         assert_eq!(
             read_team_api_key(&dir).as_deref(),
             Some(crate::merge::GATEWAY_TOKEN_PLACEHOLDER),
@@ -521,7 +521,7 @@ mod tests {
             .to_string(),
         )
         .unwrap();
-        ensure_global_team_provider(&ManagedLlmState::Enabled(sample_provider())).unwrap();
+        ensure_global_team_provider(&ManagedLlmState::Enabled(sample_provider()), None).unwrap();
         let parsed: serde_json::Value =
             serde_json::from_str(&fs::read_to_string(global_config_path(&dir)).unwrap()).unwrap();
         assert_eq!(
@@ -538,7 +538,7 @@ mod tests {
             serde_json::json!({ "provider": { "team": {} } }).to_string(),
         )
         .unwrap();
-        ensure_global_team_provider(&ManagedLlmState::Disabled).unwrap();
+        ensure_global_team_provider(&ManagedLlmState::Disabled, None).unwrap();
         let parsed: serde_json::Value =
             serde_json::from_str(&fs::read_to_string(global_config_path(&dir)).unwrap()).unwrap();
         assert!(parsed.get("provider").is_none());
@@ -552,7 +552,7 @@ mod tests {
             serde_json::json!({ "provider": { "team": { "keep": true } } }).to_string(),
         )
         .unwrap();
-        ensure_global_team_provider(&ManagedLlmState::Unknown).unwrap();
+        ensure_global_team_provider(&ManagedLlmState::Unknown, None).unwrap();
         let parsed: serde_json::Value =
             serde_json::from_str(&fs::read_to_string(global_config_path(&dir)).unwrap()).unwrap();
         assert_eq!(parsed["provider"]["team"]["keep"], true);
@@ -620,8 +620,8 @@ mod tests {
             panic!("expected Enabled");
         };
         assert_eq!(
-            team_provider_env_payload(&from_disk),
-            team_provider_env_payload(&provider)
+            team_provider_env_payload(&from_disk, None),
+            team_provider_env_payload(&provider, None)
         );
     }
 }

--- a/crates/teamclu-runtime-env/src/team_provider_sync.rs
+++ b/crates/teamclu-runtime-env/src/team_provider_sync.rs
@@ -35,8 +35,11 @@ pub struct TeamProviderSyncResult {
 pub fn sync_global_team_provider(
     managed_llm: &ManagedLlmState,
     secrets: &HashMap<String, String>,
+    // The daemon's own loopback AI proxy for this team, which is what a runtime
+    // must call — see `runtime_facing_base_url`. None leaves the cloud URL.
+    proxy_base: Option<&str>,
 ) -> anyhow::Result<bool> {
-    let changed = team_provider::ensure_global_team_provider(managed_llm)?;
+    let changed = team_provider::ensure_global_team_provider(managed_llm, proxy_base)?;
     let Some(gateway_token) = secrets.get("tc_gateway_token") else {
         return Ok(changed);
     };

--- a/crates/teamclu-runtime-env/src/team_provider_sync.rs
+++ b/crates/teamclu-runtime-env/src/team_provider_sync.rs
@@ -161,7 +161,7 @@ mod tests {
         .unwrap();
 
         let secrets = secrets_for_team_provider("tok_actor_123");
-        sync_global_team_provider(&ManagedLlmState::Enabled(sample_provider()), &secrets).unwrap();
+        sync_global_team_provider(&ManagedLlmState::Enabled(sample_provider()), &secrets, None).unwrap();
         resolve_workspace_runtime_config(
             dir.path(),
             &secrets,
@@ -207,6 +207,7 @@ mod tests {
         sync_global_team_provider(
             &ManagedLlmState::Enabled(sample_provider()),
             &secrets_for_team_provider("tok_actor_xyz"),
+            None,
         )
         .unwrap();
 
@@ -225,11 +226,11 @@ mod tests {
         let secrets = secrets_for_team_provider("shared-actor");
         let managed = ManagedLlmState::Enabled(sample_provider());
 
-        sync_global_team_provider(&managed, &secrets).unwrap();
+        sync_global_team_provider(&managed, &secrets, None).unwrap();
         let reconcile_disk = fs::read_to_string(global_config_path(&dir)).unwrap();
 
         fs::write(global_config_path(&dir), r#"{}"#).unwrap();
-        sync_global_team_provider(&managed, &secrets).unwrap();
+        sync_global_team_provider(&managed, &secrets, None).unwrap();
         let spawn_disk = fs::read_to_string(global_config_path(&dir)).unwrap();
 
         let reconcile_json: serde_json::Value = serde_json::from_str(&reconcile_disk).unwrap();
@@ -268,7 +269,7 @@ mod tests {
         );
         secrets.insert("API_TOKEN".to_string(), "ghp_spawn".to_string());
 
-        sync_global_team_provider(&ManagedLlmState::Enabled(sample_provider()), &secrets).unwrap();
+        sync_global_team_provider(&ManagedLlmState::Enabled(sample_provider()), &secrets, None).unwrap();
         resolve_workspace_runtime_config(dir.path(), &secrets, SecretResolveScope::FullConfig)
             .unwrap();
 


### PR DESCRIPTION
The team model appeared in pi's settings and in the model picker, and every call to it failed. Three defects on one path, each of which independently makes the team gateway unusable, and none of which logs anything.

## 1. `tc_gateway_token` was never bound

`TEAMCLU_TEAM_PROVIDER` names `apiKeyEnv: "tc_gateway_token"` — the env binding a runtime reads its credential from. `SystemEnvContext` set `gateway_token: None` on the spawn path.

The comment justifying that was sound for the consumer it was written for: `provider.team` is written to the active-team global config and its apiKey resolved during reconcile, so **opencode**, which reads that file, needs nothing from the env. Every other runtime registers the provider itself and looks the credential up by name.

The failure mode is why this was hard to find: pi registers a provider whose apiKey does not resolve, then reports its models as **unavailable** — and an unavailable model is absent from `get_available_models`. The symptom is identical to the provider never having been registered, and nothing logs a word.

Verified by A/B against the live host — same payload, same extension, same workspace, the only difference being this variable:

| | catalog |
|---|---|
| with `tc_gateway_token` | `team/*: default, pro, max` |
| without | team provider absent entirely |

## 2. Two TokenStores are not one TokenStore

The first attempt at (1) loaded a second `TokenStore` from the same file. That cannot work: the file holds only the **root** token, while `mint()` keeps session tokens in the instance that minted them. A token from a second store authenticates against nothing — the daemon's own proxy answered `invalid or expired token` for it.

The resolver now takes its token source after construction, from `HttpHandle.tokens` — already exposed for exactly this, and unused until now (`#[allow(dead_code)]`).

## 3. The runtime was pointed at the cloud gateway, which cannot accept its token

Runtimes were handed a daemon `ai:invoke` token and a base URL pointing at the **gateway**, which verifies GoTrue tokens. Every team-model call answered `invalid_token`. Meanwhile the daemon's own proxy — built for exactly this — had a route and **no producer**: nothing in the tree pointed anything at `/v1/ai/teams/:team_id/*path`.

So the two runtime-facing writers stop copying the cloud URL and emit `http://127.0.0.1:<port>/v1/ai/teams/<id>`. `resolve_upstream` is untouched: the cloud `llm_base_url` stays the proxy's upstream, so it also stays the cutover lever and the rollback.

The hop is not ceremony. It is the argument `cloud_token_file` already makes one field above in the same struct — *"env values are frozen at spawn and the JWT expires (~1h) well before a multi-day session ends"*. The runtime's token is daemon-lifetime; the daemon refreshes the cloud one **per request**, behind the hop, with refreshes serialized so concurrent callers cannot invalidate each other's rotation. Baking a cloud token into a config file cannot do that: a long-running agent would simply start failing an hour in, with no path to recovery.

## Verified end to end

Against the live deployment, through the URL that now gets written, with the credential that now gets bound:

| tier | result | credits |
|---|---|---|
| `default` | `"pong"` | 133 |
| `pro` | reasoning-only output (max_tokens spent on reasoning — §4.4.0.1) | 612 |
| `max` | same | 3060 |

Team balance moved 1000 → 999.62 points, exactly 133 + 612 + 3060. Both runtimes confirmed working by the reporter.

## Tests

`teamclu-runtime-env` 120 passed; the one failure is `storage_lint` naming three files this branch does not touch, and reproduces on `origin/main`. Fixtures updated for the new signatures — they pass `None`, which is the case the parameter exists to allow (no listener to point at).

Diagnostic logging used to find this was removed before submitting; it is in the branch history if the path ever needs instrumenting again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018rRCi6g5nDwrhVvC8VHEgk