### PR TITLE
fix(daemon): free one idle runtime on host capacity timeout

### DIFF
--- a/apps/daemon/src/daemon/server/runtime_lifecycle.rs
+++ b/apps/daemon/src/daemon/server/runtime_lifecycle.rs
@@ -889,12 +889,49 @@ impl DaemonServer {
                 &start.worktree,
                 &start.session_id,
                 &start.initial_prompt,
-                initial_model_override,
+                initial_model_override.clone(),
                 &request.requester_actor_id,
                 start.reset_backend_binding,
-                fork_from,
+                fork_from.clone(),
             )
             .await;
+
+        // User-facing only: one idle-attachment eviction then a single retry.
+        // Auto-recovery calls `apply_start_runtime` directly and must not
+        // steal a host slot from a session the user still has open.
+        let outcome = match outcome {
+            Err(err) if err.error_message.contains("host_capacity_timeout") => {
+                let evicted = self
+                    .agents
+                    .lock()
+                    .await
+                    .evict_one_idle_attachment_for_capacity(&start.session_id)
+                    .await;
+                match evicted {
+                    Some(runtime_id) => {
+                        info!(
+                            session_id = %start.session_id,
+                            evicted_runtime_id = %runtime_id,
+                            "runtimeStart: evicted idle attachment after host_capacity_timeout; retrying once"
+                        );
+                        self.apply_start_runtime(
+                            at,
+                            &start.workspace_id,
+                            &start.worktree,
+                            &start.session_id,
+                            &start.initial_prompt,
+                            initial_model_override,
+                            &request.requester_actor_id,
+                            start.reset_backend_binding,
+                            fork_from,
+                        )
+                        .await
+                    }
+                    None => Err(err),
+                }
+            }
+            other => other,
+        };
 
         match outcome {
             Ok(res) => RpcResponse {

--- a/apps/daemon/src/runtime/manager.rs
+++ b/apps/daemon/src/runtime/manager.rs
@@ -3436,6 +3436,59 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn evict_one_idle_attachment_for_capacity_stops_oldest_idle() {
+        let mut mgr = RuntimeManager::test_dummy_with_runtime("sess-idle");
+        mgr.get_handle_mut("sess-idle").unwrap().last_active_at = 200;
+        mgr.add_test_runtime("sess-busy");
+        mgr.get_handle_mut("sess-busy").unwrap().last_active_at = 50;
+        let turn_lock = mgr.get_handle("sess-busy").unwrap().turn_lock.clone();
+        let _guard = turn_lock.lock().await;
+
+        let evicted = mgr.evict_one_idle_attachment_for_capacity("sess-new").await;
+
+        assert_eq!(evicted.as_deref(), Some("sess-idle"));
+        assert!(mgr.get_handle("sess-idle").is_none());
+        assert!(
+            mgr.get_handle("sess-busy").is_some(),
+            "a mid-turn runtime must not be evicted even if it is older"
+        );
+    }
+
+    #[tokio::test]
+    async fn evict_one_idle_attachment_for_capacity_skips_busy_runtimes() {
+        let mut mgr = RuntimeManager::test_dummy_with_runtime("sess-turn");
+        mgr.add_test_runtime("sess-rx");
+        let turn_lock = mgr.get_handle("sess-turn").unwrap().turn_lock.clone();
+        let _guard = turn_lock.lock().await;
+        let _rx = mgr.get_handle_mut("sess-rx").unwrap().event_rx.take();
+
+        let evicted = mgr.evict_one_idle_attachment_for_capacity("sess-new").await;
+
+        assert_eq!(evicted, None);
+        assert!(mgr.get_handle("sess-turn").is_some());
+        assert!(mgr.get_handle("sess-rx").is_some());
+    }
+
+    #[tokio::test]
+    async fn evict_one_idle_attachment_for_capacity_skips_excluded_session() {
+        let mut mgr = RuntimeManager::test_dummy_with_runtime("sess-target");
+        mgr.get_handle_mut("sess-target").unwrap().last_active_at = 1;
+        mgr.add_test_runtime("sess-other");
+        mgr.get_handle_mut("sess-other").unwrap().last_active_at = 9;
+
+        let evicted = mgr
+            .evict_one_idle_attachment_for_capacity("sess-target")
+            .await;
+
+        assert_eq!(evicted.as_deref(), Some("sess-other"));
+        assert!(
+            mgr.get_handle("sess-target").is_some(),
+            "the session we are trying to start must not be evicted"
+        );
+        assert!(mgr.get_handle("sess-other").is_none());
+    }
+
+    #[tokio::test]
     async fn evict_idle_full_cycle_emits_evicted_id_for_publish() {
         let mut mgr = RuntimeManager::test_dummy_with_runtime("rt-x");
         mgr.get_handle_mut("rt-x").unwrap().last_active_at = 0;

--- a/apps/daemon/src/runtime/manager/eviction.rs
+++ b/apps/daemon/src/runtime/manager/eviction.rs
@@ -77,6 +77,46 @@ impl RuntimeManager {
         evicted
     }
 
+    /// Stop one idle attachment so a user-facing `runtimeStart` can retry after
+    /// `host_capacity_timeout`. Picks the least-recently-active runtime that:
+    /// - is not mid-turn (`turn_lock` free),
+    /// - still owns `event_rx` (not checked out),
+    /// - is not `exclude_session_id` (the session we are trying to start).
+    ///
+    /// Goes through [`Self::stop_runtime`] so the OpenCode host is detached,
+    /// never killed. Auto-recovery must not call this — only the user RPC path.
+    pub async fn evict_one_idle_attachment_for_capacity(
+        &mut self,
+        exclude_session_id: &str,
+    ) -> Option<String> {
+        let exclude = exclude_session_id.trim();
+        let candidate = self
+            .agents
+            .iter()
+            .filter(|(id, handle)| {
+                let excluded =
+                    !exclude.is_empty() && (*id == exclude || handle.session_id == exclude);
+                !excluded && handle.event_rx.is_some() && handle.turn_lock.try_lock().is_ok()
+            })
+            .min_by(|(a_id, a), (b_id, b)| {
+                a.last_active_at
+                    .cmp(&b.last_active_at)
+                    .then_with(|| a_id.cmp(b_id))
+            })
+            .map(|(id, _)| id.clone());
+        let id = candidate?;
+        if self.stop_runtime(&id).await.is_some() {
+            info!(
+                agent_id = %id,
+                "capacity: evicted idle attachment to free a host slot"
+            );
+            self.evicted_pending_publish.push(id.clone());
+            Some(id)
+        } else {
+            None
+        }
+    }
+
     /// Drain the buffer of idle-evicted agent_ids whose terminal MQTT state
     /// still needs publishing. Called once per main-loop tick.
     pub fn drain_evicted(&mut self) -> Vec<String> {

--- a/packages/app/src/lib/session-create.ts
+++ b/packages/app/src/lib/session-create.ts
@@ -383,6 +383,7 @@ export type RuntimeStartFailureCode =
   | 'runtime_rejected'
   | 'backend_session_not_resumable'
   | 'runtime_rpc_failed'
+  | 'host_capacity_timeout'
   | 'unknown'
 
 export type RuntimeStartFailure = {
@@ -398,7 +399,14 @@ function classifyRuntimeRejection(errorCode: string | undefined): RuntimeStartFa
   return 'runtime_rejected'
 }
 
-function classifyRuntimeRpcError(_error: unknown): RuntimeStartFailureCode {
+/** Exported for tests; production call site is `startAgentRuntimesAsync`. */
+export function classifyRuntimeRpcError(error: unknown): RuntimeStartFailureCode {
+  const message = error instanceof Error ? error.message : String(error)
+
+  if (/host_capacity_timeout/i.test(message)) {
+    return 'host_capacity_timeout'
+  }
+
   return 'runtime_rpc_failed'
 }
 

--- a/packages/app/src/lib/teamclu/__tests__/ensure-agent-runtime-cancelled-notify.test.ts
+++ b/packages/app/src/lib/teamclu/__tests__/ensure-agent-runtime-cancelled-notify.test.ts
@@ -124,4 +124,32 @@ describe("notifyRuntimeStartFailures", () => {
     const [, options] = mocks.toastError.mock.calls[0] as [string, { id: string }];
     expect(options.id).toBe("runtime-start-failed-agent-2");
   });
+
+  it("shows host capacity full instead of agent-not-started", async () => {
+    const i18n = (await import("@/lib/i18n")).default;
+    const { classifyRuntimeRpcError } = await import("@/lib/session-create");
+    const { notifyRuntimeStartFailures } = await import("../ensure-agent-runtime");
+
+    const reason =
+      "start_runtime failed: agent error: host_capacity_timeout: 2 active, 0 draining, 0 queued";
+    expect(classifyRuntimeRpcError(new Error(reason))).toBe("host_capacity_timeout");
+
+    notifyRuntimeStartFailures([
+      {
+        agentActorId: "agent-1",
+        code: "host_capacity_timeout",
+        reason,
+      },
+    ]);
+    await flush();
+
+    expect(mocks.toastError).toHaveBeenCalledTimes(1);
+    const [title, options] = mocks.toastError.mock.calls[0] as [
+      string,
+      { description: string },
+    ];
+    expect(title).toBe(i18n.t("daemon.agentRuntime.hostCapacityTitle"));
+    expect(title).not.toBe(i18n.t("daemon.agentRuntime.notStartedTitle"));
+    expect(options.description).toBe(i18n.t("daemon.agentRuntime.hostCapacityDesc"));
+  });
 });

--- a/packages/app/src/lib/teamclu/ensure-agent-runtime.ts
+++ b/packages/app/src/lib/teamclu/ensure-agent-runtime.ts
@@ -105,6 +105,8 @@ function failureDescription(failure: RuntimeStartFailure): string {
       return trimmed || i18n.t("daemon.agentRuntime.notStartedDesc", { shortId });
     case "runtime_rpc_failed":
       return trimmed || i18n.t("daemon.agentRuntime.notStartedDesc", { shortId });
+    case "host_capacity_timeout":
+      return i18n.t("daemon.agentRuntime.hostCapacityDesc");
     default:
       return trimmed || i18n.t("daemon.agentRuntime.notStartedDesc", { shortId });
   }
@@ -137,7 +139,11 @@ export function notifyRuntimeStartFailures(
   if (toastable.length === 0) return;
   void import("sonner").then(({ toast }) => {
     for (const failure of toastable) {
-      toast.error(i18n.t("daemon.agentRuntime.notStartedTitle"), {
+      const titleKey =
+        failure.code === "host_capacity_timeout"
+          ? "daemon.agentRuntime.hostCapacityTitle"
+          : "daemon.agentRuntime.notStartedTitle";
+      toast.error(i18n.t(titleKey), {
         id: `runtime-start-failed-${failure.agentActorId}`,
         description: failureDescription(failure),
         duration: 8000,

--- a/packages/app/src/locales/en.json
+++ b/packages/app/src/locales/en.json
@@ -3366,6 +3366,8 @@
     "agentRuntime": {
       "notStartedTitle": "Agent runtime not started",
       "notStartedDesc": "Agent {{shortId}}'s daemon did not respond to runtimeStart (it may be offline or not joined to the team).",
+      "hostCapacityTitle": "This machine's agent runtime capacity is full",
+      "hostCapacityDesc": "All OpenCode hosts are currently in use, so this session cannot start yet. Wait for another session to finish or stop one, then retry.",
       "binaryMissingDesc": "This team's agent runtime is {{agent}}, but it is not installed on this machine. Pick a runtime that is installed for this team under Settings → Agent, or install {{agent}} first. The runtime is configured per team.",
       "rpcNotReadyTitle": "MQTT/RPC not ready",
       "rpcNotReadyDesc": "Unable to send runtimeStart to the daemon. Please check the MQTT connection and team sign-in status.",

--- a/packages/app/src/locales/zh-CN.json
+++ b/packages/app/src/locales/zh-CN.json
@@ -3366,6 +3366,8 @@
     "agentRuntime": {
       "notStartedTitle": "Agent runtime 未启动",
       "notStartedDesc": "Agent {{shortId}} 的 daemon 未响应 runtimeStart（可能未在线或未加入团队）。",
+      "hostCapacityTitle": "本机 Agent 运行容量已满",
+      "hostCapacityDesc": "当前 OpenCode host 均在使用中，暂时无法启动此会话。请等待其他会话完成或停止一个会话后重试。",
       "binaryMissingDesc": "当前团队的 agent 运行时是 {{agent}}，但这台机器上没有安装它。请到「设置 → Agent」为本团队换一个已安装的运行时，或先安装 {{agent}}。运行时是每个团队独立配置的。",
       "rpcNotReadyTitle": "MQTT/RPC 未就绪",
       "rpcNotReadyDesc": "无法向 daemon 发送 runtimeStart。请检查 MQTT 连接与团队登录状态。",


### PR DESCRIPTION
## Summary
- On user-facing `runtimeStart`, if spawn fails with `host_capacity_timeout`, stop one idle attachment (`stop_runtime`, never kill OpenCode) and retry once.
- Eviction only picks idle runtimes: no in-flight turn, `event_rx` still owned, not the target session, oldest `last_active_at`. Auto-recovery still calls `apply_start_runtime` directly and will not steal user slots.
- Desktop classifies `host_capacity_timeout` and shows a capacity-full toast instead of “Agent runtime not started”.

## Test plan
- [ ] `cargo test -p amuxd --bin amuxd evict_one_idle_attachment_for_capacity`
- [ ] `vitest run src/lib/teamclu/__tests__/ensure-agent-runtime-cancelled-notify.test.ts` (capacity toast case)
- [ ] Fill OpenCode hosts with idle sessions, start a new session → should reclaim and start without toast
- [ ] Fill hosts with all mid-turn sessions, start a new session → toast: capacity full (not “runtime not started”)
- [ ] Confirm offline-session auto-restart does not evict a live user runtime for capacity


Made with [Cursor](https://cursor.com)