### PR TITLE
fix(apps): unbreak deployed data_apps — connection string and redirects

### DIFF
--- a/deploy/self-host/.env.example
+++ b/deploy/self-host/.env.example
@@ -226,6 +226,13 @@ APPS_FC_SECURITY_GROUP_ID=
 # set APPS_FC_ENDPOINT directly, or ALIYUN_ACCOUNT_ID to have it composed as
 # <accountId>.<APPS_REGION>.fc.aliyuncs.com.
 APPS_FC_ENDPOINT=
+
+# Zone the app's FC custom domain lives in (e.g. fc-apps.example.com). Requires
+# a wildcard CNAME `*.<this>` -> <accountId>.<region>-internal.fc.aliyuncs.com.
+# MUST differ from APPS_PUBLIC_DOMAIN — that one points at this proxy, so
+# forwarding to it would loop back here. Blank leaves apps on their
+# *.fcapp.run trigger URL, which returns ExternalRedirectForbidden for any 3xx.
+APPS_FC_ROUTE_DOMAIN=
 ALIYUN_ACCOUNT_ID=
 # Where the built app artifact (apps/<appId>/code.zip) is staged. Leave blank
 # ONLY if ACCESS_KEY_ID/BUCKET/ENDPOINT above are already a real Alibaba OSS

--- a/deploy/self-host/docker-compose.yml
+++ b/deploy/self-host/docker-compose.yml
@@ -380,6 +380,12 @@ services:
       # Function Compute trigger URL and Caddy never asks about a certificate.
       # Requires a wildcard A record for *.<this> pointing at this box.
       APPS_PUBLIC_DOMAIN: "${APPS_PUBLIC_DOMAIN:-}"
+      # Zone the app's FC custom domain lives in, e.g. fc-apps.example.com.
+      # MUST be a different zone from APPS_PUBLIC_DOMAIN: that one resolves to
+      # this proxy, so forwarding to it would resolve straight back here. Blank
+      # keeps apps on their *.fcapp.run trigger URL, which refuses to forward
+      # any 3xx (ExternalRedirectForbidden).
+      APPS_FC_ROUTE_DOMAIN: "${APPS_FC_ROUTE_DOMAIN:-}"
       # Per-app git repos on Gitea. Blank disables repo provisioning (503
       # gitea_unavailable naming the empty variable). May be the Caddy-proxied
       # public HTTPS URL (https://${GITEA_DOMAIN}) or the in-network address

--- a/services/fc/s.yaml
+++ b/services/fc/s.yaml
@@ -84,6 +84,7 @@ resources:
         # account-scoped (<accountId>.<region>.fc.aliyuncs.com) and unrelated to
         # the OSS ENDPOINT above. Set one of the two.
         APPS_FC_ENDPOINT: ${env('APPS_FC_ENDPOINT', '')}
+        APPS_FC_ROUTE_DOMAIN: ${env('APPS_FC_ROUTE_DOMAIN', '')}
         ALIYUN_ACCOUNT_ID: ${env('ALIYUN_ACCOUNT_ID', '')}
         # Optional dedicated OSS profile for app code artifacts. On THIS target
         # everything already lives in one Alibaba account, so leaving these

--- a/services/fc/src/lib/apps-public-host.ts
+++ b/services/fc/src/lib/apps-public-host.ts
@@ -22,6 +22,38 @@ export function appPublicLabel(slug: string, appId: string): string {
   return `${slug}-${appId.slice(0, ID_PREFIX_LEN)}`;
 }
 
+/**
+ * The zone the app's FC custom domain lives in, e.g. `fc-apps.example.com`.
+ *
+ * Deliberately a DIFFERENT zone from `APPS_PUBLIC_DOMAIN`: the public name
+ * resolves to our own proxy, so if the proxy forwarded to that same name it
+ * would resolve straight back to itself. This zone resolves to Function
+ * Compute instead, which is how the request reaches the app at all — Node's
+ * fetch cannot override `Host`, so DNS has to carry the routing.
+ *
+ * Blank keeps the old behaviour: the app is served on its `*.fcapp.run`
+ * trigger URL, which cannot forward redirects.
+ */
+export const appsFcRouteDomain = (env: Env = process.env) =>
+  env.APPS_FC_ROUTE_DOMAIN?.trim() || "";
+
+/**
+ * The host FC matches against to find this app's function, or null when the
+ * deployment has not configured a route domain.
+ *
+ * Same label as the public host so the two are trivially correlatable when
+ * reading logs on either side.
+ */
+export function appFcRouteHost(
+  slug: string | null | undefined,
+  appId: string | null | undefined,
+  env: Env = process.env,
+): string | null {
+  const domain = appsFcRouteDomain(env);
+  if (!domain || !slug || !appId) return null;
+  return `${appPublicLabel(slug, appId)}.${domain}`;
+}
+
 /** Public URL for an app, or null when this deployment has no apps domain. */
 export function appPublicUrl(
   slug: string | null | undefined,

--- a/services/fc/src/lib/provisioning/app-delete.ts
+++ b/services/fc/src/lib/provisioning/app-delete.ts
@@ -5,11 +5,14 @@ import { appFunctionName, appOssObjectName } from "./app-deploy.js";
 import type { GotrueOAuthClient } from "./gotrue-oauth.js";
 import { GITEA_AUTH_KIND, type GiteaClient } from "./gitea.js";
 import { revokeAllDeployKeys } from "./deploy-key.js";
+import { appFcRouteHost } from "../apps-public-host.js";
 
 export type TeardownAppDeps = {
   fcOps?: {
     deleteHttpTrigger?: (functionName: string) => Promise<void>;
     deleteFunction: (functionName: string) => Promise<void>;
+    /** Absent on a deployment with no route domain, and on older callers. */
+    deleteCustomDomain?: (domainName: string) => Promise<void>;
   };
   deleteOssObject?: (ossObjectName: string) => Promise<void>;
   gotrue?: GotrueOAuthClient;
@@ -19,6 +22,8 @@ export type TeardownAppDeps = {
 
 export type TeardownAppInput = {
   appId: string;
+  /** Needed to rebuild the app's custom-domain host, which carries the slug. */
+  slug?: string | null;
   fcFunctionName?: string | null;
   authMode?: AuthMode | string | null;
   oauthClientId?: string | null;
@@ -41,6 +46,17 @@ export async function teardownAppResources(
       await deps.fcOps.deleteFunction(functionName);
     } catch {
       // FC may already be gone; delete must still proceed.
+    }
+    // Separate try: a custom domain outlives its function, and a quota is
+    // account-wide — leaking one per deleted app is how the next create starts
+    // failing for an unrelated app.
+    const routeHost = appFcRouteHost(input.slug, input.appId);
+    if (routeHost && deps.fcOps.deleteCustomDomain) {
+      try {
+        await deps.fcOps.deleteCustomDomain(routeHost);
+      } catch {
+        // Same reasoning as above: teardown is best-effort.
+      }
     }
   }
 

--- a/services/fc/src/lib/provisioning/app-deploy.ts
+++ b/services/fc/src/lib/provisioning/app-deploy.ts
@@ -1,3 +1,4 @@
+import { appFcRouteHost } from "../apps-public-host.js";
 import { randomBytes } from "node:crypto";
 import {
   provisionAppPostgres,
@@ -201,6 +202,8 @@ export interface FinalizeDeps {
   fcOps: {
     ensureFunction: (name: string, a: { ossObjectName: string; env: Record<string, string> }) => Promise<void>;
     ensureHttpTrigger: (name: string) => Promise<string>;
+    /** Absent on a deployment that has no route domain configured. */
+    ensureCustomDomain?: (functionName: string, domainName: string) => Promise<string>;
   };
   genPassword?: () => string;
   extraEnv?: (input: FinalizeInput) => Record<string, string>;
@@ -276,6 +279,17 @@ export async function finalizeDeploy(deps: FinalizeDeps, input: FinalizeInput): 
     ossObjectName: input.ossObjectName,
     env,
   });
-  const fcEndpoint = await deps.fcOps.ensureHttpTrigger(input.fcFunctionName);
-  return { fcEndpoint };
+  // The trigger URL is still created: it is what the function is reachable on
+  // before a custom domain exists, and the only address a deployment without a
+  // route domain has.
+  const triggerUrl = await deps.fcOps.ensureHttpTrigger(input.fcFunctionName);
+
+  // Prefer the custom domain. `*.fcapp.run` refuses to forward any 3xx
+  // (`ExternalRedirectForbidden`), so an app that merely normalises a trailing
+  // slash is broken on it — see `ensureCustomDomain`.
+  const routeHost = appFcRouteHost(input.slug, input.appId);
+  if (routeHost && deps.fcOps.ensureCustomDomain) {
+    return { fcEndpoint: await deps.fcOps.ensureCustomDomain(input.fcFunctionName, routeHost) };
+  }
+  return { fcEndpoint: triggerUrl };
 }

--- a/services/fc/src/lib/provisioning/app-postgres.ts
+++ b/services/fc/src/lib/provisioning/app-postgres.ts
@@ -64,6 +64,26 @@ export interface AppConnection {
   connectionString: string;
 }
 
+/**
+ * Re-encode the space in `options=-c search_path=…` as `%20`.
+ *
+ * `URLSearchParams` form-encodes a space as `+`, but a Postgres connection URI
+ * is read per RFC 3986, where `+` is a literal plus and nothing else. libpq and
+ * postgres.js both hand the server an option named `+search_path`, and it
+ * answers `FATAL: unrecognized configuration parameter "+search_path"` — so
+ * every deployed data_app failed on its first query, with a 500 that named
+ * nothing.
+ *
+ * Only the `options` value is touched; a `+` anywhere else in the URL (a
+ * password, say) is left exactly as the URL serializer wrote it.
+ */
+export function percentEncodeOptions(connectionString: string): string {
+  return connectionString.replace(
+    /([?&]options=)([^&]*)/,
+    (_match, prefix: string, value: string) => prefix + value.replace(/\+/g, "%20"),
+  );
+}
+
 export async function ensureAppSchema(
   exec: SqlExecutor,
   { appId, slug, password, baseUrl }: EnsureAppSchemaParams,
@@ -78,7 +98,7 @@ export async function ensureAppSchema(
   u.password = password;
   u.searchParams.set("options", `-c search_path=${schema}`);
   const database = decodeURIComponent(u.pathname.replace(/^\//, "")) || "postgres";
-  return { schema, role, database, connectionString: u.toString() };
+  return { schema, role, database, connectionString: percentEncodeOptions(u.toString()) };
 }
 
 /** Rewrite a postgres URL so it targets `database` (pathname). */

--- a/services/fc/src/lib/provisioning/fc-client.ts
+++ b/services/fc/src/lib/provisioning/fc-client.ts
@@ -245,5 +245,50 @@ export function makeFcOps(client: any, cfg: FcOpsConfig) {
       if (!url) throw new Error("http trigger has no urlInternet");
       return url;
     },
+
+    /**
+     * Bind `domainName` to `functionName`, so requests carrying that Host reach
+     * this app.
+     *
+     * The default `*.fcapp.run` hostname refuses to forward **any** 3xx with
+     * `ExternalRedirectForbidden` (Alibaba product change, 2025-04-01) and is
+     * documented as test-only. A trailing-slash normalisation or a login
+     * redirect is enough to break an app on it, so every deployed app gets a
+     * custom domain instead.
+     *
+     * `HTTP`, not HTTPS: the only client is our own proxy, reaching FC over
+     * Alibaba's internal network. Serving HTTPS here would mean uploading a
+     * certificate to FC, which is a manual PEM snapshot that CAS never renews.
+     *
+     * Idempotent — a redeploy re-points the same domain at the same function.
+     */
+    async ensureCustomDomain(functionName: string, domainName: string): Promise<string> {
+      const routeConfig = new $fc.RouteConfig({
+        routes: [
+          new $fc.PathConfig({ path: "/*", functionName, qualifier: "LATEST" }),
+        ],
+      });
+      const body = { protocol: "HTTP", routeConfig };
+      try {
+        await client.createCustomDomain(new $fc.CreateCustomDomainRequest({
+          body: new $fc.CreateCustomDomainInput({ domainName, ...body }),
+        }));
+      } catch (e) {
+        if (!isAlreadyExists(e)) throw e;
+        await client.updateCustomDomain(domainName, new $fc.UpdateCustomDomainRequest({
+          body: new $fc.UpdateCustomDomainInput(body),
+        }));
+      }
+      return `http://${domainName}`;
+    },
+
+    /** Drop an app's custom domain. Best-effort: a missing one is done. */
+    async deleteCustomDomain(domainName: string): Promise<void> {
+      try {
+        await client.deleteCustomDomain(domainName);
+      } catch (e) {
+        if (!isNotFound(e)) throw e;
+      }
+    },
   };
 }

--- a/services/fc/src/lib/supabase-repo.ts
+++ b/services/fc/src/lib/supabase-repo.ts
@@ -3857,6 +3857,8 @@ export function createSupabaseBusinessRepository(options) {
       const admin = await serviceRoleClient("delete app and archive workspace");
       const teardownInput = {
         appId,
+        // Carries the app's custom-domain host, which is built from the slug.
+        slug: existing.slug,
         fcFunctionName: existing.fc_function_name,
         authMode: existing.auth_mode,
         oauthClientId: existing.oauth_client_id,

--- a/services/fc/test/provisioning/app-deploy.test.ts
+++ b/services/fc/test/provisioning/app-deploy.test.ts
@@ -338,3 +338,119 @@ test("gitCommitSha is optional for an app with no forge repo", () => {
   assert.equal(parseOptionalGitCommitSha("ABC1234"), "abc1234");
   assert.throws(() => parseOptionalGitCommitSha("nope"), /gitCommitSha/);
 });
+
+// ── custom domain ─────────────────────────────────────────────────────────
+//
+// `*.fcapp.run` refuses to forward any 3xx with `ExternalRedirectForbidden`
+// (Alibaba product change, 2025-04-01), so an app that merely normalises a
+// trailing slash is broken on it. Every deploy binds a custom domain instead.
+
+test("finalizeDeploy binds a custom domain and serves the app on it", async () => {
+  const prev = process.env.APPS_FC_ROUTE_DOMAIN;
+  process.env.APPS_FC_ROUTE_DOMAIN = "fc-apps.example.com";
+  try {
+    const bound: string[][] = [];
+    const out = await finalizeDeploy(
+      {
+        fcOps: {
+          ensureFunction: async () => {},
+          ensureHttpTrigger: async () => "https://fn.example.fcapp.run",
+          ensureCustomDomain: async (fn: string, domain: string) => {
+            bound.push([fn, domain]);
+            return `http://${domain}`;
+          },
+        },
+      },
+      {
+        appId: "3f1c9a2e-0000-4000-8000-000000000abc",
+        slug: "demo",
+        appType: "static_web",
+        fcFunctionName: "tc-app-3f1c9a2e-0000-4000-8000-000000000abc",
+        ossObjectName: "apps/x/code.zip",
+      },
+    );
+    // Same label as the public host, so the two correlate in logs on both sides.
+    assert.deepEqual(bound, [[
+      "tc-app-3f1c9a2e-0000-4000-8000-000000000abc",
+      "demo-3f1c9a2e.fc-apps.example.com",
+    ]]);
+    assert.deepEqual(out, { fcEndpoint: "http://demo-3f1c9a2e.fc-apps.example.com" });
+  } finally {
+    if (prev === undefined) delete process.env.APPS_FC_ROUTE_DOMAIN;
+    else process.env.APPS_FC_ROUTE_DOMAIN = prev;
+  }
+});
+
+test("finalizeDeploy falls back to the trigger URL with no route domain", async () => {
+  const prev = process.env.APPS_FC_ROUTE_DOMAIN;
+  delete process.env.APPS_FC_ROUTE_DOMAIN;
+  try {
+    const out = await finalizeDeploy(
+      {
+        fcOps: {
+          ensureFunction: async () => {},
+          ensureHttpTrigger: async () => "https://fn.example.fcapp.run",
+          ensureCustomDomain: async () => { throw new Error("must not be called"); },
+        },
+      },
+      {
+        appId: "3f1c9a2e-0000-4000-8000-000000000abc",
+        slug: "demo",
+        appType: "static_web",
+        fcFunctionName: "tc-app-x",
+        ossObjectName: "apps/x/code.zip",
+      },
+    );
+    assert.deepEqual(out, { fcEndpoint: "https://fn.example.fcapp.run" });
+  } finally {
+    if (prev !== undefined) process.env.APPS_FC_ROUTE_DOMAIN = prev;
+  }
+});
+
+test("deleting an app drops its custom domain too", async () => {
+  // The domain outlives the function and the quota is account-wide, so leaking
+  // one per deleted app is how a later create starts failing for a different
+  // app entirely.
+  const prev = process.env.APPS_FC_ROUTE_DOMAIN;
+  process.env.APPS_FC_ROUTE_DOMAIN = "fc-apps.example.com";
+  try {
+    const dropped: string[] = [];
+    const { teardownAppResources } = await import("../../src/lib/provisioning/app-delete.js");
+    await teardownAppResources(
+      {
+        fcOps: {
+          deleteFunction: async () => {},
+          deleteCustomDomain: async (d: string) => { dropped.push(d); },
+        },
+      },
+      { appId: "3f1c9a2e-0000-4000-8000-000000000abc", slug: "demo" },
+    );
+    assert.deepEqual(dropped, ["demo-3f1c9a2e.fc-apps.example.com"]);
+  } finally {
+    if (prev === undefined) delete process.env.APPS_FC_ROUTE_DOMAIN;
+    else process.env.APPS_FC_ROUTE_DOMAIN = prev;
+  }
+});
+
+test("a failing custom-domain delete never blocks the rest of teardown", async () => {
+  const prev = process.env.APPS_FC_ROUTE_DOMAIN;
+  process.env.APPS_FC_ROUTE_DOMAIN = "fc-apps.example.com";
+  try {
+    let deletedFn = false;
+    const { teardownAppResources } = await import("../../src/lib/provisioning/app-delete.js");
+    const out = await teardownAppResources(
+      {
+        fcOps: {
+          deleteFunction: async () => { deletedFn = true; },
+          deleteCustomDomain: async () => { throw new Error("gone"); },
+        },
+      },
+      { appId: "3f1c9a2e-0000-4000-8000-000000000abc", slug: "demo" },
+    );
+    assert.ok(deletedFn);
+    assert.deepEqual(out, { archivedRepoUrl: null });
+  } finally {
+    if (prev === undefined) delete process.env.APPS_FC_ROUTE_DOMAIN;
+    else process.env.APPS_FC_ROUTE_DOMAIN = prev;
+  }
+});

--- a/services/fc/test/provisioning/app-postgres.test.ts
+++ b/services/fc/test/provisioning/app-postgres.test.ts
@@ -5,6 +5,7 @@ import { PGlite } from "@electric-sql/pglite";
 import { ensureAppSchema } from "../../src/lib/provisioning/app-postgres.js";
 import { getAppsAdminExecutor } from "../../src/lib/provisioning/app-postgres.js";
 import {
+  percentEncodeOptions,
   resolveAppConnectionString,
   withDbHost,
 } from "../../src/lib/provisioning/app-postgres.js";
@@ -92,10 +93,35 @@ test("ensureAppSchema creates the schema and a scoped role on a real PG (pglite)
   assert.equal(roles.rows.length, 1);
   assert.match(conn.connectionString, /app_3f1c9a2e_0000_4000_8000_000000000abc/);
   assert.equal(conn.database, "teamclu_apps");
+  // `%20`, not `.*`: the old pattern matched the broken `-c+search_path=…` just
+  // as happily, which is why every deployed data_app shipped unable to connect.
   assert.match(
     conn.connectionString,
-    new RegExp(`[?&]options=.*search_path%3D${expectedSchema}`),
+    new RegExp(`[?&]options=-c%20search_path%3D${expectedSchema}(&|$)`),
   );
+  assert.ok(
+    !/[?&]options=[^&]*\+/.test(conn.connectionString),
+    `a '+' in options is read literally by Postgres: ${conn.connectionString}`,
+  );
+});
+
+test("options encodes its space as %20, not the form-encoded +", () => {
+  // A Postgres connection URI is read per RFC 3986, where `+` is a plus and
+  // nothing else — the server answers
+  // `FATAL: unrecognized configuration parameter "+search_path"`.
+  // Verified against a real RDS instance, which is how this was found.
+  const encoded = percentEncodeOptions(
+    "postgres://u:p@h:5432/db?options=-c+search_path%3Dapp_x&sslmode=require",
+  );
+  assert.equal(
+    encoded,
+    "postgres://u:p@h:5432/db?options=-c%20search_path%3Dapp_x&sslmode=require",
+  );
+});
+
+test("a + outside options is left exactly as the URL serializer wrote it", () => {
+  const untouched = "postgres://u:pa+ss@h:5432/db?sslmode=require";
+  assert.equal(percentEncodeOptions(untouched), untouched);
 });
 
 test("ensureAppSchema is safe to run twice (idempotent re-deploy)", async () => {


### PR DESCRIPTION
Two independent faults, both of which made a deployed app fail in a way that named nothing useful. Found by deploying `project-management` and reading the function's own logs.

## 1. Every data_app got a connection string Postgres rejects

`ensureAppSchema` built the URL with `URLSearchParams`, which form-encodes a space as `+`:

```
?options=-c+search_path%3Dapp_project_management_…
```

A Postgres connection URI is read per RFC 3986, where `+` is a literal plus and nothing else. libpq and postgres.js both hand the server an option named `+search_path`, and it answers:

```
FATAL:  unrecognized configuration parameter "+search_path"
```

…before the connection is even established. The app's DB-touching route then 500s with nothing pointing at the cause. Verified against the real RDS instance using the exact credential from the deployed function's env.

Only the `options` value is re-encoded; a `+` elsewhere in the URL (a password) is left as the serializer wrote it.

**Why it shipped:** the existing test asserted `options=.*search_path%3D…`, and `.*` matched the broken `+` just as happily. Tightened to require `%20`, plus a case proving no `+` survives in `options`. Mutation-checked: reverting the fix turns that test red.

## 2. `*.fcapp.run` refuses to forward any redirect

Since 2025-04-01 the default HTTP-trigger hostname blocks every 3xx with `ExternalRedirectForbidden` (HTTP 400), and Alibaba documents it as unfit for production. Not an edge case — `project-management` broke on a plain `/` → `/?status=all` filter normalisation. Trailing-slash handling, login redirects and post-form 303s are equally fatal.

Each deploy now binds an FC custom domain, `<slug>-<id8>.$APPS_FC_ROUTE_DOMAIN`, and serves the app there.

**`APPS_FC_ROUTE_DOMAIN` must be a different zone from `APPS_PUBLIC_DOMAIN`.** The public name resolves to our own proxy, so forwarding to that same name would resolve straight back to itself. Node's fetch cannot override `Host`, so DNS carries the routing — the new zone CNAMEs to FC. The proxy is unchanged; it already fetches whatever `fc_endpoint` holds.

The custom domain speaks **HTTP, not HTTPS**: its only client is our proxy, reaching FC over Alibaba's internal network. HTTPS would mean uploading a certificate to FC — a manual PEM snapshot that CAS never renews, a failure mode this repo has already been bitten by.

Blank `APPS_FC_ROUTE_DOMAIN` keeps the old trigger-URL behaviour, so other deploy targets and local dev are untouched. Declared in all three places the env contract requires (compose allowlist, `s.yaml`, `.env.example`); `deploy-env-parity.test.ts` green.

App delete drops the custom domain in its own `try`: the domain outlives its function and the quota is account-wide, so leaking one per deleted app is how a later create starts failing for an unrelated app.

## Deploying this

DNS is already in place: `*.fc-apps.teamclu-dev.ucar.cc` CNAME → `1457752404144823.cn-shenzhen-internal.fc.aliyuncs.com`, DNS-only, verified resolving and reachable from the self-host box (returns 404 from the FC gateway, as expected with no domain bound yet).

After merge, set on the box:

```
APPS_FC_ROUTE_DOMAIN=fc-apps.teamclu-dev.ucar.cc
```

**Existing deployed apps do not self-heal.** Both the broken connection string and the trigger URL are baked into each function at finalize, so every already-deployed app needs one redeploy.

**Unverified:** whether ICP filing covers the new `fc-apps` subdomain. FC validates the CNAME when creating a custom domain, and a filing problem would surface only on that first real call — which needs this deployed.

## Testing

`npm test` in `services/fc`: 901 tests, 0 failures (6 new). Typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U4FPAe65oAZQKuVBmhrcEr