### PR TITLE
fix: team skills still load old OpenCode cache after edit/publish

### DIFF
--- a/apps/daemon/src/http/routes.rs
+++ b/apps/daemon/src/http/routes.rs
@@ -223,6 +223,10 @@ pub fn build(state: HttpState) -> Router {
         )
         .route("/v1/workspaces/:id/skills", get(workspaces::get_skills))
         .route(
+            "/v1/workspaces/:id/skills/refresh",
+            post(workspaces::refresh_skills),
+        )
+        .route(
             "/v1/workspaces/:id/skills/:slug",
             put(workspaces::put_skill).delete(workspaces::delete_skill),
         )

--- a/apps/daemon/src/http/workspaces.rs
+++ b/apps/daemon/src/http/workspaces.rs
@@ -1115,6 +1115,40 @@ pub async fn delete_skill(
     Ok(apply_ok(outcome))
 }
 
+#[derive(Debug, Serialize)]
+pub struct SkillsRefreshResponse {
+    pub ok: bool,
+}
+
+/// `POST /v1/workspaces/:id/skills/refresh`
+///
+/// Does not rewrite files. Registers a Skills refresh so idle auto-apply
+/// disposes the OpenCode workspace instance and the next session re-reads disk.
+pub async fn refresh_skills(
+    principal: Principal,
+    State(state): State<HttpState>,
+    Path(workspace_id): Path<String>,
+) -> Result<Json<SkillsRefreshResponse>, HttpError> {
+    require_scope(&principal, "workspace:write")?;
+    let wpath = workspace_path_or_404(&workspace_id).await?;
+    let Some(refresh) = state.runtime_refresh.as_ref() else {
+        return Err(HttpError::runtime_unavailable(
+            "runtime refresh coordinator unavailable",
+        ));
+    };
+    let runtime_workspace_id = resolve_runtime_workspace_id(&state, &workspace_id, &wpath).await;
+    refresh
+        .record_change(
+            &runtime_workspace_id,
+            &wpath,
+            RefreshChangeKind::Skills,
+            RefreshSource::UiMutation,
+        )
+        .await
+        .map_err(|e| HttpError::internal(e.to_string()))?;
+    Ok(Json(SkillsRefreshResponse { ok: true }))
+}
+
 /// `PUT /v1/workspaces/:id/roles/:slug`
 pub async fn put_role(
     principal: Principal,

--- a/apps/daemon/src/runtime/supervisor.rs
+++ b/apps/daemon/src/runtime/supervisor.rs
@@ -34,7 +34,8 @@ const INSTRUCTION_PLUGIN_TEMPLATE: &str = include_str!(
 const SESSION_CONTEXT_PLUGIN_TEMPLATE: &str = include_str!(
     "../../../../packages/app/src/lib/opencode/templates/teamclu-session-context-plugin.mjs.txt"
 );
-const SESSION_CONTEXT_CLIENT_TEMPLATE: &str = include_str!("../../shared/session-context-client.mjs");
+const SESSION_CONTEXT_CLIENT_TEMPLATE: &str =
+    include_str!("../../shared/session-context-client.mjs");
 
 use crate::config::workspace_control::{
     ApplyOutcome, EnvActivationBlocker, EnvActivationDiagnostics, RuntimeStatus,
@@ -593,16 +594,68 @@ fn ensure_extended_inherent_config(
 
 /// Skill paths that moved to the global config — the ones older builds seeded
 /// into every workspace. Both the `~`-prefixed and the expanded form of the
-/// agents dir count: older builds wrote either.
+/// agents dir count: older builds wrote either. Hosted team cloud roots also
+/// belong in the global file; a workspace copy of one would outrank it.
 fn is_migrated_skill_path(path: Option<&str>) -> bool {
     let Some(path) = path else { return false };
     if path == TEAM_SKILLS_PATH || path == "~/.agents/skills" {
+        return true;
+    }
+    if is_hosted_team_skills_path(path) {
         return true;
     }
     dirs::home_dir()
         .map(|home| home.join(".agents").join("skills"))
         .map(|agents| path == agents.to_string_lossy())
         .unwrap_or(false)
+}
+
+/// `…/teams/<id>/state/cloud/skills` — the daemon-owned hosted install root.
+pub(crate) fn is_hosted_team_skills_path(path: &str) -> bool {
+    let normalized = path.replace('\\', "/");
+    let normalized = normalized.trim_end_matches('/');
+    normalized
+        .split("/teams/")
+        .nth(1)
+        .and_then(|rest| rest.split_once('/'))
+        .is_some_and(|(_, suffix)| suffix == "state/cloud/skills")
+}
+
+/// Put the two system-managed skill roots first, in the order OpenCode must
+/// search them, then keep any user-defined extras.
+///
+/// Hosted (current team) before `~/.agents/skills`. Every hosted root for a
+/// *different* team is dropped so a team switch cannot leave the previous
+/// team's packs in the search path.
+pub fn normalize_managed_skill_paths(
+    existing: &[String],
+    hosted: Option<&str>,
+    member: Option<&str>,
+) -> Vec<String> {
+    let path_eq = |a: &str, b: &str| a.replace('\\', "/") == b.replace('\\', "/");
+    let is_member =
+        |path: &str| path_eq(path, "~/.agents/skills") || member.is_some_and(|m| path_eq(path, m));
+    let is_managed = |path: &str| is_hosted_team_skills_path(path) || is_member(path);
+
+    let mut out = Vec::new();
+    if let Some(hosted) = hosted.filter(|p| !p.is_empty()) {
+        out.push(hosted.to_string());
+    }
+    if let Some(member) = member.filter(|p| !p.is_empty()) {
+        if !out.iter().any(|p| path_eq(p, member)) {
+            out.push(member.to_string());
+        }
+    }
+    for path in existing {
+        if path.trim().is_empty() || is_managed(path) {
+            continue;
+        }
+        if out.iter().any(|p| path_eq(p, path)) {
+            continue;
+        }
+        out.push(path.clone());
+    }
+    out
 }
 
 /// Seed the real skill roots into the active team's global config, absolutely —
@@ -624,23 +677,18 @@ fn is_migrated_skill_path(path: Option<&str>) -> bool {
 pub fn ensure_global_skill_paths() -> Result<bool, WorkspaceControlError> {
     use teamclu_runtime_env::opencode_config::{OpencodeConfigError, OpencodeConfigStore};
 
-    let mut wanted: Vec<String> = Vec::new();
-    if let Some(team_id) = crate::config::team_mcp::onboarded_team_id() {
-        wanted.push(
-            crate::runtime::team_skills::team_cloud_skills_dir(&team_id)
-                .to_string_lossy()
-                .into_owned(),
-        );
-    }
-    if let Some(home) = dirs::home_dir() {
-        wanted.push(
-            home.join(".agents")
-                .join("skills")
-                .to_string_lossy()
-                .into_owned(),
-        );
-    }
-    if wanted.is_empty() {
+    let hosted = crate::config::team_mcp::onboarded_team_id().map(|team_id| {
+        crate::runtime::team_skills::team_cloud_skills_dir(&team_id)
+            .to_string_lossy()
+            .into_owned()
+    });
+    let member = dirs::home_dir().map(|home| {
+        home.join(".agents")
+            .join("skills")
+            .to_string_lossy()
+            .into_owned()
+    });
+    if hosted.is_none() && member.is_none() {
         return Ok(false);
     }
 
@@ -666,14 +714,20 @@ pub fn ensure_global_skill_paths() -> Result<bool, WorkspaceControlError> {
                 "global opencode.json skills.paths is not an array".to_string(),
             )
         })?;
-        let mut changed = false;
-        for path in wanted {
-            if !paths.iter().any(|v| v.as_str() == Some(path.as_str())) {
-                paths.push(serde_json::json!(path));
-                changed = true;
-            }
+        let existing: Vec<String> = paths
+            .iter()
+            .filter_map(|v| v.as_str().map(str::to_string))
+            .collect();
+        let normalized =
+            normalize_managed_skill_paths(&existing, hosted.as_deref(), member.as_deref());
+        if existing == normalized {
+            return Ok(false);
         }
-        Ok(changed)
+        *paths = normalized
+            .into_iter()
+            .map(serde_json::Value::String)
+            .collect();
+        Ok(true)
     })
     .map_err(map_store_err)
 }
@@ -764,7 +818,9 @@ fn install_instruction_plugin_file(workspace_path: &Path) -> Result<(), Workspac
 }
 
 fn install_session_context_plugin_file(workspace_path: &Path) -> Result<(), WorkspaceControlError> {
-    use crate::runtime::workspace_runtime::{SESSION_CONTEXT_CLIENT_REL, SESSION_CONTEXT_PLUGIN_REL};
+    use crate::runtime::workspace_runtime::{
+        SESSION_CONTEXT_CLIENT_REL, SESSION_CONTEXT_PLUGIN_REL,
+    };
 
     let plugin_path = workspace_path.join(SESSION_CONTEXT_PLUGIN_REL);
     let client_path = workspace_path.join(SESSION_CONTEXT_CLIENT_REL);
@@ -772,17 +828,16 @@ fn install_session_context_plugin_file(workspace_path: &Path) -> Result<(), Work
         std::fs::create_dir_all(parent).map_err(|e| WorkspaceControlError::Io(e.to_string()))?;
     }
 
-    let write_if_changed =
-        |path: &Path, template: &str| -> Result<(), WorkspaceControlError> {
-            let should_write = match std::fs::read_to_string(path) {
-                Ok(existing) => existing != template,
-                Err(_) => true,
-            };
-            if should_write {
-                std::fs::write(path, template).map_err(|e| WorkspaceControlError::Io(e.to_string()))?;
-            }
-            Ok(())
+    let write_if_changed = |path: &Path, template: &str| -> Result<(), WorkspaceControlError> {
+        let should_write = match std::fs::read_to_string(path) {
+            Ok(existing) => existing != template,
+            Err(_) => true,
         };
+        if should_write {
+            std::fs::write(path, template).map_err(|e| WorkspaceControlError::Io(e.to_string()))?;
+        }
+        Ok(())
+    };
 
     write_if_changed(&client_path, SESSION_CONTEXT_CLIENT_TEMPLATE)?;
     write_if_changed(&plugin_path, SESSION_CONTEXT_PLUGIN_TEMPLATE)?;
@@ -2888,5 +2943,187 @@ mod tests {
             cfg["mcp"].get("user-server").is_some(),
             "a user's own server must survive the migration"
         );
+    }
+
+    #[test]
+    fn prepare_workspace_strips_managed_skill_paths_from_workspace_config() {
+        let home = tempfile::tempdir().unwrap();
+        let _guard = crate::test_brand_env::BrandEnvGuard::set_with_home("teamclu", home.path());
+        let agents = home.path().join(".agents/skills");
+        let hosted = home.path().join(".amuxd/teams/team-a/state/cloud/skills");
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("opencode.json"),
+            serde_json::json!({
+                "skills": {
+                    "paths": [
+                        agents.to_string_lossy(),
+                        hosted.to_string_lossy(),
+                        "/opt/custom/skills"
+                    ]
+                }
+            })
+            .to_string(),
+        )
+        .unwrap();
+
+        prepare_workspace(dir.path()).unwrap();
+
+        let cfg: serde_json::Value = serde_json::from_str(
+            &std::fs::read_to_string(dir.path().join("opencode.json")).unwrap(),
+        )
+        .unwrap();
+        let paths = cfg["skills"]["paths"]
+            .as_array()
+            .cloned()
+            .unwrap_or_default();
+        assert!(
+            paths
+                .iter()
+                .all(|p| p.as_str() != Some(agents.to_string_lossy().as_ref())),
+            "member path must not stay in workspace opencode.json"
+        );
+        assert!(
+            paths
+                .iter()
+                .all(|p| p.as_str() != Some(hosted.to_string_lossy().as_ref())),
+            "hosted path must not stay in workspace opencode.json"
+        );
+        assert!(
+            paths
+                .iter()
+                .any(|p| p.as_str() == Some("/opt/custom/skills")),
+            "user custom paths survive"
+        );
+    }
+}
+
+#[cfg(test)]
+mod skill_path_normalize_tests {
+    use super::*;
+
+    const HOSTED_A: &str = "/Users/me/.amuxd/teams/team-a/state/cloud/skills";
+    const HOSTED_B: &str = "/Users/me/.amuxd/teams/team-b/state/cloud/skills";
+    const MEMBER: &str = "/Users/me/.agents/skills";
+    const CUSTOM: &str = "/opt/company/skills";
+
+    #[test]
+    fn empty_config_emits_hosted_then_member() {
+        assert_eq!(
+            normalize_managed_skill_paths(&[], Some(HOSTED_A), Some(MEMBER)),
+            vec![HOSTED_A.to_string(), MEMBER.to_string()]
+        );
+    }
+
+    #[test]
+    fn member_only_existing_puts_hosted_first() {
+        assert_eq!(
+            normalize_managed_skill_paths(&[MEMBER.to_string()], Some(HOSTED_A), Some(MEMBER)),
+            vec![HOSTED_A.to_string(), MEMBER.to_string()]
+        );
+    }
+
+    #[test]
+    fn reverses_member_before_hosted() {
+        assert_eq!(
+            normalize_managed_skill_paths(
+                &[MEMBER.to_string(), HOSTED_A.to_string()],
+                Some(HOSTED_A),
+                Some(MEMBER)
+            ),
+            vec![HOSTED_A.to_string(), MEMBER.to_string()]
+        );
+    }
+
+    #[test]
+    fn dedupes_repeated_managed_paths() {
+        assert_eq!(
+            normalize_managed_skill_paths(
+                &[
+                    HOSTED_A.to_string(),
+                    MEMBER.to_string(),
+                    HOSTED_A.to_string(),
+                    MEMBER.to_string()
+                ],
+                Some(HOSTED_A),
+                Some(MEMBER)
+            ),
+            vec![HOSTED_A.to_string(), MEMBER.to_string()]
+        );
+    }
+
+    #[test]
+    fn preserves_custom_paths_and_their_order() {
+        let extra = "/home/me/extra-skills";
+        assert_eq!(
+            normalize_managed_skill_paths(
+                &[CUSTOM.to_string(), MEMBER.to_string(), extra.to_string()],
+                Some(HOSTED_A),
+                Some(MEMBER)
+            ),
+            vec![
+                HOSTED_A.to_string(),
+                MEMBER.to_string(),
+                CUSTOM.to_string(),
+                extra.to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn switching_teams_drops_previous_hosted_root() {
+        assert_eq!(
+            normalize_managed_skill_paths(
+                &[HOSTED_A.to_string(), MEMBER.to_string()],
+                Some(HOSTED_B),
+                Some(MEMBER)
+            ),
+            vec![HOSTED_B.to_string(), MEMBER.to_string()]
+        );
+    }
+
+    #[test]
+    fn no_active_team_drops_hosted_roots() {
+        assert_eq!(
+            normalize_managed_skill_paths(
+                &[HOSTED_A.to_string(), MEMBER.to_string(), CUSTOM.to_string()],
+                None,
+                Some(MEMBER)
+            ),
+            vec![MEMBER.to_string(), CUSTOM.to_string()]
+        );
+    }
+
+    #[test]
+    fn tilde_member_alias_is_treated_as_managed() {
+        assert_eq!(
+            normalize_managed_skill_paths(
+                &["~/.agents/skills".into(), CUSTOM.to_string()],
+                Some(HOSTED_A),
+                Some(MEMBER)
+            ),
+            vec![HOSTED_A.to_string(), MEMBER.to_string(), CUSTOM.to_string()]
+        );
+    }
+
+    #[test]
+    fn normalize_is_idempotent() {
+        let first = normalize_managed_skill_paths(
+            &[MEMBER.to_string(), HOSTED_A.to_string(), CUSTOM.to_string()],
+            Some(HOSTED_A),
+            Some(MEMBER),
+        );
+        let second = normalize_managed_skill_paths(&first, Some(HOSTED_A), Some(MEMBER));
+        assert_eq!(first, second);
+    }
+
+    #[test]
+    fn hosted_path_matcher_accepts_windows_separators() {
+        assert!(is_hosted_team_skills_path(
+            r"C:\Users\me\.amuxd\teams\team-a\state\cloud\skills"
+        ));
+        assert!(!is_hosted_team_skills_path(
+            "/Users/me/.amuxd/teams/team-a/shared/skills"
+        ));
     }
 }

--- a/apps/daemon/tests/http_workspace_provider_auth.rs
+++ b/apps/daemon/tests/http_workspace_provider_auth.rs
@@ -342,3 +342,138 @@ async fn post_materialize_team_mcp_clears_copies_an_older_build_left_behind() {
         "the user's own server is untouched"
     );
 }
+
+async fn test_app_with_refresh() -> (
+    TestApp,
+    tempfile::TempDir,
+    std::sync::Arc<runtime::RuntimeSupervisor>,
+) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let token_path = dir.path().join("token");
+    let cfg = HttpConfig {
+        bind: "127.0.0.1:0".into(),
+        token_file: Some(token_path.clone()),
+        port_file: Some(dir.path().join("port")),
+        heartbeat_interval: Duration::from_secs(5),
+        ..HttpConfig::default()
+    };
+    let manager = Arc::new(Mutex::new(runtime::RuntimeManager::new(
+        std::collections::HashMap::new(),
+        None,
+    )));
+    let supervisor = runtime::RuntimeSupervisor::new(manager.clone());
+    let runtime = RuntimeManagerAdapter::new(manager, 256, None);
+    let workspace_control: Arc<dyn config::WorkspaceControlStore> =
+        Arc::new(OpenCodeCompatStore::new());
+    let handle = crate::http::spawn(
+        cfg,
+        crate::http::server::metadata("actor".into(), "test"),
+        runtime,
+        Some(workspace_control),
+        Some(supervisor.clone()),
+        None,
+        test_sync_dispatcher(),
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+    )
+    .await
+    .expect("spawn http server");
+    let base = format!("http://{}", handle.local_addr);
+    let root = std::fs::read_to_string(&token_path)
+        .expect("read root token")
+        .trim()
+        .to_owned();
+    let client = Client::new();
+    let resp: Value = client
+        .post(format!("{base}/v1/auth/exchange"))
+        .bearer_auth(&root)
+        .json(&serde_json::json!({
+            "ttl_seconds": 3600,
+            "scopes": [
+                "workspace:read",
+                "workspace:write",
+                "sessions:read",
+                "sessions:write",
+                "events:read"
+            ]
+        }))
+        .send()
+        .await
+        .expect("exchange response")
+        .error_for_status()
+        .expect("exchange status")
+        .json()
+        .await
+        .expect("exchange body");
+    let session_token = resp["token"].as_str().expect("session token").to_string();
+    (
+        TestApp {
+            _handle: handle,
+            client,
+            base,
+            session_token,
+        },
+        dir,
+        supervisor,
+    )
+}
+
+#[tokio::test]
+async fn skills_refresh_records_skills_change() {
+    let (app, _dir, supervisor) = test_app_with_refresh().await;
+    let ws = tempfile::tempdir().expect("workspace");
+    let wid = ws_id(ws.path());
+    let body: Value = app
+        .client
+        .post(format!("{}/v1/workspaces/{wid}/skills/refresh", app.base))
+        .bearer_auth(&app.session_token)
+        .send()
+        .await
+        .expect("response")
+        .error_for_status()
+        .expect("status")
+        .json()
+        .await
+        .expect("json");
+    assert_eq!(body["ok"], true);
+
+    let dto = supervisor
+        .refresh_coordinator()
+        .runtime_refresh_dto(&wid)
+        .await;
+    assert!(
+        dto.change_kinds.iter().any(|k| k == "skills"),
+        "expected Skills refresh, got {:?}",
+        dto.change_kinds
+    );
+}
+
+#[tokio::test]
+async fn skills_refresh_missing_workspace_is_not_found() {
+    let (app, _dir, _supervisor) = test_app_with_refresh().await;
+    let missing = std::env::temp_dir().join(format!(
+        "teamclu-missing-workspace-{}",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    let wid = ws_id(&missing);
+    let resp = app
+        .client
+        .post(format!("{}/v1/workspaces/{wid}/skills/refresh", app.base))
+        .bearer_auth(&app.session_token)
+        .send()
+        .await
+        .expect("response");
+    assert_eq!(resp.status(), reqwest::StatusCode::NOT_FOUND);
+}

--- a/apps/desktop/src/commands/agents_skills.rs
+++ b/apps/desktop/src/commands/agents_skills.rs
@@ -95,10 +95,10 @@ pub fn ensure_agents_skills_paths(workspace_path: Option<String>) -> Result<Stri
         .map(str::trim)
         .filter(|s| !s.is_empty())
     {
-        let opencode = Path::new(ws).join("opencode.json");
-        if patch_config_file(&opencode, &agents_str)? {
-            touched.push(opencode.display().to_string());
-        }
+        // Workspace `opencode.json` used to get `~/.agents/skills` prepended here.
+        // That copy outranks the team's global hosted-first `skills.paths`, so
+        // an older member pack shadowed the hosted team skill. Claude still
+        // needs the member root; OpenCode reads it from the global config.
         let claude_ws = Path::new(ws).join(".claude").join("settings.json");
         if patch_config_file(&claude_ws, &agents_str)? {
             touched.push(claude_ws.display().to_string());
@@ -145,5 +145,29 @@ mod tests {
         let paths = v["skills"]["paths"].as_array().unwrap();
         assert_eq!(paths.len(), 1);
         assert_eq!(paths[0], "/tmp/.agents/skills");
+    }
+
+    #[test]
+    fn ensure_agents_skills_paths_does_not_write_workspace_opencode_json() {
+        let home = tempdir().unwrap();
+        let ws = tempdir().unwrap();
+        let opencode = ws.path().join("opencode.json");
+        std::fs::write(&opencode, "{}\n").unwrap();
+
+        let prev_home = std::env::var_os("HOME");
+        std::env::set_var("HOME", home.path());
+        let result = ensure_agents_skills_paths(Some(ws.path().to_string_lossy().into_owned()));
+        match prev_home {
+            Some(v) => std::env::set_var("HOME", v),
+            None => std::env::remove_var("HOME"),
+        }
+        result.unwrap();
+
+        let raw = std::fs::read_to_string(&opencode).unwrap();
+        let v: Value = serde_json::from_str(&raw).unwrap();
+        assert!(
+            v.get("skills").is_none(),
+            "workspace opencode.json must not gain a member skills.paths entry"
+        );
     }
 }

--- a/packages/app/src/components/sidebar/TeamShareListColumn.tsx
+++ b/packages/app/src/components/sidebar/TeamShareListColumn.tsx
@@ -71,6 +71,7 @@ import { detailSelectionForSection } from '@/lib/tabs/teamshare-target'
 import type { ConnectedAgentRow } from '@/lib/backend/types'
 import { useActorPresenceStore } from '@/stores/actor-presence-store'
 import { getKnownLocalDaemonActorId } from '@/lib/local-daemon-identity'
+import { encodeWorkspaceId, notifyDaemonSkillsChanged } from '@/lib/daemon-local-client'
 import { SkillScanPaths } from './SkillScanPaths'
 import { KnowledgeSyncFooter } from '@/components/teamshare/KnowledgeSyncFooter'
 import { useTeamConflictsStore } from '@/stores/team-conflicts'
@@ -1208,8 +1209,22 @@ export function TeamShareListColumn({ section }: { section: TeamShareSection }) 
                             onSelectFile={(rel) => selectSkillFile(row.id, rel)}
                             onFileRemoved={(rel) => closeSkillFiles(row.id, rel)}
                             onMutated={() => {
-                              void loadSection('skills', { force: true })
-                              void reconcileSkills().catch(() => {})
+                              void (async () => {
+                                if (workspacePath) {
+                                  try {
+                                    await notifyDaemonSkillsChanged(encodeWorkspaceId(workspacePath))
+                                  } catch {
+                                    toast.error(
+                                      t(
+                                        'teamShare.skillSavedRefreshFailed',
+                                        'Skill 已保存，但新会话可能暂时仍使用旧缓存。',
+                                      ),
+                                    )
+                                  }
+                                }
+                                void loadSection('skills', { force: true })
+                                void reconcileSkills().catch(() => {})
+                              })()
                             }}
                             refreshKey={treeRefreshKey}
                             rootCreate={rootCreate?.rowId === row.id ? rootCreate.kind : null}

--- a/packages/app/src/components/teamshare/SkillDetail.tsx
+++ b/packages/app/src/components/teamshare/SkillDetail.tsx
@@ -37,6 +37,8 @@ import {
   isSkillDirtyConflict,
   SkillDiscardIncompleteError,
   SkillSlugTakenError,
+  SkillPublishedRefreshError,
+  SkillRuntimeRefreshError,
   StaleTeamSkillPublishError,
   StaleDirtySkillPublishError,
   type TeamSkillItem,
@@ -1348,6 +1350,17 @@ export function SkillDetail({ slug }: { slug: string }) {
         setPublishOpen(false)
         toast.success(t('teamShare.skillPublished', 'Published'))
       } catch (e) {
+        if (e instanceof SkillPublishedRefreshError) {
+          setPublishOpen(false)
+          toast.error(
+            t(
+              'teamShare.skillPublishedRefreshFailed',
+              'Skill v{{v}} 已发布，本机刷新失败。请重试刷新。',
+              { v: e.version },
+            ),
+          )
+          return
+        }
         if (e instanceof StaleDirtySkillPublishError) {
           toast.error(
             t(
@@ -1407,6 +1420,16 @@ export function SkillDetail({ slug }: { slug: string }) {
         action: undoAction(trashedPath, item.slug),
       })
     } catch (e) {
+      if (e instanceof SkillRuntimeRefreshError) {
+        toast.error(
+          t(
+            'teamShare.skillSavedRefreshFailed',
+            'Skill 已保存，但新会话可能暂时仍使用旧缓存。{{msg}}',
+            { msg: e.message },
+          ),
+        )
+        return
+      }
       // A discard that got as far as moving the edits aside still has to offer
       // the undo — that path is where the user most needs it, and it is exactly
       // where a plain error toast would leave their work stranded in a
@@ -1475,6 +1498,16 @@ export function SkillDetail({ slug }: { slug: string }) {
           toast.success(t('teamShare.skillReverted', 'Restored v{{v}} as the current version', { v: version })),
         )
         .catch((e) => {
+          if (e instanceof SkillRuntimeRefreshError) {
+            toast.error(
+              t(
+                'teamShare.skillSavedRefreshFailed',
+                'Skill 已保存，但新会话可能暂时仍使用旧缓存。{{msg}}',
+                { msg: e.message },
+              ),
+            )
+            return
+          }
           if (e instanceof StaleTeamSkillPublishError) {
             toast.error(
               t(

--- a/packages/app/src/components/teamshare/SkillFileEditor.tsx
+++ b/packages/app/src/components/teamshare/SkillFileEditor.tsx
@@ -5,7 +5,7 @@ import { ArrowLeft, FolderSearch, Loader2, Save } from 'lucide-react'
 import { toast } from 'sonner'
 import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
-import { encodeWorkspaceId, putDaemonSkill } from '@/lib/daemon-local-client'
+import { encodeWorkspaceId, notifyDaemonSkillsChanged, putDaemonSkill } from '@/lib/daemon-local-client'
 import { revealInFinder } from '@/components/workspace/file-tree-operations'
 import { useTeamShareBrowserStore } from '@/stores/team-share-browser'
 import { useEffectiveWorkspacePath } from '@/lib/effective-workspace'
@@ -108,6 +108,22 @@ export function SkillFileEditor({ slug, rel }: { slug: string; rel: string }) {
       } else {
         const { writeTextFile } = await import('@tauri-apps/plugin-fs')
         await writeTextFile(filePath, content)
+        if (!workspacePath) throw new Error('no workspace')
+        try {
+          await notifyDaemonSkillsChanged(encodeWorkspaceId(workspacePath))
+        } catch (e) {
+          setBaseline(content)
+          await loadSection('skills', { force: true })
+          await reconcileSkills().catch(() => {})
+          toast.error(
+            t(
+              'teamShare.skillSavedRefreshFailed',
+              'Skill 已保存，但新会话可能暂时仍使用旧缓存。{{msg}}',
+              { msg: e instanceof Error ? e.message : String(e) },
+            ),
+          )
+          return
+        }
       }
       setBaseline(content)
       await loadSection('skills', { force: true })

--- a/packages/app/src/components/teamshare/__tests__/SkillFileEditor.test.tsx
+++ b/packages/app/src/components/teamshare/__tests__/SkillFileEditor.test.tsx
@@ -1,0 +1,134 @@
+import * as React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+
+const t = (k: string, d?: string) => d ?? k
+
+const { mockPut, mockNotify, mockWrite, mockLoad, mockReconcile } = vi.hoisted(() => ({
+  mockPut: vi.fn(async () => ({ slug: 'say-hello' })),
+  mockNotify: vi.fn(async () => {}),
+  mockWrite: vi.fn(async () => {}),
+  mockLoad: vi.fn(async () => {}),
+  mockReconcile: vi.fn(async () => {}),
+}))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t, i18n: { language: 'en', changeLanguage: vi.fn() } }),
+}))
+vi.mock('sonner', () => ({ toast: { error: vi.fn(), success: vi.fn() } }))
+vi.mock('@tauri-apps/plugin-fs', () => ({
+  stat: vi.fn(async () => ({ size: 12 })),
+  readTextFile: vi.fn(async () => 'hello-old'),
+  writeTextFile: mockWrite,
+}))
+vi.mock('@/lib/daemon-local-client', () => ({
+  encodeWorkspaceId: (p: string) => `ws:${p}`,
+  putDaemonSkill: mockPut,
+  notifyDaemonSkillsChanged: mockNotify,
+}))
+vi.mock('@/lib/effective-workspace', () => ({
+  useEffectiveWorkspacePath: () => '/Users/me/project',
+}))
+vi.mock('@/components/workspace/file-tree-operations', () => ({
+  revealInFinder: vi.fn(),
+}))
+vi.mock('../use-is-dark', () => ({ useIsDark: () => false }))
+vi.mock('@/components/editors/CodeEditor', () => ({
+  default: ({
+    content,
+    onChange,
+  }: {
+    content: string
+    onChange: (v: string) => void
+  }) => (
+    <textarea
+      data-testid="code-editor"
+      value={content}
+      onChange={(e) => onChange(e.target.value)}
+    />
+  ),
+}))
+
+const item = {
+  id: 'say-hello',
+  slug: 'say-hello',
+  name: 'say-hello',
+  dirPath: '/hosted/skills',
+  filename: 'say-hello',
+}
+
+vi.mock('@/stores/team-share-browser', () => ({
+  useTeamShareBrowserStore: (sel: (s: typeof state) => unknown) => sel(state),
+}))
+
+const state = {
+  skills: { items: [item] },
+  select: vi.fn(),
+  loadSection: mockLoad,
+  reconcileSkills: mockReconcile,
+}
+
+import { SkillFileEditor } from '../SkillFileEditor'
+import { toast } from 'sonner'
+
+describe('SkillFileEditor save', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockPut.mockResolvedValue({ slug: 'say-hello' })
+    mockNotify.mockResolvedValue(undefined)
+    mockWrite.mockResolvedValue(undefined)
+  })
+
+  it('saves SKILL.md through putDaemonSkill and does not call refresh', async () => {
+    render(<SkillFileEditor slug="say-hello" rel="SKILL.md" />)
+    await waitFor(() => expect(screen.getByTestId('code-editor')).toBeTruthy())
+    fireEvent.change(screen.getByTestId('code-editor'), { target: { value: 'hello-new' } })
+    fireEvent.click(screen.getByText('Save'))
+    await waitFor(() => expect(mockPut).toHaveBeenCalled())
+    expect(mockPut).toHaveBeenCalledWith(
+      'ws:/Users/me/project',
+      'say-hello',
+      expect.objectContaining({ content: 'hello-new' }),
+    )
+    expect(mockWrite).not.toHaveBeenCalled()
+    expect(mockNotify).not.toHaveBeenCalled()
+  })
+
+  it('writes auxiliary files then notifies daemon skills refresh', async () => {
+    render(<SkillFileEditor slug="say-hello" rel="scripts/hello.js" />)
+    await waitFor(() => expect(screen.getByTestId('code-editor')).toBeTruthy())
+    fireEvent.change(screen.getByTestId('code-editor'), { target: { value: 'hello-new' } })
+    fireEvent.click(screen.getByText('Save'))
+    await waitFor(() => expect(mockWrite).toHaveBeenCalled())
+    expect(mockWrite).toHaveBeenCalledWith(
+      '/hosted/skills/say-hello/scripts/hello.js',
+      'hello-new',
+    )
+    expect(mockPut).not.toHaveBeenCalled()
+    expect(mockNotify).toHaveBeenCalledWith('ws:/Users/me/project')
+  })
+
+  it('does not refresh when the auxiliary write fails', async () => {
+    mockWrite.mockRejectedValueOnce(new Error('disk full'))
+    render(<SkillFileEditor slug="say-hello" rel="scripts/hello.js" />)
+    await waitFor(() => expect(screen.getByTestId('code-editor')).toBeTruthy())
+    fireEvent.change(screen.getByTestId('code-editor'), { target: { value: 'hello-new' } })
+    fireEvent.click(screen.getByText('Save'))
+    await waitFor(() => expect(mockWrite).toHaveBeenCalled())
+    expect(mockNotify).not.toHaveBeenCalled()
+    expect(toast.error).toHaveBeenCalled()
+  })
+
+  it('treats a successful write plus failed refresh as saved, not save-failed', async () => {
+    mockNotify.mockRejectedValueOnce(new Error('daemon down'))
+    render(<SkillFileEditor slug="say-hello" rel="scripts/hello.js" />)
+    await waitFor(() => expect(screen.getByTestId('code-editor')).toBeTruthy())
+    fireEvent.change(screen.getByTestId('code-editor'), { target: { value: 'hello-new' } })
+    fireEvent.click(screen.getByText('Save'))
+    await waitFor(() => expect(mockNotify).toHaveBeenCalled())
+    expect(toast.error).toHaveBeenCalledWith(
+      expect.stringContaining('Skill 已保存，但新会话可能暂时仍使用旧缓存'),
+    )
+    expect(toast.error).not.toHaveBeenCalledWith(expect.stringContaining('Save failed'))
+  })
+})

--- a/packages/app/src/lib/daemon-local-client.ts
+++ b/packages/app/src/lib/daemon-local-client.ts
@@ -1051,6 +1051,14 @@ export async function putDaemonSkill(
   return result.ok ? result.data : null
 }
 
+/** Register a Skills refresh without rewriting files. Next idle apply disposes the OpenCode instance. */
+export async function notifyDaemonSkillsChanged(workspaceId: string): Promise<void> {
+  await daemonFetchData<{ ok: boolean }>(
+    `/v1/workspaces/${workspaceId}/skills/refresh`,
+    { method: 'POST' },
+  )
+}
+
 export async function deleteDaemonSkill(
   workspaceId: string,
   slug: string,

--- a/packages/app/src/locales/en.json
+++ b/packages/app/src/locales/en.json
@@ -147,6 +147,8 @@
     "skillPublishStaleBody": "{{versions}} shipped after that. Publishing v{{next}} replaces them with your copy, so those changes will be gone.",
     "skillPublishSubmit": "Publish",
     "skillPublished": "Published",
+    "skillPublishedRefreshFailed": "Skill v{{v}} was published, but this machine failed to refresh. Retry the refresh — do not publish again.",
+    "skillSavedRefreshFailed": "Skill saved, but new sessions may still use a stale cache. {{msg}}",
     "skillPublishStaleBase": "Someone else published while you were editing. Your draft is kept — refresh and resolve the conflict.",
     "skillPublishFailed": "Publish failed: {{msg}}",
     "skillPublishStaleBase": "Someone else published while you were editing. Your draft is kept — refresh and resolve the conflict.",

--- a/packages/app/src/locales/zh-CN.json
+++ b/packages/app/src/locales/zh-CN.json
@@ -147,6 +147,8 @@
     "skillPublishStaleBody": "之后团队已经发过 {{versions}}。发布 v{{next}} 会用你这份覆盖掉它们，那些改动会丢失。",
     "skillPublishSubmit": "发布",
     "skillPublished": "已发布",
+    "skillPublishedRefreshFailed": "Skill v{{v}} 已发布，本机刷新失败。请重试刷新，不要再次发布。",
+    "skillSavedRefreshFailed": "Skill 已保存，但新会话可能暂时仍使用旧缓存。{{msg}}",
     "skillPublishStaleBase": "在你编辑期间有人发布了新版本。你的草稿已保留——刷新后处理冲突。",
     "skillPublishFailed": "发布失败：{{msg}}",
     "skillPublishStaleBase": "其他人已经发布新版本。你的草稿还在——请刷新并处理冲突。",

--- a/packages/app/src/stores/__tests__/team-share-publish-refresh.test.ts
+++ b/packages/app/src/stores/__tests__/team-share-publish-refresh.test.ts
@@ -1,0 +1,133 @@
+import { describe, test, expect, beforeEach, vi } from 'vitest'
+
+const {
+  notifyDaemonSkillsChanged,
+  publishTeamSkillVersion,
+  installTeamSkill,
+  detachTeamSkill,
+  invoke,
+} = vi.hoisted(() => ({
+  notifyDaemonSkillsChanged: vi.fn(async () => {}),
+  publishTeamSkillVersion: vi.fn(async () => ({
+    version: 4,
+    summary: 'hi',
+    whenToUse: null,
+    whenNotToUse: null,
+    requires: null,
+  })),
+  installTeamSkill: vi.fn(async () => ({})),
+  detachTeamSkill: vi.fn(async () => {}),
+  invoke: vi.fn(async (cmd: string) => {
+    if (cmd === 'team_skill_installed_dir') return '/hosted/skills/say-hello'
+    if (cmd === 'team_skill_pack_and_upload') return { contentHash: 'abc', size: 12 }
+    if (cmd === 'team_skill_rebaseline') return {}
+    return null
+  }),
+}))
+
+vi.mock('@/lib/utils', () => ({ isTauri: () => true }))
+vi.mock('@/lib/effective-workspace', () => ({
+  effectiveWorkspacePath: async () => '/Users/me/project',
+}))
+vi.mock('@/lib/daemon-local-client', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/daemon-local-client')>()
+  return {
+    ...actual,
+    notifyDaemonSkillsChanged,
+    encodeWorkspaceId: (p: string) => `ws:${p}`,
+  }
+})
+vi.mock('@/lib/backend/provider', () => ({
+  getBackend: () => ({
+    teamSkills: { publishTeamSkillVersion, installTeamSkill },
+    marketplace: { detachTeamSkill },
+  }),
+}))
+vi.mock('@/lib/auth/session-store', () => ({
+  getFreshAccessToken: async () => 'token',
+}))
+vi.mock('@/lib/server-config', () => ({
+  getEffectiveServerConfig: async () => ({ cloudApiUrl: 'https://api.example' }),
+}))
+vi.mock('@tauri-apps/api/core', () => ({ invoke }))
+
+import {
+  SkillPublishedRefreshError,
+  useTeamShareBrowserStore,
+} from '../team-share-browser'
+import { useCurrentTeamStore } from '../current-team'
+
+const store = () => useTeamShareBrowserStore.getState()
+
+function skillRow() {
+  return {
+    id: 'say-hello',
+    slug: 'say-hello',
+    name: 'say-hello',
+    invocationName: 'say-hello',
+    category: 'other',
+    content: '',
+    dirPath: '/hosted/skills',
+    filename: 'say-hello',
+    origin: 'registry',
+    kind: 'team-installed',
+    personalSource: null,
+    personalSourceLabel: null,
+    summary: 'hi',
+    whenToUse: null,
+    whenNotToUse: null,
+    requires: null,
+    status: 'published',
+    supersededBy: null,
+    ownerActorId: 'actor-1',
+    latestVersion: 3,
+    installed: true,
+    installedVersion: 3,
+    hasUpdate: false,
+    createdAt: null,
+    updatedAt: null,
+    marketplaceOrigin: 'local',
+    upstreamSubscribed: false,
+  }
+}
+
+describe('publishSkillVersion refresh', () => {
+  let reconciled = 0
+
+  beforeEach(() => {
+    notifyDaemonSkillsChanged.mockReset()
+    notifyDaemonSkillsChanged.mockResolvedValue(undefined)
+    publishTeamSkillVersion.mockClear()
+    installTeamSkill.mockClear()
+    invoke.mockClear()
+    reconciled = 0
+    useCurrentTeamStore.setState({ team: { id: 'team-1' } } as never)
+    useTeamShareBrowserStore.setState({
+      subjectActorId: 'actor-1',
+      skills: { items: [skillRow()] as never, loading: false, loaded: true, error: null },
+      skillLocalState: {
+        'say-hello': { state: 'dirty', installedVersion: '3' },
+      } as never,
+      reconcileSkills: async () => {
+        reconciled += 1
+      },
+      loadSection: async () => {},
+    })
+  })
+
+  test('calls refresh after rebaseline even when reconcile reports no disk change', async () => {
+    await store().publishSkillVersion('say-hello', { changelog: 'n' })
+    expect(invoke).toHaveBeenCalledWith('team_skill_rebaseline', expect.anything())
+    expect(notifyDaemonSkillsChanged).toHaveBeenCalledWith('ws:/Users/me/project')
+    expect(reconciled).toBe(1)
+  })
+
+  test('cloud success plus refresh failure is not a generic publish failure', async () => {
+    notifyDaemonSkillsChanged.mockRejectedValueOnce(new Error('daemon down'))
+    await expect(
+      store().publishSkillVersion('say-hello', { changelog: 'n' }),
+    ).rejects.toBeInstanceOf(SkillPublishedRefreshError)
+    expect(publishTeamSkillVersion).toHaveBeenCalled()
+    expect(reconciled).toBe(1)
+  })
+})

--- a/packages/app/src/stores/team-share-browser.ts
+++ b/packages/app/src/stores/team-share-browser.ts
@@ -18,6 +18,7 @@ import {
 } from '@/lib/skills/auto-follow'
 import { useCurrentTeamStore } from '@/stores/current-team'
 import { effectiveWorkspacePath } from '@/lib/effective-workspace'
+import { isTauri } from '@/lib/utils'
 import { useTabsStore } from '@/stores/tabs'
 import {
   decodeTeamShareTarget,
@@ -82,6 +83,7 @@ import {
   putDaemonMcp,
   installDaemonTeamMcp,
   reconcileDaemonTeamCloudConfig,
+  notifyDaemonSkillsChanged,
   type DaemonMcpServerConfig,
   type DaemonMcpServerProbeResult,
 } from '@/lib/daemon-local-client'
@@ -930,6 +932,33 @@ export class SkillDiscardIncompleteError extends Error {
   }
 }
 
+/** Disk is already right; OpenCode cache refresh did not register. */
+export class SkillRuntimeRefreshError extends Error {
+  constructor(message = 'skill_runtime_refresh_failed') {
+    super(message)
+    this.name = 'SkillRuntimeRefreshError'
+  }
+}
+
+/** Cloud publish succeeded; this machine's OpenCode cache did not refresh. */
+export class SkillPublishedRefreshError extends Error {
+  constructor(readonly version: number) {
+    super(`skill_published_refresh_failed:${version}`)
+    this.name = 'SkillPublishedRefreshError'
+  }
+}
+
+async function refreshLocalSkillsRuntime(): Promise<void> {
+  if (!isTauri()) return
+  const wsPath = await workspacePath()
+  if (!wsPath) throw new SkillRuntimeRefreshError('no workspace')
+  try {
+    await notifyDaemonSkillsChanged(encodeWorkspaceId(wsPath))
+  } catch (e) {
+    throw new SkillRuntimeRefreshError(e instanceof Error ? e.message : String(e))
+  }
+}
+
 /**
  * Download one version and lay it down.
  *
@@ -1207,6 +1236,7 @@ export const useTeamShareBrowserStore = create<TeamShareBrowserState>((set, get)
     // (or only after restart).
     await get().reconcileSkills().catch(() => {})
     await get().loadSection('skills', { force: true })
+    await refreshLocalSkillsRuntime()
   },
 
   uninstallSkill: async (slug) => {
@@ -1226,6 +1256,7 @@ export const useTeamShareBrowserStore = create<TeamShareBrowserState>((set, get)
     })
     closeSkillTabs(slug)
     await get().loadSection('skills', { force: true })
+    await refreshLocalSkillsRuntime()
   },
 
   deletePersonalSkill: async (slug) => {
@@ -1251,6 +1282,7 @@ export const useTeamShareBrowserStore = create<TeamShareBrowserState>((set, get)
     closeSkillTabs(slug)
     await get().loadSection('skills', { force: true })
     window.dispatchEvent(new CustomEvent(SKILLS_CHANGED_EVENT))
+    await refreshLocalSkillsRuntime()
   },
 
   deleteTeamSkill: async (slug) => {
@@ -1272,6 +1304,7 @@ export const useTeamShareBrowserStore = create<TeamShareBrowserState>((set, get)
     closeSkillTabs(slug)
     await get().loadSection('skills', { force: true })
     window.dispatchEvent(new CustomEvent(SKILLS_CHANGED_EVENT))
+    await refreshLocalSkillsRuntime()
   },
 
   installMcp: async (name) => {
@@ -1610,8 +1643,19 @@ export const useTeamShareBrowserStore = create<TeamShareBrowserState>((set, get)
       await backend.marketplace.detachTeamSkill(teamId, slug).catch(() => {})
     }
 
+    // Rebaseline often leaves disk bytes unchanged, so reconcile will not
+    // record a Skills refresh. The OpenCode instance still has the old pack
+    // cached and must be told explicitly.
+    let refreshError: SkillPublishedRefreshError | null = null
+    try {
+      await refreshLocalSkillsRuntime()
+    } catch {
+      refreshError = new SkillPublishedRefreshError(version.version)
+    }
+
     await get().reconcileSkills()
     await get().loadSection('skills', { force: true })
+    if (refreshError) throw refreshError
   },
 
   keepArchivedCopy: async (slug, newSlug) => {
@@ -1624,6 +1668,7 @@ export const useTeamShareBrowserStore = create<TeamShareBrowserState>((set, get)
     await invoke('team_skill_restore_trashed', { trashedPath: path, slug: newSlug })
     get().dismissArchived(slug)
     await get().loadSection('skills', { force: true })
+    await refreshLocalSkillsRuntime()
   },
 
   dismissRetired: (slug) =>
@@ -1651,6 +1696,7 @@ export const useTeamShareBrowserStore = create<TeamShareBrowserState>((set, get)
       })
     await get().reconcileSkills()
     await get().loadSection('skills', { force: true })
+    await refreshLocalSkillsRuntime()
   },
 
   reconcileSkills: async () => {
@@ -1858,6 +1904,7 @@ export const useTeamShareBrowserStore = create<TeamShareBrowserState>((set, get)
         .loadSection('skills', { force: true })
         .catch(() => {})
     }
+    await refreshLocalSkillsRuntime()
     return trashedPath
   },
 
@@ -1870,6 +1917,7 @@ export const useTeamShareBrowserStore = create<TeamShareBrowserState>((set, get)
     set((s) => ({ draftRecoveryRevision: s.draftRecoveryRevision + 1 }))
     await get().reconcileSkills()
     await get().loadSection('skills', { force: true })
+    await refreshLocalSkillsRuntime()
   },
 
   forkSkill: async (slug, newSlug) => {


### PR DESCRIPTION
## Summary
- Normalize OpenCode `skills.paths` so the hosted team root always outranks `~/.agents/skills`, and stop writing the member root into workspace `opencode.json` (that copy was shadowing global order).
- Add `POST /v1/workspaces/:id/skills/refresh` so the UI can register `RefreshChangeKind::Skills` without rewriting files.
- After auxiliary skill-file saves, tree mutations, and publish/install/revert/discard, notify the daemon unconditionally. Publish already succeeded on the cloud is reported as a refresh failure, not a publish failure.

## Test plan
- [ ] On a machine whose global `skills.paths` still has `~/.agents/skills` first, restart daemon and confirm hosted root is now first; custom paths remain.
- [ ] Hosted `say-hello` prints `hello-new`, member copy prints `hello-old`; new session uses `hello-new`.
- [ ] Edit a non-`SKILL.md` file (e.g. `scripts/hello.js`), save, start a new session — output matches the saved file.
- [ ] Publish a team skill when rebaseline leaves disk unchanged; new session still uses the published content.
- [ ] If local refresh fails after a successful publish, UI says the version was published and must not look like a generic publish failure.
- [ ] An in-flight turn is not interrupted; pending refresh applies after it ends.


Made with [Cursor](https://cursor.com)