### PR TITLE
test(daemon): 回收前等 fake 进程 exec 完 —— 修 main 上那条 reap 假红

### DIFF
--- a/apps/daemon/src/cli/process.rs
+++ b/apps/daemon/src/cli/process.rs
@@ -662,6 +662,17 @@ mod tests {
             .spawn()
             .unwrap();
         let pgid = child.id();
+        // Do not hand back a fake the reaper cannot recognise yet: between
+        // `fork` and `execve` the child's `/proc/<pid>/cmdline` is empty, and a
+        // reap in that window reports `StaleOrReused` instead of `Reaped`. The
+        // deadline is a stuck-process guard, not a latency estimate — this
+        // normally settles in well under a millisecond.
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+        while std::time::Instant::now() < deadline
+            && !crate::runtime::opencode_http::process_registry::test_group_is_verifiable(pgid)
+        {
+            std::thread::sleep(std::time::Duration::from_millis(1));
+        }
         (child, pgid)
     }
 

--- a/apps/daemon/src/runtime/opencode_http/process_registry.rs
+++ b/apps/daemon/src/runtime/opencode_http/process_registry.rs
@@ -449,6 +449,13 @@ mod tests {
 
     #[test]
     fn default_registry_uses_branded_amuxd_home() {
+        // Resolves `amuxd_home_from_env()` twice — once inside `default()`,
+        // once in the assertion — and that reads process-global `HOME` /
+        // `AMUXD_HOME`. Another test moving those in between compares two
+        // different homes. Same shape as the `resolve_workdir` tests fixed in
+        // #1219; the guard pins a home and holds `TEST_HOME_LOCK`.
+        let home = tempfile::tempdir().unwrap();
+        let _env = crate::test_brand_env::BrandEnvGuard::set_amuxd_home(home.path());
         let registry = ServeProcessRegistry::default();
         assert_eq!(
             registry.path,

--- a/apps/daemon/src/runtime/opencode_http/process_registry.rs
+++ b/apps/daemon/src/runtime/opencode_http/process_registry.rs
@@ -52,6 +52,20 @@ pub fn test_mark_survivor_pgid(pgid: u32) {
         .insert(pgid);
 }
 
+/// Whether the reaper would currently recognise this group as one of ours.
+///
+/// Exposed for tests that spawn a fake `opencode serve` and then reap it: a
+/// just-`fork`ed child already has a pid and a process group, but until its
+/// `execve` completes `/proc/<pid>/cmdline` is EMPTY, so
+/// [`group_has_managed_member`] says no and the group is classified
+/// `StaleOrReused` rather than `Reaped`. Measured at ~4-8% per group on Linux;
+/// on macOS `cmdline_of` shells out to `ps`, and those milliseconds hide the
+/// window, which is why this only ever failed on CI.
+#[cfg(all(test, unix))]
+pub fn test_group_is_verifiable(pgid: u32) -> bool {
+    i32::try_from(pgid).is_ok_and(group_has_managed_member)
+}
+
 #[cfg(test)]
 pub fn test_clear_survivor_pgids() {
     TEST_SURVIVOR_PGIDS
@@ -421,6 +435,15 @@ mod tests {
             .spawn()
             .unwrap();
         let pgid = child.id();
+        // Do not hand back a fake the reaper cannot recognise yet: between
+        // `fork` and `execve` the child's `/proc/<pid>/cmdline` is empty, and a
+        // reap in that window reports `StaleOrReused` instead of `Reaped`. The
+        // deadline is a stuck-process guard, not a latency estimate — this
+        // normally settles in well under a millisecond.
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+        while std::time::Instant::now() < deadline && !super::test_group_is_verifiable(pgid) {
+            std::thread::sleep(std::time::Duration::from_millis(1));
+        }
         (child, pgid)
     }
 


### PR DESCRIPTION
修 #1218 之后 main 上一直红的那条。完整证据链在 https://github.com/different-ai-studio/teamclu/pull/1218#issuecomment-5509935767，这里是结论和改动。

## 现象

`reap_cleans_current_and_draining_generations` 从 #1218 合入起**每一轮 main 都红**：

```
assert_eq!(report.reaped.len(), 3);   // 一轮拿到 1，一轮拿到 2
```

而**前一行 `assert_eq!(report.registered_count(), 3)` 是过的** —— 三条都注册上了，只是有一两条被分到了 `Reaped` 之外。

## 真因：fork→exec 窗口里 `/proc/<pid>/cmdline` 是空的

`fork` 之后、`execve` 完成之前，子进程已经有 pid、有进程组（`kill(-pgid, 0)` 成功），但 **`/proc/<pid>/cmdline` 是空字符串**。于是 `group_has_managed_member` 找不到含 "opencode"+"serve" 的成员，`reap_verified_group` 走进 `refusing to reap unverified opencode process group` 分支，返回 `StaleOrReused`。

测试连着生成三个 fake **然后立刻回收** —— 它回收进了自己刚打开的窗口。

在 Debian 容器里复现（`/bin/sh -> dash`，与 runner 一致）：

```
10/120 组「活着但验不过」(8.3%)，cmdline: ['']
```

这能解释每一个细节：为什么只有生成**三个**的那条会挂（另外八个各生成一个，全过）；为什么 `registered_count()` 仍是 3；为什么剩余数在 1 和 2 之间跳；以及**为什么 macOS 永远不复现** —— 那边 `cmdline_of` 要 fork 一个 `ps`，那几毫秒刚好把窗口盖住。

## 路上死掉的两个假设（都是量出来的，不是argue出来的）

1. **三次写同一个 `<home>/opencode`，`O_TRUNC` 打死前一个 `sh`** —— 同文件 vs 独立文件各 30 次，**结果不可区分**，一个进程组都没死过。（我一开始就是这么猜的，也据此给过一个错的改法建议，已在 #1218 更正。）
2. **dash 尾调用 exec 成 `sleep 30` 导致 cmdline 不含关键词** —— 它不会：进程组里始终同时有 `/bin/sh …/opencode serve` 和 `sleep 30`。

## 改动

**commit 1** —— spawner 在这个 fake **变成 reaper 要找的样子**之前不返回。同一容器同一脚本：

```
立即返回（现状）:        7/180 验不过 (3.9%)
等到 exec 完成:          0/180 验不过 (0.0%)
```

deadline 是防卡死的兜底、不是延迟估计 —— 正常情况远不到 1 毫秒。两个模块各有一份 spawner，`cli/process.rs` 那份的测试每个只生成一个所以命中率低得多，但窗口是同一个，一起改了。

**commit 2** —— 上一个 commit 顺带把 `default_registry_uses_branded_amuxd_home` 逼了出来：它两次解析 `amuxd_home_from_env()`（一次在 `default()` 里、一次在断言里），中间不持锁，于是可能拿两个不同的 home 比。跟 #1219 修的 `resolve_workdir` 同型，是这套测试里这一族的**第四例**（前三例：`PATH`、`HOME`/`AMUXD_HOME`、功能开关 env）。等 exec 只是改变了调度把它照出来，竞争本来就在。

## 生产不受影响

`reap_all` 在生产里是 daemon 启动时对**上一次运行注册的**进程组跑的，那些进程早就 exec 完了。这是测试回收进了自己的启动窗口。

## 验证

`cargo test -p amuxd --bin amuxd`：**1713 passed, 0 failed**；过滤到 `process_registry` / `cli::process` 那批连跑三次全绿。

复现脚本我留着，需要可以附上。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NSLRgWQJVe4uVJ824WdBdE
