### PR TITLE
fix(desktop): re-apply the macOS traffic-light offset after AppKit relayout

### DIFF
--- a/apps/desktop/src/lib.rs
+++ b/apps/desktop/src/lib.rs
@@ -747,9 +747,26 @@ pub fn run() {
                         tauri::WindowEvent::Resized { .. } => {
                             commands::window_chrome::reposition_traffic_lights(&main_win_clone);
                         }
+                        // Same reason as `Resized`. The window is `visible: true`,
+                        // so it is on screen showing the skeleton before AppKit has
+                        // finished laying out the titlebar — that layout puts the
+                        // buttons back at their default origin, and the offset the
+                        // `setup` call applied is lost. Without a re-apply here the
+                        // buttons sit at the default position for the whole splash
+                        // and jump 10pt the first time anything resizes the window.
+                        //
+                        // Idempotent: the offset is always measured from the origins
+                        // captured once in `ORIGINAL_ORIGINS`, so repeated calls
+                        // land on the same place rather than drifting.
+                        #[cfg(target_os = "macos")]
+                        tauri::WindowEvent::Moved { .. } => {
+                            commands::window_chrome::reposition_traffic_lights(&main_win_clone);
+                        }
                         // DAU heartbeat: fires `app_active` once the app
                         // returns to focus after >=4h idle.
                         tauri::WindowEvent::Focused(true) => {
+                            #[cfg(target_os = "macos")]
+                            commands::window_chrome::reposition_traffic_lights(&main_win_clone);
                             maybe_emit_app_active(&close_app_handle);
                         }
                         _ => {}


### PR DESCRIPTION
The macOS window buttons sit at their default position for the whole skeleton screen, then jump ~10pt once the app is up.

## Cause

`reposition_traffic_lights` (`window_chrome.rs:83`) moves the three standard buttons by a fixed `(+10, -10)` from origins captured once in a `OnceLock`. So only two positions can ever appear on screen — **AppKit default** and **default + offset** — a 10pt step, which matches the shift being reported.

The window is `visible: true`, so it is on screen showing the skeleton *before* AppKit has finished laying out the titlebar. That layout puts the buttons back at their default origin and discards what the `setup` call applied — exactly what the existing `Resized` handler's own comment already describes:

```rust
// Re-apply traffic light positions after window resize,
// because macOS resets button positions during resize/animations.
```

Until something resized the window, nothing re-applied it. Hence: default during the splash, offset afterwards.

## Fix

Re-apply on `Moved` and on `Focused(true)` in addition to `Resized`. `Focused(true)` fires when the app takes focus at launch, which is around when the skeleton appears.

Safe to repeat: the offset is always measured from `ORIGINAL_ORIGINS`, so repeated calls land on the same place rather than drifting — the buttons cannot walk away over time.

## What is not verified

**This has not been checked on screen.** The mechanism is read from the code; I could not launch the desktop app in this environment to watch startup.

One thing stayed unknown through the diagnosis: whether the `setup`-time call takes effect at all, or fails silently — it is an `if let Ok(win.ns_window())` with no else branch, so a not-yet-ready window would be indistinguishable from success.

If the jump survives this change, the next candidate is starting the window hidden and showing it only once positioned. That was not chosen first because it trades a moving button for a late-appearing window, which is a different visible artefact rather than a strict improvement.

## Testing

`cargo check -p teamclu` clean. No test covers traffic-light geometry (it is AppKit state, not observable from the Rust side without a running window server).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U4FPAe65oAZQKuVBmhrcEr