### PR TITLE
Harden skills reconcile, publish, and ClawHub uninstall

### DIFF
--- a/apps/daemon/src/backend/cloud_api/mod.rs
+++ b/apps/daemon/src/backend/cloud_api/mod.rs
@@ -774,18 +774,18 @@ impl Backend for CloudApiBackend {
     }
 
     async fn team_skills(&self, team_id: &str) -> BackendResult<Vec<TeamSkillRow>> {
+        // `items` is required. A missing field must not deserialize as `[]` —
+        // empty desired set is HTTP 200 with an items array, including `[]`.
+        // 404 / 5xx / auth / decode stay Err so reconcile keeps the installed
+        // set. Mapping NotFound to Ok([]) used to wipe every hosted pack on a
+        // proxy misroute. See docs/architecture/hosted-skill-reconcile-fail-closed.md.
         #[derive(serde::Deserialize)]
         struct Resp {
-            #[serde(default)]
             items: Vec<TeamSkillRow>,
         }
         let path = format!("/v1/teams/{team_id}/skills");
-        match self.get::<Resp>(&path).await {
-            Ok(r) => Ok(r.items),
-            // A team with no registry is not an error, same as team MCP's 404.
-            Err(BackendError::NotFound(_)) => Ok(Vec::new()),
-            Err(e) => Err(e),
-        }
+        let resp: Resp = self.get(&path).await?;
+        Ok(resp.items)
     }
 
     async fn team_skill_download(
@@ -3076,6 +3076,111 @@ mod tests {
         let backend = CloudApiBackend::new(config(&server));
         let result = backend.get_effective_default_agent("team-1").await.unwrap();
         assert_eq!(result, Some("agent-123".to_string()));
+    }
+
+    #[tokio::test]
+    async fn team_skills_401_is_auth_err_not_empty_list() {
+        let server = MockServer::start().await;
+        mount_refresh(&server).await;
+        Mock::given(method("GET"))
+            .and(path("/v1/teams/team-1/skills"))
+            .respond_with(
+                ResponseTemplate::new(401).set_body_json(unauthorized_envelope("JWT expired")),
+            )
+            .mount(&server)
+            .await;
+        let backend = CloudApiBackend::new(config(&server));
+        let err = backend.team_skills("team-1").await.unwrap_err();
+        assert!(matches!(err, BackendError::Auth(_)), "got {err:?}");
+    }
+
+    #[tokio::test]
+    async fn team_skills_404_is_not_found_err_not_empty_list() {
+        let server = MockServer::start().await;
+        mount_refresh(&server).await;
+        Mock::given(method("GET"))
+            .and(path("/v1/teams/team-1/skills"))
+            .respond_with(ResponseTemplate::new(404).set_body_json(serde_json::json!({
+                "error": { "code": "not_found", "message": "team not found" }
+            })))
+            .mount(&server)
+            .await;
+        let backend = CloudApiBackend::new(config(&server));
+        let err = backend.team_skills("team-1").await.unwrap_err();
+        assert!(matches!(err, BackendError::NotFound(_)), "got {err:?}");
+    }
+
+    #[tokio::test]
+    async fn team_skills_500_is_provider_err_not_empty_list() {
+        let server = MockServer::start().await;
+        mount_refresh(&server).await;
+        Mock::given(method("GET"))
+            .and(path("/v1/teams/team-1/skills"))
+            .respond_with(ResponseTemplate::new(500))
+            .mount(&server)
+            .await;
+        let backend = CloudApiBackend::new(config(&server));
+        let err = backend.team_skills("team-1").await.unwrap_err();
+        assert!(matches!(err, BackendError::Provider { .. }), "got {err:?}");
+    }
+
+    #[tokio::test]
+    async fn team_skills_200_without_items_is_decode_err() {
+        let server = MockServer::start().await;
+        mount_refresh(&server).await;
+        Mock::given(method("GET"))
+            .and(path("/v1/teams/team-1/skills"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({})))
+            .mount(&server)
+            .await;
+        let backend = CloudApiBackend::new(config(&server));
+        let err = backend.team_skills("team-1").await.unwrap_err();
+        assert!(matches!(err, BackendError::Serde(_)), "got {err:?}");
+    }
+
+    #[tokio::test]
+    async fn team_skills_200_empty_items_is_empty_desired_set() {
+        let server = MockServer::start().await;
+        mount_refresh(&server).await;
+        Mock::given(method("GET"))
+            .and(path("/v1/teams/team-1/skills"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "items": []
+            })))
+            .mount(&server)
+            .await;
+        let backend = CloudApiBackend::new(config(&server));
+        let rows = backend.team_skills("team-1").await.unwrap();
+        assert!(rows.is_empty());
+    }
+
+    #[tokio::test]
+    async fn team_skills_200_with_items_is_desired_set() {
+        let server = MockServer::start().await;
+        mount_refresh(&server).await;
+        Mock::given(method("GET"))
+            .and(path("/v1/teams/team-1/skills"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "items": [{
+                    "slug": "deploy-check",
+                    "summary": "check",
+                    "category": "devops",
+                    "whenToUse": "before release",
+                    "whenNotToUse": "not locally",
+                    "latestVersion": 3,
+                    "installed": true,
+                    "installedVersion": 2
+                }]
+            })))
+            .mount(&server)
+            .await;
+        let backend = CloudApiBackend::new(config(&server));
+        let rows = backend.team_skills("team-1").await.unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].slug, "deploy-check");
+        assert_eq!(rows[0].latest_version, 3);
+        assert!(rows[0].installed);
+        assert_eq!(rows[0].installed_version, Some(2));
     }
 
     #[tokio::test]

--- a/apps/daemon/src/backend/mod.rs
+++ b/apps/daemon/src/backend/mod.rs
@@ -56,8 +56,7 @@ pub mod records;
 pub use records::{
     ActorDirectoryRow, BackendParticipantRow, BackendSessionAndParticipants, BackendSessionRow,
     ClaimResult, GatewaySessionRow, SessionRoster, SessionRosterEntry, SessionRosterSelfAgent,
-    StoredMessage, WorkspaceRow,
-    WorkspaceUpsert,
+    StoredMessage, WorkspaceRow, WorkspaceUpsert,
 };
 
 /// MQTT settings delivered by `/v1/config/bootstrap`. The full broker URL

--- a/apps/daemon/src/runtime/team_skills.rs
+++ b/apps/daemon/src/runtime/team_skills.rs
@@ -45,9 +45,9 @@ use std::time::{Duration, Instant};
 use tokio::sync::Mutex as AsyncMutex;
 
 use teamclu_skillpack::{
-    apply_zip_mode, build_manifest_for, inspect, list_managed_paths, read_origin, sanitize_zip_path,
-    swap_managed_files, write_origin, write_registry_frontmatter, DirtyState, RegistryFields,
-    SkillOrigin, ORIGIN_VERSION, SOURCE_TEAM,
+    apply_zip_mode, build_manifest_for, commit_staged_pack, inspect, list_managed_paths,
+    read_origin, sanitize_zip_path, sha256_hex, write_origin, write_registry_frontmatter,
+    RegistryFields, SkillOrigin, ORIGIN_VERSION, SOURCE_TEAM,
 };
 
 use crate::backend::{Backend, TeamSkillRow};
@@ -126,21 +126,10 @@ impl TeamSkillReconciler {
     /// which only exists to pull the next tick forward.
     pub async fn reconcile_now(&self, team_id: &str) -> TeamSkillReconcileOutcome {
         let _guard = self.reconcile_lock.lock().await;
-        let rows = match self.backend.team_skills(team_id).await {
-            Ok(rows) => rows,
-            Err(e) => {
-                // Leave the disk exactly as it is. An unreachable registry must
-                // never read as "the team removed everything" — that would
-                // strip a working agent of its skills every time the network
-                // blinked, and the packs would only come back on the next
-                // successful fetch.
-                tracing::warn!(team_id, error = %e, "team skills fetch failed; keeping the installed set");
-                return TeamSkillReconcileOutcome::default();
-            }
-        };
-
         let root = team_cloud_skills_dir(team_id);
-        let outcome = self.apply(team_id, &root, &rows).await;
+        let Some(outcome) = self.fetch_and_apply(team_id, &root).await else {
+            return TeamSkillReconcileOutcome::default();
+        };
 
         self.last_fetch
             .lock()
@@ -157,6 +146,31 @@ impl TeamSkillReconciler {
             );
         }
         outcome
+    }
+
+    /// Fetch the desired set and make `root` match it.
+    ///
+    /// `None` means the fetch failed (401 / 404 / 5xx / decode). The disk is
+    /// left alone and the TTL is not advanced, so the next tick retries.
+    /// Empty desired set is `Some` of an apply against `[]`.
+    async fn fetch_and_apply(
+        &self,
+        team_id: &str,
+        root: &Path,
+    ) -> Option<TeamSkillReconcileOutcome> {
+        let rows = match self.backend.team_skills(team_id).await {
+            Ok(rows) => rows,
+            Err(e) => {
+                // Leave the disk exactly as it is. An unreachable registry must
+                // never read as "the team removed everything" — that would
+                // strip a working agent of its skills every time the network
+                // blinked, and the packs would only come back on the next
+                // successful fetch.
+                tracing::warn!(team_id, error = %e, "team skills fetch failed; keeping the installed set");
+                return None;
+            }
+        };
+        Some(self.apply(team_id, root, &rows).await)
     }
 
     async fn apply(
@@ -275,20 +289,37 @@ impl TeamSkillReconciler {
             .await
             .map_err(|e| format!("read download body: {e}"))?;
 
+        if !download.content_hash.is_empty() {
+            let actual = sha256_hex(&bytes);
+            if actual != download.content_hash {
+                return Err(format!(
+                    "zip content_hash mismatch: expected {}, got {actual}",
+                    download.content_hash
+                ));
+            }
+        }
+        if download.size > 0 && download.size as usize != bytes.len() {
+            return Err(format!(
+                "zip size mismatch: expected {}, got {}",
+                download.size,
+                bytes.len()
+            ));
+        }
+
         let target = root.join(&row.slug);
         let staging = tempfile::tempdir().map_err(|e| format!("staging dir: {e}"))?;
         extract_zip_to_dir(&bytes, staging.path())?;
 
-        // Deletions are authorised only by a baseline we recorded ourselves.
-        let baseline = read_origin(&target).and_then(|o| o.files);
-        swap_managed_files(&target, staging.path(), baseline.as_ref())
-            .map_err(|e| format!("install files: {e}"))?;
+        // Finish the new tree in staging — frontmatter then origin — and only
+        // then make it live. Swap-then-origin left vN files next to a vN-1
+        // baseline when origin write failed, which inspect reads as Dirty and
+        // auto-follow never retries. See hosted-skill-reconcile-fail-closed.md.
         let shipped =
             list_managed_paths(staging.path()).map_err(|e| format!("list package files: {e}"))?;
 
         let requires = requires_list(row.requires.as_ref());
         write_registry_frontmatter(
-            &target,
+            staging.path(),
             &RegistryFields {
                 slug: &row.slug,
                 version,
@@ -302,13 +333,10 @@ impl TeamSkillReconciler {
         )
         .map_err(|e| format!("frontmatter: {e}"))?;
 
-        // Baseline last, and only after the frontmatter rewrite: it describes
-        // the directory as installed, not the archive as shipped. Scoped to the
-        // files the package shipped, so anything a script writes beside itself
-        // stays outside the set the pack claims to own.
-        let files = build_manifest_for(&target, &shipped).map_err(|e| format!("manifest: {e}"))?;
+        let files =
+            build_manifest_for(staging.path(), &shipped).map_err(|e| format!("manifest: {e}"))?;
         write_origin(
-            &target,
+            staging.path(),
             &SkillOrigin {
                 version: ORIGIN_VERSION,
                 registry: SOURCE_TEAM.to_string(),
@@ -320,6 +348,8 @@ impl TeamSkillReconciler {
             },
         )
         .map_err(|e| format!("origin.json: {e}"))?;
+
+        commit_staged_pack(&target, staging.path()).map_err(|e| format!("install files: {e}"))?;
 
         Ok(())
     }
@@ -493,8 +523,7 @@ fn is_dirty_pack(path: &Path) -> bool {
 
 fn archive_removed_pack(team_id: &str, dir: &Path, slug: &str) -> Result<(), String> {
     let archive_root = global_team_cloud_dir(team_id).join("archived-skills");
-    std::fs::create_dir_all(&archive_root)
-        .map_err(|e| format!("create archive dir: {e}"))?;
+    std::fs::create_dir_all(&archive_root).map_err(|e| format!("create archive dir: {e}"))?;
     let dest = archive_root.join(format!("{slug}-{}", now_millis()));
     std::fs::rename(dir, dest).map_err(|e| format!("archive skill {slug}: {e}"))?;
     Ok(())
@@ -656,5 +685,290 @@ mod tests {
         assert!(state
             .change_kinds
             .contains(&crate::runtime::refresh::RefreshChangeKind::Skills));
+    }
+
+    fn seed_installed_pack(root: &Path, slug: &str, version: i64, body: &str) {
+        let skill = root.join(slug);
+        write(
+            &skill,
+            "SKILL.md",
+            &format!("---\nname: {slug}\n---\n{body}\n"),
+        );
+        let files = teamclu_skillpack::build_manifest(&skill).unwrap();
+        write_origin(
+            &skill,
+            &SkillOrigin {
+                version: ORIGIN_VERSION,
+                registry: SOURCE_TEAM.to_string(),
+                slug: slug.into(),
+                installed_version: version.to_string(),
+                installed_at: 1,
+                team_id: Some("team-1".into()),
+                files: Some(files),
+            },
+        )
+        .unwrap();
+    }
+
+    fn skill_zip(body: &str) -> Vec<u8> {
+        use std::io::Write;
+        let mut buf = Vec::new();
+        {
+            let mut zip = zip::ZipWriter::new(std::io::Cursor::new(&mut buf));
+            let opts: zip::write::SimpleFileOptions = Default::default();
+            zip.start_file("SKILL.md", opts).unwrap();
+            zip.write_all(format!("---\nname: deploy-check\n---\n{body}\n").as_bytes())
+                .unwrap();
+            zip.finish().unwrap();
+        }
+        buf
+    }
+
+    fn cloud_config(server: &wiremock::MockServer) -> crate::provider_config::CloudApiConfig {
+        crate::provider_config::CloudApiConfig {
+            url: server.uri(),
+            refresh_token: "refresh".to_string(),
+            team_id: "team-1".to_string(),
+            actor_id: "agent-1".to_string(),
+        }
+    }
+
+    async fn mount_refresh(server: &wiremock::MockServer) {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+        Mock::given(method("POST"))
+            .and(path("/v1/auth/refresh"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "accessToken": "access-token",
+                "refreshToken": "rt-2",
+                "expiresAt": 9999999999_i64
+            })))
+            .mount(server)
+            .await;
+    }
+
+    async fn reconciler_for(server: &wiremock::MockServer) -> TeamSkillReconciler {
+        use crate::backend::cloud_api::CloudApiBackend;
+        TeamSkillReconciler::new(std::sync::Arc::new(CloudApiBackend::new(cloud_config(
+            server,
+        ))))
+    }
+
+    #[tokio::test]
+    async fn list_401_keeps_installed_packs() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        seed_installed_pack(root, "deploy-check", 1, "v1");
+
+        let server = MockServer::start().await;
+        mount_refresh(&server).await;
+        Mock::given(method("GET"))
+            .and(path("/v1/teams/team-1/skills"))
+            .respond_with(ResponseTemplate::new(401).set_body_json(serde_json::json!({
+                "error": { "code": "unauthorized", "message": "JWT expired" }
+            })))
+            .mount(&server)
+            .await;
+
+        assert!(reconciler_for(&server)
+            .await
+            .fetch_and_apply("team-1", root)
+            .await
+            .is_none());
+        assert!(root.join("deploy-check/SKILL.md").is_file());
+        assert_eq!(
+            read_origin(&root.join("deploy-check"))
+                .unwrap()
+                .installed_version,
+            "1"
+        );
+    }
+
+    #[tokio::test]
+    async fn list_404_keeps_installed_packs() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        seed_installed_pack(root, "deploy-check", 1, "v1");
+
+        let server = MockServer::start().await;
+        mount_refresh(&server).await;
+        Mock::given(method("GET"))
+            .and(path("/v1/teams/team-1/skills"))
+            .respond_with(ResponseTemplate::new(404).set_body_json(serde_json::json!({
+                "error": { "code": "not_found", "message": "no such team" }
+            })))
+            .mount(&server)
+            .await;
+
+        assert!(reconciler_for(&server)
+            .await
+            .fetch_and_apply("team-1", root)
+            .await
+            .is_none());
+        assert!(root.join("deploy-check/SKILL.md").is_file());
+    }
+
+    #[tokio::test]
+    async fn list_200_empty_items_uninstalls_clean_packs() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        seed_installed_pack(root, "deploy-check", 1, "v1");
+
+        let server = MockServer::start().await;
+        mount_refresh(&server).await;
+        Mock::given(method("GET"))
+            .and(path("/v1/teams/team-1/skills"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "items": []
+            })))
+            .mount(&server)
+            .await;
+
+        let outcome = reconciler_for(&server)
+            .await
+            .fetch_and_apply("team-1", root)
+            .await
+            .expect("200 empty list is a desired set");
+        assert_eq!(outcome.removed, 1);
+        assert!(!root.join("deploy-check").exists());
+    }
+
+    #[tokio::test]
+    async fn list_200_items_installs_pack() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+
+        let zip = skill_zip("v3 body");
+        let hash = sha256_hex(&zip);
+
+        let server = MockServer::start().await;
+        mount_refresh(&server).await;
+        Mock::given(method("GET"))
+            .and(path("/v1/teams/team-1/skills"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "items": [{
+                    "slug": "deploy-check",
+                    "summary": "check",
+                    "category": "devops",
+                    "whenToUse": "before release",
+                    "whenNotToUse": "not locally",
+                    "latestVersion": 3,
+                    "installed": true,
+                    "installedVersion": 1
+                }]
+            })))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path(
+                "/v1/teams/team-1/skills/deploy-check/versions/3/download",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "url": format!("{}/zip/deploy-check.zip", server.uri()),
+                "contentHash": hash,
+                "size": zip.len()
+            })))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/zip/deploy-check.zip"))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(zip.clone()))
+            .mount(&server)
+            .await;
+        Mock::given(method("PUT"))
+            .and(path("/v1/teams/team-1/skills/deploy-check/install"))
+            .respond_with(ResponseTemplate::new(204))
+            .mount(&server)
+            .await;
+
+        let outcome = reconciler_for(&server)
+            .await
+            .fetch_and_apply("team-1", root)
+            .await
+            .expect("200 items is a desired set");
+        assert_eq!(outcome.installed, 1);
+        let installed = root.join("deploy-check");
+        assert!(installed.join("SKILL.md").is_file());
+        let origin = read_origin(&installed).expect("origin");
+        assert_eq!(origin.installed_version, "3");
+        assert_eq!(
+            inspect(&installed, origin.files.as_ref()),
+            teamclu_skillpack::DirtyState::Clean
+        );
+    }
+
+    #[tokio::test]
+    async fn zip_content_hash_mismatch_does_not_touch_disk() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        seed_installed_pack(root, "deploy-check", 1, "v1");
+        let before = std::fs::read_to_string(root.join("deploy-check/SKILL.md")).unwrap();
+
+        let zip = skill_zip("tampered");
+        let server = MockServer::start().await;
+        mount_refresh(&server).await;
+        Mock::given(method("GET"))
+            .and(path("/v1/teams/team-1/skills"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "items": [{
+                    "slug": "deploy-check",
+                    "summary": "check",
+                    "category": "devops",
+                    "whenToUse": "x",
+                    "whenNotToUse": "y",
+                    "latestVersion": 2,
+                    "installed": true
+                }]
+            })))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path(
+                "/v1/teams/team-1/skills/deploy-check/versions/2/download",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "url": format!("{}/zip/deploy-check.zip", server.uri()),
+                "contentHash": "0".repeat(64),
+                "size": zip.len()
+            })))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/zip/deploy-check.zip"))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(zip))
+            .mount(&server)
+            .await;
+
+        let outcome = reconciler_for(&server)
+            .await
+            .fetch_and_apply("team-1", root)
+            .await
+            .expect("hash mismatch is an install failure, not a fetch failure");
+        assert_eq!(outcome.installed, 0);
+        assert_eq!(
+            std::fs::read_to_string(root.join("deploy-check/SKILL.md")).unwrap(),
+            before
+        );
+        assert_eq!(
+            read_origin(&root.join("deploy-check"))
+                .unwrap()
+                .installed_version,
+            "1"
+        );
     }
 }

--- a/apps/desktop/src/commands/clawhub.rs
+++ b/apps/desktop/src/commands/clawhub.rs
@@ -753,6 +753,10 @@ pub fn clawhub_uninstall(workspace_path: String, slug: String) -> Result<String,
 
     lock.skills.remove(&slug);
     write_lockfile(&workspace_path, &lock)?;
+    // Slug is reusable. Left behind, the old decision governs whatever pack
+    // claims the name next -- set_skill_permission_ask only writes ask
+    // when the key is absent. Same helper, same reason as team uninstall.
+    clear_skill_permission(&workspace_path, &slug);
 
     Ok(format!("Uninstalled {}", slug))
 }
@@ -861,5 +865,73 @@ mod tests {
         let _home = HomeGuard::set(home_dir.path());
         let dir = global_skills_dir().unwrap();
         assert_eq!(dir, home_dir.path().join(".agents/skills"));
+    }
+
+    fn workspace_with_permission(value: &str) -> tempfile::TempDir {
+        let ws = tempfile::tempdir().expect("tempdir");
+        std::fs::write(
+            ws.path().join("opencode.json"),
+            serde_json::json!({
+                "permission": { "bash": "ask", "skill": { "deploy-check": value, "other": "allow" } }
+            })
+            .to_string(),
+        )
+        .unwrap();
+        ws
+    }
+
+    fn skill_permissions(ws: &std::path::Path) -> serde_json::Value {
+        let raw = std::fs::read_to_string(ws.join("opencode.json")).unwrap();
+        serde_json::from_str::<serde_json::Value>(&raw).unwrap()["permission"]["skill"].clone()
+    }
+
+    fn write_clawhub_lock(ws: &std::path::Path, slug: &str) {
+        let mut lock = Lockfile::default();
+        lock.skills.insert(
+            slug.to_string(),
+            LockfileEntry {
+                version: Some("1.0.0".into()),
+                installed_at: 1,
+                source: Some(SOURCE_CLAWHUB.to_string()),
+            },
+        );
+        write_lockfile(&ws.display().to_string(), &lock).unwrap();
+    }
+
+    /// A slug is reusable, so an approval that outlives its pack ends up
+    /// governing whatever content claims the name next.
+    #[test]
+    fn uninstall_forgets_the_skills_permission() {
+        let home = tempfile::tempdir().expect("tempdir");
+        let _home = HomeGuard::set(home.path());
+        let ws = workspace_with_permission("allow");
+        write_clawhub_lock(ws.path(), "deploy-check");
+        std::fs::create_dir_all(global_skills_dir().unwrap().join("deploy-check")).unwrap();
+
+        clawhub_uninstall(ws.path().display().to_string(), "deploy-check".into())
+            .expect("uninstall");
+
+        let skills = skill_permissions(ws.path());
+        assert!(skills.get("deploy-check").is_none(), "the entry must go");
+        assert_eq!(skills["other"], "allow");
+        let raw = std::fs::read_to_string(ws.path().join("opencode.json")).unwrap();
+        let json: serde_json::Value = serde_json::from_str(&raw).unwrap();
+        assert_eq!(json["permission"]["bash"], "ask");
+    }
+
+    #[test]
+    fn uninstall_leaves_the_config_untouched_when_there_is_no_entry() {
+        let home = tempfile::tempdir().expect("tempdir");
+        let _home = HomeGuard::set(home.path());
+        let ws = tempfile::tempdir().expect("tempdir");
+        let config = ws.path().join("opencode.json");
+        std::fs::write(&config, r#"{"permission":{"skill":{"other":"allow"}}}"#).unwrap();
+        write_clawhub_lock(ws.path(), "deploy-check");
+        let before = std::fs::read_to_string(&config).unwrap();
+
+        clawhub_uninstall(ws.path().display().to_string(), "deploy-check".into())
+            .expect("uninstall");
+
+        assert_eq!(std::fs::read_to_string(&config).unwrap(), before);
     }
 }

--- a/apps/desktop/src/commands/skillssh.rs
+++ b/apps/desktop/src/commands/skillssh.rs
@@ -11,76 +11,15 @@
 //! import. It keeps the parallel (rayon) directory walk, because a zip can
 //! carry its `SKILL.md` at any depth.
 
-use std::io::Read;
 use std::path::{Path, PathBuf};
 
+use teamclu_skillpack::{build_manifest, write_origin, SkillOrigin, ORIGIN_VERSION};
+
+use super::clawhub::{extract_zip_to_dir, now_millis};
+
+const SOURCE_IMPORT: &str = "import";
+
 // ─── Import skill from local .zip (manual upload) ─────────────────────────────
-
-/// Sanitize a relative path inside a zip (same rules as ClawHub).
-fn sanitize_skill_zip_path(raw: &str) -> Option<String> {
-    let normalized = raw.trim_start_matches("./").trim_start_matches('/');
-    if normalized.is_empty() || normalized.ends_with('/') {
-        return None;
-    }
-    if normalized.contains("..") || normalized.contains('\\') {
-        return None;
-    }
-    Some(normalized.to_string())
-}
-
-fn extract_skill_zip_to_dir(zip_path: &Path, target_dir: &Path) -> Result<(), String> {
-    let file = std::fs::File::open(zip_path).map_err(|e| format!("Failed to open zip: {}", e))?;
-    let mut archive =
-        zip::ZipArchive::new(file).map_err(|e| format!("Failed to read zip archive: {}", e))?;
-
-    std::fs::create_dir_all(target_dir)
-        .map_err(|e| format!("Failed to create extract dir: {}", e))?;
-
-    let canonical_target = target_dir
-        .canonicalize()
-        .unwrap_or_else(|_| target_dir.to_path_buf());
-
-    for i in 0..archive.len() {
-        let mut file = archive
-            .by_index(i)
-            .map_err(|e| format!("Failed to read zip entry {}: {}", i, e))?;
-
-        let raw_name = file.name().to_string();
-        let safe_path = match sanitize_skill_zip_path(&raw_name) {
-            Some(p) => p,
-            None => continue,
-        };
-
-        let out_path = target_dir.join(&safe_path);
-
-        if let Ok(canonical_out) = out_path.canonicalize() {
-            if !canonical_out.starts_with(&canonical_target) {
-                eprintln!(
-                    "[Skills] Skipping zip entry with path traversal: {}",
-                    raw_name
-                );
-                continue;
-            }
-        }
-
-        if let Some(parent) = out_path.parent() {
-            std::fs::create_dir_all(parent).map_err(|e| {
-                format!(
-                    "Failed to create parent dir for zip entry {}: {}",
-                    safe_path, e
-                )
-            })?;
-        }
-
-        let mut buf = Vec::new();
-        file.read_to_end(&mut buf)
-            .map_err(|e| format!("Failed to read zip entry bytes {}: {}", safe_path, e))?;
-        std::fs::write(&out_path, &buf)
-            .map_err(|e| format!("Failed to write extracted file {}: {}", safe_path, e))?;
-    }
-
-    Ok(())
-}
 
 fn skill_md_paths_under(root: &Path) -> Result<Vec<PathBuf>, String> {
     let mut out = Vec::new();
@@ -147,6 +86,7 @@ pub fn import_skill_from_zip(
     workspace_path: Option<String>,
     zip_path: String,
     is_global: bool,
+    force: Option<bool>,
 ) -> Result<String, String> {
     use std::fs;
 
@@ -169,7 +109,8 @@ pub fn import_skill_from_zip(
     }
 
     let import_result = (|| -> Result<String, String> {
-        extract_skill_zip_to_dir(&zip_path, &temp_dir)?;
+        let zip_bytes = fs::read(&zip_path).map_err(|e| format!("Failed to read zip: {}", e))?;
+        extract_zip_to_dir(&zip_bytes, &temp_dir)?;
 
         let extract_root = temp_dir
             .canonicalize()
@@ -209,14 +150,38 @@ pub fn import_skill_from_zip(
         let home = dirs::home_dir().ok_or_else(|| "HOME directory not found".to_string())?;
         let target_dir = home.join(".agents").join("skills").join(&slug);
 
+        let force = force.unwrap_or(false);
+        if target_dir.exists() && !force {
+            return Err(format!(
+                "Already installed: {} (use force=true to overwrite)",
+                target_dir.display()
+            ));
+        }
         if target_dir.exists() {
-            let _ = fs::remove_dir_all(&target_dir);
+            fs::remove_dir_all(&target_dir)
+                .map_err(|e| format!("Failed to remove existing skill dir: {}", e))?;
         }
 
         fs::create_dir_all(&target_dir)
             .map_err(|e| format!("Failed to create target directory: {}", e))?;
 
         copy_skill_directory(&skill_src_dir.to_path_buf(), &target_dir)?;
+
+        let files = build_manifest(&target_dir)
+            .map_err(|e| format!("Failed to measure imported skill: {}", e))?;
+        write_origin(
+            &target_dir,
+            &SkillOrigin {
+                version: ORIGIN_VERSION,
+                registry: SOURCE_IMPORT.to_string(),
+                slug: slug.clone(),
+                installed_version: "1".to_string(),
+                installed_at: now_millis(),
+                team_id: None,
+                files: Some(files),
+            },
+        )
+        .map_err(|e| format!("Failed to write origin.json: {}", e))?;
 
         Ok(format!(
             "Imported skill '{}' to {}",
@@ -475,4 +440,83 @@ fn copy_skill_directory(src: &std::path::PathBuf, dst: &std::path::PathBuf) -> R
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_home::HomeGuard;
+    use std::io::Write;
+    use zip::write::SimpleFileOptions;
+
+    fn write_zip(path: &std::path::Path, entries: &[(&str, &[u8])]) {
+        let file = std::fs::File::create(path).unwrap();
+        let mut zip = zip::ZipWriter::new(file);
+        let opts = SimpleFileOptions::default();
+        for (name, bytes) in entries {
+            zip.start_file(*name, opts).unwrap();
+            zip.write_all(bytes).unwrap();
+        }
+        zip.finish().unwrap();
+    }
+
+    fn import(zip: &std::path::Path, force: Option<bool>) -> Result<String, String> {
+        import_skill_from_zip(None, zip.display().to_string(), true, force)
+    }
+
+    #[test]
+    fn import_refuses_overwrite_unless_force() {
+        let home = tempfile::tempdir().expect("tempdir");
+        let _home = HomeGuard::set(home.path());
+        let skill_dir = home.path().join(".agents/skills/my-skill");
+        std::fs::create_dir_all(&skill_dir).unwrap();
+        std::fs::write(skill_dir.join("SKILL.md"), "ORIGINAL\n").unwrap();
+
+        let zip_dir = tempfile::tempdir().expect("tempdir");
+        let zip_path = zip_dir.path().join("pack.zip");
+        write_zip(
+            &zip_path,
+            &[("my-skill/SKILL.md", b"---\nname: my-skill\n---\nNEW\n")],
+        );
+
+        let err = import(&zip_path, None).expect_err("must refuse");
+        assert!(err.contains("Already installed"), "{err}");
+        assert_eq!(
+            std::fs::read_to_string(skill_dir.join("SKILL.md")).unwrap(),
+            "ORIGINAL\n"
+        );
+
+        import(&zip_path, Some(true)).expect("force overwrite");
+        assert_eq!(
+            std::fs::read_to_string(skill_dir.join("SKILL.md")).unwrap(),
+            "---\nname: my-skill\n---\nNEW\n"
+        );
+        let origin = teamclu_skillpack::read_origin(&skill_dir).expect("origin");
+        assert_eq!(origin.registry, SOURCE_IMPORT);
+        assert_eq!(origin.slug, "my-skill");
+    }
+
+    #[test]
+    fn import_skips_zip_path_traversal() {
+        let home = tempfile::tempdir().expect("tempdir");
+        let _home = HomeGuard::set(home.path());
+
+        let zip_dir = tempfile::tempdir().expect("tempdir");
+        let zip_path = zip_dir.path().join("safe-skill.zip");
+        write_zip(
+            &zip_path,
+            &[
+                ("SKILL.md", b"---\nname: safe-skill\n---\nbody\n"),
+                ("../../outside.txt", b"pwned\n"),
+            ],
+        );
+
+        import(&zip_path, None).expect("import");
+
+        assert!(!home.path().join("outside.txt").exists());
+        assert!(!zip_dir.path().join("outside.txt").exists());
+        let installed = home.path().join(".agents/skills/safe-skill/SKILL.md");
+        assert!(installed.is_file(), "skill should still install");
+        assert!(!home.path().join(".agents/skills/outside.txt").exists());
+    }
 }

--- a/apps/desktop/src/commands/team_skills.rs
+++ b/apps/desktop/src/commands/team_skills.rs
@@ -18,9 +18,9 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::collections::BTreeSet;
 use teamclu_skillpack::{
-    build_manifest, build_manifest_for, inspect, list_managed_paths, read_origin,
-    remove_managed_files, swap_managed_files, write_origin, write_registry_frontmatter, DirtyState,
-    RegistryFields, SkillOrigin, ORIGIN_VERSION,
+    build_manifest, build_manifest_for, commit_staged_pack, inspect, list_managed_paths,
+    read_origin, remove_managed_files, swap_managed_files, write_origin,
+    write_registry_frontmatter, DirtyState, RegistryFields, SkillOrigin, ORIGIN_VERSION,
 };
 use teamclu_types::skill_frontmatter::{parse_frontmatter, write_frontmatter, FrontmatterValue};
 use zip::write::SimpleFileOptions;
@@ -539,18 +539,14 @@ fn team_skill_install_blocking(
         tempfile::tempdir().map_err(|e| format!("Failed to create staging dir: {}", e))?;
     extract_zip_to_dir(&zip_bytes, staging.path())?;
 
-    // Deletions are authorised only by a baseline we recorded ourselves at
-    // install time. Nothing else ever writes one — a directory with no record
-    // is reported `missing` and reinstalled rather than claimed.
-    let baseline = read_origin(&target).and_then(|o| o.files);
-    swap_managed_files(&target, staging.path(), baseline.as_ref())
-        .map_err(|e| format!("Failed to install skill files: {}", e))?;
-
+    // Finish the new tree in staging (frontmatter + origin) before making it
+    // live. Swap-then-origin left mixed versions when origin write failed —
+    // see docs/architecture/hosted-skill-reconcile-fail-closed.md.
     let shipped = list_managed_paths(staging.path())
         .map_err(|e| format!("Failed to list package files: {}", e))?;
-    let frontmatter_written = write_install_frontmatter(&target, &req)?;
+    let frontmatter_written = write_install_frontmatter(staging.path(), &req)?;
     stamp_installed_state(
-        &target,
+        staging.path(),
         InstalledStamp {
             slug: &slug,
             version: req.version,
@@ -558,6 +554,8 @@ fn team_skill_install_blocking(
             shipped: Some(&shipped),
         },
     )?;
+    commit_staged_pack(&target, staging.path())
+        .map_err(|e| format!("Failed to install skill files: {}", e))?;
 
     // Lockfile stays workspace-scoped for update checks, even though the pack
     // itself always lives under ~/.agents/skills.

--- a/crates/teamclu-skillpack/Cargo.toml
+++ b/crates/teamclu-skillpack/Cargo.toml
@@ -7,7 +7,5 @@ edition = "2021"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.10"
-teamclu-types = { path = "../teamclu-types" }
-
-[dev-dependencies]
 tempfile = "3"
+teamclu-types = { path = "../teamclu-types" }

--- a/crates/teamclu-skillpack/src/commit.rs
+++ b/crates/teamclu-skillpack/src/commit.rs
@@ -1,0 +1,275 @@
+//! Make a staged pack live without leaving mixed versions behind.
+//!
+//! Design: `docs/architecture/hosted-skill-reconcile-fail-closed.md` §2.
+//!
+//! The installer used to swap files into the live directory and only then write
+//! `origin.json`. `swap_managed_files` never touches `.clawhub/` — the
+//! bookkeeping directory is excluded from the manifest — so a failed origin
+//! write left vN files sitting next to a vN-1 baseline. `inspect` reads that
+//! as Dirty, auto-follow skips the pack forever, and nothing rolls the swap
+//! back.
+//!
+//! The contract here is: `staged` is already the complete new tree (extracted
+//! files, rewritten frontmatter, matching origin.json). We snapshot `target`,
+//! copy the managed files, copy origin last. Any failure after the live tree
+//! is touched restores the snapshot. Success means origin version and files
+//! are the same version.
+
+use std::io;
+use std::path::{Path, PathBuf};
+
+use crate::origin::{read_origin, ORIGIN_DIR};
+use crate::swap::swap_managed_files;
+
+const ORIGIN_FILE: &str = "origin.json";
+
+fn origin_file(dir: &Path) -> PathBuf {
+    dir.join(ORIGIN_DIR).join(ORIGIN_FILE)
+}
+
+/// Copy `staged` onto `target` as one install.
+///
+/// `staged` must already contain `.clawhub/origin.json`. Missing origin is
+/// refused before `target` is touched — a pack without a baseline is how the
+/// mixed-version bug starts.
+pub fn commit_staged_pack(target: &Path, staged: &Path) -> io::Result<()> {
+    commit_staged_pack_with(target, staged, copy_origin)
+}
+
+fn copy_origin(staged: &Path, target: &Path) -> io::Result<()> {
+    let src = origin_file(staged);
+    let dest_dir = target.join(ORIGIN_DIR);
+    std::fs::create_dir_all(&dest_dir)?;
+    std::fs::copy(&src, dest_dir.join(ORIGIN_FILE))?;
+    Ok(())
+}
+
+fn commit_staged_pack_with(
+    target: &Path,
+    staged: &Path,
+    write_origin: impl FnOnce(&Path, &Path) -> io::Result<()>,
+) -> io::Result<()> {
+    if !origin_file(staged).is_file() {
+        return Err(io::Error::new(
+            io::ErrorKind::NotFound,
+            "staged pack is missing origin.json; refusing to make it live",
+        ));
+    }
+
+    let snapshot = snapshot_tree(target)?;
+    let baseline = read_origin(target).and_then(|o| o.files);
+
+    let result = (|| {
+        swap_managed_files(target, staged, baseline.as_ref())?;
+        write_origin(staged, target)?;
+        Ok(())
+    })();
+
+    if let Err(e) = result {
+        if let Err(restore_err) = restore_tree(target, snapshot.as_ref().map(|d| d.path())) {
+            return Err(io::Error::new(
+                io::ErrorKind::Other,
+                format!("commit failed ({e}); restore failed ({restore_err})"),
+            ));
+        }
+        return Err(e);
+    }
+    Ok(())
+}
+
+fn snapshot_tree(target: &Path) -> io::Result<Option<tempfile::TempDir>> {
+    if !target.exists() {
+        return Ok(None);
+    }
+    let backup = tempfile::tempdir()?;
+    copy_tree(target, backup.path())?;
+    Ok(Some(backup))
+}
+
+fn restore_tree(target: &Path, backup: Option<&Path>) -> io::Result<()> {
+    if target.exists() {
+        std::fs::remove_dir_all(target)?;
+    }
+    if let Some(backup) = backup {
+        copy_tree(backup, target)?;
+    }
+    Ok(())
+}
+
+fn copy_tree(from: &Path, to: &Path) -> io::Result<()> {
+    std::fs::create_dir_all(to)?;
+    for entry in std::fs::read_dir(from)? {
+        let entry = entry?;
+        let file_type = entry.file_type()?;
+        if file_type.is_symlink() {
+            continue;
+        }
+        let dest = to.join(entry.file_name());
+        if file_type.is_dir() {
+            copy_tree(&entry.path(), &dest)?;
+        } else if file_type.is_file() {
+            std::fs::copy(entry.path(), dest)?;
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+fn live_pack_is_clean(target: &Path) -> bool {
+    use crate::manifest::inspect;
+    let Some(origin) = read_origin(target) else {
+        return false;
+    };
+    matches!(
+        inspect(target, origin.files.as_ref()),
+        crate::DirtyState::Clean
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::frontmatter::{write_registry_frontmatter, RegistryFields};
+    use crate::manifest::{build_manifest_for, inspect, list_managed_paths, DirtyState};
+    use crate::origin::{write_origin, SkillOrigin, ORIGIN_VERSION};
+    use crate::SOURCE_TEAM;
+
+    fn write(dir: &Path, rel: &str, body: &str) {
+        let path = dir.join(rel);
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(path, body).unwrap();
+    }
+
+    fn stamp(dir: &Path, slug: &str, version: i64) {
+        let shipped = list_managed_paths(dir).unwrap();
+        write_registry_frontmatter(
+            dir,
+            &RegistryFields {
+                slug,
+                version,
+                owner: None,
+                category: Some("devops"),
+                summary: Some("check"),
+                when_to_use: Some("before release"),
+                when_not_to_use: Some("not locally"),
+                requires: None,
+            },
+        )
+        .unwrap();
+        let files = build_manifest_for(dir, &shipped).unwrap();
+        write_origin(
+            dir,
+            &SkillOrigin {
+                version: ORIGIN_VERSION,
+                registry: SOURCE_TEAM.to_string(),
+                slug: slug.into(),
+                installed_version: version.to_string(),
+                installed_at: 1,
+                team_id: Some("team-a".into()),
+                files: Some(files),
+            },
+        )
+        .unwrap();
+    }
+
+    fn origin_version(dir: &Path) -> String {
+        read_origin(dir).unwrap().installed_version
+    }
+
+    fn skill_body(dir: &Path) -> String {
+        std::fs::read_to_string(dir.join("SKILL.md")).unwrap()
+    }
+
+    #[test]
+    fn successful_commit_origin_version_matches_files() {
+        let tmp = tempfile::tempdir().unwrap();
+        let target = tmp.path().join("deploy-check");
+        write(&target, "SKILL.md", "---\nname: deploy-check\n---\nv1\n");
+        stamp(&target, "deploy-check", 1);
+        assert!(live_pack_is_clean(&target));
+
+        let staged = tmp.path().join("staged");
+        write(&staged, "SKILL.md", "---\nname: deploy-check\n---\nv2\n");
+        write(&staged, "scripts/new.sh", "echo new\n");
+        stamp(&staged, "deploy-check", 2);
+
+        commit_staged_pack(&target, &staged).unwrap();
+
+        assert!(skill_body(&target).contains("v2"));
+        assert!(target.join("scripts/new.sh").is_file());
+        assert_eq!(origin_version(&target), "2");
+        assert!(live_pack_is_clean(&target));
+    }
+
+    #[test]
+    fn origin_write_failure_restores_previous_pack_and_is_not_dirty() {
+        let tmp = tempfile::tempdir().unwrap();
+        let target = tmp.path().join("deploy-check");
+        write(&target, "SKILL.md", "---\nname: deploy-check\n---\nv1\n");
+        write(&target, "NOTES.md", "mine\n");
+        stamp(&target, "deploy-check", 1);
+        let v1_body = skill_body(&target);
+
+        let staged = tmp.path().join("staged");
+        write(&staged, "SKILL.md", "---\nname: deploy-check\n---\nv2\n");
+        stamp(&staged, "deploy-check", 2);
+
+        let err = commit_staged_pack_with(&target, &staged, |_staged, _target| {
+            Err(io::Error::other("origin write failed"))
+        })
+        .unwrap_err();
+        assert!(err.to_string().contains("origin write failed"));
+
+        assert_eq!(skill_body(&target), v1_body, "files must roll back to v1");
+        assert_eq!(origin_version(&target), "1");
+        assert_eq!(
+            std::fs::read_to_string(target.join("NOTES.md")).unwrap(),
+            "mine\n",
+            "files the pack never owned must survive the failed upgrade"
+        );
+        let baseline = read_origin(&target).and_then(|o| o.files);
+        match inspect(&target, baseline.as_ref()) {
+            DirtyState::Dirty { .. } => {
+                panic!("origin-write failure must not pin the pack Dirty")
+            }
+            DirtyState::Clean => {}
+            other => panic!("expected Clean after rollback, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn origin_write_failure_on_fresh_install_leaves_no_tree() {
+        let tmp = tempfile::tempdir().unwrap();
+        let target = tmp.path().join("deploy-check");
+        let staged = tmp.path().join("staged");
+        write(&staged, "SKILL.md", "---\nname: deploy-check\n---\nv1\n");
+        stamp(&staged, "deploy-check", 1);
+
+        commit_staged_pack_with(&target, &staged, |_staged, _target| {
+            Err(io::Error::other("origin write failed"))
+        })
+        .unwrap_err();
+
+        assert!(
+            !target.exists(),
+            "a failed first install must not leave a half tree"
+        );
+    }
+
+    #[test]
+    fn refusing_a_staging_dir_without_origin_does_not_touch_target() {
+        let tmp = tempfile::tempdir().unwrap();
+        let target = tmp.path().join("deploy-check");
+        write(&target, "SKILL.md", "---\nname: deploy-check\n---\nv1\n");
+        stamp(&target, "deploy-check", 1);
+        let before = skill_body(&target);
+
+        let staged = tmp.path().join("staged");
+        write(&staged, "SKILL.md", "---\nname: deploy-check\n---\nv2\n");
+
+        let err = commit_staged_pack(&target, &staged).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::NotFound);
+        assert_eq!(skill_body(&target), before);
+        assert_eq!(origin_version(&target), "1");
+    }
+}

--- a/crates/teamclu-skillpack/src/lib.rs
+++ b/crates/teamclu-skillpack/src/lib.rs
@@ -29,16 +29,18 @@
 //!    help someone decide; "SKILL.md and scripts/check.sh changed, refs/old.md
 //!    was deleted" does.
 
+pub mod commit;
 pub mod frontmatter;
 pub mod manifest;
 pub mod origin;
 pub mod swap;
 pub mod zip_path;
 
+pub use commit::commit_staged_pack;
 pub use frontmatter::{write_registry_frontmatter, RegistryFields, SOURCE_TEAM};
 pub use manifest::{
-    build_manifest, build_manifest_for, inspect, list_managed_paths, DirtyState, FileManifest,
-    ManagedFile,
+    build_manifest, build_manifest_for, inspect, list_managed_paths, sha256_hex, DirtyState,
+    FileManifest, ManagedFile,
 };
 pub use origin::{read_origin, write_origin, SkillOrigin, ORIGIN_DIR, ORIGIN_VERSION};
 pub use swap::{remove_managed_files, swap_managed_files};

--- a/crates/teamclu-skillpack/src/manifest.rs
+++ b/crates/teamclu-skillpack/src/manifest.rs
@@ -88,11 +88,14 @@ impl DirtyState {
     }
 }
 
-pub fn file_sha256(path: &Path) -> std::io::Result<String> {
-    let bytes = std::fs::read(path)?;
+pub fn sha256_hex(bytes: &[u8]) -> String {
     let mut hasher = Sha256::new();
-    hasher.update(&bytes);
-    Ok(format!("{:x}", hasher.finalize()))
+    hasher.update(bytes);
+    format!("{:x}", hasher.finalize())
+}
+
+pub fn file_sha256(path: &Path) -> std::io::Result<String> {
+    Ok(sha256_hex(&std::fs::read(path)?))
 }
 
 fn mtime_ms(meta: &std::fs::Metadata) -> u64 {

--- a/crates/teamclu-skillpack/src/swap.rs
+++ b/crates/teamclu-skillpack/src/swap.rs
@@ -293,7 +293,10 @@ mod tests {
         assert!(!gone, "files the pack never owned keep the directory alive");
         assert!(!target.join("SKILL.md").exists());
         assert!(!target.join("scripts").exists());
-        assert!(!target.join(".clawhub").exists(), "our bookkeeping goes too");
+        assert!(
+            !target.join(".clawhub").exists(),
+            "our bookkeeping goes too"
+        );
         assert_eq!(
             std::fs::read_to_string(target.join("NOTES.md")).unwrap(),
             "mine\n"

--- a/docs/architecture/clawhub-uninstall-clears-skill-permission.md
+++ b/docs/architecture/clawhub-uninstall-clears-skill-permission.md
@@ -1,0 +1,211 @@
+# ClawHub 卸载必须清掉 permission.skill
+
+> 目标落位：`docs/architecture/clawhub-uninstall-clears-skill-permission.md`
+> 状态：**本 pass 落地 P0 + 相关 P1（zip 覆盖拒绝、Settings 权限 fail-closed、ClawHub 已安装集、auto-follow 401）。**
+> 前置阅读：`docs/architecture/team-skills-registry.md`（slug 即内容身份、lockfile / origin.json / `permission.skill` 管线）。
+
+`permission.skill` is keyed by slug, and a slug is reusable. Team uninstall already
+forgets the entry (`clear_skill_permission`). ClawHub uninstall did not, so an
+allow granted to pack A silently governs pack B that later reuses the name.
+
+## 1. 要解决什么
+
+**P0 — slug-reuse grant.** `clawhub_uninstall` (`apps/desktop/src/commands/clawhub.rs`)
+removes the pack directory and the lockfile row, then returns. Team uninstall
+(`team_skill_uninstall`) does the same **and** calls `clear_skill_permission`.
+`set_skill_permission_ask` only inserts when the key is absent. Sequence:
+
+1. User installs ClawHub skill `deploy-check`, later sets `permission.skill["deploy-check"] = "allow"`.
+2. User uninstalls it. Directory + lockfile go away; the allow stays in `opencode.json`.
+3. User (or auto-follow) installs a different pack under the same slug.
+4. Install writes `ask` only if the key is missing → old allow applies to new code.
+
+The comments at `clawhub.rs` ~405–417 already describe this exact failure mode.
+They were written for the helper; ClawHub uninstall never called it.
+
+**Related P1s in this pass** (same permission / origin / installed-set surface):
+
+| # | Bug | Why it belongs with P0 |
+|---|---|---|
+| 1 | Zip import silently `remove_dir_all`s an existing slug; local sanitizer duplicates `sanitize_zip_path`; no `origin.json` | Same slug-reuse / traversal / bookkeeping contract as ClawHub install |
+| 2 | Settings `putDaemonPermissions` returns `null` when the daemon is down; `SkillsSection` still `setSkillPermissions(updated)` | Fail-open on a permission write, same family as leftover allow |
+| 3 | ClawHub marketplace unions every folder under skills roots as "installed" | Team packs look ClawHub-installed; Uninstall then errors (`source == team`) |
+| 4 | `TeamSkillAutoFollow` swallows every reconcile error, including 401 | Expired session looks like "nothing to do"; packs drift with no signal |
+
+## 2. 不改什么
+
+- MQTT protocol, Caddy, NanoMQ, Supabase schema, refresh-token rotation, daemon runtime, FC routes.
+- `apps/daemon/**`, `services/fc/**`.
+- `crates/teamclu-skillpack` — read-only reuse (`sanitize_zip_path`, `write_origin`, `build_manifest`, `apply_zip_mode` via the existing ClawHub unpacker).
+
+## 3. P0 — `clawhub_uninstall` 调 `clear_skill_permission`
+
+### 3.1 行为
+
+After a successful lockfile row removal, call `clear_skill_permission(&workspace_path, &slug)` —
+the same helper team uninstall already uses. It:
+
+- no-ops when `opencode.json` is missing, unparseable, or has no entry for the slug
+  (the daemon watches this file; a no-op rewrite would restart the runtime);
+- removes only that slug; leaves `permission.bash` and other skill keys alone.
+
+`clawhub_uninstall` already refuses `source == team` (those must go through
+`team_skill_uninstall`, which also clears the server-side install record).
+Permission clear runs only on the ClawHub path that actually deletes the pack.
+
+Workspace-shaped limitation is accepted, same as team uninstall: packs are
+global (`~/.agents/skills/<slug>`), `permission.skill` is per-workspace, and the
+command is handed one path. Other workspaces keep their entry. Documented, not
+fixed here.
+
+### 3.2 测试
+
+Analog of `uninstall_forgets_the_skills_permission` in `team_skills.rs`:
+
+- HOME + workspace with `opencode.json` carrying `deploy-check: allow` and `other: allow`
+- lockfile row `source: clawhub`
+- `clawhub_uninstall` → `deploy-check` gone, `other` and `permission.bash` stay
+
+Optional sibling: missing / unparseable config still succeeds (helper already
+guarantees this; P0 test is the grant-reuse one).
+
+## 4. P1.1 — Zip import: no silent overwrite, one sanitizer, origin.json
+
+`import_skill_from_zip` (`apps/desktop/src/commands/skillssh.rs`) today:
+
+- uses a local `sanitize_skill_zip_path` that happens to match
+  `teamclu_skillpack::sanitize_zip_path` today, and will drift;
+- `remove_dir_all`s `~/.agents/skills/<slug>` if it exists;
+- writes no `.clawhub/origin.json`.
+
+### 4.1 Overwrite
+
+Match `clawhub_install`: refuse unless `force == true`.
+
+```
+Already installed: ~/.agents/skills/<slug> (use force=true to overwrite)
+```
+
+New optional arg `force: Option<bool>` (Tauri: omitted → `None` → false).
+Frontend keep current invoke (no force) so a second import of the same slug
+surfaces the error instead of clobbering a team / ClawHub / hand-written pack.
+A confirm-and-retry-with-force dialog is leftover, not this pass.
+
+### 4.2 Sanitizer
+
+Delete the local copy. Unpack through `clawhub::extract_zip_to_dir` (already
+calls `sanitize_zip_path` + `apply_zip_mode`). Two unpackers on different `zip`
+crate majors still share one path rule; zip import should not be a third copy.
+
+### 4.3 `origin.json`
+
+Team inspect treats `registry != "team"` as `foreign` and will not overwrite.
+A zip import without origin looks like `missing` — auto-follow may install a
+team pack over it. Write origin after copy:
+
+| field | value |
+|---|---|
+| `version` | `ORIGIN_VERSION` |
+| `registry` | `"import"` (not `"team"`, not the ClawHub URL) |
+| `slug` | derived folder name |
+| `installedVersion` | `"1"` |
+| `files` | `build_manifest` of what we just copied |
+
+No lockfile row. A zip import is not a ClawHub install; P1.3 would otherwise
+have to special-case another source. Origin is enough for the team contract.
+
+### 4.4 Tests
+
+- existing slug + `force=false` → error, bytes unchanged
+- existing slug + `force=true` → replaced, origin written
+- zip entry `../../outside.txt` is not written outside the extract / skills root
+
+## 5. P1.2 — Settings permission writes fail closed
+
+`putDaemonPermissions` (`packages/app/src/lib/daemon-local-client.ts`) returns
+`null` on `ok: false` (daemon down, status 0, HTTP error) and does **not** throw.
+
+`SkillDetail.tsx` already fails closed:
+
+```
+const saved = await putDaemonSkill(...)
+if (saved === null) throw new Error('daemon rejected the update')
+```
+
+`SkillsSection.tsx` `handleDefaultPermissionChange` / `handleSkillPermissionChange`
+await the put, then `setSkillPermissions(updated)` regardless. The toggle looks
+saved; `opencode.json` never changed.
+
+Fix: same null check, `setError(...)`, do not update local state. The Allow /
+Ask / Deny buttons read `skillPermissions`, so the UI stays on the last known
+server value.
+
+Do **not** change `putDaemonPermissions` itself to throw — other callers and
+the `null` contract stay. Only the Settings writer that claimed success.
+
+## 6. P1.3 — ClawHub installed-set is lockfile `source=clawhub` only
+
+`ClawHubMarketplace.loadInstalled` today:
+
+1. unions every key in `.clawhub/lock.json` (team + ClawHub);
+2. unions every directory under workspace/home `.claude/skills` and `.agents/skills`.
+
+A team pack therefore shows **Installed**, and Uninstall calls `clawhub_uninstall`,
+which errors `"came from the team registry — uninstall it there"`.
+
+Lockfile `source`:
+
+- `"clawhub"` → ClawHub
+- `"team"` → team registry
+- absent → ClawHub (entries written before the team registry; see `LockfileEntry`)
+
+Helper `clawhubInstalledSlugs(lock)` keeps `source == null | "" | "clawhub"`.
+Drop the filesystem scan. Test: mixed lockfile → only ClawHub slugs; team slug
+on the explore list still shows Install, not Installed.
+
+## 7. P1.4 — Auto-follow must not swallow 401
+
+`reconcileSkills` catches the initial `listTeamSkills` failure and returns, so
+offline is not read as "the team removed everything". That is correct for
+network blips. A 401 / `missing_auth` is not a blip — the session is dead and
+the next tick will fail the same way.
+
+`TeamSkillAutoFollow` then `.catch(() => {})`s the whole reconcile, including
+auth.
+
+Fix:
+
+1. `isCloudAuthError` next to `CloudApiError` (`status === 401` or `code === "missing_auth"`).
+2. `reconcileSkills` rethrows auth errors; still swallows everything else.
+3. The component toasts once per `teamId` (ref, reset on team switch) so a 10
+   minute timer does not spam. Other errors stay silent.
+
+## 8. 本 pass 明确不做（leftover）
+
+| Item | Why later |
+|---|---|
+| Settings create/edit via FS vs daemon | Separate writer path; not the fail-closed bug |
+| Rust `pack_and_upload` 401 retry | Daemon/FC adjacent; out of desktop-only scope |
+| Dead skills.sh discovery (`discover_skill_directory` et al. in `skillssh.rs`) | Unreachable; delete in a cleanup pass |
+| Expo / iOS skill permission | Desktop-only this pass |
+| E2E expansion | Unit/component tests cover the grant-reuse and UI claims |
+| Diagnostics `teamclu-team/skills` string | Copy-only |
+| Zip import confirm-and-`force` dialog | Command refuses; Settings already shows the invoke error |
+| Cross-workspace permission clear | Same limitation as team uninstall; needs a workspace enumerator |
+| `clawhub_check_updates` iterating team lockfile rows | Related installed-set smell; not a grant bug |
+
+## 9. 落地清单
+
+| Path | Change |
+|---|---|
+| `apps/desktop/src/commands/clawhub.rs` | `clear_skill_permission` on uninstall + test |
+| `apps/desktop/src/commands/skillssh.rs` | `force`, shared unpacker, `origin.json`, tests |
+| `packages/app/src/components/settings/SkillsSection.tsx` | null → error, no local write |
+| `packages/app/src/components/settings/__tests__/SkillsSection.test.tsx` | daemon-down does not flip the toggle |
+| `packages/app/src/lib/clawhub/types.ts` | `source` + `clawhubInstalledSlugs` |
+| `packages/app/src/components/settings/ClawHubMarketplace.tsx` | lockfile-only installed set |
+| `packages/app/src/lib/backend/cloud-api/http.ts` | `isCloudAuthError` |
+| `packages/app/src/stores/team-share-browser.ts` | rethrow 401 |
+| `packages/app/src/components/TeamSkillAutoFollow.tsx` | toast expired session |
+
+Tests: `cargo test` for `clawhub` / `skillssh`; vitest for the TS files above.

--- a/docs/architecture/hosted-skill-reconcile-fail-closed.md
+++ b/docs/architecture/hosted-skill-reconcile-fail-closed.md
@@ -1,0 +1,129 @@
+# Hosted skill 对账：失败必须关死，不能当成空集或半次安装
+
+> 目标落位：`docs/architecture/hosted-skill-reconcile-fail-closed.md`
+> 状态：**P0-1 + P0-2 已落地。** P1-3（zip `contentHash` 校验）顺手做了，装在同一条安装管线上。
+> 相关：`docs/architecture/team-skills-registry.md` §8.1 / §8.2
+>
+> 明确不做：MQTT 加速、Caddy / NanoMQ / Supabase schema、refresh-token 轮转、改 `services/fc`。
+
+共享 agent 的 skill 集由 daemon 对账（`apps/daemon/src/runtime/team_skills.rs`）。对账读服务端期望集，多的装、少的卸、版本不符的换。这条路径无人值守，所以「失败」和「团队清空了」必须分得开，「装到一半」必须能退回上一版。本文件修的就是这两处把失败读成成功的洞。
+
+## 1. P0-1：列表 404 不是空期望集
+
+### 1.1 现状（已核实）
+
+`apps/daemon/src/backend/cloud_api/mod.rs` 的 `team_skills()` 把 `GET /v1/teams/:id/skills` 的 `NotFound` 映射成 `Ok(vec![])`，注释写的是「和 team MCP 的 404 一样，没注册表不算错」。
+
+`runtime/team_skills.rs::reconcile_now` 只在 `Err` 时 fail-close：打一条 warn，**不**改 `last_fetch`，磁盘原样保留。`Ok([])` 会走进 `apply()`，把每一个非 dirty 的 hosted pack 删掉。
+
+401 走 `BackendError::Auth`，本来就会 keep。洞只在 404：代理误路由、打到错的 team、网关把「找不到这条路径」答成 404，都会被读成「团队卸光了」。
+
+FC 的空列表是 **HTTP 200 + `{ items: [] }`**（`services/fc/src/lib/routes/team-skills.ts`：`return { body: { items } }`）。注册表存在、这个 actor 一件都没装，走的是这条。404 不是这条。
+
+MCP / env 的 404→空是另一类资源：从没开过团队 MCP，空配置就是事实。Skills 对账会**删除**磁盘上的包，404 不能借用那条语义。本文件不改 MCP / env。
+
+### 1.2 规则
+
+`GET /v1/teams/:id/skills` 只有这一种东西算期望集：
+
+| 响应 | 对账 |
+|---|---|
+| HTTP 200，body 是对象，带 `items` 数组（可空） | 这就是期望集。`[]` 表示卸光非 dirty pack |
+| HTTP 401 / 403 | `Err`（Auth / Provider）→ keep |
+| HTTP 404 | `Err`（NotFound）→ keep |
+| HTTP 5xx | `Err`（Provider）→ keep |
+| 200 但 JSON 解不出、缺 `items`、`items` 不是数组 | `Err`（Serde）→ keep |
+| 网络失败 | `Err` → keep |
+
+`#[serde(default)]` 从 `items` 上拿掉：缺字段必须解失败，不能静默变成 `[]`。
+
+默认 `Backend::team_skills` 已经是 `Err(NotFound)`，不是 `Ok([])`。cloud_api 之前把这条护栏在 HTTP 层拆掉了。
+
+### 1.3 测试
+
+cloud_api 客户端：401 / 404 / 5xx / 200 缺 `items` 都是 `Err`；200 `{ items: [] }` 是 `Ok([])`；200 带行是 `Ok(rows)`。
+
+对账（真实 `CloudApiBackend` + 临时 `AMUXD_HOME`）：
+
+- 401 → 已装 pack 还在，`removed = 0`
+- 404 → 同上
+- 200 `{ items: [] }` → 非 dirty pack 被卸掉
+- 200 带 `installed: true` 的行 → pack 被装上，origin 版本和文件一致
+
+## 2. P0-2：原子安装或回滚
+
+### 2.1 现状（已核实）
+
+`install()` 的顺序是：解压到 staging → **`swap_managed_files` 把文件拷进活目录** → 回写 frontmatter → 算 manifest → **最后 `write_origin`**。
+
+`swap_managed_files` 不碰 `.clawhub/`（manifest 排除了这本书）。origin 只能另写。若 origin 写失败：
+
+- 磁盘上的 `SKILL.md` 等已经是 vN
+- `.clawhub/origin.json` 仍是 vN-1（或没有）
+- `inspect()` 拿旧 baseline 比新文件 → **Dirty**
+- `apply()` 见 Dirty 就跳过升级，这个 pack **从此钉死**，自动跟随再也不会碰它
+- 没有把 swap 撤回去的路径
+
+进程在 swap 和 origin 之间崩溃是同一类窗口；origin 写失败是它的可复现形态。
+
+### 2.2 修复
+
+在 `crates/teamclu-skillpack` 加 `commit_staged_pack`。安装管线改成：
+
+```
+下载 zip
+校验 contentHash（有才校，见 §3）
+解压到 staging
+在 staging 上回写 frontmatter
+在 staging 上写 origin.json（此时 staging 已是完整的新树：文件 + 匹配的 origin）
+commit_staged_pack(target, staging)
+  → 给 target 整树做快照（含用户自己的文件）
+  → swap_managed_files（只动包声明的文件）
+  → 把 staging 的 origin.json 拷进 target
+  → 任一步失败：用快照把 target 恢复成进入 commit 之前的样子
+```
+
+成功之后：origin 的 `installedVersion` 和磁盘文件是同一版，`inspect` 为 Clean。失败之后：要么仍是旧版且 Clean，要么（全新安装）target 不存在。不会留下「文件 vN / origin vN-1」。
+
+origin 必须在 staging 上先写好，`commit` 发现 staging 没有 `origin.json` 就拒绝动手——这是「先写 origin 再让新树活」那条备选的可执行形态。活目录上的 origin 仍然最后落地，因为先改活 origin 再换文件会留下另一种 Dirty（origin vN / 文件 vN-1）。
+
+快照走 `tempfile`，不放在 skills 根下。放成根下的兄弟目录会被 `installed_versions` 扫成又一个 pack。
+
+### 2.3 测试
+
+skillpack：
+
+- origin 写入失败 → target 回到旧版，`inspect` 不是 Dirty，origin 版本和文件一致
+- 成功 commit → origin 版本和文件一致
+- 全新安装 origin 失败 → target 不残留半棵树
+
+desktop 下载安装走同一条 `commit_staged_pack`（同一个洞，改动量就是换调用顺序）。`team_skill_install_from_dir` 可能 staging ≡ target，本轮不动。
+
+## 3. P1-3（顺手）：换文件之前校验 zip `contentHash`
+
+`GET .../download` 已经带 `contentHash`（zip 的 sha256 hex）和 `size`。下载后、解压前：
+
+- `contentHash` 非空且和字节对不上 → `Err`，磁盘不动
+- `size > 0` 且和字节长度对不上 → 同上
+- `contentHash` 为空 → 不校，不挡安装（旧服务端 / 缺字段）。缺哈希不是「校验失败」
+
+哈希在 `teamclu-skillpack::sha256_hex`，和文件 manifest 用同一套 sha256 hex。
+
+## 4. 明确不做
+
+- MQTT `actor_notify()` 把下一次对账提前到现在
+- 改 MCP / env 的 404→空（那些资源空配置就是事实）
+- 改 Caddy、NanoMQ、Supabase schema、refresh-token 轮转
+- 重置 daemon identity
+- 动 `services/fc`
+- 进程在 swap 与 origin rename 之间被杀的极窄窗口：失败路径会回滚，崩溃不会。pack 很小，接受；真要封死得上目录级 rename + 非托管文件合并，本轮不做
+
+## 5. 落地位置
+
+| 文件 | 改动 |
+|---|---|
+| `crates/teamclu-skillpack/src/commit.rs` | `commit_staged_pack` + 失败回滚 |
+| `crates/teamclu-skillpack/src/manifest.rs` | `sha256_hex` |
+| `apps/daemon/src/backend/cloud_api/mod.rs` | `team_skills()` 不再把 404 变成 `[]`；`items` 不再 default |
+| `apps/daemon/src/runtime/team_skills.rs` | staging 上写完 origin 再 commit；下载后校 hash |
+| `apps/desktop/src/commands/team_skills.rs` | 下载安装改走 `commit_staged_pack` |

--- a/docs/architecture/skill-publish-atomicity-and-blob-verification.md
+++ b/docs/architecture/skill-publish-atomicity-and-blob-verification.md
@@ -1,0 +1,118 @@
+# Skill 发布原子性与包体校验
+
+> 目标落位：`docs/architecture/skill-publish-atomicity-and-blob-verification.md`
+> 状态：**本轮落地**（应用层）。drizzle / supabase 表默认值迁移、pg-repo `listTeamSkillInstallerActorIds`、MQTT 加速本轮不做。
+> 前置阅读：[`team-skills-registry.md`](./team-skills-registry.md) §5 / §6，[`skills-marketplace.md`](./skills-marketplace.md) §5.1 / §8.1。
+
+## 1. 要解决什么
+
+发布 v1 和「包体真的在、而且是声称的那一份」目前是两件没绑在一起的事。几个已经在代码里核实过的缺口：
+
+1. **v1 不是事务。** `createTeamSkill` 先插 `team_skills` 再插 `team_skill_versions`。adopt 已经用 txn（Path B）/ 补偿删除（Path A）把这个坑填了；本地发布还没有。失败模式：skill 行在、版本行不在 → 读起来是 "v1"、下载 404、slug 被占、无法重发。
+2. **发布不要求 verified blob。** prepare/complete 把 `amuxc_blobs.verified` 翻成 true，但 create / createVersion 只检查 `contentHash` 非空。可以登记一个从未上传的哈希。
+3. **complete 只比对 size。** HEAD/list 对得上字节数就把行标 verified。同 size 不同内容会过。
+4. **Path A `prepareTeamSkillBlob` 不返回 `verified`。** 路由 `if (!prepared.verified)` 把缺省当成需要上传。同一个 zip 第二次 prepare 仍发 presigned PUT，内容寻址去重名存实亡。Path B 返回 `verified`。
+5. **`whenToUse` / `whenNotToUse` 在 OpenAPI 和 `requirePublishFields` 里是选填，表上 NOT NULL 且无 DEFAULT。** 省略时插入 NULL → Postgres `23502`。市场表已经是 `NOT NULL DEFAULT ''`。
+
+## 2. v1 创建必须在一个事务里
+
+adopt 的注释已经写清了为什么：
+
+> Committing the skill row and then failing on the version row leaves a skill stuck at "v1" with no v1 to download, and — because the slug is now taken — no way to re-adopt it either.
+
+本地 `POST /v1/teams/:id/skills` 是同一对插入，同一条失败模式。
+
+| 后端 | 做法 |
+|---|---|
+| Path B (`pg-repo`) | `db.transaction`：skill 行 + version 行，和 adopt / createVersion 一样 |
+| Path A (`supabase-repo`) | PostgREST 没有跨语句事务。版本插入失败则按 id 补偿删除刚建的 skill 行（与 adopt 同一形状）。真正的 RPC 事务本轮不做 |
+
+校验（slug / 发布门 / changelog / **verified blob**）全部发生在写入之前。事务里不再做网络 I/O。
+
+`POST .../versions`（v2+）Path B 已经在事务里；不改语义，只加 verified 检查。
+
+## 3. 发布门：verified blob
+
+客户端顺序不变：prepare →（需要时）PUT → complete → POST skill / versions。服务端现在拒绝第三步没做完的第四步。
+
+```
+createTeamSkill / createTeamSkillVersion
+  contentHash 必须是 64 hex（小写）
+  amuxc_blobs(team_id, content_hash).verified = true
+  否则 422 blob_unverified
+```
+
+市场订阅版本（`blob_scope='marketplace'`）不走这条：字节在 `marketplace/blobs/…`，不在 `amuxc_blobs`。adopt / 惰性对齐 / revert 复制已有版本的 blob 指针，不重新上传。revert 不重新要求 complete。
+
+## 4. complete：先 size，再 hash
+
+`POST .../skill-blobs/complete`（及市场孪生 `.../admin/marketplace/skill-blobs/complete`）：
+
+1. 对象必须存在，`stat.size` 必须等于登记的 size。否则 `422 blob_missing`（已有）。
+2. **再读字节算 sha256。** digest 必须等于 `contentHash`。否则 `422 blob_hash_mismatch`，不标 verified。
+3. 然后才把 `amuxc_blobs.verified` 翻成 true（团队包）。市场 complete 没有账本行，hash 通过即视为 verified。
+
+实现落在现有 `BlobStorage` 上：S3 `GetObject` 流式 hash，Supabase Storage `download` 后 hash。不新造存储、不把 zip 送进业务 API 的请求体。
+
+**上限。** 包体 `size > 16 MiB` 时本轮仍只比 size（FC / 函数内存）。技能 zip 实际远小于这个数。超过的包能标 verified，但没有内容证明——见 §8。
+
+## 5. Path A `verified` 与 Path B 对齐
+
+`POST .../skill-blobs/prepare` 的 `requiresUpload = !prepared.verified`。
+
+Path B 已经 `SELECT verified` 并返回。Path A 的 `prepareTeamSkillBlob` 在 `upsert ... ignoreDuplicates` 之后必须再读那一行，返回 `{ contentHash, size, ossKey, verified }`。`ignoreDuplicates` 保留已有行的 `verified=true`，所以第二次 prepare 同一个哈希会跳过 PUT。
+
+这是内容寻址去重能工作的全部原因。缺了 `verified`，每个发布者都重新上传一份已经在桶里的字节。
+
+## 6. 发布门里的 whenToUse / whenNotToUse
+
+registry 文档 §6 曾经把这两个当必填，后来改成选填：空是一个真实答案，占位文案比空更糟。OpenAPI `TeamSkillPublish` 和 `requirePublishFields` 已经是选填。
+
+表是 `when_to_use text NOT NULL`、无 DEFAULT。省略 → 应用层送 `undefined` → 驱动插 NULL → `23502`。
+
+**对齐市场表：应用层缺省 `''`，OpenAPI 保持选填。**
+
+```
+未传 / undefined  → 存 ''
+传 ""             → 存 ''
+传空白            → trim 后存 ''
+传非空            → trim 后存
+```
+
+`summary` / `category` / `changelog` 仍必填且非空。
+
+drizzle schema 加上 `.default("")` 与市场表同构，标明意图。**本轮不生成 drizzle 迁移，也不改 supabase 的 `ALTER COLUMN ... SET DEFAULT`。** 线上表仍是 NOT NULL 无 DEFAULT；保护来自应用层插入 `''`。pglite bootstrap（`test/db/team-skills-bootstrap.ts`）补上 `DEFAULT ''`，让测试库和市场表一致。
+
+## 7. 安装鉴权（OpenAPI 补第四道门）
+
+代码里的门是四道，OpenAPI 只写了三道。真实规则（`assertCanInstallFor` / `assertCanInstallTeamSkillFor`）：
+
+1. 目标是调用者自己的 member actor → 放行
+2. 目标是调用者**拥有的 agent**（personal 或 team）→ 放行。成员自己的机器是 agent 不是 member；桌面端分享/发布要把安装记在那台机器的 actor 上
+3. 目标是 `visibility='team'` 且调用者不是 owner → 要团队 admin
+4. 目标是别人的 member actor → 一律拒绝
+
+本轮只改 OpenAPI 描述，不改门本身。
+
+## 8. 本轮不做（留下的债）
+
+| 项 | 为什么留下 |
+|---|---|
+| drizzle 迁移给 `team_skills.when_to_use` / `when_not_to_use` 加 `DEFAULT ''`（postgres） | 应用层已经送 `''`；生成迁移会碰 `services/fc/src/db/migrations` 的整条链。线上无 DEFAULT 仍靠应用层 |
+| supabase `ALTER COLUMN SET DEFAULT ''` | 同上，Path A 也靠应用层 |
+| Path A `createTeamSkill` 做成 RPC 真事务 | 补偿删除覆盖主失败模式；RPC 要 supabase 迁移 |
+| `listTeamSkillInstallerActorIds` 的 pg-repo 实现 | 只服务 MQTT 加速，MQTT 本轮不动 |
+| MQTT 加速（`actor_notify` 把下次对账提前到现在） | 不做只是慢 10 分钟，registry 文档 §12 已标 |
+| complete 对 >16 MiB 的包只比 size | 避免在 FC 里读进大对象。真要内容证明再加流式上限或服务端 KMS |
+| 下载时再验 `verified` | 见下载契约 §5；新发布已经被 §3 挡住 |
+
+## 9. 落地顺序
+
+OpenAPI-first，然后两边 repo，然后测试：
+
+1. OpenAPI：download 路径；元数据 GET summary；install 四道门；marketplace list 的 `limit`
+2. Path A prepare 返回 `verified`
+3. complete 在 size 之后 hash
+4. createTeamSkill 包进事务 / 补偿删除，且要求 verified blob
+5. createTeamSkillVersion 要求 verified blob
+6. `whenToUse` / `whenNotToUse` 缺省 `''`

--- a/docs/architecture/team-skill-package-download-contract.md
+++ b/docs/architecture/team-skill-package-download-contract.md
@@ -1,0 +1,92 @@
+# 团队 Skill 包下载契约
+
+> 目标落位：`docs/architecture/team-skill-package-download-contract.md`
+> 状态：**补契约** — 路由已实现，OpenAPI 此前漏了这条；元数据 GET 的 summary 误写成「解析包体」。
+> 前置阅读：[`team-skills-registry.md`](./team-skills-registry.md) §5 / §8.2，[`skills-marketplace.md`](./skills-marketplace.md) §4.2 / §4.3 / §8.2。
+
+## 1. 要解决什么
+
+安装管线要的是**短时效签名 URL**，不是包体元数据，也不是 FC 代理的 zip 字节。
+
+两条容易混的 GET 现在必须拆开：
+
+| | 元数据 | 下载 |
+|---|---|---|
+| 路径 | `GET /v1/teams/{teamId}/skills/{slug}/versions/{version}` | `GET /v1/teams/{teamId}/skills/{slug}/versions/{version}/download` |
+| 做什么 | 返回版本行（changelog、快照字段、`contentHash`、`size`） | 解析包体落点，签发短时效 URL |
+| 不做什么 | 不碰对象存储、不签发 URL | 不代理 zip 字节经过业务 API |
+| OpenAPI | `getTeamSkillVersion` | `downloadTeamSkillVersion`（本文件落地后写入） |
+
+路由层已实现下载（`services/fc/src/lib/routes/team-skills.ts`），客户端（桌面 `resolveDownload`、daemon `team_skill_download`）已经在打它。缺的是契约：OpenAPI 没有这条路径，元数据 GET 的 summary 还写着 "Resolve a version's package blob"。
+
+## 2. 下载解析：两条 blob 路径
+
+版本行上的 `blob_scope` 决定字节在哪。**客户端永远见不到 `object_path` / `oss_key`**，只拿到 `{ url, contentHash, size }`。
+
+```
+GET .../versions/{v}/download
+        |
+        |- blob_scope = 'marketplace'
+        |     object_path 已快照在 team_skill_versions 上
+        |     -> 直接签这条路径
+        |     -> 不查 amuxc_blobs（市场包刻意不进那张表）
+        |
+        |- blob_scope = 'team'（默认）
+              content_hash -> amuxc_blobs(team_id, content_hash) -> oss_key
+              -> 签 oss_key
+              -> 没有 oss_key：409 blob_missing
+```
+
+路径形状（同一 skills 命名空间，前缀不同）：
+
+```
+teams/<teamId>/blobs/sha256/<aa>/<bb>/<hash>          团队自己发的包
+marketplace/blobs/sha256/<aa>/<bb>/<hash>             市场包
+```
+
+`SKILLS_STORAGE_BUCKET` 在两个后端上不是同一种东西：`TEAM_BLOBS_BACKEND=s3` 时是共享桶里的 **key 前缀**；不设时才是 Supabase Storage 的 **桶名**。签名函数是同一个（`createSkillDownloadUrl`）。
+
+市场包为什么不进 `amuxc_blobs`：那张表按 `team_id` 隔离，目录不属于任何团队。给它塞「无主 blob」会污染被 OSS 同步共用的账本，也会让 GC 面对一类它没设计过的行。下载解析按 `blob_scope` 分支，就是为了让市场包在没有那一行的情况下仍然可签。
+
+`object_path` 写在团队自己的版本行上、而不是每次回目录表查：这一行一旦写下，下载就不再依赖目录项还在不在。下架 / 删除目录项只让它不再更新，不会让已经装上的包 409。
+
+## 3. 签名 URL 的时效
+
+`createSkillDownloadUrl(objectPath, expiresIn = 900)` — **默认 900 秒（15 分钟）**。
+
+- 业务 API 响应里**不**带回 `expiresIn`；客户端把 `url` 当一次性凭据用，过期就重新打 download。
+- 900 秒覆盖「对账拉到清单 → 下载 zip → 解压」这条同步路径，短到丢在日志里也很快失效。
+- 签名 URL 自带凭据。daemon / 桌面端 **GET 这个 URL 时不得附带业务 API 的 bearer**——对象存储是第三方，把团队 token 送过去等于泄漏。
+
+鉴权在签发这一步：调用者必须是该团队成员。URL 一旦发出，持有者在过期前都能拉字节；这是短时效的代价，不是漏洞。
+
+## 4. 响应形状
+
+```json
+{ "url": "https://…", "contentHash": "<64 hex>", "size": 12345 }
+```
+
+`contentHash` / `size` 来自版本行（市场包同样），让安装端在解压前能对一下它以为自己在装的那一版。`url` 是唯一新增的字段；元数据 GET 没有它。
+
+错误：
+
+| 状态 | code | 何时 |
+|---|---|---|
+| 400 | `validation_failed` | `version` 不是正整数 |
+| 401 / 403 | | 未登录 / 不是成员 |
+| 404 | `not_found` | slug 或 version 不存在 |
+| 409 | `blob_missing` | team 包还没有 `amuxc_blobs.oss_key`，或 marketplace 包缺 `object_path` |
+
+## 5. 明确不做
+
+- FC 代理 zip 字节（包可以到数 MB，业务 API 不是传输面）
+- 把 `object_path` / `oss_key` 暴露给客户端
+- 下载时校验 `amuxc_blobs.verified`（历史行可能未标；新发布的门在 publish，见 [`skill-publish-atomicity-and-blob-verification.md`](./skill-publish-atomicity-and-blob-verification.md)）
+- 改 MQTT / Caddy / NanoMQ / daemon runtime
+
+## 6. OpenAPI
+
+落地：`docs/openapi/teamclu-api.v1.yaml`
+
+- 新增 `GET /v1/teams/{teamId}/skills/{slug}/versions/{version}/download`
+- 元数据 GET 的 summary 改为版本记录，不再声称它解析包体

--- a/docs/openapi/teamclu-api.v1.yaml
+++ b/docs/openapi/teamclu-api.v1.yaml
@@ -1834,6 +1834,12 @@ paths:
         - name: cursor
           in: query
           schema: { type: string }
+        - name: limit
+          in: query
+          description: >
+            Page size. Default 100, max 200. Pass 1 to probe whether the
+            catalog is non-empty (sidebar entry, design §10.1).
+          schema: { type: integer, minimum: 1, maximum: 200 }
       responses:
         "200":
           description: Catalog entries.
@@ -2354,7 +2360,7 @@ paths:
   /v1/teams/{teamId}/skills/{slug}/versions/{version}:
     get:
       operationId: getTeamSkillVersion
-      summary: Resolve a version's package blob
+      summary: Version record (metadata, not the package bytes)
       tags: [TeamSkills]
       parameters:
         - $ref: "#/components/parameters/TeamId"
@@ -2370,6 +2376,57 @@ paths:
             application/json:
               schema: { $ref: "#/components/schemas/TeamSkillVersion" }
         "404": { $ref: "#/components/responses/Error" }
+  /v1/teams/{teamId}/skills/{slug}/versions/{version}/download:
+    get:
+      operationId: downloadTeamSkillVersion
+      summary: Short-lived signed URL for the package zip
+      description: >
+        Does not proxy bytes. Resolves the version's package location and
+        returns a signed GET URL (expires in 900 seconds).
+
+
+        `blob_scope=marketplace` signs the `object_path` snapshotted on
+        the version row and never looks up `amuxc_blobs` — marketplace
+        packages are deliberately absent from that table. `blob_scope=team`
+        (default) resolves `contentHash → amuxc_blobs.oss_key` for this
+        team. Clients never see `object_path` / `oss_key`; the response
+        is always `{ url, contentHash, size }`.
+
+
+        The signed URL carries its own credentials. Do not attach the
+        caller's bearer token when fetching it.
+
+
+        Design: docs/architecture/team-skill-package-download-contract.md
+      tags: [TeamSkills]
+      parameters:
+        - $ref: "#/components/parameters/TeamId"
+        - $ref: "#/components/parameters/TeamSkillSlug"
+        - name: version
+          in: path
+          required: true
+          schema: { type: integer, minimum: 1 }
+      responses:
+        "200":
+          description: Signed download URL for this version's package.
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [url, contentHash, size]
+                properties:
+                  url: { type: string, format: uri }
+                  contentHash: { type: string }
+                  size: { type: integer }
+        "400": { $ref: "#/components/responses/Error" }
+        "401": { $ref: "#/components/responses/Error" }
+        "403": { $ref: "#/components/responses/Error" }
+        "404": { $ref: "#/components/responses/Error" }
+        "409":
+          description: Package blob is not uploaded yet (`blob_missing`).
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
   /v1/teams/{teamId}/skills/{slug}/versions/{version}/revert:
     post:
       operationId: revertTeamSkillVersion
@@ -2435,10 +2492,14 @@ paths:
       operationId: installTeamSkill
       summary: Record an install
       description: >
-        Three gates. Installing for yourself is always allowed. Installing onto
-        a `visibility=team` agent actor requires a team admin. Installing onto
-        another member's actor is always refused — an admin owns the team's
-        shared agents, not a teammate's personal setup.
+        Four gates. (1) Installing for yourself (the caller's member actor) is
+        always allowed. (2) Installing onto an agent the caller owns — personal
+        or team — is allowed: a member's own machine is an agent, not a member
+        actor, and the install has to be recorded against the actor the daemon
+        will be asked "what do you have installed". (3) Installing onto a
+        `visibility=team` agent the caller does not own requires a team admin.
+        (4) Installing onto another member's actor is always refused — an admin
+        owns the team's shared agents, not a teammate's personal setup.
       tags: [TeamSkills]
       parameters:
         - $ref: "#/components/parameters/TeamId"
@@ -6256,8 +6317,9 @@ components:
         whenNotToUse:
           type: string
           description: >
-            Required, and shown next to whenToUse rather than folded away —
-            two overlapping skills can only be told apart by their boundaries.
+            Optional; empty is a real answer (stored as ""). Shown next to
+            whenToUse rather than folded away — two overlapping skills can
+            only be told apart by their boundaries.
         requires:
           type: [array, "null"]
           items: { type: string }

--- a/packages/app/src/components/TeamSkillAutoFollow.tsx
+++ b/packages/app/src/components/TeamSkillAutoFollow.tsx
@@ -2,6 +2,7 @@ import * as React from 'react'
 import { toast } from 'sonner'
 import { useTranslation } from 'react-i18next'
 import { isTauri } from '@/lib/utils'
+import { isCloudAuthError } from '@/lib/backend/cloud-api/http'
 import { RECONCILE_INTERVAL_MS } from '@/lib/skills/auto-follow'
 import { useTeamShareBrowserStore } from '@/stores/team-share-browser'
 
@@ -23,7 +24,11 @@ import { useTeamShareBrowserStore } from '@/stores/team-share-browser'
  * transient failure to retry, it is a pack that left this machine because of
  * somebody else's decision, and unlike a conflict it has no row left to surface
  * in. See the effect below.
+ *
+ * Auth (401 / expired session) is not transient: the next tick fails the same
+ * way. Toast once per team so the 10-minute timer does not spam.
  */
+
 const NO_RETIREMENTS: Record<string, never> = {}
 
 export function TeamSkillAutoFollow({ teamId }: { teamId: string | null }) {
@@ -38,12 +43,14 @@ export function TeamSkillAutoFollow({ teamId }: { teamId: string | null }) {
   // because `kept` has to stay in the store for the detail pane to explain it —
   // clearing it on announce would take the explanation with it.
   const announced = React.useRef(new Set<string>())
+  const authToastShown = React.useRef(false)
 
   // Paired with the store dropping `skillRetired` on the same switch: slugs are
   // unique per team, not globally, so team A's notices must not be announced
   // while the user is looking at team B.
   React.useEffect(() => {
     announced.current = new Set()
+    authToastShown.current = false
   }, [teamId])
 
   /*
@@ -84,7 +91,16 @@ export function TeamSkillAutoFollow({ teamId }: { teamId: string | null }) {
 
     const run = () => {
       if (cancelled) return
-      void reconcile().catch(() => {})
+      void reconcile().catch((e) => {
+        if (!isCloudAuthError(e) || authToastShown.current) return
+        authToastShown.current = true
+        toast.error(
+          t(
+            'teamShare.skillAutoFollowSessionExpired',
+            '登录已过期，团队技能无法自动同步。请重新登录。',
+          ),
+        )
+      })
     }
 
     run()
@@ -93,7 +109,7 @@ export function TeamSkillAutoFollow({ teamId }: { teamId: string | null }) {
       cancelled = true
       window.clearInterval(timer)
     }
-  }, [teamId, reconcile])
+  }, [teamId, reconcile, t])
 
   return null
 }

--- a/packages/app/src/components/__tests__/TeamSkillAutoFollow.test.tsx
+++ b/packages/app/src/components/__tests__/TeamSkillAutoFollow.test.tsx
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, waitFor } from '@testing-library/react'
+import { CloudApiError } from '@/lib/backend/cloud-api/http'
+
+const toastError = vi.fn()
+const reconcile = vi.fn()
+
+vi.mock('sonner', () => ({ toast: { error: (...a: unknown[]) => toastError(...a), info: vi.fn() } }))
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (_k: string, d?: string) => d ?? _k }),
+}))
+vi.mock('@/lib/utils', () => ({ isTauri: () => true }))
+vi.mock('@/stores/team-share-browser', () => ({
+  useTeamShareBrowserStore: (sel: (s: Record<string, unknown>) => unknown) =>
+    sel({
+      reconcileSkills: reconcile,
+      skillRetired: {},
+      dismissRetired: vi.fn(),
+    }),
+}))
+
+import { TeamSkillAutoFollow } from '../TeamSkillAutoFollow'
+
+describe('TeamSkillAutoFollow', () => {
+  beforeEach(() => {
+    toastError.mockReset()
+    reconcile.mockReset()
+    reconcile.mockResolvedValue(undefined)
+  })
+
+  it('toasts an expired session instead of swallowing 401', async () => {
+    reconcile.mockRejectedValue(new CloudApiError(401, 'missing_auth', 'expired', null))
+    render(<TeamSkillAutoFollow teamId="team-1" />)
+    await waitFor(() => {
+      expect(toastError).toHaveBeenCalled()
+    })
+    expect(String(toastError.mock.calls[0][0])).toMatch(/登录已过期/)
+  })
+
+  it('does not toast ordinary reconcile failures', async () => {
+    reconcile.mockRejectedValue(new Error('network down'))
+    render(<TeamSkillAutoFollow teamId="team-1" />)
+    await waitFor(() => {
+      expect(reconcile).toHaveBeenCalled()
+    })
+    expect(toastError).not.toHaveBeenCalled()
+  })
+})

--- a/packages/app/src/components/settings/ClawHubMarketplace.tsx
+++ b/packages/app/src/components/settings/ClawHubMarketplace.tsx
@@ -31,7 +31,7 @@ import type {
   ClawHubSkillDetail,
   ClawHubLockfile,
 } from "@/lib/clawhub/types"
-import { parseStats } from "@/lib/clawhub/types"
+import { clawhubInstalledSlugs, parseStats } from "@/lib/clawhub/types"
 import { useEffectiveWorkspacePath } from "@/lib/effective-workspace"
 import {
   Dialog,
@@ -94,43 +94,17 @@ export const ClawHubMarketplace = React.memo(function ClawHubMarketplace({
   const loadInstalled = React.useCallback(async () => {
     if (!workspacePath) return
     const loadGen = ++installedLoadGenRef.current
-    const allSlugs = new Set<string>()
-
-    const [, fsModule, pathModule] = await Promise.all([
-      invoke<ClawHubLockfile>("clawhub_list_installed", { workspacePath })
-        .then(lock => { for (const slug of Object.keys(lock.skills)) allSlugs.add(slug) })
-        .catch(() => {}),
-      import("@tauri-apps/plugin-fs").catch(() => null),
-      import("@tauri-apps/api/path").catch(() => null),
-    ])
-
-    if (loadGen !== installedLoadGenRef.current) return
-
-    if (fsModule && pathModule) {
-      try {
-        const home = await pathModule.homeDir()
-        const dirsToCheck = [
-          `${workspacePath}/.claude/skills`,
-          `${workspacePath}/.agents/skills`,
-          `${home.replace(/\/$/, '')}/.claude/skills`,
-          `${home.replace(/\/$/, '')}/.agents/skills`,
-        ]
-
-        await Promise.allSettled(dirsToCheck.map(async (dir) => {
-          if (await fsModule.exists(dir)) {
-            const entries = await fsModule.readDir(dir)
-            entries
-              .filter((e: { isDirectory?: boolean; name?: string }) => e.isDirectory && e.name)
-              .forEach((e: { name?: string }) => allSlugs.add(e.name!))
-          }
-        }))
-      } catch {
-        // fs scan failed
-      }
+    try {
+      const lock = await invoke<ClawHubLockfile>("clawhub_list_installed", { workspacePath })
+      if (loadGen !== installedLoadGenRef.current) return
+      // Lockfile is shared with the team registry. Only ClawHub rows (and
+      // legacy rows with no source) belong in this marketplace's Installed set;
+      // a team pack looking installed here makes Uninstall error.
+      setInstalledSlugs(new Set(clawhubInstalledSlugs(lock)))
+    } catch {
+      if (loadGen !== installedLoadGenRef.current) return
+      setInstalledSlugs(new Set())
     }
-
-    if (loadGen !== installedLoadGenRef.current) return
-    setInstalledSlugs(allSlugs)
   }, [workspacePath])
 
   const loadExplore = React.useCallback(

--- a/packages/app/src/components/settings/SkillsSection.tsx
+++ b/packages/app/src/components/settings/SkillsSection.tsx
@@ -534,11 +534,21 @@ ${skillContent.trim()}`
     try {
       const wid = encodeWorkspaceId(workspacePath)
       const updated: SkillPermissionMap = { ...skillPermissions, '*': value }
-      await putDaemonPermissions(wid, updated)
+      const saved = await putDaemonPermissions(wid, updated)
+      if (saved === null) {
+        throw new Error(
+          t(
+            'settings.skills.permissionSaveFailed',
+            'Could not save permission. Is the daemon running?',
+          ),
+        )
+      }
       setSkillPermissions(updated)
       setHasChanges(true)
+      setError(null)
     } catch (err) {
       console.error('[SkillsSection] Failed to update default permission:', err)
+      setError(err instanceof Error ? err.message : String(err))
     }
   }
 
@@ -553,11 +563,21 @@ ${skillContent.trim()}`
       } else {
         updated = { ...skillPermissions, [skillName]: value as SkillPermission }
       }
-      await putDaemonPermissions(wid, updated)
+      const saved = await putDaemonPermissions(wid, updated)
+      if (saved === null) {
+        throw new Error(
+          t(
+            'settings.skills.permissionSaveFailed',
+            'Could not save permission. Is the daemon running?',
+          ),
+        )
+      }
       setSkillPermissions(updated)
       setHasChanges(true)
+      setError(null)
     } catch (err) {
       console.error('[SkillsSection] Failed to update skill permission:', err)
+      setError(err instanceof Error ? err.message : String(err))
     }
   }
 

--- a/packages/app/src/components/settings/__tests__/ClawHubMarketplace.test.tsx
+++ b/packages/app/src/components/settings/__tests__/ClawHubMarketplace.test.tsx
@@ -15,6 +15,7 @@ type ExploreItem = { slug: string; displayName: string; summary?: string | null 
 type ExploreResult = { items: ExploreItem[]; nextCursor: null }
 
 let exploreResponses: Array<ReturnType<typeof deferred<ExploreResult>>> = []
+let installedLock: { skills: Record<string, { version: string | null; installedAt: number; source?: string }> } = { skills: {} }
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({ t: (k: string, d?: string) => d ?? k, i18n: { language: 'en', changeLanguage: vi.fn() } }),
@@ -27,7 +28,7 @@ vi.mock('@/stores/workspace', () => ({
 }))
 vi.mock('@tauri-apps/api/core', () => ({
   invoke: vi.fn(async (cmd: string) => {
-    if (cmd === 'clawhub_list_installed') return { skills: {} }
+    if (cmd === 'clawhub_list_installed') return installedLock
     if (cmd === 'clawhub_explore') {
       const next = exploreResponses.shift()
       return next?.promise ?? { items: [], nextCursor: null }
@@ -36,7 +37,10 @@ vi.mock('@tauri-apps/api/core', () => ({
   }),
 }))
 vi.mock('@/lib/utils', () => ({ cn: (...a: string[]) => a.join(' ') }))
-vi.mock('@/lib/clawhub/types', () => ({ parseStats: () => ({}) }))
+vi.mock('@/lib/clawhub/types', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/clawhub/types')>()
+  return { ...actual, parseStats: () => ({}) }
+})
 vi.mock('../shared', () => ({
   SettingCard: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
 }))
@@ -46,6 +50,7 @@ import { ClawHubMarketplace } from '../ClawHubMarketplace'
 describe('ClawHubMarketplace', () => {
   beforeEach(() => {
     exploreResponses = []
+    installedLock = { skills: {} }
   })
 
   afterEach(() => {
@@ -100,5 +105,36 @@ describe('ClawHubMarketplace', () => {
     })
 
     expect(screen.getByText('Alpha')).toBeTruthy()
+  })
+
+  it('does not treat team lockfile rows as ClawHub-installed', async () => {
+    installedLock = {
+      skills: {
+        alpha: { version: '3', installedAt: 1, source: 'team' },
+        beta: { version: '1', installedAt: 1, source: 'clawhub' },
+      },
+    }
+    const first = deferred<ExploreResult>()
+    exploreResponses.push(first)
+
+    render(<ClawHubMarketplace />)
+
+    await act(async () => {
+      first.resolve({
+        items: [
+          { slug: 'alpha', displayName: 'Alpha', summary: 'Team pack colliding' },
+          { slug: 'beta', displayName: 'Beta', summary: 'ClawHub pack' },
+        ],
+        nextCursor: null,
+      })
+    })
+
+    expect(await screen.findByText('Alpha')).toBeTruthy()
+    expect(screen.getByText('Beta')).toBeTruthy()
+    // Team slug still offers Install; ClawHub slug shows Installed.
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /Installed/ })).toBeTruthy()
+    })
+    expect(screen.getAllByRole('button', { name: 'Install' })).toHaveLength(1)
   })
 })

--- a/packages/app/src/components/settings/__tests__/SkillsSection.test.tsx
+++ b/packages/app/src/components/settings/__tests__/SkillsSection.test.tsx
@@ -4,10 +4,12 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 
 const t = (k: string, d?: string) => d ?? k
 
-const { workspaceState, mockLoadAllSkills, mockInvoke } = vi.hoisted(() => ({
+const { workspaceState, mockLoadAllSkills, mockInvoke, mockPutDaemonPermissions, mockGetDaemonPermissions } = vi.hoisted(() => ({
   workspaceState: { workspacePath: null as string | null },
   mockLoadAllSkills: vi.fn(async () => ({ skills: [], overrides: [] })),
   mockInvoke: vi.fn(),
+  mockPutDaemonPermissions: vi.fn(),
+  mockGetDaemonPermissions: vi.fn(),
 }))
 const { mockLoadRolesSkillsWorkspaceState } = vi.hoisted(() => ({
   mockLoadRolesSkillsWorkspaceState: vi.fn(async () => ({
@@ -77,6 +79,13 @@ vi.mock('../SkillsDiagnosticsDialog', () => ({
   SkillsDiagnosticsDialog: ({ open }: { open: boolean }) =>
     open ? <div data-testid="skills-diagnostics-dialog">Diagnostics open</div> : null,
 }))
+vi.mock('@/lib/daemon-local-client', () => ({
+  encodeWorkspaceId: (path: string) => path,
+  getDaemonPermissions: mockGetDaemonPermissions,
+  putDaemonPermissions: mockPutDaemonPermissions,
+  reloadDaemonRuntime: vi.fn(),
+  deleteDaemonSkill: vi.fn(),
+}))
 import { SkillsSection } from '../SkillsSection'
 
 describe('SkillsSection', () => {
@@ -98,6 +107,10 @@ describe('SkillsSection', () => {
       },
     })
     mockInvoke.mockReset()
+    mockGetDaemonPermissions.mockReset()
+    mockGetDaemonPermissions.mockResolvedValue({ '*': 'ask' })
+    mockPutDaemonPermissions.mockReset()
+    mockPutDaemonPermissions.mockResolvedValue(null)
     mockInvoke.mockImplementation(async (method: string) => {
       if (method === 'clawhub_list_installed') return { skills: {} }
       if (method === 'clawhub_explore') return { items: [], nextCursor: null }
@@ -302,5 +315,44 @@ describe('SkillsSection', () => {
     await waitFor(() => {
       expect(screen.getByTestId('marketplace-content')).toBeTruthy()
     })
+  })
+
+  it('does not claim a permission write succeeded when the daemon is down', async () => {
+    workspaceState.workspacePath = '/workspace/project'
+    mockPutDaemonPermissions.mockResolvedValue(null)
+
+    render(<SkillsSection />)
+
+    expect(await screen.findByText('Default Permission')).toBeTruthy()
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Ask' }).className).toMatch(/bg-accent/)
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Allow' }))
+
+    expect(await screen.findByText('Could not save permission. Is the daemon running?')).toBeTruthy()
+    expect(mockPutDaemonPermissions).toHaveBeenCalled()
+    // Local state stays on the last loaded value (ask), not the clicked allow.
+    const allow = screen.getByRole('button', { name: 'Allow' })
+    const ask = screen.getByRole('button', { name: 'Ask' })
+    expect(ask.className.split(' ')).toContain('bg-accent')
+    expect(allow.className.split(' ')).not.toContain('bg-accent')
+  })
+
+  it('updates local permission state only after the daemon accepts the write', async () => {
+    workspaceState.workspacePath = '/workspace/project'
+    mockPutDaemonPermissions.mockResolvedValue({ restartRequired: false })
+
+    render(<SkillsSection />)
+
+    expect(await screen.findByText('Default Permission')).toBeTruthy()
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Ask' }).className).toMatch(/bg-accent/)
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Allow' }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Allow' }).className).toMatch(/bg-accent/)
+    })
+    expect(screen.queryByText('Could not save permission. Is the daemon running?')).toBeNull()
   })
 })

--- a/packages/app/src/lib/backend/cloud-api/http.ts
+++ b/packages/app/src/lib/backend/cloud-api/http.ts
@@ -15,6 +15,11 @@ export class CloudApiError extends Error {
   }
 }
 
+/** 401 / missing session -- not a transient blip the next tick will heal. */
+export function isCloudAuthError(error: unknown): boolean {
+  return error instanceof CloudApiError && (error.status === 401 || error.code === "missing_auth")
+}
+
 export type CloudApiClient = {
   get<T>(path: string): Promise<T>;
   post<T>(path: string, body: unknown, options?: { idempotencyKey?: string }): Promise<T>;

--- a/packages/app/src/lib/clawhub/__tests__/lockfile-source.test.ts
+++ b/packages/app/src/lib/clawhub/__tests__/lockfile-source.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest'
+import { clawhubInstalledSlugs, isClawHubLockfileSource } from '../types'
+
+describe('isClawHubLockfileSource', () => {
+  it('treats absent and empty source as ClawHub (legacy lockfile rows)', () => {
+    expect(isClawHubLockfileSource(undefined)).toBe(true)
+    expect(isClawHubLockfileSource(null)).toBe(true)
+    expect(isClawHubLockfileSource('')).toBe(true)
+    expect(isClawHubLockfileSource('clawhub')).toBe(true)
+  })
+
+  it('rejects team (and any other) sources', () => {
+    expect(isClawHubLockfileSource('team')).toBe(false)
+    expect(isClawHubLockfileSource('import')).toBe(false)
+  })
+})
+
+describe('clawhubInstalledSlugs', () => {
+  it('keeps ClawHub and legacy rows, drops team rows', () => {
+    expect(
+      clawhubInstalledSlugs({
+        version: 1,
+        skills: {
+          'from-clawhub': { version: '1', installedAt: 1, source: 'clawhub' },
+          'legacy-row': { version: '1', installedAt: 1 },
+          'from-team': { version: '3', installedAt: 1, source: 'team' },
+        },
+      }),
+    ).toEqual(['from-clawhub', 'legacy-row'])
+  })
+})

--- a/packages/app/src/lib/clawhub/types.ts
+++ b/packages/app/src/lib/clawhub/types.ts
@@ -76,11 +76,25 @@ export interface ClawHubUpdateInfo {
 export interface ClawHubLockfileEntry {
   version: string | null
   installedAt: number
+  /** Absent on pre-team-registry rows, which are all ClawHub. */
+  source?: string | null
 }
 
 export interface ClawHubLockfile {
   version: number
   skills: Record<string, ClawHubLockfileEntry>
+}
+
+/** Lockfile `source` values that the ClawHub marketplace may treat as installed. */
+export function isClawHubLockfileSource(source?: string | null): boolean {
+  return source == null || source === '' || source === 'clawhub'
+}
+
+/** Slugs the ClawHub UI may show as Installed / Uninstall. Team rows stay out. */
+export function clawhubInstalledSlugs(lock: ClawHubLockfile): string[] {
+  return Object.entries(lock.skills)
+    .filter(([, entry]) => isClawHubLockfileSource(entry.source))
+    .map(([slug]) => slug)
 }
 
 // ─── Stats helper (stats field is untyped from API) ──────────────────────────

--- a/packages/app/src/stores/__tests__/team-share-skill-retired.test.ts
+++ b/packages/app/src/stores/__tests__/team-share-skill-retired.test.ts
@@ -55,6 +55,7 @@ vi.mock('@/lib/effective-workspace', () => ({
   useEffectiveWorkspacePath: () => '/ws',
 }))
 
+import { CloudApiError } from '@/lib/backend/cloud-api/http'
 import { useTeamShareBrowserStore } from '../team-share-browser'
 import { useCurrentTeamStore } from '../current-team'
 
@@ -159,5 +160,13 @@ describe('a team skill deleted out from under this machine', () => {
     await store().reconcileSkills()
     store().dismissRetired('deploy-check')
     expect(store().skillRetired).toEqual({})
+  })
+
+  test('an expired session is not swallowed as a transient fetch failure', async () => {
+    listTeamSkills.mockRejectedValue(
+      new CloudApiError(401, 'missing_auth', 'Missing auth session access token.', null),
+    )
+    await expect(store().reconcileSkills()).rejects.toBeInstanceOf(CloudApiError)
+    expect(uninstalled).toEqual([])
   })
 })

--- a/packages/app/src/stores/team-share-browser.ts
+++ b/packages/app/src/stores/team-share-browser.ts
@@ -7,6 +7,7 @@ import { frontmatterString } from '@/lib/skills/frontmatter'
 import { resolveTeamSyncRoot } from '@/lib/team-skill-paths'
 import { invoke } from '@tauri-apps/api/core'
 import { getBackend } from '@/lib/backend/provider'
+import { isCloudAuthError } from '@/lib/backend/cloud-api/http'
 import { getFreshAccessToken } from '@/lib/auth/session-store'
 import { ensureAgentsSkillsPaths } from '@/lib/skills/ensure-agents-paths'
 import {
@@ -1764,9 +1765,12 @@ export const useTeamShareBrowserStore = create<TeamShareBrowserState>((set, get)
           : backend.teamSkills.listTeamSkills(teamId),
         listInstalledPacks(),
       ])
-    } catch {
+    } catch (e) {
       // Offline, or the registry is unreachable. Leave disk exactly as it is —
       // a failed fetch must never be read as "the team removed everything".
+      // Auth is the exception: the next tick will fail the same way, so the
+      // caller has to surface an expired session instead of looking idle.
+      if (isCloudAuthError(e)) throw e
       return
     }
     // Only ever holds removal back — see `planReconcile`.

--- a/services/fc/src/lib/routes/team-skills.ts
+++ b/services/fc/src/lib/routes/team-skills.ts
@@ -76,15 +76,11 @@ export function registerTeamSkills(router) {
     const contentHash = String(body.contentHash ?? "").trim().toLowerCase();
     // Re-resolve placeholder so we know expected size before checking storage.
     const prepared = await ctx.repository.prepareTeamSkillBlob(ctx.params.teamId, body);
-    const { statSkillObject } = await import("../skills-storage.js");
-    const stat = await statSkillObject(prepared.ossKey);
-    if (!stat || stat.size !== prepared.size) {
-      throw new ApiError(
-        422,
-        "blob_missing",
-        `Blob missing or size mismatch: expected ${prepared.size}, got ${stat?.size ?? "none"}`,
-      );
-    }
+    const { verifySkillPackageObject } = await import("../skills-storage.js");
+    await verifySkillPackageObject(prepared.ossKey, {
+      contentHash,
+      size: prepared.size,
+    });
     const done = await ctx.repository.completeTeamSkillBlob(ctx.params.teamId, {
       contentHash,
       size: prepared.size,

--- a/services/fc/src/lib/skills-storage.ts
+++ b/services/fc/src/lib/skills-storage.ts
@@ -1,3 +1,4 @@
+import { ApiError } from "./http-utils.js";
 import { SKILLS_BUCKET, blobStorageFor } from "./team-blob-storage.js";
 
 // ---------------------------------------------------------------------------
@@ -23,6 +24,7 @@ const storage = {
   createDownloadUrl: (p: string, e?: number) =>
     blobStorageFor(SKILLS_BUCKET).createDownloadUrl(p, e),
   stat: (p: string) => blobStorageFor(SKILLS_BUCKET).stat(p),
+  hashSha256: (p: string) => blobStorageFor(SKILLS_BUCKET).hashSha256(p),
 };
 
 export function createSkillUploadUrl(objectPath: string): Promise<string> {
@@ -33,9 +35,61 @@ export function statSkillObject(objectPath: string): Promise<{ size: number } | 
   return storage.stat(objectPath);
 }
 
+export function hashSkillObject(objectPath: string): Promise<string | null> {
+  return storage.hashSha256(objectPath);
+}
+
 export function createSkillDownloadUrl(
   objectPath: string,
   expiresIn = 900,
 ): Promise<string> {
   return storage.createDownloadUrl(objectPath, expiresIn);
+}
+
+/**
+ * Packages above this size are still size-checked on complete, but the bytes
+ * are not pulled into FC to hash. Skill zips are well under this; see
+ * docs/architecture/skill-publish-atomicity-and-blob-verification.md §4 / §8.
+ */
+export const SKILL_PACKAGE_HASH_CAP_BYTES = 16 * 1024 * 1024;
+
+export function skillPackageBytesMatch(
+  stat: { size: number } | null,
+  digest: string | null,
+  expected: { contentHash: string; size: number },
+  hashCap = SKILL_PACKAGE_HASH_CAP_BYTES,
+): { ok: true } | { ok: false; code: string; message: string } {
+  if (!stat || stat.size !== expected.size) {
+    return {
+      ok: false,
+      code: "blob_missing",
+      message: `Blob missing or size mismatch: expected ${expected.size}, got ${stat?.size ?? "none"}`,
+    };
+  }
+  if (expected.size > hashCap) return { ok: true };
+  const want = expected.contentHash.toLowerCase();
+  if (!digest || digest !== want) {
+    return {
+      ok: false,
+      code: "blob_hash_mismatch",
+      message: `Blob hash mismatch: expected ${want}, got ${digest ?? "none"}`,
+    };
+  }
+  return { ok: true };
+}
+
+/** HEAD/list for size, then hash bytes when the package is within the cap. */
+export async function verifySkillPackageObject(
+  objectPath: string,
+  expected: { contentHash: string; size: number },
+): Promise<void> {
+  const stat = await statSkillObject(objectPath);
+  const digest =
+    stat && expected.size <= SKILL_PACKAGE_HASH_CAP_BYTES
+      ? await hashSkillObject(objectPath)
+      : null;
+  const result = skillPackageBytesMatch(stat, digest, expected);
+  if (result.ok === false) {
+    throw new ApiError(422, result.code, result.message);
+  }
 }

--- a/services/fc/src/lib/supabase-repo.ts
+++ b/services/fc/src/lib/supabase-repo.ts
@@ -3833,11 +3833,28 @@ export function createSupabaseBusinessRepository(options) {
       }
       const changelog = String(body.changelog ?? "").trim();
       if (!changelog) throw new ApiError(400, "validation_failed", "changelog is required");
-      const contentHash = String(body.contentHash ?? "").trim();
-      if (!contentHash) throw new ApiError(400, "validation_failed", "contentHash is required");
+      const contentHash = String(body.contentHash ?? "").trim().toLowerCase();
+      if (!/^[a-f0-9]{64}$/.test(contentHash)) {
+        throw new ApiError(400, "validation_failed", "contentHash must be a sha256 hex digest");
+      }
 
       const callerActorId = (await this.resolveCallerActorForTeam(teamId))?.id;
       if (!callerActorId) throw new ApiError(403, "forbidden", "not a member of this team");
+
+      const { data: blob, error: blobErr } = await supabase
+        .from("amuxc_blobs")
+        .select("verified, size")
+        .eq("team_id", teamId)
+        .eq("content_hash", contentHash)
+        .maybeSingle();
+      if (blobErr) throw blobErr;
+      if (!blob?.verified) {
+        throw new ApiError(
+          422,
+          "blob_unverified",
+          "package blob must be uploaded and verified before publish",
+        );
+      }
 
       const { data, error } = await supabase
         .from("team_skills")
@@ -3847,8 +3864,8 @@ export function createSupabaseBusinessRepository(options) {
           owner_actor_id: body.ownerActorId ?? callerActorId,
           summary: fields.summary,
           category: fields.category,
-          when_to_use: fields.whenToUse,
-          when_not_to_use: fields.whenNotToUse,
+          when_to_use: fields.whenToUse ?? "",
+          when_not_to_use: fields.whenNotToUse ?? "",
           requires: fields.requires ?? null,
           status: TEAM_SKILL_STATUSES.includes(body.status) ? body.status : "published",
           latest_version: 1,
@@ -3871,24 +3888,34 @@ export function createSupabaseBusinessRepository(options) {
         skill_id: data.id,
         version: 1,
         content_hash: contentHash,
-        size: Number(body.size ?? 0),
+        size: Number(body.size ?? blob.size ?? 0),
         changelog,
         summary: fields.summary,
         category: fields.category,
-        when_to_use: fields.whenToUse,
-        when_not_to_use: fields.whenNotToUse,
+        when_to_use: fields.whenToUse ?? "",
+        when_not_to_use: fields.whenNotToUse ?? "",
         requires: fields.requires ?? null,
         created_by: callerActorId,
       });
-      if (vErr) throw vErr;
+      if (vErr) {
+        // No transactions over PostgREST. Same compensating delete adopt uses:
+        // a skill row without v1 is stuck, and the slug is taken so retry dies.
+        const { error: cleanupErr } = await supabase.from("team_skills").delete().eq("id", data.id);
+        if (cleanupErr) {
+          console.error("[createTeamSkill] orphan team_skills row left behind:", data.id, cleanupErr);
+        }
+        throw vErr;
+      }
       return mapTeamSkillRow(data);
     },
 
     async createTeamSkillVersion(teamId, slug, body: any = {}) {
       const changelog = String(body.changelog ?? "").trim();
       if (!changelog) throw new ApiError(400, "validation_failed", "changelog is required");
-      const contentHash = String(body.contentHash ?? "").trim();
-      if (!contentHash) throw new ApiError(400, "validation_failed", "contentHash is required");
+      const contentHash = String(body.contentHash ?? "").trim().toLowerCase();
+      if (!/^[a-f0-9]{64}$/.test(contentHash)) {
+        throw new ApiError(400, "validation_failed", "contentHash must be a sha256 hex digest");
+      }
 
       if (body.expectedLatestVersion === undefined || body.expectedLatestVersion === null) {
         throw new ApiError(400, "validation_failed", "expectedLatestVersion is required");
@@ -3905,6 +3932,21 @@ export function createSupabaseBusinessRepository(options) {
       const callerActorId = (await this.resolveCallerActorForTeam(teamId))?.id;
       if (!callerActorId) throw new ApiError(403, "forbidden", "not a member of this team");
 
+      const { data: blob, error: blobErr } = await supabase
+        .from("amuxc_blobs")
+        .select("verified, size")
+        .eq("team_id", teamId)
+        .eq("content_hash", contentHash)
+        .maybeSingle();
+      if (blobErr) throw blobErr;
+      if (!blob?.verified) {
+        throw new ApiError(
+          422,
+          "blob_unverified",
+          "package blob must be uploaded and verified before publish",
+        );
+      }
+
       const patch = requireTeamSkillFields(body, { partial: true });
 
       const { data, error } = await supabase.rpc("publish_team_skill_version", {
@@ -3912,7 +3954,7 @@ export function createSupabaseBusinessRepository(options) {
         p_slug: slug,
         p_expected_latest_version: expectedLatestVersion,
         p_content_hash: contentHash,
-        p_size: Number(body.size ?? 0),
+        p_size: Number(body.size ?? blob.size ?? 0),
         p_changelog: changelog,
         p_summary: patch.summary ?? null,
         p_category: patch.category ?? null,
@@ -4152,7 +4194,22 @@ export function createSupabaseBusinessRepository(options) {
         { onConflict: "team_id,content_hash", ignoreDuplicates: true },
       );
       if (error) throw error;
-      return { contentHash, size, ossKey };
+      // Re-read so a previously verified blob is returned as verified:true.
+      // ignoreDuplicates keeps that flag; without this SELECT the route treats
+      // missing `verified` as needs-upload and content-addressed dedupe dies.
+      const { data: row, error: rErr } = await admin
+        .from("amuxc_blobs")
+        .select("oss_key, size, verified")
+        .eq("team_id", teamId)
+        .eq("content_hash", contentHash)
+        .maybeSingle();
+      if (rErr) throw rErr;
+      return {
+        contentHash,
+        size: row?.size ?? size,
+        ossKey: row?.oss_key ?? ossKey,
+        verified: !!row?.verified,
+      };
     },
 
     async completeTeamSkillBlob(teamId, body: any = {}) {
@@ -4780,8 +4837,13 @@ function requireTeamSkillFields(body: any, { partial = false } = {}): any {
     out[key] = value.trim();
   };
   // Present-but-empty is a real answer here, and it is stored as one.
+  // Omitted on a full publish (not a patch) defaults to "" so the NOT NULL
+  // columns without a DB default do not 23502. Matches marketplace tables.
   const optional = (key: string, value: unknown) => {
-    if (value === undefined) return;
+    if (value === undefined) {
+      if (!partial) out[key] = "";
+      return;
+    }
     out[key] = typeof value === "string" ? value.trim() : "";
   };
   // `summary` and `category` stay required: one is the list subtitle, the other

--- a/services/fc/src/lib/supabase-repo/marketplace.ts
+++ b/services/fc/src/lib/supabase-repo/marketplace.ts
@@ -8,7 +8,7 @@
 
 import { ApiError } from "../http-utils.js";
 import { marketplaceObjectPath } from "../validation/marketplace-paths.js";
-import { statSkillObject } from "../skills-storage.js";
+import { statSkillObject, verifySkillPackageObject } from "../skills-storage.js";
 
 const SLUG_RE = /^[a-z0-9][a-z0-9-]{1,63}$/;
 const CATEGORIES = [
@@ -310,15 +310,17 @@ export function makeSupabaseMarketplaceMethods({
     },
 
     async completeMarketplaceSkillBlob(body: any = {}) {
-      const prepared = await this.prepareMarketplaceSkillBlob(body);
-      if (prepared.requiresUpload) {
-        throw new ApiError(
-          422,
-          "blob_missing",
-          `Blob missing or size mismatch: expected ${prepared.size}`,
-        );
+      const contentHash = String(body.contentHash ?? "").trim().toLowerCase();
+      if (!/^[a-f0-9]{64}$/.test(contentHash)) {
+        throw new ApiError(400, "validation_failed", "contentHash must be a sha256 hex digest");
       }
-      return { ...prepared, verified: true };
+      const size = Number(body.size ?? NaN);
+      if (!Number.isFinite(size) || size < 0) {
+        throw new ApiError(400, "validation_failed", "size must be a non-negative number");
+      }
+      const objectPath = marketplaceObjectPath(contentHash);
+      await verifySkillPackageObject(objectPath, { contentHash, size });
+      return { contentHash, size, objectPath, verified: true };
     },
 
     async createMarketplaceSkill(body: any = {}) {

--- a/services/fc/src/lib/team-blob-storage.ts
+++ b/services/fc/src/lib/team-blob-storage.ts
@@ -9,6 +9,7 @@ import {
   UploadPartCommand,
 } from "@aws-sdk/client-s3";
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
+import { createHash } from "node:crypto";
 import { createServiceRoleClient } from "./supabase.js";
 import { getS3Client, OSS_BUCKET } from "./oss.js";
 
@@ -135,6 +136,12 @@ export interface BlobStorage {
   /** `null` when the object does not exist. */
   stat(objectPath: string): Promise<{ size: number } | null>;
   /**
+   * SHA-256 hex of the object bytes. `null` when the object does not exist.
+   * Used by skill-package complete to prove the uploaded zip is the claimed
+   * contentHash, not merely the claimed size.
+   */
+  hashSha256(objectPath: string): Promise<string | null>;
+  /**
    * Remove the bytes. Idempotent: an object that is already gone is a success,
    * because the only caller is a collector and "not there" is the outcome it
    * wanted. Real failures (credentials, network, bucket gone) still throw.
@@ -209,6 +216,15 @@ export function supabaseBlobStorage(bucket: () => string): BlobStorage {
       return { size: (entry as { metadata?: { size?: number } }).metadata?.size ?? 0 };
     },
 
+    async hashSha256(objectPath) {
+      const { data, error } = await createServiceRoleClient()
+        .storage.from(bucket())
+        .download(objectPath);
+      if (error || !data) return null;
+      const buf = Buffer.from(await data.arrayBuffer());
+      return createHash("sha256").update(buf).digest("hex");
+    },
+
     async remove(objectPath) {
       const { error } = await createServiceRoleClient()
         .storage.from(bucket())
@@ -267,6 +283,23 @@ export function s3BlobStorage(bucket: () => string, prefix: () => string): BlobS
           new HeadObjectCommand({ Bucket: bucket(), Key: key(objectPath) }),
         );
         return { size: head.ContentLength ?? 0 };
+      } catch (e) {
+        if (isMissingObject(e)) return null;
+        throw e;
+      }
+    },
+
+    async hashSha256(objectPath) {
+      try {
+        const obj = await getS3Client().send(
+          new GetObjectCommand({ Bucket: bucket(), Key: key(objectPath) }),
+        );
+        if (!obj.Body) return null;
+        const hash = createHash("sha256");
+        for await (const chunk of obj.Body as AsyncIterable<Uint8Array>) {
+          hash.update(chunk);
+        }
+        return hash.digest("hex");
       } catch (e) {
         if (isMissingObject(e)) return null;
         throw e;

--- a/services/fc/test/marketplace.test.ts
+++ b/services/fc/test/marketplace.test.ts
@@ -155,3 +155,19 @@ test("marketplace object paths never look team-scoped (GC assertion)", () => {
     true,
   );
 });
+
+test("GET /v1/marketplace/skills forwards limit", async () => {
+  const repo = fakeRepo();
+  await request(
+    {
+      httpMethod: "GET",
+      path: "/v1/marketplace/skills",
+      queryStringParameters: { limit: "1" },
+    },
+    repo,
+  );
+  assert.deepEqual(repo.calls[0], {
+    method: "listMarketplaceSkills",
+    args: [{ limit: 1 }],
+  });
+});

--- a/services/fc/test/supabase-repo.test.ts
+++ b/services/fc/test/supabase-repo.test.ts
@@ -839,6 +839,7 @@ test("prepareTeamSkillBlob writes amuxc_blobs with the service-role client", asy
   const out = await repo.prepareTeamSkillBlob("team-1", { contentHash: hash, size: 42 });
 
   assert.equal(out.ossKey, `teams/team-1/blobs/sha256/aa/aa/${hash}`);
+  assert.equal(out.verified, false);
   const write = adminCalls.find((c) => c.table === "amuxc_blobs" && c.op === "upsert");
   assert.ok(write, "the placeholder row must be upserted with the service-role client");
   assert.equal(write.row.verified, false);
@@ -877,6 +878,26 @@ test("completeTeamSkillBlob checks as the caller and flips verified as service_r
     callerCalls.some((c) => c.table === "amuxc_blobs" && c.op === "update"),
     false,
   );
+});
+
+test("prepareTeamSkillBlob returns verified from the existing amuxc_blobs row", async () => {
+  const hash = "c".repeat(64);
+  const adminCalls = [];
+  const caller = fakeSupabase({
+    ...BLOB_CALLER_AUTH,
+    tableData: { actors: [{ id: "actor-1" }] },
+  });
+  const admin = fakeSupabase({
+    tableCalls: adminCalls,
+    tableData: {
+      amuxc_blobs: [{ oss_key: `teams/team-1/blobs/sha256/cc/cc/${hash}`, size: 42, verified: true }],
+    },
+  });
+  const repo = createRepo(caller, { createServiceRoleClient: () => admin });
+  const out = await repo.prepareTeamSkillBlob("team-1", { contentHash: hash, size: 42 });
+  assert.equal(out.verified, true);
+  assert.equal(out.ossKey, `teams/team-1/blobs/sha256/cc/cc/${hash}`);
+  assert.ok(adminCalls.some((c) => c.table === "amuxc_blobs" && c.op === "select"));
 });
 
 function fakeSupabase({
@@ -1040,6 +1061,10 @@ function createSelectableQuery(table, calls, data, error) {
     },
     eq(column, value) {
       calls.push({ table, op: "eq", column, value });
+      return query;
+    },
+    is(column, value) {
+      calls.push({ table, op: "is", column, value });
       return query;
     },
     in(column, values) {

--- a/services/fc/test/team-skills.test.ts
+++ b/services/fc/test/team-skills.test.ts
@@ -1,6 +1,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { handleBusinessApiRequest } from "../src/lib/business-api.js";
+import { skillPackageBytesMatch, SKILL_PACKAGE_HASH_CAP_BYTES } from "../src/lib/skills-storage.js";
 
 // Route-level coverage for the team skills registry.
 // Design: docs/architecture/team-skills-registry.md
@@ -21,6 +22,7 @@ function fakeRepo(overrides: Record<string, unknown> = {}) {
     createTeamSkill: record("createTeamSkill", { slug: "deploy-check" }),
     createTeamSkillVersion: record("createTeamSkillVersion", { version: 2 }),
     getTeamSkillVersion: record("getTeamSkillVersion", { version: 1, contentHash: "abc" }),
+    getTeamSkillDownload: record("getTeamSkillDownload", { ossKey: "teams/t/blobs/x", contentHash: "abc", size: 12 }),
     updateTeamSkill: record("updateTeamSkill", { slug: "deploy-check", status: "deprecated" }),
     deleteTeamSkill: record("deleteTeamSkill"),
     prepareTeamSkillBlob: record("prepareTeamSkillBlob", {
@@ -288,4 +290,59 @@ test("POST skill-blobs/prepare skips the upload URL when the blob is already ver
   const body = JSON.parse(res.body);
   assert.equal(body.requiresUpload, false);
   assert.equal(body.presignedPut, null);
+});
+
+test("GET versions/:v/download is routed to the repository before storage", async () => {
+  const { ApiError } = await import("../src/lib/http-utils.js");
+  const seen: unknown[] = [];
+  const repo = fakeRepo({
+    getTeamSkillDownload: async (...args: unknown[]) => {
+      seen.push(args);
+      throw new ApiError(409, "blob_missing", "skip-storage-for-test");
+    },
+  });
+  const res = await request(
+    { httpMethod: "GET", path: "/v1/teams/team-1/skills/deploy-check/versions/1/download" },
+    repo,
+  );
+  assert.equal(res.statusCode, 409);
+  assert.deepEqual(seen[0], ["team-1", "deploy-check", 1]);
+});
+
+test("GET versions/:v/download rejects a non-numeric version", async () => {
+  const repo = fakeRepo();
+  const res = await request(
+    { httpMethod: "GET", path: "/v1/teams/team-1/skills/deploy-check/versions/latest/download" },
+    repo,
+  );
+  assert.equal(res.statusCode, 400);
+  assert.equal(repo.calls.length, 0);
+});
+
+test("skillPackageBytesMatch requires size then hash", () => {
+  const hash = "a".repeat(64);
+  assert.equal(skillPackageBytesMatch(null, hash, { contentHash: hash, size: 12 }).ok, false);
+  assert.equal(
+    skillPackageBytesMatch({ size: 11 }, hash, { contentHash: hash, size: 12 }).ok,
+    false,
+  );
+  const sizeMismatch = skillPackageBytesMatch({ size: 11 }, hash, { contentHash: hash, size: 12 });
+  if (sizeMismatch.ok !== false) throw new Error("expected fail");
+  assert.equal(sizeMismatch.code, "blob_missing");
+
+  const hashMismatch = skillPackageBytesMatch({ size: 12 }, "b".repeat(64), {
+    contentHash: hash,
+    size: 12,
+  });
+  if (hashMismatch.ok !== false) throw new Error("expected fail");
+  assert.equal(hashMismatch.code, "blob_hash_mismatch");
+
+  assert.equal(skillPackageBytesMatch({ size: 12 }, hash, { contentHash: hash, size: 12 }).ok, true);
+
+  // Oversized packages skip the hash (size-only fallback).
+  const big = SKILL_PACKAGE_HASH_CAP_BYTES + 1;
+  assert.equal(
+    skillPackageBytesMatch({ size: big }, null, { contentHash: hash, size: big }).ok,
+    true,
+  );
 });


### PR DESCRIPTION
## Summary
Full review of skills surfaces (desktop, daemon, FC). Fixes the P0/P1 issues that could wipe hosted packs, pin a failed install as dirty, publish unverified blobs, or reuse a leftover ClawHub `permission.skill` on a new slug.

## Design
- `docs/architecture/hosted-skill-reconcile-fail-closed.md`
- `docs/architecture/skill-publish-atomicity-and-blob-verification.md`
- `docs/architecture/team-skill-package-download-contract.md`
- `docs/architecture/clawhub-uninstall-clears-skill-permission.md`

## What changed
- **Daemon reconcile:** `GET /v1/teams/:id/skills` 404/401/5xx stay `Err` (keep disk). Only HTTP 200 with an `items` array is a desired set. Install stages origin then `commit_staged_pack`; origin-write failure rolls back. Zip `contentHash` checked before extract when present.
- **FC publish:** v1 create is transactional (Path B) / compensating-delete (Path A). Require a verified blob. Path A `prepare` returns `verified`. Download route documented in OpenAPI. Install authz documents owned personal agents.
- **Desktop:** ClawHub uninstall clears `permission.skill`. Zip import refuses overwrite unless force, uses `sanitize_zip_path`, writes `origin.json`. Settings permission writes fail closed when amuxd is down. Auto-follow surfaces 401. ClawHub installed-set is lockfile `source=clawhub` only.

## Tests
- `cargo test -p teamclu-skillpack` (37)
- daemon `team_skills` tests (17), including 401/404 keep and 200 `[]` uninstalls
- `cargo test --lib clawhub` / `skillssh`
- FC `team-skills` + marketplace + pg-repo authz + blob storage
- vitest SkillsSection / ClawHubMarketplace / AutoFollow

## Leftovers (not in this PR)
- MQTT skills reconcile accelerator
- drizzle migrations / postgres `DEFAULT ''` on `when_to_use`
- `listTeamSkillInstallerActorIds` on pg-repo
- Settings create/edit still goes through FS, not daemon
- Expo has no skills UI
- Hash skip for packages >16 MiB

## Test plan
- [ ] Hosted agent: 404 on skills list does not delete `state/cloud/skills`
- [ ] Kill origin write mid-install; pack is not stuck Dirty
- [ ] ClawHub uninstall then reinstall same slug does not inherit old `allow`
- [ ] Zip import of an existing slug is refused without force
- [ ] Settings permission change with daemon down shows an error
- [ ] Publish without a verified blob is rejected