### PR TITLE
fix(threads): harden fork binding lookup and createThread idempotency

### DIFF
--- a/apps/daemon/src/daemon/session_resume.rs
+++ b/apps/daemon/src/daemon/session_resume.rs
@@ -29,6 +29,34 @@ pub(crate) fn binding_for(
         .cloned()
 }
 
+/// Parent session binding for thread fork. Tries the thread's workspace first, then
+/// any binding row for the parent session (parent may have run under another workspace).
+pub(crate) fn resolve_parent_binding_for_fork(
+    store: &SessionStore,
+    parent_session_id: &str,
+    preferred_workspace_id: &str,
+    agent_type: amux::AgentType,
+) -> Option<SessionBinding> {
+    if !preferred_workspace_id.is_empty() {
+        if let Some(binding) = binding_for(
+            store,
+            parent_session_id,
+            agent_type,
+            preferred_workspace_id,
+        ) {
+            return Some(binding);
+        }
+    }
+    store
+        .all_for_session(parent_session_id)
+        .into_iter()
+        .filter(|b| {
+            b.agent_type == agent_type as i32 && !b.acp_session_id.trim().is_empty()
+        })
+        .next_back()
+        .cloned()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -59,5 +87,25 @@ mod tests {
             .as_deref(),
             Some("acp-a")
         );
+    }
+
+    #[test]
+    fn parent_binding_for_fork_falls_back_to_other_workspace() {
+        let mut store = SessionStore::default();
+        store.upsert(SessionBinding::new(
+            "parent-1",
+            "ws-parent",
+            amux::AgentType::Opencode as i32,
+            "acp-parent",
+        ));
+        let binding = resolve_parent_binding_for_fork(
+            &store,
+            "parent-1",
+            "ws-thread",
+            amux::AgentType::Opencode,
+        )
+        .expect("parent binding");
+        assert_eq!(binding.workspace_id, "ws-parent");
+        assert_eq!(binding.acp_session_id, "acp-parent");
     }
 }

--- a/apps/daemon/src/daemon/thread_runtime.rs
+++ b/apps/daemon/src/daemon/thread_runtime.rs
@@ -10,6 +10,7 @@ use crate::config::SessionStore;
 use crate::daemon::server::StartRuntimeError;
 use crate::proto::amux;
 use crate::runtime::backend::{AgentBackend, ForkSpec};
+use crate::daemon::session_resume::resolve_parent_binding_for_fork;
 use crate::runtime::execution_context::{ExecutionContext, ProcessEnvRevision};
 
 #[derive(Debug, Clone)]
@@ -52,19 +53,19 @@ pub(crate) async fn fork_thread_binding(
     context: &ExecutionContext,
     params: &ThreadForkParams,
 ) -> Result<String, StartRuntimeError> {
-    let parent_binding = sessions
-        .lookup(
-            &params.parent_session_id,
-            &params.workspace_id,
-            params.agent_type as i32,
+    let parent_binding = resolve_parent_binding_for_fork(
+        sessions,
+        &params.parent_session_id,
+        &params.workspace_id,
+        params.agent_type,
+    )
+    .ok_or_else(|| {
+        StartRuntimeError::new(
+            "PARENT_RUNTIME_NEVER_ATTACHED",
+            "parent session has no backend binding to fork from",
+            "thread_fork",
         )
-        .ok_or_else(|| {
-            StartRuntimeError::new(
-                "PARENT_RUNTIME_NEVER_ATTACHED",
-                "parent session has no backend binding to fork from",
-                "thread_fork",
-            )
-        })?;
+    })?;
 
     let (fork_leaf_id, fork_opencode_message_id) =
         resolve_fork_anchor(backend, params).await.ok_or_else(|| {

--- a/services/fc/src/lib/supabase-repo.ts
+++ b/services/fc/src/lib/supabase-repo.ts
@@ -1955,6 +1955,23 @@ export function createSupabaseBusinessRepository(options) {
         .maybeSingle();
       if (existingErr) throw existingErr;
       if (existing) {
+        if (existing.parent_session_id !== parentSessionId) {
+          throw new ApiError(
+            400,
+            "validation_failed",
+            "rootMessageId is already bound to a different parent session",
+          );
+        }
+        const { data: threadSeat, error: threadSeatErr } = await supabase
+          .from("session_participants")
+          .select("actor_id")
+          .eq("session_id", existing.id)
+          .eq("actor_id", callerActorId)
+          .maybeSingle();
+        if (threadSeatErr) throw threadSeatErr;
+        if (!threadSeat) {
+          throw new ApiError(403, "forbidden", "not a participant in the thread session");
+        }
         const { items } = await this.listSessionParticipants(existing.id);
         return { ...mapSessionFull(existing), participants: items };
       }


### PR DESCRIPTION
## Summary
- Thread fork resolves the parent backend binding via workspace fallback when the thread runs under a different cloud workspace than the parent, fixing false `PARENT_RUNTIME_NEVER_ATTACHED` errors after #1188.
- `createThread` idempotent returns now validate that the existing thread's `parent_session_id` matches the request and that the caller is a participant in the thread session.

## Test plan
- [x] `pnpm rust:check`
- [ ] Open a thread whose parent ran under a different workspace and confirm `runtimeStart` forks successfully
- [ ] Retry `createThread` with the same `rootMessageId` and confirm idempotent return works for the same parent
- [ ] Retry `createThread` with mismatched `parentSessionId` and confirm 400


Made with [Cursor](https://cursor.com)