### PR TITLE
feat(fc): serve the deployment's own AI gateway to teams that never configured one

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -270,7 +270,7 @@ Cloud API endpoints: see `docs/openapi/teamclu-api.v1.yaml` (the contract) —
 
 Team share onboarding endpoints (see `docs/openapi/teamclu-api.v1.yaml`):
 
-- `GET  /v1/teams/:id/workspace-config` — merged shape `{ syncMode, llm }`. The legacy `{ defaultWorkspaceId, pinnedWorkspaceIds }` shape now lives at `GET /v1/teams/:id/workspace-defaults` (PUT path is unchanged).
+- `GET  /v1/teams/:id/workspace-config` — merged shape `{ syncMode, llm }`. The legacy `{ defaultWorkspaceId, pinnedWorkspaceIds }` shape now lives at `GET /v1/teams/:id/workspace-defaults` (PUT path is unchanged). A team with no stored `llm_base_url` is served the deployment's own gateway (`<request origin>/ai/v1/teams/:id` + the three tiers) whenever FC has `AI_GATEWAY_INTERNAL_URL`/`AI_GATEWAY_SERVICE_TOKEN`; a stored baseUrl always wins, and `enabled=false` **with** a baseUrl is how a team opts out (`services/fc/src/lib/team-llm-defaults.ts`).
 - `PUT  /v1/teams/:id/llm-config` — sets the team's AI gateway (`{ enabled, baseUrl, models }`). FC no longer provisions LiteLLM; the gateway is configured, not minted.
 
 <!-- seahelm:suggest:start -->

--- a/docs/openapi/teamclu-api.v1.yaml
+++ b/docs/openapi/teamclu-api.v1.yaml
@@ -137,7 +137,9 @@ paths:
           description: |
             Created team. Writes the teams row and seeds team_workspace_config;
             the team's AI gateway is configured separately via
-            `PUT /v1/teams/{teamId}/llm-config`.
+            `PUT /v1/teams/{teamId}/llm-config`. Until a team does that,
+            `GET /v1/teams/{teamId}/workspace-config` serves the deployment's
+            own gateway as the default (see `MergedWorkspaceConfig.llm`).
           headers:
             X-Request-Id:
               $ref: "#/components/headers/RequestId"
@@ -7296,6 +7298,34 @@ components:
           type:
             - string
             - "null"
+        llm:
+          type: object
+          description: |
+            The team's AI gateway as the client should use it. When the team
+            has stored a `baseUrl` (via `PUT /v1/teams/{teamId}/llm-config`)
+            that config is returned verbatim — including `enabled: false` with
+            a `baseUrl`, which is how a team opts out. A team with NO stored
+            `baseUrl` is served the deployment's own gateway instead: `enabled`
+            true, `baseUrl` `<request origin>/ai/v1/teams/{teamId}`, and the
+            three public tiers as `models` — provided this Cloud API runs a
+            gateway (`AI_GATEWAY_INTERNAL_URL` + `AI_GATEWAY_SERVICE_TOKEN`).
+            Nothing flips `llm_enabled` at team creation, so without this
+            default every new team had a signup credit grant and no model.
+          required: [enabled, baseUrl, models]
+          properties:
+            enabled: { type: boolean }
+            baseUrl:
+              type:
+                - string
+                - "null"
+            models:
+              type: array
+              items:
+                type: object
+                required: [id, name]
+                properties:
+                  id: { type: string }
+                  name: { type: string }
     UsageSummary:
       type: object
       required: [credits, inputTokens, outputTokens, requests]

--- a/docs/specs/2026-08-28-team-ai-gateway-design.md
+++ b/docs/specs/2026-08-28-team-ai-gateway-design.md
@@ -181,6 +181,8 @@ public_models = { default, pro, max }     ← 唯一对外契约
 
 Tauri 端不再从云端拉团队的模型列表：`provider.team` 的形状与这三个 id 由客户端固定持有，只有 baseURL 在运行时拼（本地 amuxd 端口 + teamId），`llm_enabled` 仍来自云端。
 
+⚠️ **谁把 `llm_enabled` 打开**（2026-09-02 补记）：原设计没有定这一条。`llm_enabled` 列默认 false，建团队不碰它，唯一写入方 `PUT /llm-config` 的设置页又在钉死三档时删掉了（a12259df），结果 305 个团队只有 3 个开着——赠送额度都发了，客户端却到不了网关。现在由 FC 兜底：`GET /workspace-config` 对没有存过 `llm_base_url` 的团队按请求 origin 下发本部署的网关（附录 B）。
+
 **为什么写死是安全的**：三档 tier 本来就是**稳定名字**，真正会变的是它们指向哪个上游 —— 而那层映射在服务端的 catalog 里（§4.3）。改后端、调价、加权重、切供应商都**不需要发客户端**。今天 `litellm/config.yaml` 的注释写的就是这个意图：「The app selects a capability tier, not a vendor model.」本设计把它变成硬契约。
 
 代价说清楚：**真要加第四档就需要发一次客户端**。这是刻意接受的 —— 加档是产品决策，不该是一次配置改动。
@@ -1145,7 +1147,7 @@ UPDATE amux.team_workspace_config
 |---|---|
 | provider 形状、三档 model id | **客户端写死** |
 | baseURL | 运行时拼：本地 amuxd 端口 + teamId |
-| `llm_enabled` | 云端 `workspace-config.llm.enabled` |
+| `llm_enabled` | 云端 `workspace-config.llm.enabled`。**没有存过 `llm_base_url` 的团队，FC 直接按请求 origin 下发本部署的网关**（`<origin>/ai/v1/teams/<id>` + 三档），见 `services/fc/src/lib/team-llm-defaults.ts`；显式 `PUT /llm-config` 存了 baseUrl 的团队以存的为准，`enabled=false` + baseUrl 即退出 |
 | **上游到底打新网关还是老 LiteLLM** | **云端 `llm_base_url`，由 amuxd 解析**（见 §11.2） |
 
 最后一行是关键：解析上游的职责从客户端**往后移了一跳**到 amuxd。客户端写死的同时，§11.2 那个「一条 UPDATE 灰度、一条 UPDATE 回滚」的杠杆完整保留 —— 只是现在读 `llm_base_url` 的是 daemon 而不是客户端。daemon 侧优先级不变：`llm.baseUrl` → `llm.aiGatewayEndpoint`（`apps/daemon/src/backend/cloud_api/mod.rs:718-721`）。

--- a/services/fc/src/lib/routes/team-share.ts
+++ b/services/fc/src/lib/routes/team-share.ts
@@ -1,4 +1,5 @@
 import { ApiError } from "../http-utils.js";
+import { withTeamLlmDefaults } from "../team-llm-defaults.js";
 
 function validateLlmConfigInput(body) {
   const enabled = body?.enabled;
@@ -28,7 +29,9 @@ function validateLlmConfigInput(body) {
 export function registerTeamShare(router) {
   router.get("/v1/teams/:teamId/workspace-config", async (ctx) => {
     const result = await ctx.repository.getWorkspaceConfig(ctx.params.teamId);
-    return { body: result };
+    // A team that never configured a gateway is served this deployment's own
+    // (see team-llm-defaults.ts); a stored baseUrl always stands.
+    return { body: withTeamLlmDefaults(result, ctx.params.teamId, ctx.getHeader) };
   });
 
   router.put("/v1/teams/:teamId/llm-config", async (ctx) => {

--- a/services/fc/src/lib/team-llm-defaults.ts
+++ b/services/fc/src/lib/team-llm-defaults.ts
@@ -1,0 +1,128 @@
+// ---------------------------------------------------------------------------
+// Default team AI gateway config, for teams that never configured one.
+//
+// Every team is meant to have the gateway's three tiers from day one — that is
+// what the signup credit grant exists for (design §4.8). But `llm_enabled`
+// defaults to false, nothing flips it when a team is created, and the
+// owner-facing form that used to was removed when the tiers were pinned
+// client-side (§4.3.1, a12259df). Measured on 2026-09-02: 302 of 305 teams
+// held a credit balance and had no model, because the daemon only writes
+// `provider.team` for `enabled=true` + a baseUrl (runtime/managed_llm.rs).
+//
+// So a team with no stored baseUrl is served this deployment's own gateway,
+// addressed through the origin the caller reached FC on. That origin is the
+// right one by construction: the daemon proxies `/v1/ai/teams/:id/*` to
+// whatever baseUrl it is handed, and the gateway is mounted under `/ai/` on the
+// same host as the Cloud API (Caddyfile, `handle_path /ai/*`). Deriving it from
+// the request rather than a new env var keeps both deploy targets (compose and
+// Serverless Devs) correct without another entry in two allowlists.
+//
+// An explicit `PUT /llm-config` with a baseUrl still wins — including
+// `enabled=false` with a baseUrl set, which is how a team opts out. A stored
+// `enabled=false` with NO baseUrl is indistinguishable from "never configured"
+// (the retired form wrote exactly that for "off"), and is treated as such.
+// ---------------------------------------------------------------------------
+import { aiGatewayConfigured } from "./ai-gateway.js";
+
+export type TeamLlmModel = { id: string; name: string };
+export type TeamLlm = {
+  enabled: boolean;
+  baseUrl: string | null;
+  models: TeamLlmModel[];
+};
+
+/**
+ * The public tiers, in the order the desktop lists them. Mirrors
+ * `TEAM_MODEL_TIERS` in packages/app/src/lib/team-provider.ts and
+ * crates/teamclu-runtime-env/src/team_provider.rs. Current clients ignore the
+ * served list (the ids are pinned on their side); older ones require it to be
+ * non-empty before they will show the team provider at all.
+ */
+export const TEAM_MODEL_TIERS: readonly TeamLlmModel[] = Object.freeze([
+  { id: "default", name: "标准" },
+  { id: "pro", name: "高级" },
+  { id: "max", name: "旗舰" },
+]);
+
+type HeaderReader = (name: string) => string | undefined | null;
+
+function firstValue(raw: string | undefined | null): string {
+  if (!raw) return "";
+  const first = raw.split(",")[0];
+  return first ? first.trim() : "";
+}
+
+// Hostname or IPv4 literal, with an optional port. Deliberately no IPv6
+// literals and no userinfo: a caller who can put anything else in Host only
+// ever changes the URL served back to themselves, but a malformed value must
+// not produce a malformed baseUrl the daemon then fails on.
+const HOST_RE = /^[A-Za-z0-9]([A-Za-z0-9-]*[A-Za-z0-9])?(\.[A-Za-z0-9]([A-Za-z0-9-]*[A-Za-z0-9])?)*(:\d{1,5})?$/;
+
+/**
+ * The origin the caller reached this deployment on, from the proxy's
+ * forwarding headers (Caddy sets all three by default) with `Host` as the
+ * fallback for a deploy target that fronts FC directly. `null` when there is
+ * no usable host — never a guess.
+ */
+export function requestOrigin(getHeader: HeaderReader): string | null {
+  const host = firstValue(getHeader("x-forwarded-host")) || firstValue(getHeader("host"));
+  if (!host || !HOST_RE.test(host)) return null;
+  const proto = (firstValue(getHeader("x-forwarded-proto")) || "https").toLowerCase();
+  if (proto !== "http" && proto !== "https") return null;
+  return `${proto}://${host}`;
+}
+
+// Route params arrive as the RAW path segment (hono-adapter keeps them
+// percent-encoded on purpose), so a plain encodeURIComponent would double-encode
+// them. Normalise through a decode first; a segment that does not decode is
+// encoded as-is rather than spliced raw.
+function pathSegment(teamId: string): string {
+  try {
+    return encodeURIComponent(decodeURIComponent(teamId));
+  } catch {
+    return encodeURIComponent(teamId);
+  }
+}
+
+/** The gateway baseUrl for `teamId` on the deployment at `origin`. */
+export function defaultTeamGatewayBaseUrl(origin: string, teamId: string): string {
+  return `${origin.replace(/\/+$/, "")}/ai/v1/teams/${pathSegment(teamId)}`;
+}
+
+/**
+ * The `llm` block to serve for `teamId`: the stored one when it names a
+ * baseUrl (or when this deployment runs no gateway, or the request has no
+ * usable origin), otherwise the deployment default. Returns `stored` by
+ * reference when nothing changes, so callers can tell the two apart.
+ */
+export function applyTeamLlmDefaults(
+  teamId: string,
+  stored: TeamLlm | null | undefined,
+  getHeader: HeaderReader,
+): TeamLlm | null | undefined {
+  const storedBaseUrl = typeof stored?.baseUrl === "string" ? stored.baseUrl.trim() : "";
+  if (storedBaseUrl) return stored;
+  if (!aiGatewayConfigured()) return stored;
+  const origin = requestOrigin(getHeader);
+  if (!origin) return stored;
+  return {
+    enabled: true,
+    baseUrl: defaultTeamGatewayBaseUrl(origin, teamId),
+    models: TEAM_MODEL_TIERS.map((m) => ({ ...m })),
+  };
+}
+
+/**
+ * `GET /workspace-config` response with the `llm` block defaulted. Leaves the
+ * payload untouched (same reference) when the stored config stands.
+ */
+export function withTeamLlmDefaults<T extends { llm?: TeamLlm | null }>(
+  result: T,
+  teamId: string,
+  getHeader: HeaderReader,
+): T {
+  if (!result || typeof result !== "object") return result;
+  const llm = applyTeamLlmDefaults(teamId, result.llm, getHeader);
+  if (llm === result.llm) return result;
+  return { ...result, llm };
+}

--- a/services/fc/test/team-share.test.ts
+++ b/services/fc/test/team-share.test.ts
@@ -2,6 +2,7 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import { handleBusinessApiRequest } from "../src/lib/business-api.js";
 import { ApiError } from "../src/lib/http-utils.js";
+import { requestOrigin } from "../src/lib/team-llm-defaults.js";
 
 function makeRepo(overrides: any = {}) {
   const calls = [];
@@ -139,4 +140,144 @@ test("PUT /v1/teams/:id/llm-config malformed model entry → 400", async () => {
   assert.equal(res.statusCode, 400);
   assert.equal(JSON.parse(res.body).error.code, "validation_failed");
   assert.equal(repo.calls.length, 0);
+});
+
+// ── Default gateway for unconfigured teams (team-llm-defaults.ts) ──────────
+
+const GATEWAY_ENV_KEYS = ["AI_GATEWAY_INTERNAL_URL", "AI_GATEWAY_SERVICE_TOKEN"] as const;
+
+async function withGatewayEnv(configured: boolean, fn: () => Promise<void>) {
+  const saved = GATEWAY_ENV_KEYS.map((k) => [k, process.env[k]] as const);
+  for (const k of GATEWAY_ENV_KEYS) delete process.env[k];
+  if (configured) {
+    process.env.AI_GATEWAY_INTERNAL_URL = "http://ai-gateway:4001";
+    process.env.AI_GATEWAY_SERVICE_TOKEN = "svc-token";
+  }
+  try {
+    await fn();
+  } finally {
+    for (const [k, v] of saved) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+  }
+}
+
+const FRESH_LLM = { enabled: false, baseUrl: null, models: [] };
+
+function forwardedHeaders(extra: Record<string, string> = {}) {
+  return {
+    ...bearerHeaders(),
+    "X-Forwarded-Host": "api.example.com",
+    "X-Forwarded-Proto": "https",
+    ...extra,
+  };
+}
+
+test("GET workspace-config: a team with no gateway config is served this deployment's own", async () => {
+  await withGatewayEnv(true, async () => {
+    const repo = makeRepo({
+      getWorkspaceConfigResult: { syncMode: null, litellmTeamId: null, llm: FRESH_LLM },
+    });
+    const res = await handleBusinessApiRequest({
+      httpMethod: "GET",
+      path: "/v1/teams/team-1/workspace-config",
+      headers: forwardedHeaders(),
+    }, { createRepository: () => repo });
+
+    assert.equal(res.statusCode, 200);
+    assert.deepEqual(JSON.parse(res.body), {
+      syncMode: null,
+      litellmTeamId: null,
+      llm: {
+        enabled: true,
+        baseUrl: "https://api.example.com/ai/v1/teams/team-1",
+        models: [
+          { id: "default", name: "标准" },
+          { id: "pro", name: "高级" },
+          { id: "max", name: "旗舰" },
+        ],
+      },
+    });
+  });
+});
+
+test("GET workspace-config: enabled-without-baseUrl is unusable, so it is defaulted too", async () => {
+  await withGatewayEnv(true, async () => {
+    const repo = makeRepo({
+      getWorkspaceConfigResult: {
+        syncMode: "oss",
+        llm: { enabled: true, baseUrl: null, models: [{ id: "stale", name: "Stale" }] },
+      },
+    });
+    const res = await handleBusinessApiRequest({
+      httpMethod: "GET",
+      path: "/v1/teams/team%2Fodd/workspace-config",
+      headers: forwardedHeaders(),
+    }, { createRepository: () => repo });
+
+    assert.equal(res.statusCode, 200);
+    const body = JSON.parse(res.body);
+    assert.equal(body.llm.enabled, true);
+    // The team id is encoded into the path, never spliced raw.
+    assert.equal(body.llm.baseUrl, "https://api.example.com/ai/v1/teams/team%2Fodd");
+    assert.deepEqual(body.llm.models.map((m) => m.id), ["default", "pro", "max"]);
+  });
+});
+
+test("GET workspace-config: a stored baseUrl stands, even with the team switched off", async () => {
+  await withGatewayEnv(true, async () => {
+    const stored = { enabled: false, baseUrl: "https://proxy.example.com/v1", models: [] };
+    const repo = makeRepo({ getWorkspaceConfigResult: { syncMode: null, llm: stored } });
+    const res = await handleBusinessApiRequest({
+      httpMethod: "GET",
+      path: "/v1/teams/team-1/workspace-config",
+      headers: forwardedHeaders(),
+    }, { createRepository: () => repo });
+
+    assert.equal(res.statusCode, 200);
+    assert.deepEqual(JSON.parse(res.body).llm, stored);
+  });
+});
+
+test("GET workspace-config: no default when this deployment runs no gateway", async () => {
+  await withGatewayEnv(false, async () => {
+    const repo = makeRepo({ getWorkspaceConfigResult: { syncMode: null, llm: FRESH_LLM } });
+    const res = await handleBusinessApiRequest({
+      httpMethod: "GET",
+      path: "/v1/teams/team-1/workspace-config",
+      headers: forwardedHeaders(),
+    }, { createRepository: () => repo });
+
+    assert.equal(res.statusCode, 200);
+    assert.deepEqual(JSON.parse(res.body).llm, FRESH_LLM);
+  });
+});
+
+test("GET workspace-config: no default without a usable request host", async () => {
+  await withGatewayEnv(true, async () => {
+    const repo = makeRepo({ getWorkspaceConfigResult: { syncMode: null, llm: FRESH_LLM } });
+    const res = await handleBusinessApiRequest({
+      httpMethod: "GET",
+      path: "/v1/teams/team-1/workspace-config",
+      headers: forwardedHeaders({ "X-Forwarded-Host": "not a host" }),
+    }, { createRepository: () => repo });
+
+    assert.equal(res.statusCode, 200);
+    assert.deepEqual(JSON.parse(res.body).llm, FRESH_LLM);
+  });
+});
+
+test("requestOrigin: first forwarded hop wins, Host is the fallback, junk is refused", () => {
+  const h = (m: Record<string, string>) => (name: string) => m[name.toLowerCase()];
+  assert.equal(
+    requestOrigin(h({ "x-forwarded-host": "api.example.com, edge.internal", "x-forwarded-proto": "https, http" })),
+    "https://api.example.com",
+  );
+  assert.equal(requestOrigin(h({ host: "fc.local:9000" })), "https://fc.local:9000");
+  assert.equal(requestOrigin(h({ host: "fc.local", "x-forwarded-proto": "http" })), "http://fc.local");
+  assert.equal(requestOrigin(h({})), null);
+  assert.equal(requestOrigin(h({ host: "[::1]:9000" })), null);
+  assert.equal(requestOrigin(h({ host: "api.example.com/evil" })), null);
+  assert.equal(requestOrigin(h({ host: "api.example.com", "x-forwarded-proto": "ftp" })), null);
 });


### PR DESCRIPTION
## Why

A user (`fsle00@126.com`, team `fsle00`, signed up 8/22) reported 「无法获取模型列表」. Diagnosis against production:

- Every team is meant to have the gateway's three tiers from day one — that is what the 10,000,000-credit signup grant (design §4.8) is for. The grant was there. The model was not.
- `team_workspace_config.llm_enabled` defaults to `false`, nothing flips it at team creation, and the owner-facing form that used to (设置 → 团队 LLM) was removed when the tiers were pinned client-side (a12259df). `PUT /llm-config` has no caller left in `packages/app/src`.
- The daemon only writes `provider.team` for `enabled=true` + a baseUrl (`runtime/managed_llm.rs`), so a fresh team's opencode has no provider at all.
- Measured 2026-09-02: **305 teams, 287 with a credit balance, 3 with the gateway on** — all three switched on by hand. The reporting user had never sent a message (0 rows in `ai_usage_logs` and in the retained `_litellm` spend log for their team).

## What

`GET /v1/teams/:id/workspace-config` now fills the `llm` block for any team without a stored `llm_base_url`:

- `enabled: true`, `baseUrl: <request origin>/ai/v1/teams/:id`, `models`: the three public tiers (标准/高级/旗舰).
- Only when this Cloud API runs a gateway (`AI_GATEWAY_INTERNAL_URL` + `AI_GATEWAY_SERVICE_TOKEN`), and only when the request carries a usable host.
- Origin comes from `X-Forwarded-Host`/`X-Forwarded-Proto` (Caddy sets them) with `Host` as fallback, rather than a new env var: the gateway is mounted under `/ai/` on the same host as the Cloud API, so the host the daemon reached us on is the host it should call. No new allowlist entry to go missing on one of the two deploy targets.
- A stored baseUrl always stands, including `enabled: false` + baseUrl, which is how a team opts out. A stored `enabled: false` with no baseUrl is indistinguishable from "never configured" (the retired form wrote exactly that for "off") and is treated as such.
- Route params arrive as the raw path segment (hono-adapter keeps them percent-encoded), so the team id is decoded before re-encoding; a naive `encodeURIComponent` double-encoded it.

Contract (`MergedWorkspaceConfig.llm`), design doc (§4.3.1 + 附录 B) and CLAUDE.md now say who turns the flag on, which the original design never did.

## Verification

- `services/fc`: `npm test` → 907 tests, 0 failing (13 skipped: sync-flow needs a local Supabase). New tests cover the default, the stored-baseUrl override, no-gateway and no-host fallbacks, and `requestOrigin` parsing.
- `npx tsc -p tsconfig.json --noEmit` (the image build config) clean. `npm run typecheck` (tsconfig.test.json) has 27 pre-existing errors in three untouched test files, identical on `main`.
- `npm run openapi:lint` clean.
- The new-path proof already exists in production: team `e84103ca` on a beta.39 daemon got 200s on all three tiers through `/ai/` on 9/1.

## Deploy notes

- Merging touches `services/fc/**`, so self-host auto-deploys. After that the remaining 301 teams get the default on their next `workspace-config` read; no backfill SQL needed.
- Team `fsle00` was already switched on by hand (same UPDATE as the 9/1 switch) so the user is not waiting on this PR — but they are on **v0.4.1-beta.20**, whose daemon still sends `sk-tc-*` keys the gateway rejects (401 verified) and whose opencode mirror host (`teamclu.ucar.cc`) fails TLS. They need the OSS beta.39 build. Separate decision pending: the GitHub Releases channel is stuck at beta.20 since #1027, so GitHub-mode updaters on ≤beta.20 never see a newer version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012HaqQS95HQSsXnzirGPaCe
