### PR TITLE
ci(pgtap): 镜像拉取改成带退避重试，别再被 ECR 限流秒杀

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,6 +164,28 @@ jobs:
       # plain pg_isready health check can go green against the instance that is
       # about to shut down; the wait below looks for the second "ready to accept
       # connections" instead.
+      # `public.ecr.aws` rate-limits anonymous pulls by source IP, and hosted
+      # runners share theirs — so a burst of runs (ours or anyone else's on the
+      # same egress) gets `toomanyrequests: Rate exceeded`. Left to the implicit
+      # pull inside `docker run`, that is an instant exit 125 with no container,
+      # which reads as "the image would not start" and has been filed as an
+      # infrastructure mystery more than once. Pull explicitly, and back off:
+      # the image never changes between attempts, so a retry is only ever
+      # waiting out somebody else's quota.
+      - name: Pull the Postgres image
+        run: |
+          image=public.ecr.aws/supabase/postgres:17.6.1.106
+          for attempt in 1 2 3 4 5; do
+            if docker pull "$image"; then
+              exit 0
+            fi
+            delay=$((attempt * 15))
+            echo "pull attempt $attempt failed; retrying in ${delay}s"
+            sleep "$delay"
+          done
+          echo "could not pull $image after 5 attempts"
+          exit 1
+
       - name: Start Postgres (same image as the deployment)
         run: |
           docker run -d --name pgtap \


### PR DESCRIPTION
`Database Tests (pgTAP)` 有时候在**四秒内**就红，一个测试都没跑：

```
Unable to find image 'public.ecr.aws/supabase/postgres:17.6.1.106' locally
docker: Error response from daemon: toomanyrequests: Rate exceeded
##[error]Process completed with exit code 125
```

**`public.ecr.aws` 对匿名拉取按来源 IP 限流**，而 GitHub 托管 runner 共享出口 IP —— 所以只要短时间内 run 一多（我们自己的，或同一出口后面任何人的），就会撞上。

跟 pgTAP、跟迁移、跟容器都没关系：**容器根本没被创建**。

这一点是真正的代价所在 —— 它至少被读成过一次「一个起不来的容器」（#1199 的描述里），而一个基础设施故障长着数据库故障的样子，会把人送去读 SQL。

## 改法

拉取拆成独立一步，带退避重试。镜像在两次尝试之间不会变，所以重试只是在等别人的配额过去；五次尝试摊开 150 秒。`docker run` 之后直接用本地镜像启动，其余一个字没动。

如果这样还挡不住，下一档是给 ECR Public 做认证（任意 AWS 凭证都能抬高匿名限额）或把镜像镜像到 GHCR —— 两者都需要 secret 或一个 registry，这个改动不需要。

## 验证

这次红的实例：[run 33598479217 / job 100146749629](https://github.com/different-ai-studio/teamclu/actions/runs/33598479217/job/100146749629)。同一分支上一轮同一个 job 是绿的，本 PR 没碰任何 SQL、迁移或测试。

本 PR 自己的 pgTAP job 就是这条改动的验证。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NSLRgWQJVe4uVJ824WdBdE
