### PR TITLE
fix(team-skills): stop the trash decoy from colliding with the discard it sets up

### DIFF
--- a/apps/desktop/src/commands/team_skills.rs
+++ b/apps/desktop/src/commands/team_skills.rs
@@ -2424,7 +2424,11 @@ mod tests {
 
         let trash = trash_dir().unwrap();
         std::fs::create_dir_all(&trash).unwrap();
-        let orphan = trash.join(format!("say-hello-{}", now_millis()));
+        // A second in the past, deliberately: `move_to_trash` names its own
+        // destination `{slug}-{now_millis()}`, so on a runner fast enough to put
+        // this line and the discard below in the same millisecond, that rename
+        // would target this very directory and fail with ENOTEMPTY.
+        let orphan = trash.join(format!("say-hello-{}", now_millis() - 1_000));
         write_installed_skill(&orphan, "team-a", 1);
 
         let err = team_skill_restore_trashed(


### PR DESCRIPTION
**Stacked on #1199** — based on that branch, not `main`, so CI here runs with the clippy fix applied and can therefore reach the step this commit is about. Retarget to `main` once #1199 merges.

## The bug

`restore_into_a_team_rejects_missing_or_mismatched_recovery` plants an orphan in the trash and then discards a skill:

```rust
let orphan = trash.join(format!("say-hello-{}", now_millis()));  // decoy, then filled
write_installed_skill(&orphan, "team-a", 1);
...
team_skill_discard_local(...)   // move_to_trash: dest = trash/{slug}-{now_millis()}
```

Both names are `{slug}-{millis}`. When the two `now_millis()` calls land in the same millisecond, `move_to_trash`'s rename target **is** the non-empty decoy:

```
discard: "Failed to move skill aside: Directory not empty (os error 39)"
```

238 tests run in 0.59s on the runner, so this is not a rare race there — it is every run.

## The fix

The decoy dates itself a second into the past. The discard happens later, so its timestamp can never be that value. The name keeps the `{slug}-{millis}` shape the test's slug-mismatch assertions depend on, and 1s is nowhere near `TRASH_TTL_MS`. The sibling test `pruning_keeps_the_recent_and_drops_the_stale` already uses the same `now - 1000` idiom.

Product code is untouched: two user-initiated discards of one skill inside a millisecond is not a real scenario, and making `move_to_trash` retry on a colliding destination is a design call for the skills owner rather than something to slip into a CI fix.

## Why this was invisible until now

`Rust Format & Clippy` runs `fmt` → `clippy` → `cargo test -p teamclu --locked --lib`. It had been failing at that third step since **2026-09-01 11:04** (`discard_rolls_back_when_recovery_metadata_cannot_be_written`, `EISDIR`). At 16:31 `dc3fd715` broke clippy, and from then on the job died one step earlier — masking the test failure entirely. #1199 removes the clippy layer; this removes the one underneath.

## Verification

`cargo test -p teamclu --locked --lib` → **242 passed, 0 failed**.

Being straight about what that does and does not prove: a local pass is weak evidence *for this specific fix*, because reproducing the collision requires two calls in the same millisecond — which a loaded CI runner produces reliably and a laptop usually does not. What the local run does establish is that nothing else in `--lib` is red. CI on this branch is the real check, and is also the point of opening it: to find out whether there is a further layer under this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012VwtgkVPKr9vf5T2XDEZZA