### PR TITLE
fix(fc): drop the reserved FC_SUPABASE_URL from the Alibaba FC env map

### DIFF
--- a/services/fc/s.yaml
+++ b/services/fc/s.yaml
@@ -117,9 +117,15 @@ resources:
         # /v1/config/bootstrap there.
         MQTT_PUBLIC_TCP_BROKER_URL: ${env('MQTT_PUBLIC_TCP_BROKER_URL', '')}
         # Self-host may point FC at an external Supabase project while keeping
-        # the bundled stack as rollback. Compose maps FC_SUPABASE_* → SUPABASE_*;
-        # on this target set SUPABASE_* directly and leave these blank.
-        FC_SUPABASE_URL: ${env('FC_SUPABASE_URL', '')}
+        # the bundled stack as rollback; compose maps FC_SUPABASE_* → SUPABASE_*
+        # there. This target CANNOT declare FC_SUPABASE_URL: Function Compute
+        # reserves the whole `FC_` prefix, and a function update carrying one is
+        # rejected outright with `InvalidArgument: the environment variable name
+        # '...' is reserved by Function Compute` — that failure blocked the
+        # entire deploy, not just the variable. It costs nothing here anyway:
+        # src/index.ts reads FC_SUPABASE_URL only as an override and falls back
+        # to SUPABASE_URL, which this target sets directly. Listed in
+        # EXPECTED_ONLY_IN_COMPOSE in test/deploy-env-parity.test.ts.
         TRUSTED_EXTERNAL_JWT_SECRET: ${env('TRUSTED_EXTERNAL_JWT_SECRET', '')}
         SUPABASE_URL: ${env('SUPABASE_URL')}
         SUPABASE_PUBLIC_URL: ${env('SUPABASE_PUBLIC_URL', '')}

--- a/services/fc/test/deploy-env-parity.test.ts
+++ b/services/fc/test/deploy-env-parity.test.ts
@@ -29,6 +29,14 @@ const EXPECTED_ONLY_IN_COMPOSE = new Set([
   // The container listens on these; FC's runtime supplies its own.
   "PORT",
   "HOST",
+  // Function Compute reserves the `FC_` prefix: a function update that carries
+  // this key is rejected with `InvalidArgument: the environment variable name
+  // 'FC_SUPABASE_URL' is reserved by Function Compute`, which fails the WHOLE
+  // deploy. Declaring it on that target was also pointless — src/index.ts reads
+  // it as an override over SUPABASE_URL, which s.yaml sets directly. Anything
+  // else the FC target must reach compose-side has to be named without the
+  // prefix; do not "fix" a parity failure by adding an FC_* key to s.yaml.
+  "FC_SUPABASE_URL",
 ]);
 const EXPECTED_ONLY_IN_S_YAML = new Set([
   // Self-host runs behind Caddy, which is a transparent proxy that adds no


### PR DESCRIPTION
## What

`services/fc/s.yaml` declared `FC_SUPABASE_URL` in `environmentVariables`. Function Compute reserves the whole `FC_` prefix, so every deploy to that target was rejected:

```
InvalidArgument: code: 400, The environment variable name 'FC_SUPABASE_URL'
is reserved by Function Compute
```

The rejection kills the **entire** function update, not just the variable — the Alibaba FC deploy path has been unshippable since 94495c8a (`feat(apps): self-serve publish via Gitea + FC deploy`) added the key.

## How it surfaced

Deploying `services/fc` to belayo (`teamclaw-belayo-live-api`) today. The failure is clean — the function stayed at its 2026-08-24 code, zero production impact — but it is also silent until you actually try to deploy, and nothing in CI exercises that path.

## Why removing it is safe

`FC_SUPABASE_URL` never did anything on this target. `src/index.ts:35` reads it only as an override:

```ts
process.env.FC_SUPABASE_URL?.trim() || process.env.SUPABASE_URL || ""
```

and `s.yaml` sets `SUPABASE_URL` directly. Only self-host needs the indirection: compose maps `FC_SUPABASE_*` → `SUPABASE_*` so the box can point FC at an external Supabase project while keeping the bundled stack as rollback.

## Why the test changes too

`deploy-env-parity.test.ts` requires both targets to declare the same keys — that rule is what pushed `FC_SUPABASE_URL` into `s.yaml` in the first place. It moves to `EXPECTED_ONLY_IN_COMPOSE` with the reason spelled out, so the next parity failure on an `FC_*` key doesn't get "fixed" the same way again.

## Verification

- Re-ran the belayo deploy after the change: `✅ Done`, function updated `2026-09-02T01:30:46Z`, env map 72 → 67 keys with **no value changed** on any surviving key
- `/v1/config/bootstrap`, `/v1/sessions`, `/v1/teams` all answer `401 missing_auth` (app up, not crashing)
- All four `deploy-env-parity` tests green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012VwtgkVPKr9vf5T2XDEZZA