### PR TITLE
fix(knowledge): 写入受限目录时如实上报，别把「存下了」说成「共享了」

### DIFF
--- a/apps/daemon/assets/knowledge-templates/mcp-manifest.json
+++ b/apps/daemon/assets/knowledge-templates/mcp-manifest.json
@@ -19,7 +19,7 @@
     },
     {
       "name": "knowledge_create",
-      "description": "Create a new vault page from a template. Refuses to overwrite an existing path — use knowledge_write to edit. 从模板新建页面；已存在则拒绝，改请用 knowledge_write。",
+      "description": "Create a new vault page from a template. Refuses to overwrite an existing path — use knowledge_write to edit. 从模板新建页面；已存在则拒绝，改请用 knowledge_write。 If the reply carries teamSync:\"not-syncing\", the page was saved on this device only and is not reaching the team — say so rather than reporting it as shared. 若返回 teamSync:\"not-syncing\"，说明只存在本机、没有同步给团队，要如实告知，不要说成已共享。",
       "inputSchema": {
         "type": "object",
         "required": ["path"],
@@ -34,7 +34,7 @@
     },
     {
       "name": "knowledge_write",
-      "description": "Write or replace a vault page. All paths are validated to stay inside the vault. 写入/覆盖页面，路径被限制在 vault 内。",
+      "description": "Write or replace a vault page. All paths are validated to stay inside the vault. 写入/覆盖页面，路径被限制在 vault 内。 If the reply carries teamSync:\"not-syncing\", the page was saved on this device only and is not reaching the team — say so rather than reporting it as shared. 若返回 teamSync:\"not-syncing\"，说明只存在本机、没有同步给团队，要如实告知，不要说成已共享。",
       "inputSchema": {
         "type": "object",
         "required": ["path", "content"],
@@ -48,7 +48,7 @@
     },
     {
       "name": "knowledge_salvage",
-      "description": "Capture a conclusion from the current conversation into the vault as a salvage draft (00-salvage/<date>-<slug>.md with provenance frontmatter). Use when the user says something is worth keeping. 把对话中值得固化的结论存入知识库（打捞草稿）。",
+      "description": "Capture a conclusion from the current conversation into the vault as a salvage draft (00-salvage/<date>-<slug>.md with provenance frontmatter). Use when the user says something is worth keeping. 把对话中值得固化的结论存入知识库（打捞草稿）。 If the reply carries teamSync:\"not-syncing\", the page was saved on this device only and is not reaching the team — say so rather than reporting it as shared. 若返回 teamSync:\"not-syncing\"，说明只存在本机、没有同步给团队，要如实告知，不要说成已共享。",
       "inputSchema": {
         "type": "object",
         "required": ["title", "content"],

--- a/apps/daemon/src/daemon/server/knowledge.rs
+++ b/apps/daemon/src/daemon/server/knowledge.rs
@@ -24,6 +24,8 @@ use std::path::{Path, PathBuf};
 
 use serde_json::{json, Value};
 
+use crate::sync::oss::state::{ForbiddenPaths, LocalSyncState};
+
 use crate::config::{
     global_team_store::sync_content_root,
     knowledge_scaffold::{domain_index_template, scaffold_at, today_iso},
@@ -113,6 +115,59 @@ fn resolve_in_vault(root: &Path, rel: &str) -> Result<PathBuf, String> {
     Ok(root.join(clean))
 }
 
+fn now_secs() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+/// The sync path for a vault-relative page — what the engine and the path ACL
+/// key on. The vault is the `knowledge/` prefix of the synced tree.
+fn sync_path(rel: &str) -> String {
+    format!("knowledge/{}", rel.trim_start_matches('/'))
+}
+
+/// Fields to add to a write's reply when the sync engine already knows this
+/// path — or the directory holding it — is not reaching the team.
+///
+/// **Reported, never refused.** The caller asked for the page to exist, and a
+/// page that exists locally is strictly better than one that exists nowhere.
+/// What these tools must stop doing is answering a bare `ok: true`, which an
+/// agent reads as "shared with the team" and then tells the user so. The write
+/// lands, the server 403s on the next tick, `engine::record_forbidden` drops it
+/// from the dirty set at debug level — deliberately quiet — and the page never
+/// reaches a single teammate while everyone involved believes it did.
+///
+/// The wording is deliberately about what is observable rather than about
+/// permissions. The ACL design keeps a restricted directory's existence away
+/// from a device that is not granted it: the refusal is logged at debug rather
+/// than warn, kept out of the error counts, and expires so a later grant heals
+/// silently. Saying "not syncing" honours that; saying "you lack access to
+/// this directory" would not.
+///
+/// Absence of these fields is **not** a promise that the page will sync. It
+/// means no refusal has been recorded — which is also the answer for a team
+/// that has never had a sync failure at all.
+fn team_sync_fields(blocked: &ForbiddenPaths, rel: &str) -> Option<(&'static str, String)> {
+    if !blocked.blocks(&sync_path(rel), now_secs()) {
+        return None;
+    }
+    Some((
+        "not-syncing",
+        "saved on this device; this path is not currently syncing to the team".to_string(),
+    ))
+}
+
+/// Merge [`team_sync_fields`] into a reply body.
+fn with_team_sync(mut body: serde_json::Map<String, Value>, note: Option<(&str, String)>) -> Value {
+    if let Some((status, message)) = note {
+        body.insert("teamSync".into(), Value::String(status.to_string()));
+        body.insert("teamSyncNote".into(), Value::String(message));
+    }
+    Value::Object(body)
+}
+
 fn str_field<'a>(payload: &'a Value, key: &str) -> Option<&'a str> {
     payload
         .get(key)
@@ -138,11 +193,18 @@ impl DaemonServer {
             Err(e) => return e,
         };
         let root = vault_root(&team_id);
+        // Read once per command rather than per file. Cheap (one small JSON)
+        // and only for the actions that write — `search` and `health` have
+        // nothing to say about whether a page reaches the team.
+        let blocked = match action {
+            "create" | "write" | "salvage" => LocalSyncState::peek_forbidden(&team_id),
+            _ => ForbiddenPaths::default(),
+        };
         match action {
             "scaffold" => knowledge_scaffold(&root, &payload),
-            "create" => knowledge_create(&root, &payload),
-            "write" => knowledge_write(&root, &payload),
-            "salvage" => knowledge_salvage(&root, &payload),
+            "create" => knowledge_create(&root, &payload, &blocked),
+            "write" => knowledge_write(&root, &payload, &blocked),
+            "salvage" => knowledge_salvage(&root, &payload, &blocked),
             "search" => index::search(&root, &index_root(&team_id), &payload),
             "manifest_get" => manifest_get(&root),
             "manifest_set" => manifest_set(&root, &payload),
@@ -206,6 +268,7 @@ fn create_or_write(
     root: &Path,
     payload: &Value,
     overwrite: bool,
+    blocked: &ForbiddenPaths,
 ) -> String {
     let Some(path) = str_field(payload, "path") else {
         return err("invalid_path", "path is required (relative to the vault)");
@@ -235,26 +298,32 @@ fn create_or_write(
         }
     }
     match std::fs::write(&target, body) {
-        Ok(()) => ok(json!({
-            "path": target
+        Ok(()) => {
+            let rel = target
                 .strip_prefix(root)
-                .map(|p| p.to_string_lossy().into_owned())
-                .unwrap_or_else(|_| target.to_string_lossy().into_owned()),
-            "overwritten": overwrite && target.exists(),
-        })),
+                .map(|p| p.to_string_lossy().replace('\\', "/"))
+                .unwrap_or_else(|_| target.to_string_lossy().into_owned());
+            let mut body = serde_json::Map::new();
+            body.insert("path".into(), Value::String(rel.clone()));
+            body.insert(
+                "overwritten".into(),
+                Value::Bool(overwrite && target.exists()),
+            );
+            ok(with_team_sync(body, team_sync_fields(blocked, &rel)))
+        }
         Err(e) => err("write_failed", format!("write failed: {e}")),
     }
 }
 
-fn knowledge_create(root: &Path, payload: &Value) -> String {
-    create_or_write(root, payload, false)
+fn knowledge_create(root: &Path, payload: &Value, blocked: &ForbiddenPaths) -> String {
+    create_or_write(root, payload, false, blocked)
 }
 
-fn knowledge_write(root: &Path, payload: &Value) -> String {
-    create_or_write(root, payload, true)
+fn knowledge_write(root: &Path, payload: &Value, blocked: &ForbiddenPaths) -> String {
+    create_or_write(root, payload, true, blocked)
 }
 
-fn knowledge_salvage(root: &Path, payload: &Value) -> String {
+fn knowledge_salvage(root: &Path, payload: &Value, blocked: &ForbiddenPaths) -> String {
     let Some(content) = str_field(payload, "content") else {
         return err("invalid_content", "content is required for salvage");
     };
@@ -292,7 +361,12 @@ fn knowledge_salvage(root: &Path, payload: &Value) -> String {
         {
             Ok(mut file) => {
                 return match std::io::Write::write_all(&mut file, body.as_bytes()) {
-                    Ok(()) => ok(json!({ "path": format!("{SALVAGE_DIR}/{name}") })),
+                    Ok(()) => {
+                        let rel = format!("{SALVAGE_DIR}/{name}");
+                        let mut body = serde_json::Map::new();
+                        body.insert("path".into(), Value::String(rel.clone()));
+                        ok(with_team_sync(body, team_sync_fields(blocked, &rel)))
+                    }
                     Err(e) => err("write_failed", format!("write failed: {e}")),
                 };
             }
@@ -634,7 +708,11 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let root = tmp.path();
         let salvage = |title: &str, content: &str| {
-            let reply = knowledge_salvage(root, &json!({ "title": title, "content": content }));
+            let reply = knowledge_salvage(
+                root,
+                &json!({ "title": title, "content": content }),
+                &ForbiddenPaths::default(),
+            );
             let v: Value = serde_json::from_str(&reply).unwrap();
             assert_eq!(v["ok"], true, "{v}");
             v["result"]["path"].as_str().unwrap().to_string()
@@ -667,7 +745,7 @@ mod tests {
             "content": "标题 + 利益点 + 行动指令",
             "source": "chat",
         });
-        let reply = knowledge_salvage(root, &payload);
+        let reply = knowledge_salvage(root, &payload, &ForbiddenPaths::default());
         let v: Value = serde_json::from_str(&reply).unwrap();
         assert_eq!(v["ok"], true);
         let path = v["result"]["path"].as_str().unwrap();
@@ -676,6 +754,71 @@ mod tests {
         let raw = std::fs::read_to_string(root.join(path)).unwrap();
         assert!(raw.contains("type: salvage"));
         assert!(raw.contains("source: chat"));
+    }
+
+    /// The refusals the sync engine would have on record, as of now.
+    fn refused(paths: &[&str]) -> ForbiddenPaths {
+        ForbiddenPaths::from_entries(paths.iter().map(|p| {
+            (
+                (*p).to_string(),
+                crate::sync::oss::state::ForbiddenPath {
+                    last_tried_at: now_secs(),
+                    reason: "not accessible".into(),
+                },
+            )
+        }))
+    }
+
+    /// A page written into a directory the server refuses must not come back
+    /// as a bare `ok` — that is what an agent turns into "saved for the team".
+    #[test]
+    fn a_write_into_a_refused_directory_says_so() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+
+        // The refusal the engine recorded for a sibling. A page written into
+        // the same directory for the first time has no entry of its own, which
+        // is exactly the case this has to catch.
+        let blocked = refused(&["knowledge/hr/salary.md"]);
+
+        let reply = create_or_write(
+            root,
+            &json!({ "path": "hr/onboarding.md", "title": "Onboarding", "content": "x" }),
+            false,
+            &blocked,
+        );
+        let v: Value = serde_json::from_str(&reply).unwrap();
+        assert_eq!(v["ok"], true, "the page still gets written: {v}");
+        assert_eq!(v["result"]["teamSync"], "not-syncing", "{v}");
+        assert!(
+            root.join("hr/onboarding.md").exists(),
+            "page must exist locally"
+        );
+
+        // A page somewhere else in the vault is untouched by that refusal.
+        let elsewhere = create_or_write(
+            root,
+            &json!({ "path": "20-domains/pricing.md", "title": "Pricing", "content": "x" }),
+            false,
+            &blocked,
+        );
+        let v2: Value = serde_json::from_str(&elsewhere).unwrap();
+        assert!(v2["result"].get("teamSync").is_none(), "{v2}");
+    }
+
+    #[test]
+    fn salvage_reports_a_refused_path_too() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        let blocked = refused(&[&sync_path("00-salvage/2026-01-01-old.md")]);
+        let reply = knowledge_salvage(
+            root,
+            &json!({ "title": "对账口径", "content": "一" }),
+            &blocked,
+        );
+        let v: Value = serde_json::from_str(&reply).unwrap();
+        assert_eq!(v["ok"], true);
+        assert_eq!(v["result"]["teamSync"], "not-syncing", "{v}");
     }
 
     #[test]

--- a/apps/daemon/src/sync/oss/state.rs
+++ b/apps/daemon/src/sync/oss/state.rs
@@ -76,6 +76,65 @@ pub struct ForbiddenPath {
     pub reason: String,
 }
 
+/// The directory part of a sync path, or `None` for a bare filename.
+fn parent_dir(path: &str) -> Option<&str> {
+    path.rsplit_once('/').map(|(dir, _)| dir)
+}
+
+/// A read-only view of [`LocalSyncState::forbidden`], for callers that want to
+/// know whether a write will reach the team without taking ownership of the
+/// state file. Built by [`LocalSyncState::peek_forbidden`].
+#[derive(Debug, Default)]
+pub struct ForbiddenPaths(HashMap<String, ForbiddenPath>);
+
+impl ForbiddenPaths {
+    /// Whether the server is currently refusing this path — or the directory
+    /// it sits in.
+    ///
+    /// Directory-level because the ACL is: a page written for the first time
+    /// has no refusal of its own yet, so the one recorded against a sibling is
+    /// the only evidence there is. Exact-path only would answer "fine" for
+    /// every new file in a restricted directory — which is precisely the case
+    /// worth reporting.
+    ///
+    /// Same expiry as [`LocalSyncState::is_forbidden_now`], so a later grant
+    /// stops being reported without anyone being told anything.
+    pub fn blocks(&self, path: &str, now_secs: u64) -> bool {
+        let fresh =
+            |p: &ForbiddenPath| now_secs.saturating_sub(p.last_tried_at) < FORBIDDEN_RETRY_SECS;
+        if self.0.get(path).is_some_and(fresh) {
+            return true;
+        }
+        // Same directory, compared exactly — NOT a prefix match. A prefix would
+        // make one refusal under `knowledge/hr/` report the whole of
+        // `knowledge/` as blocked, because every knowledge path starts with it.
+        //
+        // Descendants are left out for the opposite reason: the server's rules
+        // are prefixes at any depth, so a refusal on `knowledge/hr/salary.md`
+        // could come from a rule on `knowledge/hr/` or on that one file, and
+        // the recorded refusal does not say which. Reporting only the directory
+        // we have direct evidence for keeps this to what was observed.
+        let Some(dir) = parent_dir(path) else {
+            return false;
+        };
+        self.0
+            .iter()
+            .any(|(known, entry)| parent_dir(known) == Some(dir) && fresh(entry))
+    }
+
+    /// Whether anything is known at all — an empty set means "no evidence",
+    /// not "everything is fine".
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    /// Build from explicit entries, for a caller that already holds the state
+    /// (or a test that wants a specific one) rather than the file on disk.
+    pub fn from_entries(entries: impl IntoIterator<Item = (String, ForbiddenPath)>) -> Self {
+        Self(entries.into_iter().collect())
+    }
+}
+
 /// How long to leave a forbidden path alone before trying once more.
 ///
 /// A day, because the only thing that changes the answer is an administrator
@@ -184,6 +243,23 @@ impl LocalSyncState {
             serde_json::to_string_pretty(self).map_err(|e| format!("state: serialize: {e}"))?;
         std::fs::write(&path, json).map_err(|e| format!("state: write {}: {e}", path.display()))?;
         Ok(())
+    }
+
+    /// The refusals recorded for a team, read WITHOUT [`Self::load_at`]'s
+    /// recovery behaviour.
+    ///
+    /// `load_at` renames an unparseable state file to `.corrupt` so the next
+    /// tick rebuilds from scratch. That is correct for the sync engine, which
+    /// owns this file — and wrong for a passing reader: a tool asking "would
+    /// this path reach my team?" must not be able to reset sync state as a
+    /// side effect of asking. Anything unreadable here answers "nothing
+    /// known", which degrades to today's behaviour rather than to a surprise.
+    pub fn peek_forbidden(team_id: &str) -> ForbiddenPaths {
+        let path = crate::config::global_team_store::global_sync_state_path(team_id);
+        let parsed = std::fs::read_to_string(&path)
+            .ok()
+            .and_then(|body| serde_json::from_str::<Self>(&body).ok());
+        ForbiddenPaths(parsed.map(|s| s.forbidden).unwrap_or_default())
     }
 
     /// Load OSS sync state for a team from the daemon global location
@@ -600,5 +676,63 @@ mod tests {
         assert!(dir.path().join(".copilot361/sync/state.json").is_file());
         let reloaded = LocalSyncState::load(ws, "team-x").unwrap();
         assert_eq!(reloaded.last_server_seq, 99);
+    }
+
+    fn at(secs: u64) -> ForbiddenPath {
+        ForbiddenPath {
+            last_tried_at: secs,
+            reason: "not accessible".into(),
+        }
+    }
+
+    #[test]
+    fn forbidden_view_answers_for_the_directory_not_just_the_file() {
+        let set = ForbiddenPaths::from_entries([("knowledge/hr/salary.md".to_string(), at(1_000))]);
+
+        // The file itself.
+        assert!(set.blocks("knowledge/hr/salary.md", 1_000));
+        // A sibling written for the first time — no entry of its own, and the
+        // case the whole view exists for.
+        assert!(set.blocks("knowledge/hr/onboarding.md", 1_000));
+        // Not the parent's other children, and not a prefix that merely starts
+        // with the same letters.
+        assert!(!set.blocks("knowledge/pricing.md", 1_000));
+        assert!(!set.blocks("knowledge/hr-public/notes.md", 1_000));
+        // Nested deeper is a different directory; the ACL is per-directory and
+        // guessing beyond the evidence would report a block nobody recorded.
+        assert!(!set.blocks("knowledge/hr/2026/q1.md", 1_000));
+    }
+
+    #[test]
+    fn forbidden_view_expires_with_the_same_window_as_the_engine() {
+        let set = ForbiddenPaths::from_entries([("knowledge/hr/salary.md".to_string(), at(1_000))]);
+        assert!(set.blocks("knowledge/hr/other.md", 1_000 + FORBIDDEN_RETRY_SECS - 1));
+        assert!(
+            !set.blocks("knowledge/hr/other.md", 1_000 + FORBIDDEN_RETRY_SECS),
+            "a grant must stop being reported without anyone being told"
+        );
+    }
+
+    /// `load_at` quarantines an unparseable state file so the next tick
+    /// rebuilds. A read-only caller asking "would this reach my team?" must not
+    /// be able to trigger that by asking.
+    #[test]
+    fn peeking_never_quarantines_a_corrupt_state_file() {
+        // `BrandEnvGuard` already takes `TEST_HOME_LOCK`, and that mutex is not
+        // reentrant — taking it here as well deadlocks the test against itself.
+        let home = tempfile::tempdir().unwrap();
+        let _env = crate::test_brand_env::BrandEnvGuard::set_amuxd_home(home.path());
+
+        let path = crate::config::global_team_store::global_sync_state_path("team-peek");
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(&path, b"{ not json").unwrap();
+
+        let set = LocalSyncState::peek_forbidden("team-peek");
+        assert!(set.is_empty(), "unreadable state answers 'nothing known'");
+        assert!(path.is_file(), "the state file must survive being read");
+        assert!(
+            !path.with_extension("json.corrupt").exists(),
+            "peeking must not run load_at's recovery"
+        );
     }
 }


### PR DESCRIPTION
#1149 那份评审的第 7 条：knowledge 工具对刚上线的目录级 ACL 一无所知。工具面经 #1171 进 main，评审留在了一个已关闭的 PR 上，所以这条一直没人处理。

## 现象

agent 往团队设了权限的目录写一页 → `write` 返回**裸 `ok: true`** → 下一个 tick 服务端 403 → `engine::record_forbidden` 把它移出 dirty set、**debug 级日志、不计入错误数**。

这三件事**每一件都是刻意的**：ACL 设计就是不让无权设备知道受限目录存在（`record_forbidden` 的注释原话是 warn 会把受限路径写进不该知道它的人的日志；不计入 stats 是因为「更糟的是它暗示了该目录的存在」；24 小时过期是为了让后来的授权自愈而不必告诉任何人）。

**合在一起就不是了**：这一页谁也收不到，而 agent 早就告诉用户「已经存进团队知识库了」。

## 改法

`write` / `create` / `salvage` 在同步引擎**已经记录过**该路径或其所在目录被拒时，回包多两个字段：

```json
{ "path": "hr/onboarding.md",
  "teamSync": "not-syncing",
  "teamSyncNote": "saved on this device; this path is not currently syncing to the team" }
```

**报告，不拒绝。** 调用方要的是这一页存在，本地存在远好过哪都不存在 —— 这跟 salvage 撞名那条是同一类教训。要停掉的是「裸 `ok` 被读成已共享」。

**措辞只讲可观察事实**：「没在同步」，而不是「你没有这个目录的权限」。理由同上 —— 跟 `record_forbidden` 用 debug 不用 warn 是同一条。

## 两处「显而易见的写法是错的」

**1. 用 `peek_forbidden`，不用 `load_at`。**

`load_at` 在解析失败时会把 state.json 改名成 `.corrupt`，让下一个 tick 重建。那是同步引擎作为文件所有者的正确恢复动作 —— 但一个只是**提问**的工具不该有这种副作用：问一句「这条路径能到队友那儿吗」，不该能把同步状态重置掉。读不出来就答「无信息」。这条单独有测试。

**2. 目录匹配是「父目录完全相等」，不是前缀。**

前缀匹配会让 `knowledge/hr/` 下的一条拒绝把**整个 `knowledge/` 顶层**都判成不同步 —— 因为每条 knowledge 路径都以 `knowledge/` 开头。我第一版就是这么写的，复查时才发现。

也不向下推子目录，理由相反：服务端规则是**任意深度前缀**，`knowledge/hr/salary.md` 的一条拒绝可能来自 `knowledge/hr/` 的规则、也可能来自那一个文件的规则，**记录本身不说是哪个**。只报有直接证据的那一层。

## MCP manifest 一起改了

三个写工具的描述都加了双语说明：返回 `teamSync:"not-syncing"` 时要如实告知只存在本机、不要说成已共享。

**不改这个，这个修复在最关键的一环就是隐形的** —— 说「已保存」的是 agent，而 agent 只知道 manifest 告诉它的东西。

## 语义边界

**字段缺席不等于保证能同步**，只等于「没有记录到拒绝」—— 对一个从没出过同步失败的团队来说也是这个答案。注释里写明了。

## 测试

新增 5 条：目录级判定（同目录命中、别的目录不命中、`hr-public` 这种前缀近似不命中、子目录不命中）、与引擎同一个 24 小时过期窗口、只读入口不改名 `.corrupt`、写入受限目录如实上报、salvage 同样上报。

`cargo test -p amuxd --bin amuxd`：**1687 passed, 0 failed**（main 上是 1682）。

写这批测试时抓到一个自己的 bug：那条只读入口的测试手动拿了 `TEST_HOME_LOCK`，而紧接着的 `BrandEnvGuard::set_amuxd_home` 又去拿同一把锁 —— `std::sync::Mutex` 不可重入，测试把自己锁死了。直接提 PR 的话这会是 CI 上一个卡到超时的 job。

## 同一份评审里仍未处理的

2 字中文词走 LIKE 全表扫、`visibility` 的 confirm 不构成人工确认、缺 `read`、`manifest_set` 两个坑、`overwritten` 恒真、socket 主循环 inline await、agent 写的页对 `health()` 隐形、`today_iso()` 是 UTC。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NSLRgWQJVe4uVJ824WdBdE
