### PR TITLE
fix(daemon): mutate OpenCode MCP args in place for session deeplink injection

### DIFF
--- a/apps/daemon/shared/session-context-client.mjs
+++ b/apps/daemon/shared/session-context-client.mjs
@@ -94,6 +94,9 @@ export async function injectSessionIdForTool(toolName, args, backendSessionId, d
  * OpenCode 1.18.x `tool.execute.before` hook handler.
  *
  * Contract: input.tool (string), input.sessionID (string), output.args (mutable).
+ * Mutate output.args in place — OpenCode's MCP path keeps the original args
+ * object (`trigger(..., { args: b })` then `execute(b)`), so replacing
+ * output.args would drop the injected session_id.
  */
 export async function handleToolExecuteBefore(input, output, deps = {}) {
   if (!input || typeof input !== "object" || !output || typeof output !== "object") {
@@ -108,7 +111,17 @@ export async function handleToolExecuteBefore(input, output, deps = {}) {
     throw new Error("session_context_unavailable");
   }
   const inject = deps.injectSessionIdForTool ?? injectSessionIdForTool;
-  output.args = await inject(toolName, output.args ?? {}, String(backendSessionId).trim(), deps);
+  const injected = await inject(
+    toolName,
+    output.args ?? {},
+    String(backendSessionId).trim(),
+    deps,
+  );
+  if (output.args && typeof output.args === "object" && !Array.isArray(output.args)) {
+    Object.assign(output.args, injected);
+    return;
+  }
+  output.args = injected;
 }
 
 export function sessionContextUnavailableResult() {

--- a/apps/daemon/shared/session-context-client.test.mjs
+++ b/apps/daemon/shared/session-context-client.test.mjs
@@ -163,6 +163,29 @@ test("handleToolExecuteBefore injects for real OpenCode production tool id", asy
   assert.equal(output.args.session_id, "teamclu-a");
 });
 
+test("handleToolExecuteBefore mutates the original args object OpenCode keeps", async () => {
+  // OpenCode 1.18.x MCP path: trigger(..., { args: b }) then execute(b).
+  // Replacing output.args leaves b unchanged; introspect then sees no session_id.
+  const originalArgs = { scheme: "copilot361" };
+  const output = { args: originalArgs };
+  await handleToolExecuteBefore(
+    {
+      tool: "teamclu-introspect_get_session_deeplink",
+      sessionID: "backend-a",
+      callID: "call-a",
+    },
+    output,
+    {
+      injectSessionIdForTool: async (_tool, args) => ({
+        ...args,
+        session_id: "teamclu-a",
+      }),
+    },
+  );
+  assert.equal(originalArgs.session_id, "teamclu-a");
+  assert.equal(output.args, originalArgs);
+});
+
 test("concurrent A/B resolve injects distinct TeamClu sessions", async () => {
   const resolver = async (backendSessionId) => {
     if (backendSessionId === "backend-a") return "teamclu-a";

--- a/apps/daemon/shared/session-context-plugin-install.test.mjs
+++ b/apps/daemon/shared/session-context-plugin-install.test.mjs
@@ -42,7 +42,8 @@ test("installed OpenCode plugin loads shared client and injects OpenCode tool id
     const hooks = await factory();
     assert.equal(typeof hooks["tool.execute.before"], "function");
 
-    const output = { args: { scheme: "copilot361" } };
+    const originalArgs = { scheme: "copilot361" };
+    const output = { args: originalArgs };
     await hooks["tool.execute.before"](
       {
         tool: "teamclu-introspect_get_session_deeplink",
@@ -57,7 +58,8 @@ test("installed OpenCode plugin loads shared client and injects OpenCode tool id
         }),
       },
     );
-    assert.equal(output.args.session_id, "teamclu-a");
+    assert.equal(originalArgs.session_id, "teamclu-a");
+    assert.equal(output.args, originalArgs);
   } finally {
     await fs.rm(dir, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Description

OpenCode 1.18.x executes MCP tools with the **original** `args` object passed into `tool.execute.before` (`trigger(..., { args: b })` then `execute(b)`). The `teamclu-session-context` plugin previously replaced `output.args` with a new object after injecting `session_id`, so the object OpenCode actually executed never received the injection.

This caused session-scoped introspect tools (notably `get_session_deeplink`) to fail at runtime with `session_id is required` even when the plugin hook ran successfully.

**Fix:** When `output.args` is a plain object, mutate it in place via `Object.assign(output.args, injected)` instead of assigning a replacement object. Fall back to `output.args = injected` only when args is missing or not a plain object.

Follow-up to the OpenCode tool-id normalization fix in #1113 — both are required for deeplink resolution in managed OpenCode sessions.

## Related Issue

Complements #1113 (OpenCode server_tool id recognition).

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Test plan

- [x] `node --test apps/daemon/shared/session-context-client.test.mjs`
- [x] `node --test apps/daemon/shared/session-context-plugin-install.test.mjs`
- [ ] After merge + desktop rebuild: attach agent in a workspace, call `get_session_deeplink` in-session without explicit `session_id` — should return a deeplink instead of `session_id is required`

## Additional Notes

The session-context plugin is still installed per worktree today; users on old plugin copies need app restart / workspace re-attach (or `prepare_workspace`) to pick up the embedded template after the sidecar rebuilds.

Made with [Cursor](https://cursor.com)