### PR TITLE
docs(self-host): name the ten .env keys the deploy overwrites

### DIFF
--- a/deploy/self-host/.env.example
+++ b/deploy/self-host/.env.example
@@ -3,6 +3,39 @@
 #   ./bootstrap/gen-secrets.sh   (fills ANON_KEY / SERVICE_ROLE_KEY / MQTT_SERVICE_TOKEN)
 #   docker compose up -d
 
+# ── ⚠️ TEN KEYS ARE NOT YOURS TO EDIT ON THE BOX ───────────────────────
+# self-host-deploy.yml rewrites them from GitHub secrets on EVERY deploy, so
+# editing them in the server's .env works until the next push to main and is
+# then silently reverted. The deploy log says only `set <KEY>` — it never says
+# what it replaced, so the revert leaves no trace and the feature just breaks
+# again later, seemingly on its own. That has already happened once with
+# DEEPSEEK_API_KEY: a fix verified live was undone twenty minutes later by an
+# unrelated PR's deploy.
+#
+# They are marked `[CI]` at their definitions below. Change them here:
+#
+#   Settings → Environments → self-host-production → Secrets
+#
+# NOT under Settings → Secrets and variables → Actions. The deploy job declares
+# `environment: self-host-production`, and an environment secret outranks a
+# repository one — a repo-level secret of the same name is shadowed and does
+# nothing, while looking exactly like a successful change.
+#
+# Two behaviours, and the difference matters:
+#   upsert  — an empty secret is SKIPPED, leaving whatever the box has
+#   sync    — an empty secret DELETES the line, which is how you hand a setting
+#             back to its compose default (e.g. clearing FC_SUPABASE_URL points
+#             fc at the bundled Supabase)
+#
+#   upsert: DEEPSEEK_API_KEY, TRUSTED_EXTERNAL_JWT_SECRET
+#   sync:   AGENT_MANAGEMENT_GRANT_SECRET, FC_SUPABASE_URL,
+#           FC_SUPABASE_PUBLIC_URL, FC_SUPABASE_ANON_KEY,
+#           FC_SUPABASE_SERVICE_ROLE_KEY, GOOGLE_CLIENT_ID,
+#           GOOGLE_CLIENT_SECRET, AUTH_EGRESS_PROXY
+#
+# Everything else in this file is yours: the deploy never touches it, so an
+# edit here sticks.
+
 # ── core secret (everything derives from this) ─────────────────────────
 # Must be >= 32 chars. Used by Supabase + EMQX JWT auth (HS256).
 JWT_SECRET=
@@ -98,11 +131,16 @@ BACKEND_KIND=supabase
 CRON_TRIGGER_SECRET=
 # Optional: point FC at a separately hosted Supabase project. Blank uses the
 # bundled kong stack (compose maps these FC_SUPABASE_* overrides into SUPABASE_*).
+# [CI] sync — set in the self-host-production environment; empty secret deletes it.
 FC_SUPABASE_URL=
+# [CI] sync — set in the self-host-production environment; empty secret deletes it.
 FC_SUPABASE_PUBLIC_URL=
+# [CI] sync — set in the self-host-production environment; empty secret deletes it.
 FC_SUPABASE_ANON_KEY=
+# [CI] sync — set in the self-host-production environment; empty secret deletes it.
 FC_SUPABASE_SERVICE_ROLE_KEY=
 # Partner JWT shared with an external login provider (phone / Web SSO flows).
+# [CI] upsert — set in the self-host-production environment, not here.
 TRUSTED_EXTERNAL_JWT_SECRET=
 # Runtime feature flags for /v1/config/{public,bootstrap}. Profile selects the
 # durable defaults in services/fc/src/lib/feature-profiles.ts; JSON is emergency
@@ -117,6 +155,7 @@ MARKETPLACE_ADMIN_SECRET=
 # with TRUSTED_EXTERNAL_JWT_SECRET would let the external login provider mint
 # management grants for every Agent in every team. Empty means agent management
 # is off: FC answers 503 agent_management_unavailable.
+# [CI] sync — set in the self-host-production environment; empty secret deletes it.
 AGENT_MANAGEMENT_GRANT_SECRET=
 # Standalone postgres backend (only with --profile postgres):
 #   set BACKEND_KIND=postgres and uncomment:
@@ -305,7 +344,9 @@ APPLE_CLIENT_IDS=tech.teamclaw.mobile,com.teamclu.mobile
 # Register exactly this as the client's Authorized redirect URI:
 #   https://<SUPABASE_DOMAIN>/auth/v1/callback
 ENABLE_GOOGLE_SIGNUP=false
+# [CI] sync — set in the self-host-production environment; empty secret deletes it.
 GOOGLE_CLIENT_ID=
+# [CI] sync — set in the self-host-production environment; empty secret deletes it.
 GOOGLE_CLIENT_SECRET=
 
 # Egress proxy for GoTrue's outbound HTTP, needed only where Google is not
@@ -318,6 +359,7 @@ GOOGLE_CLIENT_SECRET=
 # which looks like a proxy bug: the proxy reaches Google and then fails to write
 # the 200 back to the client. Leave blank where Google is reachable directly.
 #   AUTH_EGRESS_PROXY=https://user:password@proxy.example.com:3129
+# [CI] sync — set in the self-host-production environment; empty secret deletes it.
 AUTH_EGRESS_PROXY=
 
 # ── Phone login (optional; needs all three + SERVICE_ROLE_KEY) ─────────
@@ -441,6 +483,7 @@ LITELLM_DEFAULT_TEAM_MAX_BUDGET_USD=
 # deepseek-v4-pro) — set DEEPSEEK_API_KEY to enable them. Additional models can
 # also be added at runtime in the admin UI (persisted via STORE_MODEL_IN_DB).
 # Never commit real keys: this file is a template, .env is gitignored.
+# [CI] upsert — Settings → Environments → self-host-production → Secrets.
 DEEPSEEK_API_KEY=
 OPENAI_API_KEY=
 ANTHROPIC_API_KEY=


### PR DESCRIPTION
Editing any of these ten on the box works — until the next push to main, when `self-host-deploy.yml` rewrites them from GitHub secrets and silently reverts you. Its log says only `set <KEY>`, never what it replaced, so the revert leaves no trace and the feature appears to break again later on its own.

That is not hypothetical. Yesterday a `DEEPSEEK_API_KEY` fix was verified live — new key in the container, upstream `/models` returning 200 — and was undone twenty minutes later by an unrelated PR's deploy putting the dead key back. The two of us then disagreed about whether the gateway worked, because we had tested on opposite sides of that deploy.

## What this adds

A header block in `.env.example`, plus a `[CI]` marker at each of the ten definitions so the warning is where someone editing that line will actually see it.

It also records **where they live**, which is the part that cost time: the deploy job declares `environment: self-host-production`, and an environment secret outranks a repository one. A repo-level secret of the same name is shadowed and does nothing — while looking exactly like a successful change. I set one there first and had to undo it.

And the upsert/sync distinction, which is not cosmetic:

| | empty secret |
|---|---|
| `upsert` (2 keys) | skipped — the box keeps what it has |
| `sync` (8 keys) | **deletes the line** — this is how a setting is handed back to its compose default, e.g. clearing `FC_SUPABASE_URL` points fc at the bundled Supabase |

Everything else in the file is unmanaged: the deploy never touches it, so an edit there sticks. The point of the block is to make that boundary visible, since nothing in the repo stated it before.

Docs only. `deploy-env-parity.test.ts` still passes (4/4) — every compose variable remains documented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018rRCi6g5nDwrhVvC8VHEgk