### PR TITLE
fix(daemon): fail-closed skill refresh on attach and mixed pending

### DIFF
--- a/apps/daemon/src/daemon/server/runtime_lifecycle.rs
+++ b/apps/daemon/src/daemon/server/runtime_lifecycle.rs
@@ -576,17 +576,19 @@ impl DaemonServer {
         let should_bind_remote_target = !session_id.is_empty() && !requester_actor_id.is_empty();
 
         if let Some(supervisor) = self.runtime_supervisor.as_ref() {
-            if let Err(error) = supervisor
-                .apply_pending_skills_refresh(&ws_id, std::path::Path::new(&resolved_worktree))
+            supervisor
+                .require_skills_refresh_for_attach(&ws_id, std::path::Path::new(&resolved_worktree))
                 .await
-            {
-                tracing::warn!(
-                    workspace_id = %ws_id,
-                    worktree = %resolved_worktree,
-                    error = %error,
-                    "pending skills refresh before session attach failed"
-                );
-            }
+                .map_err(|error| StartRuntimeError {
+                    error_code: match &error {
+                        crate::config::workspace_control::WorkspaceControlError::ActiveTurn(_) => {
+                            "WORKSPACE_BUSY".to_string()
+                        }
+                        _ => "SKILLS_REFRESH_FAILED".to_string(),
+                    },
+                    error_message: error.to_string(),
+                    failed_stage: "skills_refresh".to_string(),
+                })?;
         }
 
         // Spawn.

--- a/apps/daemon/src/http/runtime_adapter.rs
+++ b/apps/daemon/src/http/runtime_adapter.rs
@@ -27,13 +27,14 @@ use serde::{Deserialize, Serialize};
 use tokio::sync::broadcast;
 use uuid::Uuid;
 
+use crate::config::workspace_control::WorkspaceControlError;
 use crate::proto::amux;
 use crate::runtime::acp_event_frame::AcpEventFrame;
 use crate::runtime::adapter::{runtime_envelopes_from_acp_event, RuntimeEnvelope};
 use crate::runtime::supervisor::prepare_workspace;
 use crate::runtime::RuntimeManager;
 
-use super::errors::HttpError;
+use super::errors::{ErrorCode, HttpError};
 use super::events::SessionEvent;
 
 /// Parameters accepted by [`RuntimeAdapter::create_session`].
@@ -539,6 +540,18 @@ impl Clone for StubRuntimeAdapter {
     }
 }
 
+fn map_skills_attach_barrier_error(error: WorkspaceControlError) -> HttpError {
+    match error {
+        WorkspaceControlError::ActiveTurn(id) => HttpError::new(
+            ErrorCode::SessionBusy,
+            format!("workspace {id} has an active agent turn; retry after the turn ends"),
+        ),
+        other => HttpError::internal(format!(
+            "pending skills refresh before session attach failed: {other}"
+        )),
+    }
+}
+
 // ── RuntimeManager facade ───────────────────────────────────────────────────
 
 pub struct RuntimeManagerAdapter {
@@ -810,17 +823,10 @@ impl RuntimeManagerAdapter {
         })?;
         if let Some(supervisor) = self.runtime_supervisor.get() {
             let workspace_id = workspace_id.as_deref().unwrap_or("");
-            if let Err(error) = supervisor
-                .apply_pending_skills_refresh(workspace_id, std::path::Path::new(&worktree))
+            supervisor
+                .require_skills_refresh_for_attach(workspace_id, std::path::Path::new(&worktree))
                 .await
-            {
-                tracing::warn!(
-                    workspace_id,
-                    worktree,
-                    error = %error,
-                    "pending skills refresh before session attach failed"
-                );
-            }
+                .map_err(map_skills_attach_barrier_error)?;
         }
         let mut manager = self.manager.lock().await;
         manager
@@ -1641,6 +1647,59 @@ mod tests {
             crate::runtime::execution_context::ProcessEnvRevision::from_bindings(
                 &captures[0].extra_env
             )
+        );
+    }
+
+    #[tokio::test]
+    async fn spawn_runtime_refuses_when_skills_refresh_is_blocked_by_active_turn() {
+        let workspace = tempfile::tempdir().unwrap();
+        let workspace_id =
+            crate::runtime::refresh::refresh_watch::workspace_runtime_id(workspace.path());
+        let mut manager = RuntimeManager::new(RuntimeManager::default_launch_configs(), None);
+        let attach_captures = crate::runtime::test_support::install_capturing_backend(&mut manager);
+        manager.add_test_workspace_runtime(
+            "rt-busy",
+            &workspace.path().to_string_lossy(),
+            &workspace_id,
+            amux::AgentStatus::Active,
+        );
+        let manager = Arc::new(tokio::sync::Mutex::new(manager));
+        let supervisor = crate::runtime::RuntimeSupervisor::new(manager.clone());
+        supervisor
+            .refresh_coordinator()
+            .record_change(
+                &workspace_id,
+                workspace.path(),
+                crate::runtime::refresh::RefreshChangeKind::Skills,
+                crate::runtime::refresh::RefreshSource::UiMutation,
+            )
+            .await
+            .unwrap();
+        let adapter = RuntimeManagerAdapter::new_with_execution_context_assembler(
+            manager,
+            16,
+            Some(supervisor.refresh_coordinator()),
+            Some(Arc::new(CapturingContextAssembler {
+                captured: Arc::new(std::sync::Mutex::new(Vec::new())),
+            })),
+        );
+        adapter.set_runtime_supervisor(supervisor);
+
+        let err = adapter
+            .spawn_runtime_in_worktree(
+                Uuid::new_v4(),
+                amux::AgentType::Opencode,
+                Some(workspace_id),
+                None,
+                None,
+                workspace.path().to_string_lossy().as_ref(),
+            )
+            .await
+            .expect_err("busy pending skills must refuse spawn");
+        assert_eq!(err.code, ErrorCode::SessionBusy);
+        assert!(
+            attach_captures.lock().unwrap().is_empty(),
+            "fail-closed attach must not start a runtime"
         );
     }
 

--- a/apps/daemon/src/runtime/refresh.rs
+++ b/apps/daemon/src/runtime/refresh.rs
@@ -459,6 +459,31 @@ impl RuntimeRefreshCoordinator {
         }
     }
 
+    /// Drop one pending kind after it has been applied independently.
+    ///
+    /// Skills can be cache-invalidated without applying MCP/env/provider
+    /// changes. When `kind` is the last remaining kind the workspace is
+    /// removed (clean); otherwise other kinds stay pending.
+    pub async fn clear_change_kind(&self, workspace_id: &str, kind: RefreshChangeKind) {
+        let mut guard = self.inner.write().await;
+        let Some(state) = guard.workspaces.get_mut(workspace_id) else {
+            return;
+        };
+        state.change_kinds.remove(&kind);
+        if state.change_kinds.is_empty() {
+            guard.workspaces.remove(workspace_id);
+            return;
+        }
+        state.strongest_impact = strongest_impact(state.change_kinds.iter().copied());
+        state.recommended_action = recommended_action_for_kinds(&state.change_kinds);
+        if state.status == WorkspaceRefreshStatus::Applying {
+            state.status = WorkspaceRefreshStatus::Pending;
+        }
+        state.apply_attempt_id = None;
+        state.auto_apply_blocked_by_active_runtime = false;
+        state.last_error = None;
+    }
+
     pub async fn mark_apply_failed(
         &self,
         workspace_id: &str,
@@ -775,6 +800,39 @@ mod tests {
         let dto = coordinator.runtime_refresh_dto("ws-apply-race").await;
         assert_eq!(dto.status, "pending");
         assert!(dto.change_kinds.contains(&"skills".to_string()));
+        assert!(dto.change_kinds.contains(&"mcp".to_string()));
+    }
+
+    #[tokio::test]
+    async fn clear_change_kind_keeps_other_pending_kinds() {
+        let coordinator = RuntimeRefreshCoordinator::new();
+        let workspace = ws_path("ws-clear-kind");
+        coordinator
+            .record_change(
+                "ws-clear-kind",
+                &workspace,
+                RefreshChangeKind::Skills,
+                RefreshSource::UiMutation,
+            )
+            .await
+            .unwrap();
+        coordinator
+            .record_change(
+                "ws-clear-kind",
+                &workspace,
+                RefreshChangeKind::Mcp,
+                RefreshSource::FilesystemWatch,
+            )
+            .await
+            .unwrap();
+
+        coordinator
+            .clear_change_kind("ws-clear-kind", RefreshChangeKind::Skills)
+            .await;
+
+        let dto = coordinator.runtime_refresh_dto("ws-clear-kind").await;
+        assert_eq!(dto.status, "pending");
+        assert!(!dto.change_kinds.iter().any(|k| k == "skills"));
         assert!(dto.change_kinds.contains(&"mcp".to_string()));
     }
 

--- a/apps/daemon/src/runtime/supervisor.rs
+++ b/apps/daemon/src/runtime/supervisor.rs
@@ -1912,6 +1912,9 @@ impl RuntimeSupervisor {
     /// Idle workspaces dispose the cached OpenCode directory instance before
     /// this returns. An active turn is left running; the pending Skills
     /// refresh is applied by the auto-applier (or the next attach) once idle.
+    ///
+    /// Mixed pending (Skills plus MCP/env/…) still invalidates the Skills
+    /// cache and clears only the Skills kind. Other kinds stay pending.
     pub async fn apply_pending_skills_refresh(
         &self,
         workspace_id: &str,
@@ -1925,7 +1928,11 @@ impl RuntimeSupervisor {
         }) else {
             return Ok(SkillsRefreshApplyStatus::Applied(ApplyOutcome::AppliedLive));
         };
-        if !auto_applicable_refresh(&state) {
+        if !state
+            .change_kinds
+            .iter()
+            .any(|kind| matches!(kind, RefreshChangeKind::Skills))
+        {
             return Ok(SkillsRefreshApplyStatus::Applied(ApplyOutcome::AppliedLive));
         }
         let busy = {
@@ -1941,11 +1948,17 @@ impl RuntimeSupervisor {
         self.refresh
             .set_auto_apply_blocked_by_active_runtime(workspace_id, false)
             .await;
+        // Do not call `apply_refresh`: that clears every pending kind.
         match self
-            .apply_refresh(workspace_id, workspace_path, false)
+            .reload_workspace(workspace_id, workspace_path, false)
             .await
         {
-            Ok(outcome) => Ok(SkillsRefreshApplyStatus::Applied(outcome)),
+            Ok(outcome) => {
+                self.refresh
+                    .clear_change_kind(workspace_id, RefreshChangeKind::Skills)
+                    .await;
+                Ok(SkillsRefreshApplyStatus::Applied(outcome))
+            }
             Err(WorkspaceControlError::ActiveTurn(_)) => {
                 self.refresh
                     .set_auto_apply_blocked_by_active_runtime(workspace_id, true)
@@ -1953,6 +1966,26 @@ impl RuntimeSupervisor {
                 Ok(SkillsRefreshApplyStatus::PendingActiveTurn)
             }
             Err(err) => Err(err),
+        }
+    }
+
+    /// Session attach barrier: only an applied Skills refresh may proceed.
+    ///
+    /// `PendingActiveTurn` and dispose/apply errors both refuse the spawn so
+    /// a new session cannot attach to a stale OpenCode instance.
+    pub async fn require_skills_refresh_for_attach(
+        &self,
+        workspace_id: &str,
+        workspace_path: &Path,
+    ) -> Result<ApplyOutcome, WorkspaceControlError> {
+        match self
+            .apply_pending_skills_refresh(workspace_id, workspace_path)
+            .await?
+        {
+            SkillsRefreshApplyStatus::Applied(outcome) => Ok(outcome),
+            SkillsRefreshApplyStatus::PendingActiveTurn => {
+                Err(WorkspaceControlError::ActiveTurn(workspace_id.to_owned()))
+            }
         }
     }
 }
@@ -2814,6 +2847,164 @@ mod tests {
             .await;
         assert_eq!(dto.status, "pending");
         assert!(dto.auto_apply_blocked_by_active_runtime);
+        assert!(dto.change_kinds.iter().any(|k| k == "skills"));
+    }
+
+    #[tokio::test]
+    async fn apply_pending_skills_refresh_clears_only_skills_when_mixed() {
+        use wiremock::matchers::{method, path, query_param};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        let dir = tempfile::tempdir().unwrap();
+        let workspace_id = refresh_watch::workspace_runtime_id(dir.path());
+        let directory = dir.path().to_string_lossy().into_owned();
+        Mock::given(method("POST"))
+            .and(path("/instance/dispose"))
+            .and(query_param("directory", directory))
+            .respond_with(ResponseTemplate::new(200))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let pool = OpenCodeHostPool::new(Arc::new(BaseUrlFactory {
+            base_url: server.uri(),
+        }));
+        let supervisor = RuntimeSupervisor::new_with_host_pool(
+            Arc::new(AsyncMutex::new(RuntimeManager::new(
+                RuntimeManager::default_launch_configs(),
+                None,
+            ))),
+            pool.clone(),
+        );
+        let (_revision, _lease) = seed_domain(&pool, &workspace_id, "v1").await;
+
+        for kind in [
+            refresh::RefreshChangeKind::Skills,
+            refresh::RefreshChangeKind::Mcp,
+            refresh::RefreshChangeKind::EnvVars,
+        ] {
+            supervisor
+                .refresh_coordinator()
+                .record_change(
+                    &workspace_id,
+                    dir.path(),
+                    kind,
+                    refresh::RefreshSource::UiMutation,
+                )
+                .await
+                .unwrap();
+        }
+
+        let status = supervisor
+            .apply_pending_skills_refresh(&workspace_id, dir.path())
+            .await
+            .expect("apply skills from mixed pending");
+        assert!(matches!(
+            status,
+            SkillsRefreshApplyStatus::Applied(ApplyOutcome::ReloadRequired)
+        ));
+        let dto = supervisor
+            .refresh_coordinator()
+            .runtime_refresh_dto(&workspace_id)
+            .await;
+        assert_eq!(dto.status, "pending");
+        assert!(!dto.change_kinds.iter().any(|k| k == "skills"));
+        assert!(dto.change_kinds.contains(&"mcp".to_string()));
+        assert!(dto.change_kinds.contains(&"env_vars".to_string()));
+    }
+
+    #[tokio::test]
+    async fn require_skills_refresh_for_attach_fails_closed_when_busy() {
+        let dir = tempfile::tempdir().unwrap();
+        let workspace_id = refresh_watch::workspace_runtime_id(dir.path());
+        let supervisor = RuntimeSupervisor::new(Arc::new(AsyncMutex::new(RuntimeManager::new(
+            RuntimeManager::default_launch_configs(),
+            None,
+        ))));
+        {
+            let mut manager = supervisor.agents.lock().await;
+            manager.add_test_workspace_runtime(
+                "rt-busy",
+                &dir.path().to_string_lossy(),
+                &workspace_id,
+                amux::AgentStatus::Active,
+            );
+        }
+        supervisor
+            .refresh_coordinator()
+            .record_change(
+                &workspace_id,
+                dir.path(),
+                refresh::RefreshChangeKind::Skills,
+                refresh::RefreshSource::UiMutation,
+            )
+            .await
+            .unwrap();
+
+        let err = supervisor
+            .require_skills_refresh_for_attach(&workspace_id, dir.path())
+            .await
+            .expect_err("busy workspace must refuse attach");
+        assert!(matches!(
+            err,
+            WorkspaceControlError::ActiveTurn(ref id) if id == &workspace_id
+        ));
+        let dto = supervisor
+            .refresh_coordinator()
+            .runtime_refresh_dto(&workspace_id)
+            .await;
+        assert_eq!(dto.status, "pending");
+        assert!(dto.change_kinds.iter().any(|k| k == "skills"));
+    }
+
+    #[tokio::test]
+    async fn require_skills_refresh_for_attach_fails_when_dispose_errors() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/instance/dispose"))
+            .respond_with(ResponseTemplate::new(500))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let dir = tempfile::tempdir().unwrap();
+        let workspace_id = refresh_watch::workspace_runtime_id(dir.path());
+        let pool = OpenCodeHostPool::new(Arc::new(BaseUrlFactory {
+            base_url: server.uri(),
+        }));
+        let supervisor = RuntimeSupervisor::new_with_host_pool(
+            Arc::new(AsyncMutex::new(RuntimeManager::new(
+                RuntimeManager::default_launch_configs(),
+                None,
+            ))),
+            pool.clone(),
+        );
+        let (_revision, _lease) = seed_domain(&pool, &workspace_id, "v1").await;
+        supervisor
+            .refresh_coordinator()
+            .record_change(
+                &workspace_id,
+                dir.path(),
+                refresh::RefreshChangeKind::Skills,
+                refresh::RefreshSource::UiMutation,
+            )
+            .await
+            .unwrap();
+
+        let err = supervisor
+            .require_skills_refresh_for_attach(&workspace_id, dir.path())
+            .await
+            .expect_err("dispose failure must refuse attach");
+        assert!(matches!(err, WorkspaceControlError::Io(_)));
+        let dto = supervisor
+            .refresh_coordinator()
+            .runtime_refresh_dto(&workspace_id)
+            .await;
+        assert_eq!(dto.status, "pending");
         assert!(dto.change_kinds.iter().any(|k| k == "skills"));
     }
 


### PR DESCRIPTION
## Summary
- Mixed pending (Skills plus MCP/Env) no longer returns `applied` without disposing the OpenCode instance. Skills cache is invalidated independently; other kinds stay pending.
- HTTP and daemon session attach both use `require_skills_refresh_for_attach`: only `Applied` continues. `PendingActiveTurn` is busy/retry; dispose/apply errors fail the spawn so a new session cannot reuse a stale instance.

Follow-up to #1189.

## Test plan
- [x] `node scripts/daemon-cargo.js test --bin amuxd apply_pending_skills_refresh`
- [x] `node scripts/daemon-cargo.js test --bin amuxd clear_change_kind`
- [x] `node scripts/daemon-cargo.js test --bin amuxd require_skills_refresh_for_attach`
- [x] `node scripts/daemon-cargo.js test --bin amuxd spawn_runtime_refuses_when_skills`
- [x] `node scripts/daemon-cargo.js test --bin amuxd skills_plus_env_refresh`
- [ ] Manual: save a skill while MCP/env refresh is also pending, then start a new session and confirm it loads the new pack
- [ ] Manual: start a new session while another has an active turn and skills refresh is pending — spawn is refused until the turn ends


Made with [Cursor](https://cursor.com)