### PR TITLE
fix(daemon): make OpenCode cleanup verifiable and self-heal on start

### DIFF
--- a/apps/daemon/src/cli/process.rs
+++ b/apps/daemon/src/cli/process.rs
@@ -235,13 +235,13 @@ pub fn run_stop() -> anyhow::Result<()> {
     match read_pidfile()? {
         None => {
             println!("amuxd: not running (no pidfile).");
-            finalize_stop();
+            finalize_stop()?;
             return Ok(());
         }
         Some((pid, path)) if !is_alive(pid) => {
             println!("amuxd: recorded pid {pid} is not alive; clearing stale state.");
             let _ = fs::remove_file(&path);
-            finalize_stop();
+            finalize_stop()?;
             return Ok(());
         }
         Some((pid, _path)) => {
@@ -251,7 +251,7 @@ pub fn run_stop() -> anyhow::Result<()> {
             let deadline = Instant::now() + Duration::from_secs(3);
             while Instant::now() < deadline {
                 if !is_alive(pid) {
-                    finalize_stop();
+                    finalize_stop()?;
                     println!("amuxd: stopped.");
                     return Ok(());
                 }
@@ -261,13 +261,17 @@ pub fn run_stop() -> anyhow::Result<()> {
             // Last resort: managed child trees first (their process groups),
             // then the daemon itself (its own process group when it is leader).
             println!("amuxd: still running after 3s; force-stopping managed trees then daemon…");
-            reap_managed_agent_trees();
+            let report = reap_managed_agent_trees();
+            log_managed_process_cleanup("stop-force", &report);
+            if report.has_survivors() {
+                return Err(managed_process_survivor_error(&report));
+            }
             force_stop_daemon(pid);
             let force_deadline = Instant::now() + Duration::from_secs(1);
             while Instant::now() < force_deadline && is_alive(pid) {
                 std::thread::sleep(Duration::from_millis(50));
             }
-            finalize_stop();
+            finalize_stop()?;
             if is_alive(pid) {
                 anyhow::bail!(
                     "amuxd pid {pid} still alive after force stop; check process manually"
@@ -292,8 +296,10 @@ pub fn cleanup_runtime_artifacts() {
 
 /// Kill leftover `opencode serve` process group (and best-effort MCP) so a
 /// prior crashed/hard-killed daemon cannot block the next start.
-pub fn reap_managed_agent_trees() {
-    crate::runtime::opencode_http::process_registry::ServeProcessRegistry::default().reap_all();
+pub fn reap_managed_agent_trees(
+) -> crate::runtime::opencode_http::process_registry::ReapReport {
+    let report = crate::runtime::opencode_http::process_registry::ServeProcessRegistry::default()
+        .reap_all();
     #[cfg(unix)]
     {
         // Read compatibility for the pre-registry single-PGID file. New serve
@@ -306,19 +312,60 @@ pub fn reap_managed_agent_trees() {
         // Read compatibility for the pre-registry single-PID file.
         reap_opencode_pid_file_windows();
     }
+    report
 }
 
 /// Reap process groups left by a previously hard-killed daemon.
 ///
 /// The caller must hold the daemon singleton lock so this cannot signal serve
 /// generations owned by another live daemon.
-pub fn prepare_daemon_start() {
-    reap_managed_agent_trees();
+pub fn prepare_daemon_start() -> anyhow::Result<()> {
+    let report = reap_managed_agent_trees();
+    log_managed_process_cleanup("start", &report);
+    if report.has_survivors() {
+        return Err(managed_process_survivor_error(&report));
+    }
+    Ok(())
 }
 
-fn finalize_stop() {
-    reap_managed_agent_trees();
+fn finalize_stop() -> anyhow::Result<()> {
+    let report = reap_managed_agent_trees();
+    log_managed_process_cleanup("stop", &report);
     cleanup_runtime_artifacts();
+    if report.has_survivors() {
+        return Err(managed_process_survivor_error(&report));
+    }
+    Ok(())
+}
+
+fn log_managed_process_cleanup(
+    phase: &str,
+    report: &crate::runtime::opencode_http::process_registry::ReapReport,
+) {
+    println!(
+        "managed_process_cleanup phase={phase} registered={} reaped={} stale={} survivors={}",
+        report.registered_count(),
+        report.reaped.len(),
+        report.stale_or_reused.len(),
+        report.survivors.len(),
+    );
+}
+
+fn managed_process_survivor_error(
+    report: &crate::runtime::opencode_http::process_registry::ReapReport,
+) -> anyhow::Error {
+    let home = teamclu_runtime_env::amuxd_home_from_env();
+    let details: Vec<String> = report
+        .survivors
+        .iter()
+        .map(|group| format!("generation={} pgid={}", group.generation_id, group.pgid))
+        .collect();
+    anyhow::anyhow!(
+        "managed opencode process groups still alive after cleanup at {}: {}. \
+         Stop them manually or investigate why SIGKILL did not terminate the group.",
+        home.display(),
+        details.join(", "),
+    )
 }
 
 #[cfg(unix)]
@@ -585,11 +632,42 @@ fn request_graceful_stop(pid: i32) -> anyhow::Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::runtime::opencode_http::process_registry::{
+        test_clear_survivor_pgids, test_mark_survivor_pgid, ServeProcessRegistry,
+    };
+
+    struct SurvivorGuard;
+
+    impl Drop for SurvivorGuard {
+        fn drop(&mut self) {
+            test_clear_survivor_pgids();
+        }
+    }
+
+    #[cfg(unix)]
+    fn spawn_fake_opencode_serve(
+        home: &std::path::Path,
+    ) -> (std::process::Child, u32) {
+        use std::os::unix::fs::PermissionsExt;
+        use std::os::unix::process::CommandExt;
+
+        let binary = home.join("opencode");
+        std::fs::write(&binary, "#!/bin/sh\nsleep 30\n").unwrap();
+        let mut permissions = std::fs::metadata(&binary).unwrap().permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&binary, permissions).unwrap();
+        let mut child = std::process::Command::new(&binary)
+            .arg("serve")
+            .process_group(0)
+            .spawn()
+            .unwrap();
+        let pgid = child.id();
+        (child, pgid)
+    }
 
     #[cfg(unix)]
     #[test]
     fn daemon_start_preparation_reaps_a_leftover_registered_group() {
-        use std::os::unix::fs::PermissionsExt;
         use std::os::unix::process::CommandExt;
 
         let _home_guard = crate::config::global_team_store::TEST_HOME_LOCK
@@ -599,26 +677,12 @@ mod tests {
         let home = tempfile::tempdir().unwrap();
         unsafe { std::env::set_var("HOME", home.path()) };
 
-        let binary = home.path().join("opencode");
-        std::fs::write(&binary, "#!/bin/sh\nsleep 30\n").unwrap();
-        let mut permissions = std::fs::metadata(&binary).unwrap().permissions();
-        permissions.set_mode(0o755);
-        std::fs::set_permissions(&binary, permissions).unwrap();
-
-        let mut child = std::process::Command::new(&binary)
-            .arg("serve")
-            .process_group(0)
-            .spawn()
-            .unwrap();
-        let pgid = child.id();
-        crate::runtime::opencode_http::process_registry::ServeProcessRegistry::default()
+        let (mut child, pgid) = spawn_fake_opencode_serve(home.path());
+        ServeProcessRegistry::default()
             .register("previous-daemon", pgid)
             .unwrap();
-        prepare_daemon_start();
+        prepare_daemon_start().expect("start preparation should succeed after cleanup");
 
-        // Reap the test-owned leader before checking the process group. On
-        // Linux, dropping Child without wait leaves a zombie for the duration
-        // of the test process, and kill(-pgid, 0) reports zombies as alive.
         let _ = child.wait();
 
         assert!(
@@ -626,11 +690,179 @@ mod tests {
             "start preparation must reap the previous daemon's serve group"
         );
         assert!(
-            crate::runtime::opencode_http::process_registry::ServeProcessRegistry::default()
-                .snapshot()
-                .is_empty(),
+            ServeProcessRegistry::default().snapshot().is_empty(),
             "reaped groups must be removed from the registry"
         );
+
+        match previous_home {
+            Some(home) => unsafe { std::env::set_var("HOME", home) },
+            None => unsafe { std::env::remove_var("HOME") },
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn stop_without_pidfile_still_reaps_registered_groups() {
+        let _home_guard = crate::config::global_team_store::TEST_HOME_LOCK
+            .lock()
+            .unwrap_or_else(|error| error.into_inner());
+        let previous_home = std::env::var_os("HOME");
+        let home = tempfile::tempdir().unwrap();
+        unsafe { std::env::set_var("HOME", home.path()) };
+
+        let pid_path = DaemonConfig::pid_path();
+        let _ = fs::remove_file(&pid_path);
+        let (mut child, pgid) = spawn_fake_opencode_serve(home.path());
+        ServeProcessRegistry::default()
+            .register("orphan", pgid)
+            .unwrap();
+
+        run_stop().expect("stop without pidfile should succeed when cleanup succeeds");
+
+        let _ = child.wait();
+        assert!(
+            ServeProcessRegistry::default().snapshot().is_empty(),
+            "stop must reap registry entries even without a pidfile"
+        );
+
+        match previous_home {
+            Some(home) => unsafe { std::env::set_var("HOME", home) },
+            None => unsafe { std::env::remove_var("HOME") },
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn stop_with_stale_pidfile_still_reaps_registered_groups() {
+        let _home_guard = crate::config::global_team_store::TEST_HOME_LOCK
+            .lock()
+            .unwrap_or_else(|error| error.into_inner());
+        let previous_home = std::env::var_os("HOME");
+        let home = tempfile::tempdir().unwrap();
+        unsafe { std::env::set_var("HOME", home.path()) };
+
+        let pid_path = DaemonConfig::pid_path();
+        if let Some(parent) = pid_path.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        fs::write(&pid_path, "999999").unwrap();
+        let (mut child, pgid) = spawn_fake_opencode_serve(home.path());
+        ServeProcessRegistry::default()
+            .register("orphan", pgid)
+            .unwrap();
+
+        run_stop().expect("stop with stale pidfile should succeed when cleanup succeeds");
+
+        let _ = child.wait();
+        assert!(
+            ServeProcessRegistry::default().snapshot().is_empty(),
+            "stop must reap registry entries when pidfile is stale"
+        );
+
+        match previous_home {
+            Some(home) => unsafe { std::env::set_var("HOME", home) },
+            None => unsafe { std::env::remove_var("HOME") },
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn branded_amuxd_home_only_reaps_that_registry() {
+        let _home_guard = crate::config::global_team_store::TEST_HOME_LOCK
+            .lock()
+            .unwrap_or_else(|error| error.into_inner());
+        let previous_home = std::env::var_os("HOME");
+        let previous_amuxd_home = std::env::var_os(teamclu_runtime_env::AMUXD_HOME_ENV);
+        let home = tempfile::tempdir().unwrap();
+        let branded = home.path().join(".amuxd-copilot361");
+        unsafe { std::env::set_var("HOME", home.path()) };
+        unsafe { std::env::set_var(teamclu_runtime_env::AMUXD_HOME_ENV, &branded) };
+
+        let (mut child, pgid) = spawn_fake_opencode_serve(home.path());
+        ServeProcessRegistry::default()
+            .register("branded", pgid)
+            .unwrap();
+
+        let report = reap_managed_agent_trees();
+        let _ = child.wait();
+
+        assert_eq!(report.reaped.len(), 1);
+        assert_eq!(report.reaped[0].generation_id, "branded");
+        assert!(ServeProcessRegistry::default().snapshot().is_empty());
+        assert!(branded.join("opencode-pgids.json").exists());
+
+        match previous_amuxd_home {
+            Some(path) => unsafe { std::env::set_var(teamclu_runtime_env::AMUXD_HOME_ENV, path) },
+            None => unsafe { std::env::remove_var(teamclu_runtime_env::AMUXD_HOME_ENV) },
+        }
+        match previous_home {
+            Some(home) => unsafe { std::env::set_var("HOME", home) },
+            None => unsafe { std::env::remove_var("HOME") },
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn start_refuses_when_survivors_remain() {
+        let _guard = SurvivorGuard;
+        let _home_guard = crate::config::global_team_store::TEST_HOME_LOCK
+            .lock()
+            .unwrap_or_else(|error| error.into_inner());
+        let previous_home = std::env::var_os("HOME");
+        let home = tempfile::tempdir().unwrap();
+        unsafe { std::env::set_var("HOME", home.path()) };
+
+        let (mut child, pgid) = spawn_fake_opencode_serve(home.path());
+        ServeProcessRegistry::default()
+            .register("stubborn", pgid)
+            .unwrap();
+        test_mark_survivor_pgid(pgid);
+
+        let error = prepare_daemon_start().expect_err("start must fail when survivors remain");
+        assert!(
+            error.to_string().contains("managed opencode process groups still alive"),
+            "unexpected error: {error}"
+        );
+        assert_eq!(
+            ServeProcessRegistry::default().snapshot().get("stubborn"),
+            Some(&pgid)
+        );
+        let _ = child.kill();
+        let _ = child.wait();
+
+        match previous_home {
+            Some(home) => unsafe { std::env::set_var("HOME", home) },
+            None => unsafe { std::env::remove_var("HOME") },
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn stop_returns_error_when_survivors_remain() {
+        let _guard = SurvivorGuard;
+        let _home_guard = crate::config::global_team_store::TEST_HOME_LOCK
+            .lock()
+            .unwrap_or_else(|error| error.into_inner());
+        let previous_home = std::env::var_os("HOME");
+        let home = tempfile::tempdir().unwrap();
+        unsafe { std::env::set_var("HOME", home.path()) };
+
+        let pid_path = DaemonConfig::pid_path();
+        let _ = fs::remove_file(&pid_path);
+        let (mut child, pgid) = spawn_fake_opencode_serve(home.path());
+        ServeProcessRegistry::default()
+            .register("stubborn", pgid)
+            .unwrap();
+        test_mark_survivor_pgid(pgid);
+
+        let error = run_stop().expect_err("stop must fail when survivors remain");
+        assert!(
+            error.to_string().contains("managed opencode process groups still alive"),
+            "unexpected error: {error}"
+        );
+
+        let _ = child.kill();
+        let _ = child.wait();
 
         match previous_home {
             Some(home) => unsafe { std::env::set_var("HOME", home) },

--- a/apps/daemon/src/main.rs
+++ b/apps/daemon/src/main.rs
@@ -144,7 +144,7 @@ fn main() -> anyhow::Result<()> {
             // one does, so the purge has to happen before anything loads it or
             // it would delete a config that had just been bootstrapped.
             let _daemon_lock = cli::process::acquire_daemon_lock()?;
-            cli::process::prepare_daemon_start();
+            cli::process::prepare_daemon_start()?;
             config::layout::purge_v1_layout();
             config::layout::ensure();
             // App checkouts moved out of `state/` and into `teams/<id>/apps`.

--- a/apps/daemon/src/runtime/opencode_http/process_registry.rs
+++ b/apps/daemon/src/runtime/opencode_http/process_registry.rs
@@ -10,6 +10,56 @@ use tracing::warn;
 #[cfg(windows)]
 use crate::process_util::CommandNoWindow;
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ManagedGroup {
+    pub generation_id: String,
+    pub pgid: u32,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ReapReport {
+    pub reaped: Vec<ManagedGroup>,
+    pub stale_or_reused: Vec<ManagedGroup>,
+    pub survivors: Vec<ManagedGroup>,
+}
+
+impl ReapReport {
+    pub fn registered_count(&self) -> usize {
+        self.reaped.len() + self.stale_or_reused.len() + self.survivors.len()
+    }
+
+    pub fn has_survivors(&self) -> bool {
+        !self.survivors.is_empty()
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ReapOutcome {
+    StaleOrReused,
+    Reaped,
+    Survivor,
+}
+
+#[cfg(test)]
+static TEST_SURVIVOR_PGIDS: std::sync::LazyLock<std::sync::Mutex<std::collections::HashSet<u32>>> =
+    std::sync::LazyLock::new(|| std::sync::Mutex::new(std::collections::HashSet::new()));
+
+#[cfg(test)]
+pub fn test_mark_survivor_pgid(pgid: u32) {
+    TEST_SURVIVOR_PGIDS
+        .lock()
+        .unwrap_or_else(|error| error.into_inner())
+        .insert(pgid);
+}
+
+#[cfg(test)]
+pub fn test_clear_survivor_pgids() {
+    TEST_SURVIVOR_PGIDS
+        .lock()
+        .unwrap_or_else(|error| error.into_inner())
+        .clear();
+}
+
 pub struct ServeProcessRegistry {
     path: PathBuf,
     groups: parking_lot::Mutex<HashMap<String, u32>>,
@@ -70,19 +120,42 @@ impl ServeProcessRegistry {
             .filter(|pgid| registered_group_alive(*pgid))
     }
 
-    pub fn reap_all(&self) {
+    pub fn reap_all(&self) -> ReapReport {
+        let mut report = ReapReport::default();
         for (generation_id, pgid) in self.snapshot() {
-            if reap_verified_group(pgid) {
-                if let Err(error) = self.unregister(&generation_id) {
-                    warn!(
-                        generation_id,
-                        pgid,
-                        %error,
-                        "failed to unregister reaped opencode serve group"
-                    );
+            let group = ManagedGroup {
+                generation_id: generation_id.clone(),
+                pgid,
+            };
+            match reap_verified_group(pgid) {
+                ReapOutcome::StaleOrReused => {
+                    if let Err(error) = self.unregister(&generation_id) {
+                        warn!(
+                            generation_id,
+                            pgid,
+                            %error,
+                            "failed to unregister stale opencode serve group"
+                        );
+                    }
+                    report.stale_or_reused.push(group);
+                }
+                ReapOutcome::Reaped => {
+                    if let Err(error) = self.unregister(&generation_id) {
+                        warn!(
+                            generation_id,
+                            pgid,
+                            %error,
+                            "failed to unregister reaped opencode serve group"
+                        );
+                    }
+                    report.reaped.push(group);
+                }
+                ReapOutcome::Survivor => {
+                    report.survivors.push(group);
                 }
             }
         }
+        report
     }
 }
 
@@ -164,16 +237,24 @@ fn persist_groups(path: &PathBuf, groups: &HashMap<String, u32>) -> io::Result<(
 }
 
 #[cfg(unix)]
-fn reap_verified_group(pgid: u32) -> bool {
+fn reap_verified_group(pgid: u32) -> ReapOutcome {
+    #[cfg(test)]
+    if TEST_SURVIVOR_PGIDS
+        .lock()
+        .unwrap_or_else(|error| error.into_inner())
+        .contains(&pgid)
+    {
+        return ReapOutcome::Survivor;
+    }
     let Ok(pgid) = i32::try_from(pgid) else {
-        return true;
+        return ReapOutcome::StaleOrReused;
     };
     if !process_group_alive(pgid) {
-        return true;
+        return ReapOutcome::StaleOrReused;
     }
     if !group_has_managed_member(pgid) {
         warn!(pgid, "refusing to reap unverified opencode process group");
-        return true;
+        return ReapOutcome::StaleOrReused;
     }
     unsafe {
         let _ = libc::kill(-pgid, libc::SIGTERM);
@@ -194,7 +275,11 @@ fn reap_verified_group(pgid: u32) -> bool {
     // A killed child can remain as a zombie until its parent waits for it.
     // kill(-pgid, 0) still reports that group as present, but it no longer
     // contains a managed process and must not keep a stale registry entry.
-    !process_group_alive(pgid) || !group_has_managed_member(pgid)
+    if process_group_alive(pgid) && group_has_managed_member(pgid) {
+        ReapOutcome::Survivor
+    } else {
+        ReapOutcome::Reaped
+    }
 }
 
 #[cfg(unix)]
@@ -246,21 +331,21 @@ fn cmdline_of(pid: i32) -> Option<String> {
 }
 
 #[cfg(windows)]
-fn reap_verified_group(pid: u32) -> bool {
+fn reap_verified_group(pid: u32) -> ReapOutcome {
     let Ok(output) = std::process::Command::new("tasklist")
         .no_window()
         .args(["/FI", &format!("PID eq {pid}"), "/FO", "CSV", "/NH"])
         .output()
     else {
-        return false;
+        return ReapOutcome::Survivor;
     };
     let listing = String::from_utf8_lossy(&output.stdout).to_ascii_lowercase();
     if !listing.contains(&format!("\"{pid}\"")) {
-        return true;
+        return ReapOutcome::StaleOrReused;
     }
     if !listing.contains("opencode") {
         warn!(pid, "refusing to reap unverified opencode process tree");
-        return true;
+        return ReapOutcome::StaleOrReused;
     }
     let _ = std::process::Command::new("taskkill")
         .no_window()
@@ -270,7 +355,11 @@ fn reap_verified_group(pid: u32) -> bool {
     while Instant::now() < deadline && windows_pid_alive(pid) {
         std::thread::sleep(Duration::from_millis(50));
     }
-    !windows_pid_alive(pid)
+    if windows_pid_alive(pid) {
+        ReapOutcome::Survivor
+    } else {
+        ReapOutcome::Reaped
+    }
 }
 
 #[cfg(windows)]
@@ -291,8 +380,8 @@ fn registered_group_alive(pid: u32) -> bool {
 }
 
 #[cfg(not(any(unix, windows)))]
-fn reap_verified_group(_pgid: u32) -> bool {
-    false
+fn reap_verified_group(_pgid: u32) -> ReapOutcome {
+    ReapOutcome::Survivor
 }
 
 #[cfg(not(any(unix, windows)))]
@@ -302,7 +391,38 @@ fn registered_group_alive(_pgid: u32) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::ServeProcessRegistry;
+    use super::{
+        test_clear_survivor_pgids, ManagedGroup, ReapReport, ServeProcessRegistry,
+    };
+
+    struct SurvivorGuard;
+
+    impl Drop for SurvivorGuard {
+        fn drop(&mut self) {
+            test_clear_survivor_pgids();
+        }
+    }
+
+    #[cfg(unix)]
+    fn spawn_fake_opencode_serve(
+        home: &std::path::Path,
+    ) -> (std::process::Child, u32) {
+        use std::os::unix::fs::PermissionsExt;
+        use std::os::unix::process::CommandExt;
+
+        let binary = home.join("opencode");
+        std::fs::write(&binary, "#!/bin/sh\nsleep 30\n").unwrap();
+        let mut permissions = std::fs::metadata(&binary).unwrap().permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&binary, permissions).unwrap();
+        let mut child = std::process::Command::new(&binary)
+            .arg("serve")
+            .process_group(0)
+            .spawn()
+            .unwrap();
+        let pgid = child.id();
+        (child, pgid)
+    }
 
     #[test]
     fn default_registry_uses_branded_amuxd_home() {
@@ -405,14 +525,126 @@ mod tests {
         let pgid = unrelated.id();
         registry.register("stale", pgid).unwrap();
 
-        registry.reap_all();
+        let report = registry.reap_all();
 
         assert!(
             unrelated.try_wait().unwrap().is_none(),
             "an unverified process group must not be signaled"
         );
         assert!(!registry.snapshot().contains_key("stale"));
+        assert_eq!(report.stale_or_reused.len(), 1);
+        assert_eq!(
+            report.stale_or_reused[0],
+            ManagedGroup {
+                generation_id: "stale".to_string(),
+                pgid,
+            }
+        );
+        assert!(report.reaped.is_empty());
+        assert!(report.survivors.is_empty());
         let _ = unrelated.kill();
         let _ = unrelated.wait();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn reap_cleans_current_and_draining_generations() {
+        let _home_guard = crate::config::global_team_store::TEST_HOME_LOCK
+            .lock()
+            .unwrap_or_else(|error| error.into_inner());
+        let previous_home = std::env::var_os("HOME");
+        let home = tempfile::tempdir().unwrap();
+        unsafe { std::env::set_var("HOME", home.path()) };
+
+        let path = home.path().join("opencode-pgids.json");
+        let registry = ServeProcessRegistry::new(path);
+        let (mut current, current_pgid) = spawn_fake_opencode_serve(home.path());
+        let (mut draining_a, draining_a_pgid) = spawn_fake_opencode_serve(home.path());
+        let (mut draining_b, draining_b_pgid) = spawn_fake_opencode_serve(home.path());
+        registry.register("current", current_pgid).unwrap();
+        registry.register("draining-a", draining_a_pgid).unwrap();
+        registry.register("draining-b", draining_b_pgid).unwrap();
+
+        let report = registry.reap_all();
+
+        assert_eq!(report.registered_count(), 3);
+        assert_eq!(report.reaped.len(), 3);
+        assert!(report.stale_or_reused.is_empty());
+        assert!(report.survivors.is_empty());
+        assert!(registry.snapshot().is_empty());
+        let _ = current.wait();
+        let _ = draining_a.wait();
+        let _ = draining_b.wait();
+
+        match previous_home {
+            Some(home) => unsafe { std::env::set_var("HOME", home) },
+            None => unsafe { std::env::remove_var("HOME") },
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn reap_survivor_keeps_registry_entry() {
+        let _guard = SurvivorGuard;
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("opencode-pgids.json");
+        let registry = ServeProcessRegistry::new(path.clone());
+        let (mut child, pgid) = spawn_fake_opencode_serve(dir.path());
+        registry.register("stubborn", pgid).unwrap();
+        super::test_mark_survivor_pgid(pgid);
+
+        let report = registry.reap_all();
+
+        assert_eq!(report.survivors.len(), 1);
+        assert_eq!(report.survivors[0].generation_id, "stubborn");
+        assert_eq!(registry.snapshot().get("stubborn"), Some(&pgid));
+        let _ = child.kill();
+        let _ = child.wait();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn second_reap_after_success_is_idempotent() {
+        let _home_guard = crate::config::global_team_store::TEST_HOME_LOCK
+            .lock()
+            .unwrap_or_else(|error| error.into_inner());
+        let previous_home = std::env::var_os("HOME");
+        let home = tempfile::tempdir().unwrap();
+        unsafe { std::env::set_var("HOME", home.path()) };
+
+        let path = home.path().join("opencode-pgids.json");
+        let registry = ServeProcessRegistry::new(path);
+        let (mut child, pgid) = spawn_fake_opencode_serve(home.path());
+        registry.register("gen-a", pgid).unwrap();
+
+        let first = registry.reap_all();
+        let second = registry.reap_all();
+
+        assert_eq!(first.reaped.len(), 1);
+        assert_eq!(second.registered_count(), 0);
+        assert!(registry.snapshot().is_empty());
+        let _ = child.wait();
+
+        match previous_home {
+            Some(home) => unsafe { std::env::set_var("HOME", home) },
+            None => unsafe { std::env::remove_var("HOME") },
+        }
+    }
+
+    #[test]
+    fn reap_report_counts_registered_entries() {
+        let report = ReapReport {
+            reaped: vec![ManagedGroup {
+                generation_id: "a".to_string(),
+                pgid: 1,
+            }],
+            stale_or_reused: vec![ManagedGroup {
+                generation_id: "b".to_string(),
+                pgid: 2,
+            }],
+            survivors: vec![],
+        };
+        assert_eq!(report.registered_count(), 2);
+        assert!(!report.has_survivors());
     }
 }


### PR DESCRIPTION
## Summary

- `ServeProcessRegistry::reap_all()` now returns a `ReapReport` classifying each registered generation as reaped, stale/reused, or survivor (still alive after SIGKILL).
- `amuxd stop` reports cleanup results via structured log output and exits non-zero when survivors remain, so the desktop `run_bundled_once(["stop"])` path can detect incomplete cleanup without parsing registry files.
- `prepare_daemon_start()` runs the same cleanup before boot and refuses to start when survivors remain, covering daemon/desktop hard-kill scenarios where exit hooks never run.

## Test plan

- [ ] `pnpm daemon:test -- --test-threads=1 reap_cleans stop_without branded_amuxd start_refuses stop_returns second_reap daemon_start_preparation reap_ignores reap_survivor`
- [ ] Quit desktop normally with active OpenCode generations; confirm `amuxd stop` logs `survivors=0` and exits 0
- [ ] Simulate orphaned `opencode serve` (registry populated, no pidfile); confirm `amuxd stop` cleans all generations
- [ ] After hard-kill, confirm next `amuxd start` self-heals before creating a new host


Made with [Cursor](https://cursor.com)