### PR TITLE
fix(chat): keep live panel visible while answering agent questions

### DIFF
--- a/packages/app/src/components/chat/ChatInputArea.tsx
+++ b/packages/app/src/components/chat/ChatInputArea.tsx
@@ -32,7 +32,7 @@ import type { EngagedAgentUiEntry } from "@/hooks/use-engaged-agent-ui-states";
 import { hasAnyNonReadyEngaged } from "@/hooks/use-engaged-agent-ui-states";
 import { useOfflineSendPreferenceStore } from "@/stores/offline-send-preference-store";
 import { ComposerStack, type ActiveStreamingAgent } from "./ComposerStack";
-import type { Todo } from "@/stores/session-types";
+import type { Todo, PendingQuestionState } from "@/stores/session-types";
 import { CommandPopover } from "./CommandPopover";
 import type { Command as ChatCommand } from "./CommandPopover";
 import { FileInputButton } from "./FileInputButton";
@@ -189,6 +189,8 @@ interface ChatInputAreaProps {
   stackTodos?: Todo[];
   stackQueue?: QueuedMessage[];
   planSlotHidden?: boolean;
+  /** When set, question UI renders in ComposerStack and the text input is hidden. */
+  pendingQuestion?: PendingQuestionState | null;
   engagedAgents: AttachedAgent[];
   engagedUiEntries?: EngagedAgentUiEntry[];
   agentToRuntimeId?: Map<string, string>;
@@ -269,6 +271,7 @@ export function ChatInputArea({
   stackTodos = [],
   stackQueue = [],
   planSlotHidden = false,
+  pendingQuestion = null,
   engagedAgents = [],
   engagedUiEntries = [],
   agentToRuntimeId = new Map(),
@@ -536,6 +539,7 @@ export function ChatInputArea({
           onRemoveFromQueue={_onRemoveFromQueue}
           planSlotHidden={planSlotHidden}
           permissionSessionId={permissionSessionId}
+          pendingQuestion={pendingQuestion}
         >
           <PromptInput
             value={inputValue}

--- a/packages/app/src/components/chat/ChatPanel.tsx
+++ b/packages/app/src/components/chat/ChatPanel.tsx
@@ -65,7 +65,6 @@ import { ThreadListPanel } from "./ThreadListPanel";
 import { useThreadPanelStore } from "@/stores/thread-panel-store";
 import { useThreadListPanelStore } from "@/stores/thread-list-panel-store";
 import type { Todo } from "@/stores/session-types";
-import { QuestionInputDock } from "./QuestionInputDock";
 import {
   isStreamInterruptible,
   useV2StreamingStore,
@@ -1376,16 +1375,8 @@ export function ChatPanel({ compact = false }: ChatPanelProps) {
           </div>
         </div>
       ) : (
-        activeInputQuestion ? (
-          <QuestionInputDock
-            compact={compact}
-            pendingQuestion={activeInputQuestion}
-            onHeightChange={handleInputHeightChange}
-            bottomOffsetPx={terminalBottomOffset}
-          />
-        ) : activeSessionId || draftPreselectedActor ? (
-          <>
-            <ChatInputArea
+        activeSessionId || draftPreselectedActor ? (
+          <ChatInputArea
             activeSessionId={activeSessionId}
             compact={compact}
             pendingFiles={pendingFiles}
@@ -1428,8 +1419,8 @@ export function ChatPanel({ compact = false }: ChatPanelProps) {
             stackTodos={hasComposerPlanData ? (combinedTodos as Todo[]) : []}
             stackQueue={hasComposerPlanData ? messageQueue : []}
             planSlotHidden={hasComposerPlanData && !showInlineTodo}
+            pendingQuestion={activeInputQuestion}
           />
-          </>
         ) : null
       )}
 

--- a/packages/app/src/components/chat/ComposerStack.tsx
+++ b/packages/app/src/components/chat/ComposerStack.tsx
@@ -14,7 +14,9 @@ import {
 import { PermissionApprovalPanel } from "./PermissionApprovalPanel";
 import { PermissionWaitingBanner } from "./PermissionWaitingBanner";
 import { ComposerPlanSlot } from "./ComposerPlanSlot";
+import { QuestionInputDock } from "./QuestionInputDock";
 import { StreamingAgentBubble } from "./StreamingAgentBubble";
+import type { PendingQuestionState } from "@/stores/session-types";
 import {
   composerGlassChildClass,
   composerGlassFillClass,
@@ -85,6 +87,7 @@ function ComposerAgentStrip({
   actorId,
   displayNameHint,
   waitingForApproval,
+  waitingForQuestion = false,
   showInterrupt,
   onInterrupt,
   roundsTop = false,
@@ -94,10 +97,12 @@ function ComposerAgentStrip({
   onToggleExpand,
   onToggleEnlarge,
   entry,
+  suppressQuestionToolCallId,
 }: {
   actorId: string;
   displayNameHint?: string;
   waitingForApproval: boolean;
+  waitingForQuestion?: boolean;
   showInterrupt: boolean;
   onInterrupt: (agentId: string) => void;
   roundsTop?: boolean;
@@ -107,6 +112,7 @@ function ComposerAgentStrip({
   onToggleExpand: () => void;
   onToggleEnlarge: () => void;
   entry?: AgentStreamEntry;
+  suppressQuestionToolCallId?: string;
 }) {
   const { t } = useTranslation();
   const resolvedName = useActorDisplayName(actorId);
@@ -116,6 +122,13 @@ function ComposerAgentStrip({
   const canExpand = Boolean(entry);
   const showInlinePanel = expanded && canExpand && !enlarged;
   const { liveScrollRef, handleLiveScroll } = useLiveScrollFollow(showInlinePanel, entry);
+  const indicatorToolCallIds = React.useMemo(
+    () =>
+      suppressQuestionToolCallId
+        ? new Set([suppressQuestionToolCallId])
+        : undefined,
+    [suppressQuestionToolCallId],
+  );
   const interrupting = useV2StreamingStore((s) =>
     entry?.sessionId
       ? s.isInterruptedFlushPending(entry.sessionId, actorId)
@@ -129,6 +142,14 @@ function ComposerAgentStrip({
 
   const statusLabel = waitingForApproval ? (
     t("chat.streamingBar.waitingApproval", "Waiting for your approval…")
+  ) : waitingForQuestion ? (
+    <>
+      {t("chat.streamingBar.waitingQuestion", "等待你的回答")}
+      <span
+        className="ml-1.5 inline-block h-[5px] w-[5px] animate-pulse rounded-full bg-coral align-middle"
+        aria-hidden
+      />
+    </>
   ) : interrupting ? (
     <span className="inline-flex items-center gap-1.5 text-muted-foreground">
       <Loader2 className="h-3 w-3 animate-spin" aria-hidden />
@@ -294,7 +315,11 @@ function ComposerAgentStrip({
               data-testid="streaming-agent-live-scroll"
               className={LIVE_INLINE_SCROLL_CLASS}
             >
-              <StreamingAgentBubble entry={entry} variant="dock" />
+              <StreamingAgentBubble
+                entry={entry}
+                variant="dock"
+                indicatorToolCallIds={indicatorToolCallIds}
+              />
             </div>
           ) : null}
         </div>
@@ -308,11 +333,13 @@ function LiveEnlargeFloat({
   onRestore,
   onInterrupt,
   showInterrupt,
+  suppressQuestionToolCallId,
 }: {
   agent: ActiveStreamingAgent;
   onRestore: () => void;
   onInterrupt?: (agentId: string) => void;
   showInterrupt: boolean;
+  suppressQuestionToolCallId?: string;
 }) {
   const { t } = useTranslation();
   const entry = agent.entry!;
@@ -322,6 +349,13 @@ function LiveEnlargeFloat({
   const colors = actorAvatarColor(agent.actorId);
   const initial = displayName.trim().charAt(0).toUpperCase() || "A";
   const { liveScrollRef, handleLiveScroll } = useLiveScrollFollow(true, entry);
+  const indicatorToolCallIds = React.useMemo(
+    () =>
+      suppressQuestionToolCallId
+        ? new Set([suppressQuestionToolCallId])
+        : undefined,
+    [suppressQuestionToolCallId],
+  );
   const restoreRef = React.useRef<HTMLButtonElement>(null);
   const interrupting = useV2StreamingStore((s) =>
     s.isInterruptedFlushPending(entry.sessionId, agent.actorId),
@@ -424,7 +458,11 @@ function LiveEnlargeFloat({
         data-testid="streaming-agent-live-scroll"
         className={LIVE_FLOAT_SCROLL_CLASS}
       >
-        <StreamingAgentBubble entry={entry} variant="dock" />
+        <StreamingAgentBubble
+          entry={entry}
+          variant="dock"
+          indicatorToolCallIds={indicatorToolCallIds}
+        />
       </div>
     </div>
   );
@@ -438,6 +476,7 @@ export function ComposerStack({
   onRemoveFromQueue,
   planSlotHidden = false,
   permissionSessionId = null,
+  pendingQuestion = null,
   children,
 }: {
   agents: ReadonlyArray<ActiveStreamingAgent>;
@@ -449,6 +488,8 @@ export function ComposerStack({
   planSlotHidden?: boolean;
   /** Session whose pending ACP permissions render in this stack (defaults to main active). */
   permissionSessionId?: string | null;
+  /** Pending agent question — renders in-stack above input and keeps live context visible. */
+  pendingQuestion?: PendingQuestionState | null;
   children?: React.ReactNode;
 }) {
   const activeSessionId = useSessionSelectionStore((s) => s.activeSessionId);
@@ -488,12 +529,34 @@ export function ComposerStack({
   );
   const [userPinnedExpand, setUserPinnedExpand] = React.useState(false);
 
+  const hasPendingQuestion = pendingQuestion !== null;
+  const questionActorId = React.useMemo(() => {
+    if (!pendingQuestion) return null;
+    if (
+      pendingQuestion.agentActorId &&
+      agents.some((agent) => agent.actorId === pendingQuestion.agentActorId)
+    ) {
+      return pendingQuestion.agentActorId;
+    }
+    return newestActorId ?? agents[0]?.actorId ?? pendingQuestion.agentActorId ?? null;
+  }, [agents, newestActorId, pendingQuestion]);
+
+  React.useEffect(() => {
+    if (!hasPendingQuestion) return;
+    if (questionActorId) {
+      setExpandedActorId(questionActorId);
+      setEnlargedActorId(null);
+    }
+  }, [hasPendingQuestion, questionActorId, pendingQuestion?.questionId]);
+
   React.useEffect(() => {
     const ids = new Set(agents.map((agent) => agent.actorId));
     if (agents.length === 0) {
-      setExpandedActorId(null);
-      setEnlargedActorId(null);
-      setUserPinnedExpand(false);
+      if (!hasPendingQuestion) {
+        setExpandedActorId(null);
+        setEnlargedActorId(null);
+        setUserPinnedExpand(false);
+      }
       return;
     }
     if (expandedActorId && !ids.has(expandedActorId)) {
@@ -505,12 +568,12 @@ export function ComposerStack({
     if (enlargedActorId && !ids.has(enlargedActorId)) {
       setEnlargedActorId(null);
     }
-    if (!userPinnedExpand) {
+    if (!userPinnedExpand && !hasPendingQuestion) {
       setExpandedActorId(newestActorId);
-    } else if (expandedActorId === null && newestActorId) {
+    } else if (expandedActorId === null && newestActorId && !hasPendingQuestion) {
       // User closed all panels — stay closed until they open one.
     }
-  }, [agents, newestActorId, expandedActorId, enlargedActorId, userPinnedExpand]);
+  }, [agents, newestActorId, expandedActorId, enlargedActorId, userPinnedExpand, hasPendingQuestion]);
 
   const toggleExpand = React.useCallback((actorId: string) => {
     setUserPinnedExpand(true);
@@ -552,20 +615,24 @@ export function ComposerStack({
   const showApprovalOnly =
     currentEntry !== null &&
     agents.length === 0 &&
-    sessionPermissionMode !== "fullAccess";
+    sessionPermissionMode !== "fullAccess" &&
+    !hasPendingQuestion;
 
   const showWaitingOnly =
     currentEntry === null &&
     waitingRequesterActorId !== null &&
-    agents.length === 0;
+    agents.length === 0 &&
+    !hasPendingQuestion;
 
   const hasApproval = currentEntry !== null;
   const hasPermissionChrome =
     hasApproval || waitingRequesterActorId !== null;
-  const showAgentSection = agents.length > 0 || showApprovalOnly || showWaitingOnly;
+  const showAgentSection =
+    agents.length > 0 || showApprovalOnly || showWaitingOnly || hasPendingQuestion;
   const showPlan = todos.length > 0 || queue.length > 0;
   const showTopChrome = showAgentSection || showPlan;
   const planRoundsTop = showPlan && !showAgentSection;
+  const hideComposerInput = hasPendingQuestion;
 
   const approvalExpandClasses = cn(
     "grid transition-[grid-template-rows] duration-[400ms] ease-[cubic-bezier(0.22,1,0.36,1)] motion-reduce:transition-none",
@@ -590,6 +657,11 @@ export function ComposerStack({
           onRestore={restoreEnlarge}
           onInterrupt={onInterrupt}
           showInterrupt={Boolean(onInterrupt) && anchorActorId !== enlargedAgent.actorId}
+          suppressQuestionToolCallId={
+            hasPendingQuestion && questionActorId === enlargedAgent.actorId
+              ? pendingQuestion?.toolCallId
+              : undefined
+          }
         />
       ) : null}
 
@@ -646,25 +718,44 @@ export function ComposerStack({
                   ? agents.map((agent, index) => {
                       const isAnchor =
                         anchorActorId === agent.actorId && currentEntry !== null;
+                      const isQuestionAnchor =
+                        hasPendingQuestion && questionActorId === agent.actorId;
                       return (
                         <ComposerAgentStrip
                           key={agent.actorId}
                           actorId={agent.actorId}
                           displayNameHint={agent.displayName}
                           waitingForApproval={isAnchor}
-                          showInterrupt={Boolean(onInterrupt) && !isAnchor}
+                          waitingForQuestion={isQuestionAnchor}
+                          showInterrupt={
+                            Boolean(onInterrupt) && !isAnchor && !isQuestionAnchor
+                          }
                           onInterrupt={onInterrupt ?? (() => {})}
-                          roundsTop={!hasPermissionChrome && index === 0}
-                          embeddedInGlass={hasPermissionChrome}
-                          expanded={expandedActorId === agent.actorId}
+                          roundsTop={!hasPermissionChrome && index === 0 && !hasPendingQuestion}
+                          embeddedInGlass={hasPermissionChrome || hasPendingQuestion}
+                          expanded={
+                            hasPendingQuestion && isQuestionAnchor
+                              ? true
+                              : expandedActorId === agent.actorId
+                          }
                           enlarged={enlargedActorId === agent.actorId}
                           onToggleExpand={() => toggleExpand(agent.actorId)}
                           onToggleEnlarge={() => toggleEnlarge(agent.actorId)}
                           entry={agent.entry}
+                          suppressQuestionToolCallId={
+                            isQuestionAnchor ? pendingQuestion?.toolCallId : undefined
+                          }
                         />
                       );
                     })
                   : null}
+
+                {hasPendingQuestion && pendingQuestion ? (
+                  <QuestionInputDock
+                    appearance="stack"
+                    pendingQuestion={pendingQuestion}
+                  />
+                ) : null}
               </div>
             </div>
           ) : null}
@@ -683,7 +774,11 @@ export function ComposerStack({
 
       <div
         data-testid="composer-input-zone"
-        className={cn("relative z-20", composerStackFormSlotClass(showTopChrome))}
+        className={cn(
+          "relative z-20",
+          composerStackFormSlotClass(showTopChrome),
+          hideComposerInput && "hidden",
+        )}
       >
         {children}
       </div>

--- a/packages/app/src/components/chat/ComposerStack.tsx
+++ b/packages/app/src/components/chat/ComposerStack.tsx
@@ -41,6 +41,39 @@ const LIVE_INLINE_SCROLL_CLASS =
 const LIVE_FLOAT_SCROLL_CLASS =
   "min-h-0 flex-1 overflow-y-auto bg-gradient-to-b from-[#fbf9f4] to-white px-3 py-2.5 dark:from-background dark:to-paper";
 
+function agentEntryHasToolCall(
+  entry: AgentStreamEntry | undefined,
+  toolCallId: string,
+): boolean {
+  if (!entry || !toolCallId) return false;
+  if (entry.toolCalls.some((toolCall) => toolCall.id === toolCallId)) return true;
+  return entry.parts.some(
+    (part) =>
+      part.type === "tool-call" &&
+      (part.toolCallId === toolCallId || part.toolCall?.id === toolCallId),
+  );
+}
+
+function resolveQuestionAgentId(
+  pendingQuestion: PendingQuestionState,
+  agents: ReadonlyArray<ActiveStreamingAgent>,
+): string | null {
+  const { agentActorId, toolCallId } = pendingQuestion;
+  if (toolCallId) {
+    const byToolCall = agents.find((agent) =>
+      agentEntryHasToolCall(agent.entry, toolCallId),
+    );
+    if (byToolCall) return byToolCall.actorId;
+  }
+  if (
+    agentActorId &&
+    agents.some((agent) => agent.actorId === agentActorId)
+  ) {
+    return agentActorId;
+  }
+  return null;
+}
+
 function useLiveScrollFollow(active: boolean, entry: AgentStreamEntry | undefined) {
   const liveScrollRef = React.useRef<HTMLDivElement>(null);
   const stickToBottomRef = React.useRef(true);
@@ -532,14 +565,8 @@ export function ComposerStack({
   const hasPendingQuestion = pendingQuestion !== null;
   const questionActorId = React.useMemo(() => {
     if (!pendingQuestion) return null;
-    if (
-      pendingQuestion.agentActorId &&
-      agents.some((agent) => agent.actorId === pendingQuestion.agentActorId)
-    ) {
-      return pendingQuestion.agentActorId;
-    }
-    return newestActorId ?? agents[0]?.actorId ?? pendingQuestion.agentActorId ?? null;
-  }, [agents, newestActorId, pendingQuestion]);
+    return resolveQuestionAgentId(pendingQuestion, agents);
+  }, [agents, pendingQuestion]);
 
   React.useEffect(() => {
     if (!hasPendingQuestion) return;
@@ -754,6 +781,7 @@ export function ComposerStack({
                   <QuestionInputDock
                     appearance="stack"
                     pendingQuestion={pendingQuestion}
+                    disableEscapeShortcut={Boolean(enlargedActorId)}
                   />
                 ) : null}
               </div>

--- a/packages/app/src/components/chat/QuestionCard.tsx
+++ b/packages/app/src/components/chat/QuestionCard.tsx
@@ -17,13 +17,18 @@ interface QuestionCardProps {
 export const QuestionCard = React.memo(function QuestionCard({ toolCallId, questions, isCompleted }: QuestionCardProps) {
   const { t } = useTranslation()
   const pendingQuestions = useSessionStore(s => s.pendingQuestions)
+  const answeredSnapshot = useSessionStore(
+    (s) => s.answeredQuestionsByToolCallId?.[toolCallId],
+  )
   const pendingQuestion = pendingQuestions.find(q => q.toolCallId === toolCallId)
   const propQuestions = Array.isArray(questions) ? (questions as Question[]) : []
   // Tool-call arguments may lag or omit questions; the question.asked event
-  // (pendingQuestion) is authoritative.
+  // (pendingQuestion) is authoritative. After answer, read the local snapshot.
   const questionList: Question[] = propQuestions.length
     ? propQuestions
-    : ((pendingQuestion?.questions ?? []) as Question[])
+    : pendingQuestion?.questions?.length
+      ? ((pendingQuestion.questions ?? []) as Question[])
+      : ((answeredSnapshot?.questions ?? []) as Question[])
   const answerQuestion = useSessionStore(s => s.answerQuestion)
   const [answers, setAnswers] = React.useState<Record<string, string>>({})
   const [customInputs, setCustomInputs] = React.useState<Record<string, string>>({})
@@ -80,6 +85,7 @@ export const QuestionCard = React.memo(function QuestionCard({ toolCallId, quest
   // Determine if we should show the interactive UI (options to select)
   const showInteractiveUI = isPending && !hasSubmitted
   const firstQuestion = questionList[0]
+  const savedAnswers = answeredSnapshot?.answers ?? {}
   const stateLabel = isCompleted
     ? t('chat.toolCall.question.answered', 'Answered')
     : isWaitingForCompletion
@@ -96,14 +102,16 @@ export const QuestionCard = React.memo(function QuestionCard({ toolCallId, quest
       target={firstQuestion?.header || firstQuestion?.question}
       meta={stateLabel}
       status={isCompleted ? <Check className="h-3 w-3 text-green-600" /> : undefined}
-      defaultOpen={!isCompleted}
+      defaultOpen={questionList.length > 0}
     >
       {/* Questions */}
       <div className="space-y-4 px-3 py-3">
         {questionList.map((question, qIndex) => {
           const questionId = question.id || String(qIndex)
-          const selectedOption = answers[questionId]
+          const selectedOption = answers[questionId] ?? savedAnswers[questionId]
           const customInput = customInputs[questionId] || ''
+          const savedAnswer = savedAnswers[questionId]
+          const displayAnswer = customInput || selectedOption || savedAnswer
 
           return (
             <div key={questionId} className="space-y-1.5">
@@ -182,12 +190,12 @@ export const QuestionCard = React.memo(function QuestionCard({ toolCallId, quest
               )}
 
               {/* Show selected answer for completed or submitted questions */}
-              {(isCompleted || isWaitingForCompletion) && (selectedOption || customInput) && (
+              {(isCompleted || isWaitingForCompletion) && displayAnswer && (
                 <div className="px-4 py-2 rounded-lg bg-muted/30 text-sm">
                   <span className="text-muted-foreground">
                     {t('chat.toolCall.question.answerLabel', 'Answer: ')}
                   </span>
-                  <span className="font-medium">{customInput || selectedOption}</span>
+                  <span className="font-medium">{displayAnswer}</span>
                 </div>
               )}
             </div>

--- a/packages/app/src/components/chat/QuestionInputDock.tsx
+++ b/packages/app/src/components/chat/QuestionInputDock.tsx
@@ -9,8 +9,12 @@ import { cn } from "@/lib/utils";
 import { useSessionStore } from "@/stores/session";
 import type { PendingQuestionState } from "@/stores/session-types";
 
+export type QuestionInputAppearance = "overlay" | "stack";
+
 interface QuestionInputDockProps {
   pendingQuestion: PendingQuestionState;
+  /** `overlay` floats over the thread; `stack` embeds in ComposerStack. */
+  appearance?: QuestionInputAppearance;
   compact?: boolean;
   onHeightChange?: (height: number) => void;
   bottomOffsetPx?: number;
@@ -103,6 +107,7 @@ function QuestionMarkdown({ children }: { children: string }) {
 
 export function QuestionInputDock({
   pendingQuestion,
+  appearance = "overlay",
   compact = false,
   onHeightChange,
   bottomOffsetPx = 0,
@@ -248,29 +253,29 @@ export function QuestionInputDock({
 
   if (!currentQuestion) return null;
 
-  return (
-    <div
-      ref={rootRef}
-      data-testid="question-input-dock"
-      style={bottomOffsetPx ? { bottom: bottomOffsetPx } : undefined}
-      className={cn(
-        "z-10",
-        compact
-          ? "absolute bottom-0 left-0 right-0 px-2 pb-2 pt-2 bg-background"
-          : "absolute bottom-0 left-0 right-0 px-4 pb-4 pt-5",
-      )}
-    >
-      <div className={cn("relative w-full", compact ? "" : "mx-auto max-w-[46rem]")}>
-        <div
-          aria-hidden="true"
+  const isStack = appearance === "stack";
+
+  const questionSection = (
+        <section
           className={cn(
-            "pointer-events-none absolute left-[-1px] right-[-1px] top-0 bottom-[-1.75rem] bg-background",
-            compact && "hidden",
+            "relative z-10 overflow-hidden",
+            isStack
+              ? "border-t border-border/50 bg-paper"
+              : "rounded-[20px] border border-border/70 bg-card shadow-[0_18px_44px_rgba(15,23,42,0.12)]",
           )}
-        />
-        <section className="relative z-10 overflow-hidden rounded-[20px] border border-border/70 bg-card shadow-[0_18px_44px_rgba(15,23,42,0.12)]">
-          <div className="flex items-center justify-between gap-4 px-4 pb-1 pt-3">
-            <div className="min-w-0">
+        >
+          <div
+            className={cn(
+              "flex items-center justify-between gap-4",
+              isStack ? "px-3.5 pb-1 pt-3" : "px-4 pb-1 pt-3",
+            )}
+          >
+            <div className="min-w-0 flex items-center gap-2">
+              {isStack ? (
+                <span className="shrink-0 rounded border border-coral/35 px-1.5 py-0.5 font-mono text-[9.5px] font-semibold uppercase tracking-wide text-coral">
+                  {t("chat.toolCall.question.title", "Question")}
+                </span>
+              ) : null}
               <div className="truncate text-[15px] font-semibold leading-5 text-foreground">
                 {questionTitle}
               </div>
@@ -300,7 +305,7 @@ export function QuestionInputDock({
             ) : null}
           </div>
 
-          <div className="px-4 pb-3 pt-3">
+          <div className={cn(isStack ? "px-3.5 pb-3 pt-2" : "px-4 pb-3 pt-3")}>
             <QuestionMarkdown>{currentQuestion.question}</QuestionMarkdown>
 
             <div className="space-y-1">
@@ -374,7 +379,12 @@ export function QuestionInputDock({
                   type="button"
                   onClick={() => void handleContinue()}
                   disabled={!canContinue}
-                  className="h-7 shrink-0 whitespace-nowrap rounded-full bg-[#111111] px-3 text-xs font-semibold text-white shadow-sm hover:bg-[#262626] disabled:bg-[#111111]/45 disabled:text-white/75 dark:bg-[#f4f4f5] dark:text-[#18181b] dark:hover:bg-white dark:disabled:bg-[#f4f4f5]/45 dark:disabled:text-[#18181b]/70"
+                  className={cn(
+                    "h-7 shrink-0 whitespace-nowrap px-3 text-xs font-semibold shadow-sm disabled:opacity-40",
+                    isStack
+                      ? "rounded-lg bg-coral text-white hover:bg-coral/90"
+                      : "rounded-full bg-[#111111] text-white hover:bg-[#262626] disabled:bg-[#111111]/45 disabled:text-white/75 dark:bg-[#f4f4f5] dark:text-[#18181b] dark:hover:bg-white dark:disabled:bg-[#f4f4f5]/45 dark:disabled:text-[#18181b]/70",
+                  )}
                 >
                   <CornerDownLeft className="h-2.5 w-2.5" />
                   {isSubmitting
@@ -387,6 +397,38 @@ export function QuestionInputDock({
             </div>
           </div>
         </section>
+  );
+
+  if (isStack) {
+    return (
+      <div ref={rootRef} data-testid="question-input-dock" data-appearance="stack">
+        {questionSection}
+      </div>
+    );
+  }
+
+  return (
+    <div
+      ref={rootRef}
+      data-testid="question-input-dock"
+      data-appearance="overlay"
+      style={bottomOffsetPx ? { bottom: bottomOffsetPx } : undefined}
+      className={cn(
+        "z-10",
+        compact
+          ? "absolute bottom-0 left-0 right-0 px-2 pb-2 pt-2 bg-background"
+          : "absolute bottom-0 left-0 right-0 px-4 pb-4 pt-5",
+      )}
+    >
+      <div className={cn("relative w-full", compact ? "" : "mx-auto max-w-[46rem]")}>
+        <div
+          aria-hidden="true"
+          className={cn(
+            "pointer-events-none absolute left-[-1px] right-[-1px] top-0 bottom-[-1.75rem] bg-background",
+            compact && "hidden",
+          )}
+        />
+        {questionSection}
       </div>
     </div>
   );

--- a/packages/app/src/components/chat/QuestionInputDock.tsx
+++ b/packages/app/src/components/chat/QuestionInputDock.tsx
@@ -18,6 +18,8 @@ interface QuestionInputDockProps {
   compact?: boolean;
   onHeightChange?: (height: number) => void;
   bottomOffsetPx?: number;
+  /** When true, ESC is left to other overlays (e.g. enlarged live panel). */
+  disableEscapeShortcut?: boolean;
 }
 
 function getOptionValue(option: { label: string; value?: string }) {
@@ -111,6 +113,7 @@ export function QuestionInputDock({
   compact = false,
   onHeightChange,
   bottomOffsetPx = 0,
+  disableEscapeShortcut = false,
 }: QuestionInputDockProps) {
   const { t } = useTranslation();
   const answerQuestion = useSessionStore((s) => s.answerQuestion);
@@ -241,15 +244,17 @@ export function QuestionInputDock({
   ]);
 
   React.useEffect(() => {
+    if (disableEscapeShortcut) return;
+
     const onKeyDown = (event: KeyboardEvent) => {
-      if (event.key !== "Escape") return;
+      if (event.key !== "Escape" || !canSkip) return;
       event.preventDefault();
       void handleSkip();
     };
 
     window.addEventListener("keydown", onKeyDown);
     return () => window.removeEventListener("keydown", onKeyDown);
-  }, [handleSkip]);
+  }, [canSkip, disableEscapeShortcut, handleSkip]);
 
   if (!currentQuestion) return null;
 

--- a/packages/app/src/components/chat/StreamingAgentBubble.tsx
+++ b/packages/app/src/components/chat/StreamingAgentBubble.tsx
@@ -86,6 +86,7 @@ function renderOrderedPart(
   isStreamingReasoning: boolean,
   revealText: boolean,
   skipToolNames?: Set<string>,
+  indicatorToolCallIds?: ReadonlySet<string>,
 ) {
   if (part.type === "reasoning") {
     const text = part.text || part.content || "";
@@ -102,6 +103,9 @@ function renderOrderedPart(
 
   if (part.type === "tool-call" && part.toolCall) {
     if (skipToolNames?.has(part.toolCall.name)) return null;
+    const toolId = part.toolCallId ?? part.toolCall.id;
+    const questionPresentation =
+      toolId && indicatorToolCallIds?.has(toolId) ? "indicator" : "full";
     return (
       <div
         key={part.id}
@@ -109,7 +113,10 @@ function renderOrderedPart(
         data-tool-id={part.toolCall.id}
         data-tool-status={part.toolCall.status}
       >
-        <ToolCallCard toolCall={part.toolCall} />
+        <ToolCallCard
+          toolCall={part.toolCall}
+          questionPresentation={questionPresentation}
+        />
       </div>
     );
   }
@@ -129,10 +136,13 @@ function renderOrderedPart(
 export const StreamingAgentBubble = React.memo(function StreamingAgentBubble({
   entry,
   variant = "default",
+  indicatorToolCallIds,
 }: {
   entry: AgentStreamEntry;
   /** `dock` hides ActorLabel — Composer agent strip already shows identity. */
   variant?: "default" | "nested" | "dock";
+  /** Question tools answered in composer — show compact row in live panel. */
+  indicatorToolCallIds?: ReadonlySet<string>;
 }) {
   // After finalize (active=false), the persisted AGENT_REPLY ChatMessage
   // takes over the reply text — suppress outputText here to avoid showing
@@ -275,6 +285,7 @@ export const StreamingAgentBubble = React.memo(function StreamingAgentBubble({
                     part.type === "text" &&
                     index === lastLiveTextPartIndex,
                   skipToolNames,
+                  indicatorToolCallIds,
                 ),
               )}
             </div>
@@ -291,7 +302,12 @@ export const StreamingAgentBubble = React.memo(function StreamingAgentBubble({
                   data-tool-id={tc.id}
                   data-tool-status={tc.status}
                 >
-                  <ToolCallCard toolCall={tc} />
+                  <ToolCallCard
+                    toolCall={tc}
+                    questionPresentation={
+                      indicatorToolCallIds?.has(tc.id) ? "indicator" : "full"
+                    }
+                  />
                 </div>
               ))}
             </div>

--- a/packages/app/src/components/chat/ToolCallCard.tsx
+++ b/packages/app/src/components/chat/ToolCallCard.tsx
@@ -2,9 +2,7 @@ import React, { useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
   ChevronRight,
-  HelpCircle,
   ListChecks,
-  Loader2,
   Search,
   Terminal,
 } from "lucide-react";
@@ -234,12 +232,6 @@ export const ToolCallCard = React.memo(function ToolCallCard({
       : toolCall.status === "waiting"
         ? t("chat.toolCall.status.waiting", "Waiting")
         : null;
-
-  const getQuestionCount = () => {
-    if (Array.isArray(toolCall.questions)) return toolCall.questions.length;
-    const args = toolCall.arguments as { questions?: unknown } | undefined;
-    return Array.isArray(args?.questions) ? args.questions.length : 0;
-  };
 
   const getCompactPrimary = () => {
     if (isCompactSearchTool) {

--- a/packages/app/src/components/chat/ToolCallCard.tsx
+++ b/packages/app/src/components/chat/ToolCallCard.tsx
@@ -26,6 +26,7 @@ import { ReadToolCard } from "./tool-calls/ReadToolCard";
 import { RoleLoadToolCard } from "./tool-calls/RoleLoadToolCard";
 import { PageNavLinksToolCard } from "./tool-calls/PageNavLinksToolCard";
 import { QuestionCard } from "./QuestionCard";
+import { QuestionToolIndicator } from "./tool-calls/QuestionToolIndicator";
 import { RoleSkillToolCard, ManageSkillsToolCard, SkillToolCard, TaskToolCard } from "./tool-calls/TaskToolCard";
 import {
   getStatusConfig,
@@ -52,9 +53,15 @@ interface ToolCallCardProps {
     type: "search" | "file" | "terminal" | "mcp",
     data: unknown,
   ) => void;
+  /** Question tool: full card vs compact row (live dock while answering below). */
+  questionPresentation?: "full" | "indicator";
 }
 
-export const ToolCallCard = React.memo(function ToolCallCard({ toolCall, onOpenDetail }: ToolCallCardProps) {
+export const ToolCallCard = React.memo(function ToolCallCard({
+  toolCall,
+  onOpenDetail,
+  questionPresentation = "full",
+}: ToolCallCardProps) {
   const { t } = useTranslation();
   const [expanded, setExpanded] = useState(false);
   const config = getStatusConfig((key, fallback, options) =>
@@ -142,11 +149,17 @@ export const ToolCallCard = React.memo(function ToolCallCard({ toolCall, onOpenD
   // opencode `question` tool → interactive QuestionCard (options + custom
   // answer), fed by the `question_asked` raw acp event (pendingQuestions).
   if (routeName === "question") {
+    if (questionPresentation === "indicator") {
+      return <QuestionToolIndicator toolCall={toolCall} />;
+    }
     const args = toolCall.arguments as { questions?: unknown } | undefined;
+    const questions =
+      (Array.isArray(toolCall.questions) ? toolCall.questions : undefined) ??
+      args?.questions;
     return (
       <QuestionCard
         toolCallId={toolCall.id}
-        questions={args?.questions}
+        questions={questions}
         isCompleted={toolCall.status === "completed"}
       />
     );
@@ -309,38 +322,7 @@ export const ToolCallCard = React.memo(function ToolCallCard({ toolCall, onOpenD
   }
 
   if (matchesQuestionTool(toolCall)) {
-    const questionCount = getQuestionCount();
-    const isQuestionLoading = questionCount === 0 && (toolCall.status === "calling" || toolCall.status === "waiting");
-    const questionCountText = t(
-      questionCount === 1 ? "chat.toolCall.question.countOne" : "chat.toolCall.question.count",
-      questionCount === 1 ? "{{count}} question" : "{{count}} questions",
-      { count: questionCount },
-    );
-
-    return (
-      <div
-        data-testid="tool-row-question"
-        className="flex items-center gap-1.5 px-[10px] py-[4px] text-[12px] text-muted-foreground"
-      >
-        <HelpCircle className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
-        <span className="font-medium text-foreground/80">
-          {t("chat.toolCall.question.title", "Question")}
-        </span>
-        {questionCount > 0 ? (
-          <>
-            <span className="text-muted-foreground">·</span>
-            <span>{questionCountText}</span>
-          </>
-        ) : null}
-        {isQuestionLoading ? (
-          <Loader2
-            data-testid="question-tool-loading"
-            className="h-3 w-3 animate-spin text-muted-foreground"
-            aria-hidden="true"
-          />
-        ) : null}
-      </div>
-    );
+    return <QuestionToolIndicator toolCall={toolCall} />;
   }
 
   if (isCommand) {

--- a/packages/app/src/components/chat/__tests__/ComposerStack.test.tsx
+++ b/packages/app/src/components/chat/__tests__/ComposerStack.test.tsx
@@ -231,6 +231,107 @@ describe("ComposerStack", () => {
     expect(screen.getByTestId("composer-input-zone").className).toContain("hidden");
   });
 
+  it("anchors pending question to the agent that owns the tool call, not the newest agent", () => {
+    render(
+      <ComposerStack
+        agents={[
+          { actorId: "a1", displayName: "A1", entry: makeEntry("a1", 2) as never },
+          {
+            actorId: "a2",
+            displayName: "A2",
+            entry: {
+              ...makeEntry("a2", 1),
+              toolCalls: [
+                {
+                  id: "tool-q",
+                  name: "question",
+                  status: "waiting",
+                  arguments: {},
+                  startTime: new Date(),
+                },
+              ],
+            } as never,
+          },
+        ]}
+        onInterrupt={vi.fn()}
+        pendingQuestion={{
+          questionId: "q-event-1",
+          toolCallId: "tool-q",
+          messageId: "msg-1",
+          questions: [
+            {
+              id: "q-1",
+              header: "Pick one",
+              question: "Which option?",
+              options: [{ label: "A", value: "a" }],
+            },
+          ],
+        }}
+      >
+        <div>input</div>
+      </ComposerStack>,
+    );
+
+    const rows = screen.getAllByTestId("streaming-agent-row");
+    expect(rows[0]?.getAttribute("data-expanded")).toBe("false");
+    expect(rows[1]?.getAttribute("data-expanded")).toBe("true");
+  });
+
+  it("closes enlarge float on Escape without skipping an in-stack question", () => {
+    const skipQuestion = vi.fn(() => Promise.resolve());
+    useSessionStore.setState({
+      pendingQuestions: [
+        {
+          questionId: "q-event-1",
+          toolCallId: "tool-q",
+          messageId: "msg-1",
+          questions: [
+            {
+              id: "q-1",
+              header: "Pick one",
+              question: "Which option?",
+              options: [{ label: "A", value: "a" }],
+            },
+          ],
+          agentActorId: "a1",
+        },
+      ],
+      skipQuestion,
+    });
+
+    render(
+      <ComposerStack
+        agents={[{ actorId: "a1", displayName: "A1", entry: makeEntry("a1", 1) as never }]}
+        onInterrupt={vi.fn()}
+        pendingQuestion={{
+          questionId: "q-event-1",
+          toolCallId: "tool-q",
+          messageId: "msg-1",
+          questions: [
+            {
+              id: "q-1",
+              header: "Pick one",
+              question: "Which option?",
+              options: [{ label: "A", value: "a" }],
+            },
+          ],
+          agentActorId: "a1",
+        }}
+      >
+        <div>input</div>
+      </ComposerStack>,
+    );
+
+    fireEvent.click(screen.getByTestId("streaming-agent-enlarge"));
+    expect(screen.getByTestId("streaming-agent-live-float")).toBeTruthy();
+
+    fireEvent.keyDown(window, { key: "Escape" });
+
+    expect(screen.queryByTestId("streaming-agent-live-float")).toBeNull();
+    expect(skipQuestion).not.toHaveBeenCalled();
+    expect(screen.getByTestId("question-input-dock")).toBeTruthy();
+  });
+
   it("restores the enlarge float on Escape", () => {
     render(
       <ComposerStack

--- a/packages/app/src/components/chat/__tests__/ComposerStack.test.tsx
+++ b/packages/app/src/components/chat/__tests__/ComposerStack.test.tsx
@@ -200,6 +200,37 @@ describe("ComposerStack", () => {
     expect(screen.queryByTestId("streaming-agent-live-float")).toBeNull();
   });
 
+  it("keeps live context visible with an in-stack question and hides text input", () => {
+    render(
+      <ComposerStack
+        agents={[{ actorId: "a1", displayName: "A1", entry: makeEntry("a1", 1) as never }]}
+        onInterrupt={vi.fn()}
+        pendingQuestion={{
+          questionId: "q-event-1",
+          toolCallId: "tool-q",
+          messageId: "msg-1",
+          questions: [
+            {
+              id: "q-1",
+              header: "Pick one",
+              question: "Which option?",
+              options: [{ label: "A", value: "a" }],
+            },
+          ],
+          agentActorId: "a1",
+        }}
+      >
+        <div data-testid="child-input">input</div>
+      </ComposerStack>,
+    );
+
+    expect(screen.getByTestId("streaming-agent-live-panel").getAttribute("data-open")).toBe(
+      "true",
+    );
+    expect(screen.getByTestId("question-input-dock")).toBeTruthy();
+    expect(screen.getByTestId("composer-input-zone").className).toContain("hidden");
+  });
+
   it("restores the enlarge float on Escape", () => {
     render(
       <ComposerStack

--- a/packages/app/src/components/chat/__tests__/QuestionCard.test.tsx
+++ b/packages/app/src/components/chat/__tests__/QuestionCard.test.tsx
@@ -17,6 +17,10 @@ const mockSessionState = {
     messageId: string;
     questions: unknown[];
   }>,
+  answeredQuestionsByToolCallId: {} as Record<
+    string,
+    { questions: unknown[]; answers: Record<string, string> }
+  >,
   answerQuestion: vi.fn(() => Promise.resolve()),
 };
 
@@ -46,6 +50,7 @@ describe('QuestionCard', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockSessionState.pendingQuestions = [];
+    mockSessionState.answeredQuestionsByToolCallId = {};
     mockSessionState.answerQuestion = vi.fn(() => Promise.resolve());
   });
 
@@ -113,5 +118,22 @@ describe('QuestionCard', () => {
     await waitFor(() => {
       expect(answerMock).toHaveBeenCalledWith({ 'q-1': 'option-a' }, 'event-1');
     });
+  });
+
+  it('renders answered snapshot after completion when pending question is gone', () => {
+    const question = makeQuestion();
+    mockSessionState.answeredQuestionsByToolCallId = {
+      'tc-1': {
+        questions: [question],
+        answers: { 'q-1': 'Option A' },
+      },
+    };
+
+    render(
+      <QuestionCard toolCallId="tc-1" isCompleted />,
+    );
+
+    expect(screen.getByText('What would you like to do?')).toBeTruthy();
+    expect(screen.getByText('Option A')).toBeTruthy();
   });
 });

--- a/packages/app/src/components/chat/__tests__/QuestionInputDock.test.tsx
+++ b/packages/app/src/components/chat/__tests__/QuestionInputDock.test.tsx
@@ -158,6 +158,32 @@ describe('QuestionInputDock', () => {
     expect(dock.className).not.toContain('absolute');
   });
 
+  it('does not intercept Escape when disableEscapeShortcut is set', () => {
+    render(
+      <QuestionInputDock
+        disableEscapeShortcut
+        pendingQuestion={{
+          questionId: 'question-event-esc',
+          toolCallId: 'tool-call-esc',
+          messageId: 'message-esc',
+          questions: [
+            {
+              id: 'q-1',
+              header: '下一步',
+              question: '继续吗？',
+              options: [{ label: '继续', value: 'continue' }],
+            },
+          ],
+          source: 'agent',
+        }}
+      />,
+    );
+
+    fireEvent.keyDown(window, { key: 'Escape' });
+
+    expect(mockSkipQuestion).not.toHaveBeenCalled();
+  });
+
   it('can be offset above a bottom terminal panel', () => {
     render(
       <QuestionInputDock

--- a/packages/app/src/components/chat/__tests__/QuestionInputDock.test.tsx
+++ b/packages/app/src/components/chat/__tests__/QuestionInputDock.test.tsx
@@ -132,6 +132,32 @@ describe('QuestionInputDock', () => {
     expect(screen.queryByText(/### \*\*Title\*\*/)).toBeNull();
   });
 
+  it('renders stack appearance without absolute positioning', () => {
+    render(
+      <QuestionInputDock
+        appearance="stack"
+        pendingQuestion={{
+          questionId: 'question-event-stack',
+          toolCallId: 'tool-call-stack',
+          messageId: 'message-stack',
+          questions: [
+            {
+              id: 'q-1',
+              header: '下一步',
+              question: '继续吗？',
+              options: [{ label: '继续', value: 'continue' }],
+            },
+          ],
+          source: 'agent',
+        }}
+      />,
+    );
+
+    const dock = screen.getByTestId('question-input-dock');
+    expect(dock.getAttribute('data-appearance')).toBe('stack');
+    expect(dock.className).not.toContain('absolute');
+  });
+
   it('can be offset above a bottom terminal panel', () => {
     render(
       <QuestionInputDock

--- a/packages/app/src/components/chat/tool-calls/QuestionToolIndicator.tsx
+++ b/packages/app/src/components/chat/tool-calls/QuestionToolIndicator.tsx
@@ -1,0 +1,49 @@
+import { HelpCircle, Loader2 } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import type { ToolCall } from "@/stores/session";
+
+function getQuestionCount(toolCall: ToolCall): number {
+  if (Array.isArray(toolCall.questions)) return toolCall.questions.length;
+  const args = toolCall.arguments as { questions?: unknown } | undefined;
+  return Array.isArray(args?.questions) ? args.questions.length : 0;
+}
+
+export function QuestionToolIndicator({ toolCall }: { toolCall: ToolCall }) {
+  const { t } = useTranslation();
+  const questionCount = getQuestionCount(toolCall);
+  const isQuestionLoading =
+    questionCount === 0 &&
+    (toolCall.status === "calling" || toolCall.status === "waiting");
+  const questionCountText = t(
+    questionCount === 1
+      ? "chat.toolCall.question.countOne"
+      : "chat.toolCall.question.count",
+    questionCount === 1 ? "{{count}} question" : "{{count}} questions",
+    { count: questionCount },
+  );
+
+  return (
+    <div
+      data-testid="tool-row-question"
+      className="flex items-center gap-1.5 px-[10px] py-[4px] text-[12px] text-muted-foreground"
+    >
+      <HelpCircle className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+      <span className="font-medium text-foreground/80">
+        {t("chat.toolCall.question.title", "Question")}
+      </span>
+      {questionCount > 0 ? (
+        <>
+          <span className="text-muted-foreground">·</span>
+          <span>{questionCountText}</span>
+        </>
+      ) : null}
+      {isQuestionLoading ? (
+        <Loader2
+          data-testid="question-tool-loading"
+          className="h-3 w-3 animate-spin text-muted-foreground"
+          aria-hidden="true"
+        />
+      ) : null}
+    </div>
+  );
+}

--- a/packages/app/src/lib/reset-client-chat-state.ts
+++ b/packages/app/src/lib/reset-client-chat-state.ts
@@ -53,6 +53,7 @@ export function resetClientChatState(): void {
     pendingPermissions: [],
     pendingQuestions: [],
     pendingQuestionIdsBySession: {},
+    answeredQuestionsByToolCallId: {},
     sessionStatuses: {},
     sessionStatus: null,
     sessionError: null,

--- a/packages/app/src/locales/en.json
+++ b/packages/app/src/locales/en.json
@@ -593,6 +593,7 @@
     "streamingBar": {
       "streamingActive": "Replying",
       "waitingApproval": "Waiting for your approval…",
+      "waitingQuestion": "Waiting for your answer",
       "expand": "Expand",
       "collapse": "Collapse",
       "enlarge": "Enlarge",

--- a/packages/app/src/locales/zh-CN.json
+++ b/packages/app/src/locales/zh-CN.json
@@ -593,6 +593,7 @@
     "streamingBar": {
       "streamingActive": "正在回复",
       "waitingApproval": "等待你审批后继续…",
+      "waitingQuestion": "等待你的回答",
       "expand": "展开",
       "collapse": "收起",
       "enlarge": "放大",

--- a/packages/app/src/stores/session-store.test.ts
+++ b/packages/app/src/stores/session-store.test.ts
@@ -1,14 +1,29 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
 import { create as createMessage } from "@bufbuild/protobuf";
 import { MessageSchema, MessageKind } from "@/lib/proto/teamclu_pb";
 import { useSessionMessageStore } from "./session-message-store";
 import { useSessionSelectionStore } from "./session-selection-store";
 import { useSessionStore } from "./session-store";
 
+const { mockAnswerAcpQuestion } = vi.hoisted(() => ({
+  mockAnswerAcpQuestion: vi.fn(() => Promise.resolve()),
+}));
+
+vi.mock("@/lib/teamclu/answer-question", () => ({
+  answerAcpQuestion: mockAnswerAcpQuestion,
+}));
+
 beforeEach(() => {
+  mockAnswerAcpQuestion.mockReset();
+  mockAnswerAcpQuestion.mockResolvedValue(undefined);
   useSessionMessageStore.setState({ messages: {}, messageRefreshTrigger: 0 });
   useSessionSelectionStore.setState({ activeSessionId: null, currentSessionId: null });
-  useSessionStore.setState({ messages: {}, currentSessionId: null });
+  useSessionStore.setState({
+    messages: {},
+    currentSessionId: null,
+    pendingQuestions: [],
+    answeredQuestionsByToolCallId: {},
+  });
 });
 
 describe("session-store", () => {
@@ -33,5 +48,73 @@ describe("session-store", () => {
     useSessionSelectionStore.setState({ currentSessionId: "s1", activeSessionId: "s1" });
     useSessionMessageStore.setState({ messages: { s1: [fakeMessage("m1")] } });
     expect(useSessionStore.getState().currentMessages().length).toBe(1);
+  });
+
+  it("does not snapshot answered question state before answer RPC succeeds", async () => {
+    mockAnswerAcpQuestion.mockRejectedValueOnce(new Error("rpc failed"));
+    useSessionStore.setState({
+      pendingQuestions: [
+        {
+          questionId: "q1",
+          toolCallId: "tc1",
+          messageId: "m1",
+          sessionId: "s1",
+          agentActorId: "a1",
+          questions: [
+            {
+              id: "q-1",
+              header: "Pick",
+              question: "Which?",
+              options: [{ label: "A", value: "a" }],
+            },
+          ],
+        },
+      ],
+    });
+
+    await expect(
+      useSessionStore.getState().answerQuestion({ "q-1": "A" }, "q1"),
+    ).rejects.toThrow("rpc failed");
+
+    expect(useSessionStore.getState().answeredQuestionsByToolCallId).toEqual({});
+    expect(useSessionStore.getState().pendingQuestions).toHaveLength(1);
+  });
+
+  it("snapshots answered question state after answer RPC succeeds", async () => {
+    useSessionStore.setState({
+      pendingQuestions: [
+        {
+          questionId: "q1",
+          toolCallId: "tc1",
+          messageId: "m1",
+          sessionId: "s1",
+          agentActorId: "a1",
+          questions: [
+            {
+              id: "q-1",
+              header: "Pick",
+              question: "Which?",
+              options: [{ label: "A", value: "a" }],
+            },
+          ],
+        },
+      ],
+    });
+
+    await useSessionStore.getState().answerQuestion({ "q-1": "A" }, "q1");
+
+    expect(mockAnswerAcpQuestion).toHaveBeenCalledOnce();
+    expect(useSessionStore.getState().answeredQuestionsByToolCallId.tc1).toEqual({
+      questions: [
+        {
+          id: "q-1",
+          header: "Pick",
+          question: "Which?",
+          options: [{ label: "A", value: "a" }],
+        },
+      ],
+      answers: { "q-1": "A" },
+    });
+    expect(useSessionStore.getState().pendingQuestions).toHaveLength(0);
   });
 });

--- a/packages/app/src/stores/session-store.ts
+++ b/packages/app/src/stores/session-store.ts
@@ -190,12 +190,6 @@ export const useSessionStore = create<SessionState>((set, get) => ({
       const answer = answers[key];
       return answer ? [answer] : [];
     });
-    set((s: Compat) => ({
-      answeredQuestionsByToolCallId: {
-        ...(s.answeredQuestionsByToolCallId ?? {}),
-        [pending.toolCallId]: { questions: list, answers },
-      },
-    }));
     const { answerAcpQuestion } = await import("@/lib/teamclu/answer-question");
     await answerAcpQuestion({
       sessionId: pending.sessionId ?? "",
@@ -203,6 +197,12 @@ export const useSessionStore = create<SessionState>((set, get) => ({
       requestId: pending.questionId,
       answers: ordered,
     });
+    set((s: Compat) => ({
+      answeredQuestionsByToolCallId: {
+        ...(s.answeredQuestionsByToolCallId ?? {}),
+        [pending.toolCallId]: { questions: list, answers },
+      },
+    }));
     // Pi (and some backends) never emit question_replied — dismiss locally once
     // the command succeeds, same as skipQuestion.
     get().resolveQuestion(pending.questionId);
@@ -213,12 +213,6 @@ export const useSessionStore = create<SessionState>((set, get) => ({
     );
     if (!pending) return;
     const list: Compat[] = Array.isArray(pending.questions) ? pending.questions : [];
-    set((s: Compat) => ({
-      answeredQuestionsByToolCallId: {
-        ...(s.answeredQuestionsByToolCallId ?? {}),
-        [pending.toolCallId]: { questions: list, answers: {} },
-      },
-    }));
     const { answerAcpQuestion } = await import("@/lib/teamclu/answer-question");
     await answerAcpQuestion({
       sessionId: pending.sessionId ?? "",
@@ -227,6 +221,12 @@ export const useSessionStore = create<SessionState>((set, get) => ({
       answers: [],
       reject: true,
     });
+    set((s: Compat) => ({
+      answeredQuestionsByToolCallId: {
+        ...(s.answeredQuestionsByToolCallId ?? {}),
+        [pending.toolCallId]: { questions: list, answers: {} },
+      },
+    }));
     get().resolveQuestion(pending.questionId);
   },
   getSessionMessages: () => [],

--- a/packages/app/src/stores/session-store.ts
+++ b/packages/app/src/stores/session-store.ts
@@ -104,6 +104,7 @@ export const useSessionStore = create<SessionState>((set, get) => ({
   pendingPermissions: [],
   pendingQuestions: [],
   pendingQuestionIdsBySession: {},
+  answeredQuestionsByToolCallId: {},
   sessionStatuses: {},
   sessionStatus: null,
   cronSessionIds: [],
@@ -189,6 +190,12 @@ export const useSessionStore = create<SessionState>((set, get) => ({
       const answer = answers[key];
       return answer ? [answer] : [];
     });
+    set((s: Compat) => ({
+      answeredQuestionsByToolCallId: {
+        ...(s.answeredQuestionsByToolCallId ?? {}),
+        [pending.toolCallId]: { questions: list, answers },
+      },
+    }));
     const { answerAcpQuestion } = await import("@/lib/teamclu/answer-question");
     await answerAcpQuestion({
       sessionId: pending.sessionId ?? "",
@@ -205,6 +212,13 @@ export const useSessionStore = create<SessionState>((set, get) => ({
       (q: Compat) => !questionId || q.questionId === questionId,
     );
     if (!pending) return;
+    const list: Compat[] = Array.isArray(pending.questions) ? pending.questions : [];
+    set((s: Compat) => ({
+      answeredQuestionsByToolCallId: {
+        ...(s.answeredQuestionsByToolCallId ?? {}),
+        [pending.toolCallId]: { questions: list, answers: {} },
+      },
+    }));
     const { answerAcpQuestion } = await import("@/lib/teamclu/answer-question");
     await answerAcpQuestion({
       sessionId: pending.sessionId ?? "",

--- a/packages/app/src/stores/session-types.ts
+++ b/packages/app/src/stores/session-types.ts
@@ -272,6 +272,11 @@ export interface SessionState {
   // Pending questions (from question tool; multiple concurrent)
   pendingQuestions: PendingQuestionState[];
   pendingQuestionIdsBySession: Record<string, string[] | undefined>;
+  /** Snapshot Q&A by toolCallId so Process cards stay populated after answer. */
+  answeredQuestionsByToolCallId: Record<
+    string,
+    { questions: Question[]; answers: Record<string, string> }
+  >;
 
   // Todo list (from todowrite tool)
   todos: Todo[];


### PR DESCRIPTION
## Summary
- Question 出现时不再用 `QuestionInputDock` 替换整个 Composer，而是嵌入 `ComposerStack`：直播面板保持展开，下方渲染作答区，文本输入暂时隐藏
- 直播面板内对 pending question tool 只显示 compact `Question · N questions` 指示行，避免与下方作答 UI 重复
- 提交/跳过后将 Q&A 快照写入 `answeredQuestionsByToolCallId`，修复 Process 里 Question 卡片完成后无内容的问题

## Test plan
- [x] `pnpm exec vitest run src/components/chat/__tests__/ComposerStack.test.tsx`
- [x] `pnpm exec vitest run src/components/chat/__tests__/QuestionCard.test.tsx`
- [x] `pnpm exec vitest run src/components/chat/__tests__/QuestionInputDock.test.tsx`
- [ ] 手动：触发 agent question → 直播面板保留历史输出 + Question 指示行，下方作答
- [ ] 手动：提交回答后 Process 卡片展示题目与答案


Made with [Cursor](https://cursor.com)