### PR TITLE
fix(daemon): scope team skill refresh to matching workspaces

### DIFF
--- a/apps/daemon/src/daemon/server.rs
+++ b/apps/daemon/src/daemon/server.rs
@@ -1356,15 +1356,17 @@ impl DaemonServer {
         // loop reads the registry live via `snapshot()`, so upserting here takes
         // effect on the next tick without a restart.
         if let Some(registry) = self.refresh_watch_registry.clone() {
+            let team_id = self.backend.team_id().to_string();
             let workspaces = self.cloud_workspace_list().await;
             tokio::spawn(async move {
                 for workspace in workspaces {
                     registry
                         .upsert_workspace(
-                            crate::runtime::refresh::refresh_watch::WatchedWorkspace {
-                                workspace_id: workspace.workspace_id,
-                                workspace_path: PathBuf::from(&workspace.path),
-                            },
+                            crate::runtime::refresh::refresh_watch::WatchedWorkspace::new(
+                                workspace.workspace_id,
+                                PathBuf::from(&workspace.path),
+                                Some(team_id.as_str()),
+                            ),
                         )
                         .await;
                 }

--- a/apps/daemon/src/daemon/server/peers_workspaces.rs
+++ b/apps/daemon/src/daemon/server/peers_workspaces.rs
@@ -313,11 +313,19 @@ impl DaemonServer {
             }
         }
         if let Some(registry) = self.refresh_watch_registry.as_ref() {
+            let watch_team_id = if remote.team_id.trim().is_empty() {
+                team_id
+            } else {
+                remote.team_id.as_str()
+            };
             registry
-                .upsert_workspace(crate::runtime::refresh::refresh_watch::WatchedWorkspace {
-                    workspace_id: remote.id.clone(),
-                    workspace_path: canonical.clone(),
-                })
+                .upsert_workspace(
+                    crate::runtime::refresh::refresh_watch::WatchedWorkspace::new(
+                        remote.id.clone(),
+                        canonical.clone(),
+                        Some(watch_team_id),
+                    ),
+                )
                 .await;
         }
         info!(workspace_id = %remote.id, path = %canonical_str, "workspace added");

--- a/apps/daemon/src/daemon/server/runtime_lifecycle.rs
+++ b/apps/daemon/src/daemon/server/runtime_lifecycle.rs
@@ -249,10 +249,13 @@ impl DaemonServer {
                 ws_id.clone()
             };
             registry
-                .upsert_workspace(crate::runtime::refresh::refresh_watch::WatchedWorkspace {
-                    workspace_id: refresh_workspace_id,
-                    workspace_path: PathBuf::from(&resolved_worktree),
-                })
+                .upsert_workspace(
+                    crate::runtime::refresh::refresh_watch::WatchedWorkspace::new(
+                        refresh_workspace_id,
+                        PathBuf::from(&resolved_worktree),
+                        Some(team_id.as_str()),
+                    ),
+                )
                 .await;
         }
 

--- a/apps/daemon/src/runtime/refresh.rs
+++ b/apps/daemon/src/runtime/refresh.rs
@@ -114,6 +114,7 @@ pub enum RefreshSource {
     UiMutation,
     FilesystemWatch,
     StartupRescan,
+    TeamSkillReconcile,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, Hash)]

--- a/apps/daemon/src/runtime/refresh_watch.rs
+++ b/apps/daemon/src/runtime/refresh_watch.rs
@@ -67,6 +67,27 @@ const WATCH_DEBOUNCE_WINDOW: Duration = Duration::from_millis(250);
 pub struct WatchedWorkspace {
     pub workspace_id: String,
     pub workspace_path: PathBuf,
+    /// Team that owns this workspace. `None` when membership is unknown —
+    /// filesystem watches still apply, but team Skill reconcile must not
+    /// fan out to it.
+    pub team_id: Option<String>,
+}
+
+impl WatchedWorkspace {
+    pub fn new(
+        workspace_id: impl Into<String>,
+        workspace_path: PathBuf,
+        team_id: Option<&str>,
+    ) -> Self {
+        Self {
+            workspace_id: workspace_id.into(),
+            workspace_path,
+            team_id: team_id.and_then(|id| {
+                let trimmed = id.trim();
+                (!trimmed.is_empty()).then(|| trimmed.to_string())
+            }),
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -114,6 +135,16 @@ impl RefreshWatchRegistry {
 
     pub(crate) async fn snapshot(&self) -> Vec<WatchedWorkspace> {
         self.workspaces.read().await.values().cloned().collect()
+    }
+
+    pub async fn snapshot_for_team(&self, team_id: &str) -> Vec<WatchedWorkspace> {
+        self.workspaces
+            .read()
+            .await
+            .values()
+            .filter(|workspace| workspace.team_id.as_deref() == Some(team_id))
+            .cloned()
+            .collect()
     }
 
     #[cfg(test)]
@@ -499,10 +530,7 @@ mod tests {
     use tokio::sync::Mutex as AsyncMutex;
 
     fn watched_workspace(id: &str, path: &str) -> WatchedWorkspace {
-        WatchedWorkspace {
-            workspace_id: id.to_string(),
-            workspace_path: PathBuf::from(path),
-        }
+        WatchedWorkspace::new(id, PathBuf::from(path), None)
     }
 
     #[test]
@@ -588,10 +616,7 @@ mod tests {
         std::fs::create_dir_all(shared_skills.join("multiply-add")).unwrap();
         std::os::unix::fs::symlink(&shared_team, workspace.join(TEAM_LINK_NAME)).unwrap();
 
-        let workspaces = vec![WatchedWorkspace {
-            workspace_id: "ws-symlink".to_string(),
-            workspace_path: workspace.clone(),
-        }];
+        let workspaces = vec![WatchedWorkspace::new("ws-symlink", workspace.clone(), None)];
         let canonical_skills = std::fs::canonicalize(&shared_skills).unwrap();
         let roots = watch_roots(&workspaces, None);
         assert!(roots.iter().any(|root| root.path == canonical_skills));
@@ -658,10 +683,11 @@ mod tests {
     async fn watcher_state_surfaces_through_runtime_status_with_http_workspace_id() {
         let dir = tempfile::tempdir().unwrap();
         let workspace_id = workspace_runtime_id(dir.path());
-        let workspaces = vec![WatchedWorkspace {
-            workspace_id: workspace_id.clone(),
-            workspace_path: dir.path().to_path_buf(),
-        }];
+        let workspaces = vec![WatchedWorkspace::new(
+            workspace_id.clone(),
+            dir.path().to_path_buf(),
+            None,
+        )];
         let manager = RuntimeManager::new(RuntimeManager::default_launch_configs(), None);
         let supervisor = RuntimeSupervisor::new(Arc::new(AsyncMutex::new(manager)));
         let mut debounce = RefreshDebounce::new(Duration::from_millis(250));
@@ -709,10 +735,11 @@ mod tests {
             ))),
             pool.clone(),
         );
-        let workspaces = vec![WatchedWorkspace {
-            workspace_id: workspace_id.clone(),
-            workspace_path: dir.path().to_path_buf(),
-        }];
+        let workspaces = vec![WatchedWorkspace::new(
+            workspace_id.clone(),
+            dir.path().to_path_buf(),
+            None,
+        )];
         let mut debounce = RefreshDebounce::new(Duration::from_millis(250));
 
         record_classified_changes(
@@ -752,10 +779,11 @@ mod tests {
         let coordinator = RuntimeRefreshCoordinator::new();
         let dir = tempfile::tempdir().unwrap();
         let workspace_id = workspace_runtime_id(dir.path());
-        let workspaces = vec![WatchedWorkspace {
-            workspace_id: workspace_id.clone(),
-            workspace_path: dir.path().to_path_buf(),
-        }];
+        let workspaces = vec![WatchedWorkspace::new(
+            workspace_id.clone(),
+            dir.path().to_path_buf(),
+            None,
+        )];
         let mut debounce = RefreshDebounce::new(Duration::from_millis(250));
 
         coordinator.suppress_workspace_watch(
@@ -793,10 +821,11 @@ mod tests {
     async fn suppress_after_await_covers_opencode_write_unlike_suppress_before_await() {
         let dir = tempfile::tempdir().unwrap();
         let workspace_id = workspace_runtime_id(dir.path());
-        let workspaces = vec![WatchedWorkspace {
-            workspace_id: workspace_id.clone(),
-            workspace_path: dir.path().to_path_buf(),
-        }];
+        let workspaces = vec![WatchedWorkspace::new(
+            workspace_id.clone(),
+            dir.path().to_path_buf(),
+            None,
+        )];
         let opencode = dir.path().join("opencode.json");
         let content = r#"{"$schema":"https://opencode.ai/config.json"}"#;
 
@@ -885,6 +914,28 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn snapshot_for_team_keeps_matching_and_skips_unknown() {
+        let registry = RefreshWatchRegistry::new(vec![
+            WatchedWorkspace::new("ws-1", PathBuf::from("/tmp/ws-1"), Some("team-1")),
+            WatchedWorkspace::new("ws-2", PathBuf::from("/tmp/ws-2"), Some("team-2")),
+            WatchedWorkspace::new("ws-unknown", PathBuf::from("/tmp/unknown"), None),
+        ]);
+
+        let mut team_1 = registry.snapshot_for_team("team-1").await;
+        team_1.sort_by(|a, b| a.workspace_id.cmp(&b.workspace_id));
+        assert_eq!(
+            team_1
+                .iter()
+                .map(|workspace| workspace.workspace_id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["ws-1"]
+        );
+
+        assert!(registry.snapshot_for_team("team-missing").await.is_empty());
+        assert_eq!(registry.snapshot().await.len(), 3);
+    }
+
     #[test]
     fn desired_targets_map_existing_dirs_and_skip_missing() {
         let dir = tempfile::tempdir().unwrap();
@@ -892,10 +943,7 @@ mod tests {
         // Only this recursive skill root exists; the other skill/_secrets roots do not.
         std::fs::create_dir_all(ws.join(".claude/skills")).unwrap();
 
-        let workspaces = vec![WatchedWorkspace {
-            workspace_id: "ws-1".to_string(),
-            workspace_path: ws.to_path_buf(),
-        }];
+        let workspaces = vec![WatchedWorkspace::new("ws-1", ws.to_path_buf(), None)];
 
         let targets = desired_watch_targets(&workspaces, None);
 

--- a/apps/daemon/src/runtime/team_skills.rs
+++ b/apps/daemon/src/runtime/team_skills.rs
@@ -400,44 +400,14 @@ pub async fn apply_team_skill_outcome(
         return;
     };
 
-    let mut cloud_targets = Vec::new();
-    if let Some(backend) = backend {
-        match backend
-            .get_workspaces_by_agent(team_id, backend.actor_id())
-            .await
-        {
-            Ok(rows) => {
-                for row in rows {
-                    let Some((path, _)) =
-                        crate::config::workspace_path::listable_local_workspace(&row)
-                    else {
-                        continue;
-                    };
-                    cloud_targets.push(crate::runtime::refresh::refresh_watch::WatchedWorkspace {
-                        workspace_id: row.id,
-                        workspace_path: PathBuf::from(path),
-                    });
-                }
-            }
-            Err(e) => tracing::warn!(
-                team_id,
-                error = %e,
-                "team skills changed but cloud workspace list failed; using runtime refresh targets"
-            ),
-        }
-    }
-
-    let runtime_targets = match refresh_watch_registry {
-        Some(registry) => registry.snapshot().await,
-        None => Vec::new(),
-    };
-    for target in merge_refresh_targets(cloud_targets, runtime_targets) {
+    for target in resolve_team_skill_refresh_targets(team_id, backend, refresh_watch_registry).await
+    {
         if let Err(error) = refresh
             .record_change(
                 &target.workspace_id,
                 &target.workspace_path,
                 crate::runtime::refresh::RefreshChangeKind::Skills,
-                crate::runtime::refresh::RefreshSource::UiMutation,
+                crate::runtime::refresh::RefreshSource::TeamSkillReconcile,
             )
             .await
         {
@@ -447,8 +417,113 @@ pub async fn apply_team_skill_outcome(
                 error = %error,
                 "failed to record skills refresh after team skill reconcile"
             );
+            continue;
+        }
+        tracing::info!(
+            team_id,
+            workspace_id = %target.workspace_id,
+            workspace_path = %target.workspace_path.display(),
+            "team_skill_refresh_recorded"
+        );
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CloudLookupStatus {
+    Success,
+    Failed,
+    Unavailable,
+}
+
+impl CloudLookupStatus {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Success => "success",
+            Self::Failed => "failed",
+            Self::Unavailable => "unavailable",
         }
     }
+}
+
+async fn resolve_team_skill_refresh_targets(
+    team_id: &str,
+    backend: Option<&Arc<dyn Backend>>,
+    registry: Option<&Arc<crate::runtime::refresh::refresh_watch::RefreshWatchRegistry>>,
+) -> Vec<crate::runtime::refresh::refresh_watch::WatchedWorkspace> {
+    use crate::runtime::refresh::refresh_watch::WatchedWorkspace;
+
+    let (cloud_targets, cloud_lookup_status) = match backend {
+        Some(backend) => match backend
+            .get_workspaces_by_agent(team_id, backend.actor_id())
+            .await
+        {
+            Ok(rows) => {
+                let mut cloud_targets = Vec::new();
+                for row in rows {
+                    let Some((path, _)) =
+                        crate::config::workspace_path::listable_local_workspace(&row)
+                    else {
+                        continue;
+                    };
+                    cloud_targets.push(WatchedWorkspace::new(
+                        row.id,
+                        PathBuf::from(path),
+                        Some(team_id),
+                    ));
+                }
+                (cloud_targets, CloudLookupStatus::Success)
+            }
+            Err(e) => {
+                tracing::warn!(
+                    team_id,
+                    error = %e,
+                    "team skills changed but cloud workspace list failed; using team-matched runtime refresh targets"
+                );
+                (Vec::new(), CloudLookupStatus::Failed)
+            }
+        },
+        None => (Vec::new(), CloudLookupStatus::Unavailable),
+    };
+
+    let (runtime_targets, unknown_skipped) = match registry {
+        Some(registry) => {
+            let snapshot = registry.snapshot().await;
+            let unknown_skipped = snapshot
+                .iter()
+                .filter(|workspace| workspace.team_id.is_none())
+                .count();
+            if unknown_skipped > 0 {
+                tracing::warn!(
+                    team_id,
+                    unknown_skipped,
+                    "skipping refresh-watch workspaces with unknown team_id"
+                );
+            }
+            (registry.snapshot_for_team(team_id).await, unknown_skipped)
+        }
+        None => (Vec::new(), 0),
+    };
+
+    let cloud_count = cloud_targets.len();
+    let runtime_count = runtime_targets.len();
+    let targets = merge_refresh_targets(cloud_targets, runtime_targets);
+    tracing::info!(
+        team_id,
+        cloud_count,
+        runtime_count,
+        unknown_skipped,
+        deduped_count = targets.len(),
+        cloud_lookup_status = cloud_lookup_status.as_str(),
+        "team_skill_refresh_targets_resolved"
+    );
+    if targets.is_empty() {
+        tracing::warn!(
+            team_id,
+            cloud_lookup_status = cloud_lookup_status.as_str(),
+            "team skills changed but no trusted refresh targets were found"
+        );
+    }
+    targets
 }
 
 fn merge_refresh_targets(
@@ -639,19 +714,64 @@ mod tests {
         assert!(!tmp.path().join("escaped.md").exists());
     }
 
+    fn watched(
+        id: &str,
+        path: &str,
+        team_id: Option<&str>,
+    ) -> crate::runtime::refresh::refresh_watch::WatchedWorkspace {
+        crate::runtime::refresh::refresh_watch::WatchedWorkspace::new(
+            id,
+            PathBuf::from(path),
+            team_id,
+        )
+    }
+
+    fn changed_outcome() -> TeamSkillReconcileOutcome {
+        TeamSkillReconcileOutcome {
+            installed: 1,
+            removed: 0,
+        }
+    }
+
+    async fn apply_changed(
+        team_id: &str,
+        backend: Option<&Arc<dyn Backend>>,
+        refresh: &Arc<crate::runtime::refresh::RuntimeRefreshCoordinator>,
+        registry: &Arc<crate::runtime::refresh::refresh_watch::RefreshWatchRegistry>,
+    ) {
+        apply_team_skill_outcome(
+            team_id,
+            changed_outcome(),
+            backend,
+            Some(refresh),
+            Some(registry),
+        )
+        .await;
+    }
+
+    fn seed_workspace(
+        mock: &crate::backend::mock::MockBackend,
+        id: &str,
+        team_id: &str,
+        path: &Path,
+    ) {
+        mock.state.lock().unwrap().workspaces_by_id.insert(
+            id.to_string(),
+            crate::backend::WorkspaceRow {
+                id: id.to_string(),
+                team_id: team_id.to_string(),
+                path: Some(path.display().to_string()),
+                archived: false,
+                agent_id: Some(mock.actor_id().to_string()),
+            },
+        );
+    }
+
     #[test]
     fn runtime_refresh_target_overrides_stale_cloud_path() {
-        use crate::runtime::refresh::refresh_watch::WatchedWorkspace;
-
         let targets = merge_refresh_targets(
-            vec![WatchedWorkspace {
-                workspace_id: "ws-1".into(),
-                workspace_path: PathBuf::from("/tmp/stale-cloud-path"),
-            }],
-            vec![WatchedWorkspace {
-                workspace_id: "ws-1".into(),
-                workspace_path: PathBuf::from("/tmp/actual-runtime-path"),
-            }],
+            vec![watched("ws-1", "/tmp/stale-cloud-path", Some("team-1"))],
+            vec![watched("ws-1", "/tmp/actual-runtime-path", Some("team-1"))],
         );
         assert_eq!(
             targets[0].workspace_path,
@@ -661,17 +781,70 @@ mod tests {
 
     #[tokio::test]
     async fn team_skill_change_refreshes_runtime_target_without_cloud_inventory() {
-        use crate::runtime::refresh::refresh_watch::{RefreshWatchRegistry, WatchedWorkspace};
+        use crate::runtime::refresh::refresh_watch::RefreshWatchRegistry;
 
-        let registry = RefreshWatchRegistry::new(vec![WatchedWorkspace {
-            workspace_id: "ws-runtime".into(),
-            workspace_path: PathBuf::from("/tmp/actual-runtime-path"),
-        }]);
+        let registry = RefreshWatchRegistry::new(vec![watched(
+            "ws-runtime",
+            "/tmp/actual-runtime-path",
+            Some("team-1"),
+        )]);
+        let refresh = crate::runtime::refresh::RuntimeRefreshCoordinator::new();
+        apply_changed("team-1", None, &refresh, &registry).await;
+
+        let state = refresh.workspace_state("ws-runtime").await.unwrap();
+        assert_eq!(state.workspace_path, "/tmp/actual-runtime-path");
+        assert!(state
+            .change_kinds
+            .contains(&crate::runtime::refresh::RefreshChangeKind::Skills));
+        assert!(state
+            .sources
+            .contains(&crate::runtime::refresh::RefreshSource::TeamSkillReconcile));
+    }
+
+    #[tokio::test]
+    async fn team_skill_change_skips_unknown_team_runtime_target() {
+        use crate::runtime::refresh::refresh_watch::RefreshWatchRegistry;
+
+        let registry = RefreshWatchRegistry::new(vec![watched(
+            "ws-unknown",
+            "/tmp/unknown-runtime-path",
+            None,
+        )]);
+        let refresh = crate::runtime::refresh::RuntimeRefreshCoordinator::new();
+        apply_changed("team-1", None, &refresh, &registry).await;
+
+        assert!(refresh.workspace_state("ws-unknown").await.is_none());
+    }
+
+    #[tokio::test]
+    async fn team_skill_change_does_not_refresh_other_team_workspace() {
+        use crate::runtime::refresh::refresh_watch::RefreshWatchRegistry;
+
+        let registry = RefreshWatchRegistry::new(vec![
+            watched("ws-team-1", "/tmp/team-1", Some("team-1")),
+            watched("ws-team-2", "/tmp/team-2", Some("team-2")),
+        ]);
+        let refresh = crate::runtime::refresh::RuntimeRefreshCoordinator::new();
+        apply_changed("team-1", None, &refresh, &registry).await;
+
+        assert!(refresh.workspace_state("ws-team-1").await.is_some());
+        assert!(refresh.workspace_state("ws-team-2").await.is_none());
+    }
+
+    #[tokio::test]
+    async fn unchanged_reconcile_outcome_does_not_record_refresh() {
+        use crate::runtime::refresh::refresh_watch::RefreshWatchRegistry;
+
+        let registry = RefreshWatchRegistry::new(vec![watched(
+            "ws-runtime",
+            "/tmp/actual-runtime-path",
+            Some("team-1"),
+        )]);
         let refresh = crate::runtime::refresh::RuntimeRefreshCoordinator::new();
         apply_team_skill_outcome(
             "team-1",
             TeamSkillReconcileOutcome {
-                installed: 1,
+                installed: 0,
                 removed: 0,
             },
             None,
@@ -680,11 +853,87 @@ mod tests {
         )
         .await;
 
-        let state = refresh.workspace_state("ws-runtime").await.unwrap();
-        assert_eq!(state.workspace_path, "/tmp/actual-runtime-path");
-        assert!(state
-            .change_kinds
-            .contains(&crate::runtime::refresh::RefreshChangeKind::Skills));
+        assert!(refresh.workspace_state("ws-runtime").await.is_none());
+    }
+
+    #[tokio::test]
+    async fn cloud_lookup_failure_uses_only_exact_team_match() {
+        use crate::runtime::refresh::refresh_watch::RefreshWatchRegistry;
+
+        let mock = crate::backend::mock::MockBackend::with_identity("team-1", "agent-1");
+        mock.state.lock().unwrap().get_workspaces_by_team_error = Some("cloud down".to_string());
+        let backend: Arc<dyn Backend> = Arc::new(mock);
+        let registry = RefreshWatchRegistry::new(vec![
+            watched("ws-team-1", "/tmp/team-1", Some("team-1")),
+            watched("ws-team-2", "/tmp/team-2", Some("team-2")),
+            watched("ws-unknown", "/tmp/unknown", None),
+        ]);
+        let refresh = crate::runtime::refresh::RuntimeRefreshCoordinator::new();
+        apply_changed("team-1", Some(&backend), &refresh, &registry).await;
+
+        assert!(refresh.workspace_state("ws-team-1").await.is_some());
+        assert!(refresh.workspace_state("ws-team-2").await.is_none());
+        assert!(refresh.workspace_state("ws-unknown").await.is_none());
+    }
+
+    #[tokio::test]
+    async fn backend_none_does_not_cross_team_refresh() {
+        use crate::runtime::refresh::refresh_watch::RefreshWatchRegistry;
+
+        let registry = RefreshWatchRegistry::new(vec![
+            watched("ws-team-1", "/tmp/team-1", Some("team-1")),
+            watched("ws-team-2", "/tmp/team-2", Some("team-2")),
+        ]);
+        let refresh = crate::runtime::refresh::RuntimeRefreshCoordinator::new();
+        apply_changed("team-1", None, &refresh, &registry).await;
+
+        assert!(refresh.workspace_state("ws-team-1").await.is_some());
+        assert!(refresh.workspace_state("ws-team-2").await.is_none());
+    }
+
+    #[tokio::test]
+    async fn cloud_success_overlays_runtime_path_for_same_workspace_id() {
+        use crate::runtime::refresh::refresh_watch::RefreshWatchRegistry;
+
+        let cloud_dir = tempfile::tempdir().unwrap();
+        let runtime_dir = tempfile::tempdir().unwrap();
+        let mock = crate::backend::mock::MockBackend::with_identity("team-1", "agent-1");
+        seed_workspace(&mock, "ws-1", "team-1", cloud_dir.path());
+        let backend: Arc<dyn Backend> = Arc::new(mock);
+        let registry = RefreshWatchRegistry::new(vec![watched(
+            "ws-1",
+            runtime_dir.path().to_str().unwrap(),
+            Some("team-1"),
+        )]);
+        let refresh = crate::runtime::refresh::RuntimeRefreshCoordinator::new();
+        apply_changed("team-1", Some(&backend), &refresh, &registry).await;
+
+        let state = refresh.workspace_state("ws-1").await.unwrap();
+        assert_eq!(
+            state.workspace_path,
+            runtime_dir.path().display().to_string()
+        );
+    }
+
+    #[tokio::test]
+    async fn cloud_success_does_not_refresh_other_team_runtime_target() {
+        use crate::runtime::refresh::refresh_watch::RefreshWatchRegistry;
+
+        let cloud_dir = tempfile::tempdir().unwrap();
+        let mock = crate::backend::mock::MockBackend::with_identity("team-1", "agent-1");
+        seed_workspace(&mock, "ws-cloud", "team-1", cloud_dir.path());
+        let backend: Arc<dyn Backend> = Arc::new(mock);
+        let registry =
+            RefreshWatchRegistry::new(vec![watched("ws-other", "/tmp/other-team", Some("team-2"))]);
+        let refresh = crate::runtime::refresh::RuntimeRefreshCoordinator::new();
+        apply_changed("team-1", Some(&backend), &refresh, &registry).await;
+
+        let cloud_state = refresh.workspace_state("ws-cloud").await.unwrap();
+        assert_eq!(
+            cloud_state.workspace_path,
+            cloud_dir.path().display().to_string()
+        );
+        assert!(refresh.workspace_state("ws-other").await.is_none());
     }
 
     fn seed_installed_pack(root: &Path, slug: &str, version: i64, body: &str) {


### PR DESCRIPTION
## Summary
- Team Skill reconcile no longer fans out to the entire refresh-watch registry. Targets are cloud membership for that team plus registry entries whose `team_id` matches; unknown-team workspaces are skipped.
- Runtime start, cloud workspace add, and the startup cloud list now record `team_id` on watched workspaces. Cloud lookup failure / missing backend falls back only to exact team matches, never a global snapshot.
- Team Skill / draft notifications use `RefreshSource::TeamSkillReconcile` instead of `UiMutation`.

## Test plan
- [x] `node scripts/daemon-cargo.js test --bin amuxd team_skill`
- [x] `pnpm rust:clippy`
- [x] `pnpm daemon:test`
- [ ] Confirm a team Skill change on team A does not pending-refresh team B or `team_id=None` workspaces
- [ ] Confirm cloud inventory failure still refreshes only team-matched runtime targets


Made with [Cursor](https://cursor.com)