### PR TITLE
test(fc): 篡改签名要改在有效位上 —— 消掉 5% 的假绿

### DIFF
--- a/services/fc/test/agent-management-grant.test.ts
+++ b/services/fc/test/agent-management-grant.test.ts
@@ -41,8 +41,22 @@ test("agent management grant binds requester, target, team and scopes", async ()
       scopes: ["skills:list", "skills:install"],
       nonce: "nonce-1",
     });
+    // Tamper in the middle of the signature, not at its end. An HS256
+    // signature is 32 bytes encoded as 43 base64url characters, and the last
+    // character carries only 4 significant bits — the rest are padding the
+    // decoder throws away. `grant.slice(0, -1) + "x"` therefore decodes to the
+    // *same* 32 bytes whenever that character happened to be `w`, the
+    // signature still verifies, and this rejection never happens. That is
+    // about 5% of runs, one for every `w`.
+    const [header, payload, signature] = grant.split(".");
+    const at = Math.floor(signature.length / 2);
+    const tampered =
+      signature.slice(0, at) +
+      (signature[at] === "A" ? "B" : "A") +
+      signature.slice(at + 1);
+    assert.notEqual(tampered, signature, "the tamper must change something");
     await assert.rejects(
-      verifyAgentManagementGrant(`${grant.slice(0, -1)}x`),
+      verifyAgentManagementGrant(`${header}.${payload}.${tampered}`),
       /invalid or expired/,
     );
   } finally {


### PR DESCRIPTION
`agent-management-grant.test.ts` 断言「被篡改的 grant 会被拒绝」，而它的篡改方式是 `${grant.slice(0, -1)}x` —— **大约每二十次里有一次，这个篡改什么都没改**。

## 机制

HS256 签名是 32 字节，base64url 编成 43 个字符。**最后一个字符只承载 4 个有效 bit**，其余是解码时被丢弃的 padding。所以当末位恰好是 `w` 时，把它换成 `x` 解码出的仍是同样的 32 字节 —— 签名照常验过，这个测试存在的意义（那次 rejection）根本没发生。

## 实测（对真实签名器采样 300 次）

```
旧写法篡改后仍然验过:  15  (5.0%)
签名末位是 'w' 的次数:  15
```

两个数字相同，因为**就是同一批 15 个 grant**。

## 改法与验证

改成在签名**中间**篡改 —— 那里六个 bit 全部有效 —— 并且替换字符总是与原字符不同（还加了一条 `assert.notEqual` 兜底）。同样 300 次采样：

```
新写法篡改后仍然验过:  0
```

## 一点说明

我先按老办法「跑很多次看它红」验证 —— 旧写法跑 40 次**一次都没红**（5% 的话出 0 次的概率约 13%）。碰运气不算证据，所以改成直接测机制，才得到上面那组数。

另外这套测试**没有 CI job** —— `services/fc` 不在 pnpm workspace 里，`ci.yml` 也从不跑它 —— 所以这 5% 一直只由本地跑测试的人承担，这也是它活到今天的原因。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NSLRgWQJVe4uVJ824WdBdE
