### PR TITLE
fix(knowledge): manifest_set 不再写出读不回来的 YAML，也不再为没生效的键报成功

### DIFF
--- a/apps/daemon/assets/knowledge-templates/mcp-manifest.json
+++ b/apps/daemon/assets/knowledge-templates/mcp-manifest.json
@@ -81,7 +81,7 @@
     },
     {
       "name": "knowledge_manifest_set",
-      "description": "Update publish settings. Changing visibility to 'org' REQUIRES confirm=true — publishing exposes the vault org-wide and is a considered action. 修改发布设置；把 visibility 改为 org 必须带 confirm=true。",
+      "description": "Update publish settings. Changing visibility to 'org' REQUIRES confirm=true — publishing exposes the vault org-wide and is a considered action. 修改发布设置；把 visibility 改为 org 必须带 confirm=true。 A key the manifest does not already contain is refused (errorCode unknown_key) and nothing is written — scaffold creates the full set. 清单里没有的键会被拒绝（unknown_key）且不写入任何内容；完整的键由 scaffold 生成。",
       "inputSchema": {
         "type": "object",
         "properties": {

--- a/apps/daemon/src/daemon/server/knowledge.rs
+++ b/apps/daemon/src/daemon/server/knowledge.rs
@@ -428,6 +428,7 @@ fn manifest_set(root: &Path, payload: &Value) -> String {
             "knowledge.manifest.yaml not found; run scaffold first",
         );
     };
+    let mut updates: Vec<(&str, &str)> = Vec::new();
     // Visibility flips demand an explicit confirm flag — an agent must not
     // silently open the vault to the org (附录 D 安全约束).
     if let Some(vis) = str_field(payload, "visibility") {
@@ -444,44 +445,105 @@ fn manifest_set(root: &Path, payload: &Value) -> String {
         if vis != "private" && vis != "org" {
             return err("invalid_value", "visibility must be 'private' or 'org'");
         }
-        raw = replace_lenient_yaml_scalar(&raw, "visibility", vis);
+        updates.push(("visibility", vis));
     }
-    if let Some(summary) = str_field(payload, "summary") {
-        raw = replace_lenient_yaml_scalar(&raw, "summary", summary);
+    for key in ["summary", "team", "title"] {
+        if let Some(value) = str_field(payload, key) {
+            updates.push((key, value));
+        }
     }
-    if let Some(team) = str_field(payload, "team") {
-        raw = replace_lenient_yaml_scalar(&raw, "team", team);
+    if updates.is_empty() {
+        return err(
+            "nothing_to_set",
+            "give at least one of visibility, summary, team, title",
+        );
     }
-    if let Some(title) = str_field(payload, "title") {
-        raw = replace_lenient_yaml_scalar(&raw, "title", title);
+
+    // All or nothing. A key the manifest does not have cannot be written by a
+    // line rewriter, and answering `ok` for it — which is what happened before
+    // — tells the caller a setting took effect that does not exist anywhere.
+    let mut missing = Vec::new();
+    for (key, value) in &updates {
+        match replace_lenient_yaml_scalar(&raw, key, value) {
+            Some(next) => raw = next,
+            None => missing.push(*key),
+        }
     }
+    if !missing.is_empty() {
+        return err(
+            "unknown_key",
+            format!(
+                "{MANIFEST} has no {} to set; nothing was written",
+                missing.join(", ")
+            ),
+        );
+    }
+
     match std::fs::write(&path, &raw) {
-        Ok(()) => ok(json!({ "written": MANIFEST })),
+        Ok(()) => {
+            let keys: Vec<&str> = updates.iter().map(|(k, _)| *k).collect();
+            ok(json!({ "written": MANIFEST, "keys": keys }))
+        }
         Err(e) => err("write_failed", format!("manifest write failed: {e}")),
     }
+}
+
+/// A value rendered as a YAML scalar, quoted and escaped when a bare word
+/// would not survive being read back.
+///
+/// The escaping is the point. The previous version wrapped the value in quotes
+/// without touching its contents, so a summary containing a quote — `他说"好"`
+/// — was written as `summary: "他说"好""`, which is not YAML at all: the next
+/// read of the manifest fails, and the tool that produced it reported success.
+fn yaml_scalar(value: &str) -> String {
+    let bare_is_safe = !value.is_empty()
+        && value.trim() == value
+        && !value.contains(['"', '\'', '#', ':', '\n', '\r', '\t', '\\'])
+        // A leading indicator changes what YAML thinks the value *is*.
+        && !value.starts_with([
+            '&', '*', '!', '|', '>', '%', '@', '`', '-', '?', '{', '[', ',',
+        ]);
+    if bare_is_safe {
+        return value.to_string();
+    }
+    let mut out = String::with_capacity(value.len() + 2);
+    out.push('"');
+    for c in value.chars() {
+        match c {
+            '\\' => out.push_str("\\\\"),
+            '"' => out.push_str("\\\""),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            _ => out.push(c),
+        }
+    }
+    out.push('"');
+    out
 }
 
 /// Minimal line-based YAML scalar rewriter. Handles scalar values only —
 /// `version: 1`, `visibility: private`. List/map blocks pass through
 /// unchanged; users edit those by hand in Obsidian anyway.
-fn replace_lenient_yaml_scalar(raw: &str, key: &str, value: &str) -> String {
+///
+/// `None` when the key is not in the file. That distinction is the caller's
+/// whole basis for not reporting a write it never made: this used to return the
+/// input unchanged, and `manifest_set` wrote it back and answered `ok`.
+fn replace_lenient_yaml_scalar(raw: &str, key: &str, value: &str) -> Option<String> {
     let mut next = Vec::with_capacity(raw.lines().count());
+    let mut found = false;
     for line in raw.lines() {
         if let Some((k, _)) = line.split_once(':') {
-            if k.trim() == key && !line.trim_start().starts_with('#') {
+            if !found && k.trim() == key && !line.trim_start().starts_with('#') {
                 let indent = &line[..line.len() - line.trim_start().len()];
-                let formatted = if value.contains(&['"', '\'', '#', ':'][..]) || value.len() != value.trim().len() {
-                    format!("{indent}{key}: \"{value}\"")
-                } else {
-                    format!("{indent}{key}: {value}")
-                };
-                next.push(formatted);
+                next.push(format!("{indent}{key}: {}", yaml_scalar(value)));
+                found = true;
                 continue;
             }
         }
         next.push(line.to_string());
     }
-    next.join("\n") + if raw.ends_with('\n') { "\n" } else { "" }
+    found.then(|| next.join("\n") + if raw.ends_with('\n') { "\n" } else { "" })
 }
 
 // --- health (freshness / coverage) -----------------------------------------
@@ -642,10 +704,115 @@ mod tests {
     #[test]
     fn manifest_scalar_rewrite_preserves_lists() {
         let raw = "version: 1\nvisibility: private\ncollections:\n  - name: x\n";
-        let next = replace_lenient_yaml_scalar(raw, "visibility", "org");
+        let next = replace_lenient_yaml_scalar(raw, "visibility", "org").unwrap();
         assert!(next.contains("visibility: org"));
         assert!(next.contains("collections:"));
         assert!(next.contains("  - name: x"));
+        // A key the file does not have is reported, not silently skipped.
+        assert!(replace_lenient_yaml_scalar(raw, "summary", "x").is_none());
+    }
+
+    /// The manifest has to be readable again afterwards. A value carrying a
+    /// quote used to be wrapped in quotes without escaping, producing
+    /// `summary: "他说"好""` — which no YAML reader accepts.
+    #[test]
+    fn a_value_with_quotes_still_round_trips() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        std::fs::write(
+            root.join(MANIFEST),
+            "version: 1\nsummary: \"\"\nvisibility: private\n",
+        )
+        .unwrap();
+
+        let hostile = "他说\"好\" — a: b #tag \\ end";
+        let reply = manifest_set(root, &json!({ "summary": hostile }));
+        assert!(reply.contains("\"ok\":true"), "{reply}");
+
+        let raw = std::fs::read_to_string(root.join(MANIFEST)).unwrap();
+        let line = raw
+            .lines()
+            .find(|l| l.starts_with("summary:"))
+            .expect("summary line");
+        assert_eq!(
+            read_double_quoted(line.trim_start_matches("summary:").trim()).as_deref(),
+            Some(hostile),
+            "value must survive intact; line was {line}"
+        );
+        // The neighbours are untouched.
+        assert!(raw.contains("visibility: private"), "{raw}");
+        assert!(raw.contains("version: 1"), "{raw}");
+    }
+
+    /// Decode one YAML double-quoted scalar, refusing anything that does not
+    /// terminate cleanly.
+    ///
+    /// No YAML crate is in this tree, and adding one to assert a single line
+    /// would be a strange trade. This reads exactly the shape [`yaml_scalar`]
+    /// writes, which is what needs proving: the old output for a value holding
+    /// a quote — `summary: "他说"好""` — closes after 他说 and leaves `好""`
+    /// dangling, so this returns `None` for it.
+    fn read_double_quoted(text: &str) -> Option<String> {
+        let mut chars = text.chars();
+        if chars.next()? != '"' {
+            return None;
+        }
+        let mut out = String::new();
+        loop {
+            match chars.next()? {
+                '"' => break,
+                '\\' => out.push(match chars.next()? {
+                    'n' => '\n',
+                    'r' => '\r',
+                    't' => '\t',
+                    other => other,
+                }),
+                c => out.push(c),
+            }
+        }
+        // Nothing but a comment may follow the closing quote.
+        let rest = chars.as_str().trim();
+        (rest.is_empty() || rest.starts_with('#')).then_some(out)
+    }
+
+    #[test]
+    fn the_test_reader_rejects_the_old_unescaped_output() {
+        // Guards the guard: if this ever accepts the broken shape, the test
+        // above stops proving anything.
+        assert_eq!(read_double_quoted(r#""plain""#).as_deref(), Some("plain"));
+        assert!(read_double_quoted(r#""他说"好""#).is_none());
+        assert_eq!(
+            read_double_quoted(&yaml_scalar("他说\"好\"")).as_deref(),
+            Some("他说\"好\"")
+        );
+    }
+
+    /// Every requested key must exist, and a miss must leave the file alone —
+    /// a half-applied manifest is worse than a refused one.
+    #[test]
+    fn setting_a_key_the_manifest_lacks_writes_nothing() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        let before = "version: 1\nvisibility: private\n";
+        std::fs::write(root.join(MANIFEST), before).unwrap();
+
+        let reply = manifest_set(root, &json!({ "summary": "新的一句话" }));
+        assert!(reply.contains("unknown_key"), "{reply}");
+        assert_eq!(
+            std::fs::read_to_string(root.join(MANIFEST)).unwrap(),
+            before
+        );
+
+        // And a batch where only one key is missing changes nothing either.
+        let reply = manifest_set(
+            root,
+            &json!({ "visibility": "org", "confirm": true, "title": "t" }),
+        );
+        assert!(reply.contains("unknown_key"), "{reply}");
+        assert_eq!(
+            std::fs::read_to_string(root.join(MANIFEST)).unwrap(),
+            before
+        );
     }
 
     #[test]


### PR DESCRIPTION
#1149 评审第 10 条的两个坑，都在同一个改写函数里，而且**共同点是：工具为一件没发生的事报告了成功**。

## 一、带引号的值会写出读不回来的 YAML

原来只是把值裹进双引号、内容一个字不动。于是 `他说"好"` 被写成：

```yaml
summary: "他说"好""
```

没有任何读取器能接受它 —— 标量在「他说」后就闭合了，剩下 `好""` 悬在那里。**清单从此读不回来，而 `manifest_set` 回的是 `ok`。**

现在加引号时做转义（`\`、`"`、以及控制字符），并且「要不要加引号」的判据也覆盖了**以 YAML 指示符开头**的值 —— 那类字符改变的是「这个值是什么」，不只是「怎么读」。

## 二、清单里没有的键被静默跳过

改写函数匹配不到就原样返回，`manifest_set` 把它写回去、回 `ok`。于是可以对一个**没有 `summary` 行**的清单「设置 summary」，然后从任何地方都看不出没生效。

现在匹配不到返回 `None`，`manifest_set` 整个调用以 `unknown_key` 拒绝、**一个字节都不写** —— 全有或全无，因为半途生效的清单比被拒绝的更糟。MCP manifest 里也告诉了 agent 这条。

## 关于证明第一条的那个测试

「文件还能不能解析」最自然的断言需要一个 YAML 解析器，而**这棵依赖树里没有** —— 在刚把 `rusqlite` 移出去几天之后，为了校验一行再引一个进来是个奇怪的交易。

所以测试改成读回 `yaml_scalar` 写出的那个形状，**并且第二个测试守着这个读取器**：它必须接受普通标量、接受 `yaml_scalar` 对恶意值的输出、而且**必须拒绝旧代码的坏形状**。没有第二个测试的话，第一个可能因为读取器太宽松而白白通过。

## 同一个函数里还有第三个问题，我没在这个 PR 动

模板里的行是带尾注释的：

```yaml
visibility: private  # private | org — 默认仅团队可见 / private by default
```

而改写是**整行替换** —— 改一次 `visibility`，这句解释就没了。清单是给人在 Obsidian 里编辑的，注释就是它的文档。这个留作单独的改动，免得这个 PR 同时讲三件事。

## 验证

`cargo test -p amuxd --bin amuxd`：**1716 passed, 0 failed**（新增 3 条）。

顺带：这个文件的 rustfmt 差异从 main 的 3 处降到 2 处 —— 我重写的那个函数正好包含其中一处。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NSLRgWQJVe4uVJ824WdBdE
