### PR TITLE
chore(daemon): drop imports that are dead in every crate root

### DIFF
--- a/apps/daemon/src/backend/cloud_api/mod.rs
+++ b/apps/daemon/src/backend/cloud_api/mod.rs
@@ -119,7 +119,10 @@ pub struct CloudApiBackend {
     /// so concurrent requests can't submit the same (rotating) refresh token in
     /// parallel and trip Supabase's reuse detection.
     refresh_lock: Arc<tokio::sync::Mutex<()>>,
-    /// Where to persist a rotated refresh token (`~/.amuxd/backend.toml`).
+    /// Where to persist a rotated refresh token —
+    /// `teams/<team>/state/backend.toml`, not the home root. Every field in
+    /// that file is per-team, so each team keeps its own credentials instead of
+    /// one set overwriting another.
     /// `None` in tests that don't exercise persistence.
     persist_path: Option<PathBuf>,
     /// Cloud-auth health, shared across clones. Latched when a refresh is

--- a/apps/daemon/src/config/mod.rs
+++ b/apps/daemon/src/config/mod.rs
@@ -24,7 +24,7 @@ mod workspace_resolver;
 pub use daemon_config::{
     ActorConfig, AgentBackendConfig, AgentsConfig, ChannelsConfig, ClaudeAgentConfig,
     CursorAgentConfig, DaemonConfig, DiscordChannel, EmailChannel, FeishuChannel, HttpConfig,
-    KookChannel, MqttConfig, PiAgentConfig, SeaTalkChannel, TeamShareConfig, TransportKind,
+    KookChannel, MqttConfig, SeaTalkChannel, TeamShareConfig, TransportKind,
     WeChatChannel, WeComChannel, BOOTSTRAP_ACTOR_NAME, daemon_host_label,
     daemon_machine_hostname,
 };
@@ -32,37 +32,27 @@ pub use member_store::{MemberStore, PendingInvite, StoredMember};
 pub use model_catalog::DeviceModelCatalog;
 pub use model_resolution::first_available;
 pub use provider_auth::{
-    builtin_provider_auth_methods, merge_live_provider_auth_methods, ProviderAuthMethod,
-    ProviderAuthMethodType, ProviderAuthMethodsResponse,
-};
+    };
 pub use managed_skill_writer::{
     create_pack, get_pack, pack_digest, update_pack, ClaimedTeamContext, CreatePackRequest,
-    ManageSkillResponse, ManagedSkillError, ManagedSkillErrorCode, PackFileInput,
-    RuntimeActivation, UpdatePackRequest,
+    ManageSkillResponse, ManagedSkillError, ManagedSkillErrorCode, UpdatePackRequest,
 };
 pub use skill_creation_policy::{
     append_policy_to_prompt, materialize_policy_file, SKILL_CREATION_POLICY,
-    SKILL_CREATION_POLICY_VERSION,
-};
+    };
 pub use team_skill_draft::{
-    effective_team_skill_dir, get_team_skill_draft, update_team_skill_draft,
-    EffectiveSkillSource, TeamSkillDraftUpdateResult, TeamSkillDraftView,
+    get_team_skill_draft, update_team_skill_draft, TeamSkillDraftUpdateResult, TeamSkillDraftView,
 };
 pub use roles_skills::{
     find_managed_skill_in_session_inventory, is_inherent_skill, scan_roles_skills_state,
-    team_skill_roots, ManagedSkillDto, RoleRecordDto, RoleSkillLinkDto, RolesSkillsMetricsDto,
-    RolesSkillsStateDto,
-};
+    team_skill_roots,     };
 pub use session_store::{SessionBinding, SessionStore};
 pub use workspace_control::{
-    decode_workspace_path, encode_workspace_path, AllowlistDecision, AllowlistRule, ApplyOutcome,
-    McpServerConfig, NullWorkspaceControlStore, OpenCodeCompatStore, PermissionAction,
-    PermissionConfig, ProviderAuthRequest, ProviderInfo, ProviderModelConfig, RuntimeStatus,
-    WorkspaceControlError, WorkspaceControlStore,
+    decode_workspace_path, encode_workspace_path, ApplyOutcome, OpenCodeCompatStore, ProviderAuthRequest, ProviderModelConfig, WorkspaceControlStore,
 };
 pub use workspace_instructions::{
     claude_md_block_present_at, load_system_prompt, sync_teamclu_claude_md,
 };
 pub use workspace_resolver::{
-    resolve_default_workspace_path, ResolveError, ResolvedWorkspace, WorkspaceResolver,
+    resolve_default_workspace_path, WorkspaceResolver,
 };

--- a/apps/daemon/src/config/team_mcp.rs
+++ b/apps/daemon/src/config/team_mcp.rs
@@ -17,7 +17,6 @@ use serde::Deserialize;
 
 use super::global_team_store::{resolve_team_dir, TEAM_LINK_NAME};
 use super::workspace_control::{McpServerConfig, WorkspaceControlError};
-use teamclu_runtime_env::opencode_config::OpencodeConfigError;
 
 pub const INHERENT_MCP_NAMES: &[&str] = &[
     "playwright",

--- a/apps/daemon/src/daemon/server.rs
+++ b/apps/daemon/src/daemon/server.rs
@@ -16,7 +16,11 @@ use crate::backend::{
 };
 use crate::channels::{AmuxdAgentHandle, AmuxdChannelStore, ChannelManager};
 use crate::collab::{AuthManager, AuthResult, PeerState, PeerTracker, PermissionManager};
-use crate::config::{DaemonConfig, SessionBinding, SessionStore};
+use crate::config::{DaemonConfig, SessionStore};
+// Test-only: the fixtures below build bindings directly. Ungated it warns in
+// the bin build, which does not compile them.
+#[cfg(test)]
+use crate::config::SessionBinding;
 use crate::daemon::binding_target::parse_binding_to_target;
 use crate::daemon::runtime_cursor::{
     compute_effective_cursor_from_messages, last_unanswered_mention_idx,
@@ -30,7 +34,6 @@ use crate::daemon::runtime_resolution::{
 use crate::daemon::session_events::{
     format_idea_prompt, message_attachment_urls, parse_mention_actor_ids, resolve_mention_actor_ids,
 };
-use crate::daemon::session_resume::resolve_backend_session_id;
 
 #[path = "cloud_token_file.rs"]
 mod cloud_token_file;

--- a/apps/daemon/src/http/runtime_adapter.rs
+++ b/apps/daemon/src/http/runtime_adapter.rs
@@ -29,6 +29,10 @@ use uuid::Uuid;
 
 use crate::config::workspace_control::WorkspaceControlError;
 use crate::proto::amux;
+// Only the `#[cfg(test)]` startup-prompt branch below constructs one, so the
+// import carries the same gate — ungated it warns in the bin build, and removed
+// it breaks every test target that compiles this file.
+#[cfg(test)]
 use crate::runtime::acp_event_frame::AcpEventFrame;
 use crate::runtime::adapter::{runtime_envelopes_from_acp_event, RuntimeEnvelope};
 use crate::runtime::supervisor::prepare_workspace;

--- a/apps/daemon/src/onboarding/init.rs
+++ b/apps/daemon/src/onboarding/init.rs
@@ -1,6 +1,7 @@
-use crate::config::{
-    ActorConfig, AgentsConfig, DaemonConfig, HttpConfig, MqttConfig, TeamShareConfig,
-};
+use crate::config::{DaemonConfig, HttpConfig};
+// Test-only: only the fixtures below construct a whole daemon.toml.
+#[cfg(test)]
+use crate::config::{ActorConfig, AgentsConfig, MqttConfig, TeamShareConfig};
 use crate::onboarding::invite_url::{self, ParsedInvite};
 use crate::provider_config::{CloudApiConfig, ProviderConfig};
 use anyhow::{anyhow, Context, Result};
@@ -16,7 +17,8 @@ pub struct InitOutcome {
 /// Execute `amuxd init <teamclu://invite?token=...>`:
 ///  1. parse token
 ///  2. POST `/v1/invites/claim` against the Cloud API (anonymous — no bearer)
-///  3. persist `~/.amuxd/backend.toml` with `kind = "cloud_api"`
+///  3. persist `teams/<team>/state/backend.toml` with `kind = "cloud_api"`
+///     (per-team, not the home root — see `ProviderConfig::path_for_team`)
 ///  4. write `daemon.toml` if absent (broker_url left empty unless the invite
 ///     carries a `?broker=` override — the daemon resolves it from
 ///     `/v1/config/bootstrap` at startup), or preserve the existing one's

--- a/apps/daemon/src/opencode_settings/mod.rs
+++ b/apps/daemon/src/opencode_settings/mod.rs
@@ -7,7 +7,7 @@
 mod client;
 mod pool;
 
-pub use client::{LiveProviderCatalog, LiveProviderSummary, OpenCodeSettingsClient};
+pub use client::{LiveProviderCatalog};
 pub use pool::{OpenCodeSettingsService, WorkspaceSettingsContextResolver};
 
 use std::path::Path;

--- a/apps/daemon/src/remote_tools/mod.rs
+++ b/apps/daemon/src/remote_tools/mod.rs
@@ -5,10 +5,9 @@ pub mod session_target;
 pub mod turn_context;
 
 pub use mcp_config::{
-    remote_tools_mcp_config_path, write_remote_tools_mcp_config, REMOTE_TOOLS_MCP_SERVER_NAME,
-};
-pub use registry::{all_tool_names, is_known_tool, tool_input_schema, TOOL_GET_PAGE_DOM};
-pub use session_target::{resolve_member_for_session, SessionRemoteTargetStore};
+    };
+pub use registry::{tool_input_schema};
+pub use session_target::{SessionRemoteTargetStore};
 pub use turn_context::{
-    inject_remote_context, remote_context_instructions, RemoteToolTurnContextStore,
+    RemoteToolTurnContextStore,
 };

--- a/apps/daemon/src/runtime/claude_agent/process.rs
+++ b/apps/daemon/src/runtime/claude_agent/process.rs
@@ -7,7 +7,7 @@
 //! so refusing to spawn without a key would break subscription users.
 
 use std::collections::HashMap;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use tokio::io::{AsyncBufReadExt, BufReader};

--- a/apps/daemon/src/runtime/cursor_sdk/process.rs
+++ b/apps/daemon/src/runtime/cursor_sdk/process.rs
@@ -1,11 +1,11 @@
 //! Per-worktree cursor-bridge process pool.
 
 use std::collections::HashMap;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use tokio::io::{AsyncBufReadExt, BufReader};
-use tracing::{info, warn};
+use tracing::info;
 
 use super::{events, Shared};
 use crate::process_util::CommandNoWindow;

--- a/apps/daemon/src/runtime/manager.rs
+++ b/apps/daemon/src/runtime/manager.rs
@@ -13,12 +13,11 @@ use super::handle::RuntimeHandle;
 use super::refresh::RuntimeRefreshCoordinator;
 
 use crate::backend::Backend;
-use crate::config::{DaemonConfig, DeviceModelCatalog};
+use crate::config::DeviceModelCatalog;
 use crate::proto::amux;
 use crate::runtime::acp_event_frame::AcpEventFrame;
 use crate::runtime::permission_policy::PermissionPolicy;
 use crate::runtime::turn_aggregator::TurnAggregator;
-use chrono::Utc;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AgentLaunchConfig {

--- a/apps/daemon/src/runtime/manager/lookup.rs
+++ b/apps/daemon/src/runtime/manager/lookup.rs
@@ -8,7 +8,6 @@
 //! Child module of `runtime::manager`, so the `impl RuntimeManager` block
 //! reaches `agents` directly.
 
-use crate::proto::amux;
 
 use super::super::handle::RuntimeHandle;
 use super::RuntimeManager;

--- a/apps/daemon/src/runtime/manager/poll.rs
+++ b/apps/daemon/src/runtime/manager/poll.rs
@@ -7,7 +7,6 @@
 //! Child module of `runtime::manager`, so the `impl RuntimeManager` block
 //! reaches the private `agents` map directly.
 
-use crate::proto::amux;
 use crate::runtime::acp_event_frame::AcpEventFrame;
 
 use super::RuntimeManager;


### PR DESCRIPTION
Follow-up to #1206 (already merged). Cuts the bin target's unused-import warnings from 35 to 23, and fixes two stale comments that still pointed `backend.toml` at the home root — it has been per-team (`teams/<team>/state/backend.toml`) for a while, and one of those comments sent a diagnosis down the wrong path today.

## Only what the compiler proved dead in *every* crate root

`apps/daemon` is a bin-only crate whose sources are also `#[path]`-included into three integration-test crate roots. So "unused" is a property of a crate root, not of a file — `pub use session_store::{SessionBinding, SessionStore}` is genuinely used by the bin and genuinely unused by both test roots. Six names whose only use is under `#[cfg(test)]` in the same file now carry that gate, which is the one form every root agrees on.

## Why not `cargo fix`

Six of the twelve removals I first believed safe were wrong: `AcpEventFrame`, `SessionBinding`, and the four `daemon.toml` fixture types in `onboarding/init.rs` are all used from `#[cfg(test)]` blocks the bin never compiles. `cargo fix` — or a green `--bin` build, which is the usual check — deletes all six, leaves the bin green, and puts the failure in test targets that **do not compile on `main` today**, where it reads as pre-existing breakage from someone else. Verified with `--all-targets` throughout instead.

## What is deliberately left

The remaining warnings cannot be fixed by editing imports at all: no single set of imports satisfies every crate root simultaneously. Deleting to satisfy the test roots breaks the bin; keeping to satisfy the bin warns in the test roots. The real fix is a `lib.rs` for the crate so the bin and the tests share one compilation unit — a refactor, not a cleanup.

The 68 `dead_code` warnings are untouched for a related reason: `systemd_unit` is Linux-only and looks dead when compiled on macOS.

## Testing

`cargo check -p amuxd --all-targets` — 0 errors. `cargo test -p amuxd --bin amuxd` over the touched areas — 248 passed, 0 failed.

(The daemon test targets need `fix/ci-daemon-test-compile-and-clippy` to build at all; I applied that patch locally to run them and reverted it before committing.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U4FPAe65oAZQKuVBmhrcEr