### PR TITLE
feat(fc): multipart upload support on the S3 blob store

### DIFF
--- a/services/fc/src/lib/team-blob-storage.ts
+++ b/services/fc/src/lib/team-blob-storage.ts
@@ -1,8 +1,12 @@
 import {
+  AbortMultipartUploadCommand,
+  CompleteMultipartUploadCommand,
+  CreateMultipartUploadCommand,
   DeleteObjectCommand,
   GetObjectCommand,
   HeadObjectCommand,
   PutObjectCommand,
+  UploadPartCommand,
 } from "@aws-sdk/client-s3";
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
 import { createServiceRoleClient } from "./supabase.js";
@@ -79,6 +83,51 @@ function toPublicUrl(signedUrl: string): string {
   }
 }
 
+/** One finished part, as the client reports it back. */
+export interface MultipartPart {
+  partNumber: number;
+  etag: string;
+}
+
+/**
+ * Chunked upload, for backends that have it.
+ *
+ * The single presigned PUT the rest of this module deals in is one request for
+ * the whole object: the client must hold every byte in memory to sign nothing
+ * and send it once, and a connection that drops at 90% starts again at 0. This
+ * splits one object across N independently-retryable PUTs.
+ *
+ * `minPartBytes` is not a tuning knob, it is what the store rejects below.
+ * S3 refuses any part but the last under 5 MiB at CompleteMultipartUpload time
+ * — `EntityTooSmall`, after every byte has already been sent — and MinIO, which
+ * is what self-host runs, enforces the same floor. So the number has to travel
+ * to the client: a daemon configured for 1 MiB parts must learn that it cannot
+ * have them BEFORE it uploads, not from a failed complete.
+ */
+export interface MultipartSupport {
+  /** Smallest non-final part the backend accepts. */
+  minPartBytes: number;
+  /** Hard ceiling on part count for one object. */
+  maxParts: number;
+  /** Begin an upload; returns the backend's upload id. */
+  create(objectPath: string): Promise<string>;
+  /** Presign the PUT for one part. The client reads the ETag off the response. */
+  signPart(
+    objectPath: string,
+    uploadId: string,
+    partNumber: number,
+    expiresIn?: number,
+  ): Promise<string>;
+  /** Assemble the parts into the final object. */
+  complete(objectPath: string, uploadId: string, parts: MultipartPart[]): Promise<void>;
+  /**
+   * Discard an upload and its parts. Idempotent for the same reason `remove`
+   * is: the only callers are error paths, and "already gone" is the outcome
+   * they wanted. Unaborted uploads keep billing for storage nobody can read.
+   */
+  abort(objectPath: string, uploadId: string): Promise<void>;
+}
+
 /** What sync-handlers and the skills routes need from a blob store. */
 export interface BlobStorage {
   createUploadUrl(objectPath: string): Promise<string>;
@@ -91,7 +140,26 @@ export interface BlobStorage {
    * wanted. Real failures (credentials, network, bucket gone) still throw.
    */
   remove(objectPath: string): Promise<void>;
+  /**
+   * Chunked upload, or `undefined` on a backend without it.
+   *
+   * Optional rather than a throwing stub: "does this deployment do multipart"
+   * is a question the sync handler has to answer before it starts, so the
+   * client can be told to fall back to a single PUT rather than discovering it
+   * halfway through an upload.
+   */
+  multipart?: MultipartSupport;
 }
+
+/**
+ * S3's floor on every part but the last, and its ceiling on part count.
+ *
+ * Both are protocol facts rather than settings: AWS S3, MinIO and Alibaba OSS
+ * all reject a short non-final part at complete time. They are exported so the
+ * sync handler can hand them to the client instead of restating them.
+ */
+export const S3_MIN_PART_BYTES = 5 * 1024 * 1024;
+export const S3_MAX_PARTS = 10_000;
 
 export const TEAM_BLOBS_BUCKET = () => process.env.TEAM_BLOBS_STORAGE_BUCKET || "team-blobs";
 export const SKILLS_BUCKET = () => process.env.SKILLS_STORAGE_BUCKET || "team-skills";
@@ -216,6 +284,67 @@ export function s3BlobStorage(bucket: () => string, prefix: () => string): BlobS
         if (isMissingObject(e)) return;
         throw e;
       }
+    },
+
+    multipart: {
+      minPartBytes: S3_MIN_PART_BYTES,
+      maxParts: S3_MAX_PARTS,
+
+      async create(objectPath) {
+        const out = await getS3Client().send(
+          new CreateMultipartUploadCommand({ Bucket: bucket(), Key: key(objectPath) }),
+        );
+        if (!out.UploadId) throw new Error("createMultipartUpload returned no UploadId");
+        return out.UploadId;
+      },
+
+      async signPart(objectPath, uploadId, partNumber, expiresIn = 3600) {
+        // Longer-lived than the single-PUT URL by design: a multipart upload is
+        // N sequential transfers of a large object, and the last part's URL has
+        // to still be valid after the first N-1 have gone up.
+        return getSignedUrl(
+          getS3Client() as any,
+          new UploadPartCommand({
+            Bucket: bucket(),
+            Key: key(objectPath),
+            UploadId: uploadId,
+            PartNumber: partNumber,
+          }),
+          { expiresIn },
+        );
+      },
+
+      async complete(objectPath, uploadId, parts) {
+        await getS3Client().send(
+          new CompleteMultipartUploadCommand({
+            Bucket: bucket(),
+            Key: key(objectPath),
+            UploadId: uploadId,
+            // S3 requires ascending part numbers; the client assembles this
+            // list from concurrent uploads, so sort rather than trust order.
+            MultipartUpload: {
+              Parts: [...parts]
+                .sort((a, b) => a.partNumber - b.partNumber)
+                .map((pt) => ({ PartNumber: pt.partNumber, ETag: pt.etag })),
+            },
+          }),
+        );
+      },
+
+      async abort(objectPath, uploadId) {
+        try {
+          await getS3Client().send(
+            new AbortMultipartUploadCommand({
+              Bucket: bucket(),
+              Key: key(objectPath),
+              UploadId: uploadId,
+            }),
+          );
+        } catch (e) {
+          if (isMissingObject(e)) return;
+          throw e;
+        }
+      },
     },
   };
 }


### PR DESCRIPTION
**Draft on purpose: nothing calls this yet.** It is the store-level half of
chunked blob upload — the sync-handler wiring and the client side are still to
do. Opening it so the code stops living only on one machine's disk.

## Where it came from

This was sitting uncommitted in a working tree
(`teamclaw-worktrees/task/knowleage-tong-bu-wo`, last edited 2026-08-27): no
commit, no remote branch, and that worktree's branch has zero commits of its own
and is 264 behind `main`. One `git worktree remove` and it was gone. Rebased
onto current `main` — `services/fc/src/lib/team-blob-storage.ts` had not moved
since (`b199eb52` then, `b199eb52` now), so it applied clean.

## What it adds

`MultipartSupport` on the `BlobStorage` interface, implemented for
`s3BlobStorage`: `create` / `signPart` / `complete` / `abort`, plus the
`S3_MIN_PART_BYTES` / `S3_MAX_PARTS` constants.

The single presigned PUT everything else in this module uses is one request for
the whole object: the client has to hold every byte, and a connection that drops
at 90% restarts at 0.

Two shapes in the interface are deliberate:

- **`minPartBytes` / `maxParts` are exported, not internal.** They are protocol
  facts, not tuning knobs — S3 rejects any non-final part under 5 MiB at
  `CompleteMultipartUpload` time, i.e. *after* every byte has already been sent
  (`EntityTooSmall`), and MinIO (what self-host runs) enforces the same floor.
  A daemon configured for 1 MiB parts has to learn it cannot have them before it
  starts uploading, not from a failed complete.
- **`multipart` is optional, not a throwing stub.** "Does this deployment do
  chunked upload" has to be answerable before an upload begins, so a backend
  without it can be told to fall back to a single PUT rather than discovering it
  halfway through.

`complete` sorts parts by number rather than trusting the client's order (S3
requires ascending), and `abort` is idempotent for the same reason `remove` is —
its only callers are error paths, and an unaborted upload keeps billing for
storage nobody can read.

## Testing

`services/fc` is not in the pnpm workspace and has no CI job, so this was run
locally with its own `npm ci`:

- `npm run build` (`tsconfig.json` — the config the container image builds with,
  where a `src/` type error takes the whole self-host deploy down): clean.
- `npm test`: 874 tests, **861 pass / 0 fail** / 13 skipped.
- `npm run typecheck` (`tsconfig.test.json`): 26 errors, every one of them
  pre-existing in `test/*.ts` on `main` — I diffed the error list with and
  without this change and it is byte-identical.

## Before this can come out of draft

- A caller: sync-handler routes to create / sign / complete / abort, and the
  part-size negotiation reaching the client.
- Tests for the new surface — `test/team-blob-storage.test.ts` currently covers
  the single-PUT path only (4 tests, all still passing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YLHqMLpNb9kbBJm891ooYv