### PR TITLE
fix(daemon): lazy team-skill refresh and skip-not-queue prewarm

### DIFF
--- a/apps/daemon/src/daemon/server.rs
+++ b/apps/daemon/src/daemon/server.rs
@@ -1356,15 +1356,17 @@ impl DaemonServer {
         // loop reads the registry live via `snapshot()`, so upserting here takes
         // effect on the next tick without a restart.
         if let Some(registry) = self.refresh_watch_registry.clone() {
+            let team_id = self.backend.team_id().to_string();
             let workspaces = self.cloud_workspace_list().await;
             tokio::spawn(async move {
                 for workspace in workspaces {
                     registry
                         .upsert_workspace(
-                            crate::runtime::refresh::refresh_watch::WatchedWorkspace {
-                                workspace_id: workspace.workspace_id,
-                                workspace_path: PathBuf::from(&workspace.path),
-                            },
+                            crate::runtime::refresh::refresh_watch::WatchedWorkspace::new(
+                                workspace.workspace_id,
+                                PathBuf::from(&workspace.path),
+                                Some(team_id.as_str()),
+                            ),
                         )
                         .await;
                 }

--- a/apps/daemon/src/daemon/server/peers_workspaces.rs
+++ b/apps/daemon/src/daemon/server/peers_workspaces.rs
@@ -313,11 +313,19 @@ impl DaemonServer {
             }
         }
         if let Some(registry) = self.refresh_watch_registry.as_ref() {
+            let watch_team_id = if remote.team_id.trim().is_empty() {
+                team_id
+            } else {
+                remote.team_id.as_str()
+            };
             registry
-                .upsert_workspace(crate::runtime::refresh::refresh_watch::WatchedWorkspace {
-                    workspace_id: remote.id.clone(),
-                    workspace_path: canonical.clone(),
-                })
+                .upsert_workspace(
+                    crate::runtime::refresh::refresh_watch::WatchedWorkspace::new(
+                        remote.id.clone(),
+                        canonical.clone(),
+                        Some(watch_team_id),
+                    ),
+                )
                 .await;
         }
         info!(workspace_id = %remote.id, path = %canonical_str, "workspace added");

--- a/apps/daemon/src/daemon/server/runtime_lifecycle.rs
+++ b/apps/daemon/src/daemon/server/runtime_lifecycle.rs
@@ -249,10 +249,13 @@ impl DaemonServer {
                 ws_id.clone()
             };
             registry
-                .upsert_workspace(crate::runtime::refresh::refresh_watch::WatchedWorkspace {
-                    workspace_id: refresh_workspace_id,
-                    workspace_path: PathBuf::from(&resolved_worktree),
-                })
+                .upsert_workspace(
+                    crate::runtime::refresh::refresh_watch::WatchedWorkspace::new(
+                        refresh_workspace_id,
+                        PathBuf::from(&resolved_worktree),
+                        Some(team_id.as_str()),
+                    ),
+                )
                 .await;
         }
 

--- a/apps/daemon/src/runtime/manager.rs
+++ b/apps/daemon/src/runtime/manager.rs
@@ -207,6 +207,7 @@ mod opencode_snapshot;
 mod lookup;
 // Workspace-scoped runtime queries (active handles / stop-all for a workspace).
 mod workspace_query;
+pub use workspace_query::WorkspaceOccupancy;
 // Idle-runtime eviction (idle sweeper + drain buffer).
 mod eviction;
 // ACP event draining (poll_events / poll_events_for).

--- a/apps/daemon/src/runtime/manager/workspace_query.rs
+++ b/apps/daemon/src/runtime/manager/workspace_query.rs
@@ -12,6 +12,21 @@ use crate::runtime::handle::RuntimeHandle;
 
 use super::RuntimeManager;
 
+/// Whether a workspace currently has a live runtime, and whether that runtime
+/// is mid-turn. Used by the skills-refresh auto-applier to decide whether a
+/// pending change can dispose the cached OpenCode instance now, or must wait.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum WorkspaceOccupancy {
+    /// A runtime in this workspace is currently executing a turn.
+    Active,
+    /// At least one live runtime, none of them mid-turn.
+    WarmIdle,
+    /// No live runtime for this workspace.
+    Cold,
+    /// Occupancy could not be confirmed; keep pending rather than guessing.
+    Unknown,
+}
+
 impl RuntimeManager {
     fn workspace_runtime_matches(
         handle: &RuntimeHandle,
@@ -51,6 +66,24 @@ impl RuntimeManager {
             Self::workspace_runtime_matches(handle, workspace_path, workspace_id)
                 && (matches!(handle.status, amux::AgentStatus::Active) || handle.event_rx.is_none())
         })
+    }
+
+    pub fn workspace_occupancy(
+        &self,
+        workspace_path: &str,
+        workspace_id: &str,
+    ) -> WorkspaceOccupancy {
+        if self.workspace_has_active_turn(workspace_path, workspace_id) {
+            WorkspaceOccupancy::Active
+        } else if self
+            .active_handles_for_workspace(workspace_path, workspace_id)
+            .next()
+            .is_some()
+        {
+            WorkspaceOccupancy::WarmIdle
+        } else {
+            WorkspaceOccupancy::Cold
+        }
     }
 
     /// Resolution snapshot from any live runtime in this workspace.
@@ -174,5 +207,30 @@ mod tests {
         assert!(ids.iter().any(|id| id == "active-target"));
         assert!(ids.iter().any(|id| id == "checked-out-target"));
         assert!(ids.iter().any(|id| id == "idle-other"));
+    }
+
+    #[test]
+    fn occupancy_distinguishes_active_warm_idle_and_cold() {
+        let mut manager = RuntimeManager::new(RuntimeManager::test_launch_configs(), None);
+        manager.add_test_workspace_runtime(
+            "busy",
+            "/tmp/active",
+            "ws-active",
+            amux::AgentStatus::Active,
+        );
+        manager.add_test_workspace_runtime("idle", "/tmp/idle", "ws-idle", amux::AgentStatus::Idle);
+
+        assert_eq!(
+            manager.workspace_occupancy("/tmp/active", "ws-active"),
+            WorkspaceOccupancy::Active
+        );
+        assert_eq!(
+            manager.workspace_occupancy("/tmp/idle", "ws-idle"),
+            WorkspaceOccupancy::WarmIdle
+        );
+        assert_eq!(
+            manager.workspace_occupancy("/tmp/missing", "ws-missing"),
+            WorkspaceOccupancy::Cold
+        );
     }
 }

--- a/apps/daemon/src/runtime/mod.rs
+++ b/apps/daemon/src/runtime/mod.rs
@@ -51,7 +51,7 @@ pub use instruction_delivery::{
 };
 pub use manager::{
     is_gateway_workspace_id, restore_gateway_shape_for_resume, AgentLaunchConfig, CheckedOutTurn,
-    RuntimeManager, SpawnRuntimeEnv,
+    RuntimeManager, SpawnRuntimeEnv, WorkspaceOccupancy,
 };
 pub use permission_policy::PermissionPolicy;
 // Kept importable for external callers/tests even though in-crate code now

--- a/apps/daemon/src/runtime/opencode_http/host_pool.rs
+++ b/apps/daemon/src/runtime/opencode_http/host_pool.rs
@@ -15,6 +15,27 @@ const HOST_IDLE_TTL: Duration = Duration::from_secs(300);
 const HOST_SOFT_LIMIT: usize = 2;
 const HOST_HARD_LIMIT: usize = 3;
 
+/// Why a caller is taking a host slot. Prewarm must never wait in the
+/// capacity queue or consume the hard-limit spare; user runtimes and
+/// replacements may.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum HostAcquireClass {
+    UserRuntime,
+    /// Rolling replacement of a live generation (PR3 draining self-heal).
+    #[allow(dead_code)]
+    Replacement,
+    Prewarm,
+}
+
+#[derive(Debug)]
+pub enum PrewarmOutcome {
+    Reused(HostLease),
+    Started(HostLease),
+    SkippedCapacity,
+    SkippedDemandQueued,
+    SkippedDraining,
+}
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq, serde::Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum HostLifecycle {
@@ -35,7 +56,8 @@ pub struct HostGeneration {
     pub(crate) sse_tasks: parking_lot::Mutex<HashMap<String, tokio::task::JoinHandle<()>>>,
     pub(crate) reconcile_tasks: parking_lot::Mutex<Vec<tokio::task::JoinHandle<()>>>,
     pub(crate) sse_transport: parking_lot::Mutex<HashMap<String, SseTransportState>>,
-    context_service: parking_lot::RwLock<Option<Arc<crate::runtime::context_service::RuntimeContextService>>>,
+    context_service:
+        parking_lot::RwLock<Option<Arc<crate::runtime::context_service::RuntimeContextService>>>,
     lifecycle: parking_lot::RwLock<HostLifecycle>,
     route_count: AtomicUsize,
     idle_since: parking_lot::Mutex<Option<Instant>>,
@@ -73,7 +95,9 @@ impl HostGeneration {
         *self.lifecycle.read()
     }
 
-    pub(crate) fn context_service(&self) -> Option<Arc<crate::runtime::context_service::RuntimeContextService>> {
+    pub(crate) fn context_service(
+        &self,
+    ) -> Option<Arc<crate::runtime::context_service::RuntimeContextService>> {
         self.context_service.read().clone()
     }
 
@@ -268,7 +292,8 @@ pub trait GenerationFactory: Send + Sync {
 pub struct SupervisorGenerationFactory {
     registry: Arc<ServeProcessRegistry>,
     binary_hint: parking_lot::RwLock<Option<String>>,
-    context_service: parking_lot::RwLock<Option<Arc<crate::runtime::context_service::RuntimeContextService>>>,
+    context_service:
+        parking_lot::RwLock<Option<Arc<crate::runtime::context_service::RuntimeContextService>>>,
 }
 
 impl SupervisorGenerationFactory {
@@ -304,7 +329,9 @@ impl GenerationFactory for SupervisorGenerationFactory {
         mut env: HashMap<String, String>,
     ) -> Result<Arc<ServeSupervisor>, String> {
         if let Some(service) = self.context_service.read().as_ref() {
-            env.extend(service.env_for_generation(crate::proto::amux::AgentType::Opencode, &generation_id));
+            env.extend(
+                service.env_for_generation(crate::proto::amux::AgentType::Opencode, &generation_id),
+            );
         }
         let serve = Arc::new(ServeSupervisor::new(
             generation_id,
@@ -374,6 +401,11 @@ enum CapacityReservation<'a> {
     Reused(HostLease),
 }
 
+enum ActivationOutcome {
+    Reused(HostLease),
+    Started(HostLease),
+}
+
 impl CapacityPermit<'_> {
     fn commit(&mut self) {
         self.committed = true;
@@ -405,7 +437,8 @@ impl Drop for QueueTicket<'_> {
 
 pub struct OpenCodeHostPool {
     factory: Arc<dyn GenerationFactory>,
-    context_service: parking_lot::RwLock<Option<Arc<crate::runtime::context_service::RuntimeContextService>>>,
+    context_service:
+        parking_lot::RwLock<Option<Arc<crate::runtime::context_service::RuntimeContextService>>>,
     domains: parking_lot::Mutex<HashMap<IsolationDomainKey, Arc<DomainSlot>>>,
     capacity: parking_lot::Mutex<CapacityState>,
     capacity_changed: tokio::sync::Notify,
@@ -443,6 +476,7 @@ impl OpenCodeHostPool {
         env: HashMap<String, String>,
         deadline: Instant,
     ) -> Result<HostLease, HostPoolError> {
+        let _class = HostAcquireClass::UserRuntime;
         let slot = self.slot_for(&domain);
         let protected_idle_generation = {
             let _activation = slot.activation_lock.lock().await;
@@ -491,10 +525,77 @@ impl OpenCodeHostPool {
             }
             Err(error) => return Err(error),
         };
-        let mut capacity_permit = match capacity_reservation {
+        let capacity_permit = match capacity_reservation {
             CapacityReservation::Permit(permit) => permit,
             CapacityReservation::Reused(lease) => return Ok(lease),
         };
+        match self
+            .activate_generation(slot, domain, revision, env, capacity_permit)
+            .await?
+        {
+            ActivationOutcome::Reused(lease) | ActivationOutcome::Started(lease) => Ok(lease),
+        }
+    }
+
+    pub async fn try_prewarm(
+        &self,
+        domain: IsolationDomainKey,
+        revision: ProcessEnvRevision,
+        env: HashMap<String, String>,
+    ) -> Result<PrewarmOutcome, HostPoolError> {
+        let _class = HostAcquireClass::Prewarm;
+        let slot = self.slot_for(&domain);
+        {
+            let _activation = slot.activation_lock.lock().await;
+            let mut state = slot.state.lock();
+            state.requested_revision = Some(revision.clone());
+            if let Some(current) = state.current.clone() {
+                if current.process_env_revision == revision
+                    && current.lifecycle() == HostLifecycle::Ready
+                    && !state.replacement_requested
+                {
+                    state.last_error = None;
+                    return Ok(PrewarmOutcome::Reused(current.reserve_route(self)));
+                }
+            }
+        }
+
+        if self.capacity_counts().1 > 0 {
+            return Ok(PrewarmOutcome::SkippedDraining);
+        }
+        let capacity_permit = {
+            let mut capacity = self.capacity.lock();
+            if !capacity.queue.is_empty() {
+                return Ok(PrewarmOutcome::SkippedDemandQueued);
+            }
+            if capacity.active >= HOST_SOFT_LIMIT {
+                return Ok(PrewarmOutcome::SkippedCapacity);
+            }
+            capacity.active += 1;
+            CapacityPermit {
+                pool: self,
+                committed: false,
+            }
+        };
+
+        match self
+            .activate_generation(slot, domain, revision, env, capacity_permit)
+            .await
+        {
+            Ok(ActivationOutcome::Reused(lease)) => Ok(PrewarmOutcome::Reused(lease)),
+            Ok(ActivationOutcome::Started(lease)) => Ok(PrewarmOutcome::Started(lease)),
+            Err(error) => Err(error),
+        }
+    }
+
+    async fn activate_generation(
+        &self,
+        slot: Arc<DomainSlot>,
+        domain: IsolationDomainKey,
+        revision: ProcessEnvRevision,
+        env: HashMap<String, String>,
+        mut capacity_permit: CapacityPermit<'_>,
+    ) -> Result<ActivationOutcome, HostPoolError> {
         let _activation = slot.activation_lock.lock().await;
         {
             let mut state = slot.state.lock();
@@ -505,7 +606,7 @@ impl OpenCodeHostPool {
                     && !state.replacement_requested
                 {
                     state.last_error = None;
-                    return Ok(current.reserve_route(self));
+                    return Ok(ActivationOutcome::Reused(current.reserve_route(self)));
                 }
             }
         }
@@ -557,7 +658,7 @@ impl OpenCodeHostPool {
             }
         }
         capacity_permit.commit();
-        Ok(generation.reserve_route(self))
+        Ok(ActivationOutcome::Started(generation.reserve_route(self)))
     }
 
     async fn reserve_capacity(
@@ -721,7 +822,10 @@ impl OpenCodeHostPool {
         let sse_directories = generation.abort_sse_tasks();
         generation.abort_reconcile_tasks();
         if let Some(service) = generation.context_service() {
-            service.clear_generation(crate::proto::amux::AgentType::Opencode, &generation.generation_id);
+            service.clear_generation(
+                crate::proto::amux::AgentType::Opencode,
+                &generation.generation_id,
+            );
         }
         match self.factory.stop(generation) {
             ShutdownOutcome::Idle | ShutdownOutcome::Stopped => {
@@ -884,10 +988,7 @@ impl OpenCodeHostPool {
     ///
     /// A dispose that fails on the wire propagates as `Err` so callers can
     /// retry instead of silently leaving a stale instance cache behind.
-    pub async fn dispose_workspace_instance(
-        &self,
-        directory: &str,
-    ) -> crate::error::Result<usize> {
+    pub async fn dispose_workspace_instance(&self, directory: &str) -> crate::error::Result<usize> {
         let generations: Vec<Arc<HostGeneration>> = {
             let domains = self.domains.lock();
             domains
@@ -2020,5 +2121,119 @@ mod tests {
         pool.dispose_workspace_instance("/tmp/ws-a")
             .await
             .expect_err("a failed dispose must surface so the caller retries");
+    }
+
+    #[tokio::test]
+    async fn prewarm_reuses_ready_generation_without_starting() {
+        let factory = FakeGenerationFactory::new();
+        let pool = OpenCodeHostPool::new(factory.clone());
+        let lease = pool
+            .acquire(domain("a"), revision("1"), HashMap::new(), deadline())
+            .await
+            .unwrap();
+
+        let outcome = pool
+            .try_prewarm(domain("a"), revision("1"), HashMap::new())
+            .await
+            .unwrap();
+        assert!(matches!(outcome, PrewarmOutcome::Reused(_)));
+        assert_eq!(factory.start_count(), 1);
+        drop(lease);
+    }
+
+    #[tokio::test]
+    async fn prewarm_does_not_use_hard_limit_slot() {
+        let factory = FakeGenerationFactory::new();
+        let pool = OpenCodeHostPool::new(factory.clone());
+        let _a = pool
+            .acquire(domain("a"), revision("1"), HashMap::new(), deadline())
+            .await
+            .unwrap();
+        let _b = pool
+            .acquire(domain("b"), revision("1"), HashMap::new(), deadline())
+            .await
+            .unwrap();
+
+        let outcome = pool
+            .try_prewarm(domain("c"), revision("1"), HashMap::new())
+            .await
+            .unwrap();
+        assert!(matches!(outcome, PrewarmOutcome::SkippedCapacity));
+        assert_eq!(factory.start_count(), 2);
+
+        let user = pool
+            .acquire(domain("c"), revision("1"), HashMap::new(), deadline())
+            .await
+            .unwrap();
+        assert_eq!(factory.start_count(), 3);
+        drop(user);
+    }
+
+    #[tokio::test]
+    async fn prewarm_does_not_queue_ahead_of_user_acquire() {
+        let factory = FakeGenerationFactory::new();
+        let pool = OpenCodeHostPool::new(factory.clone());
+        let a = pool
+            .acquire(domain("a"), revision("1"), HashMap::new(), deadline())
+            .await
+            .unwrap();
+        let _b = pool
+            .acquire(domain("b"), revision("1"), HashMap::new(), deadline())
+            .await
+            .unwrap();
+        let _c = pool
+            .acquire(domain("c"), revision("1"), HashMap::new(), deadline())
+            .await
+            .unwrap();
+
+        let waiting_pool = Arc::clone(&pool);
+        let waiting = tokio::spawn(async move {
+            waiting_pool
+                .acquire(domain("d"), revision("1"), HashMap::new(), deadline())
+                .await
+        });
+        wait_for_queue(&pool, &domain("d"), 1).await;
+
+        let outcome = pool
+            .try_prewarm(domain("e"), revision("1"), HashMap::new())
+            .await
+            .unwrap();
+        assert!(matches!(outcome, PrewarmOutcome::SkippedDemandQueued));
+        assert_eq!(factory.start_count(), 3);
+        assert_eq!(pool.stats_for(&domain("e")).queued_acquisitions, 0);
+
+        drop(a);
+        let user = tokio::time::timeout(Duration::from_secs(2), waiting)
+            .await
+            .expect("user acquire must not wait behind a prewarm")
+            .unwrap()
+            .unwrap();
+        assert_eq!(factory.start_count(), 4);
+        drop(user);
+    }
+
+    #[tokio::test]
+    async fn prewarm_skips_when_a_generation_is_draining() {
+        let factory = FakeGenerationFactory::new();
+        let pool = OpenCodeHostPool::new(factory.clone());
+        let old = pool
+            .acquire(domain("a"), revision("1"), HashMap::new(), deadline())
+            .await
+            .unwrap();
+        let replacement = pool
+            .acquire(domain("a"), revision("2"), HashMap::new(), deadline())
+            .await
+            .unwrap();
+        assert_eq!(old.generation.lifecycle(), HostLifecycle::Draining);
+        assert_eq!(pool.stats_for(&domain("a")).draining_generations, 1);
+
+        let outcome = pool
+            .try_prewarm(domain("b"), revision("1"), HashMap::new())
+            .await
+            .unwrap();
+        assert!(matches!(outcome, PrewarmOutcome::SkippedDraining));
+        assert_eq!(factory.start_count(), 2);
+        drop(old);
+        drop(replacement);
     }
 }

--- a/apps/daemon/src/runtime/opencode_http/mod.rs
+++ b/apps/daemon/src/runtime/opencode_http/mod.rs
@@ -28,7 +28,9 @@ pub mod translate;
 pub use envelope::*;
 
 use client::{PromptBody, PromptPart};
-use host_pool::{HostGeneration, HostPoolError, OpenCodeHostPool, SupervisorGenerationFactory};
+use host_pool::{
+    HostGeneration, HostPoolError, OpenCodeHostPool, PrewarmOutcome, SupervisorGenerationFactory,
+};
 use supervisor::ServeSupervisor;
 use translate::TranslateState;
 
@@ -440,17 +442,19 @@ impl OpencodeHost {
         self.apply_binary_hint(launch_configs);
         match self
             .pool
-            .acquire(
-                isolation_domain.clone(),
-                process_env_revision,
-                extra_env,
-                std::time::Instant::now() + std::time::Duration::from_secs(30),
-            )
+            .try_prewarm(isolation_domain.clone(), process_env_revision, extra_env)
             .await
         {
-            Ok(lease) => {
+            Ok(PrewarmOutcome::Reused(lease) | PrewarmOutcome::Started(lease)) => {
                 events::ensure_sse_task(&lease.generation, &canonical_dir(worktree));
                 info!(?isolation_domain, "workspace opencode host prewarmed");
+            }
+            Ok(
+                PrewarmOutcome::SkippedCapacity
+                | PrewarmOutcome::SkippedDemandQueued
+                | PrewarmOutcome::SkippedDraining,
+            ) => {
+                info!(?isolation_domain, "workspace opencode host prewarm skipped");
             }
             Err(error) => {
                 warn!(?isolation_domain, %error, "workspace opencode host prewarm failed");

--- a/apps/daemon/src/runtime/refresh.rs
+++ b/apps/daemon/src/runtime/refresh.rs
@@ -114,6 +114,7 @@ pub enum RefreshSource {
     UiMutation,
     FilesystemWatch,
     StartupRescan,
+    TeamSkillReconcile,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, Hash)]

--- a/apps/daemon/src/runtime/refresh_watch.rs
+++ b/apps/daemon/src/runtime/refresh_watch.rs
@@ -67,6 +67,27 @@ const WATCH_DEBOUNCE_WINDOW: Duration = Duration::from_millis(250);
 pub struct WatchedWorkspace {
     pub workspace_id: String,
     pub workspace_path: PathBuf,
+    /// Team that owns this workspace. `None` when membership is unknown —
+    /// filesystem watches still apply, but team Skill reconcile must not
+    /// fan out to it.
+    pub team_id: Option<String>,
+}
+
+impl WatchedWorkspace {
+    pub fn new(
+        workspace_id: impl Into<String>,
+        workspace_path: PathBuf,
+        team_id: Option<&str>,
+    ) -> Self {
+        Self {
+            workspace_id: workspace_id.into(),
+            workspace_path,
+            team_id: team_id.and_then(|id| {
+                let trimmed = id.trim();
+                (!trimmed.is_empty()).then(|| trimmed.to_string())
+            }),
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -114,6 +135,16 @@ impl RefreshWatchRegistry {
 
     pub(crate) async fn snapshot(&self) -> Vec<WatchedWorkspace> {
         self.workspaces.read().await.values().cloned().collect()
+    }
+
+    pub async fn snapshot_for_team(&self, team_id: &str) -> Vec<WatchedWorkspace> {
+        self.workspaces
+            .read()
+            .await
+            .values()
+            .filter(|workspace| workspace.team_id.as_deref() == Some(team_id))
+            .cloned()
+            .collect()
     }
 
     #[cfg(test)]
@@ -499,10 +530,7 @@ mod tests {
     use tokio::sync::Mutex as AsyncMutex;
 
     fn watched_workspace(id: &str, path: &str) -> WatchedWorkspace {
-        WatchedWorkspace {
-            workspace_id: id.to_string(),
-            workspace_path: PathBuf::from(path),
-        }
+        WatchedWorkspace::new(id, PathBuf::from(path), None)
     }
 
     #[test]
@@ -588,10 +616,7 @@ mod tests {
         std::fs::create_dir_all(shared_skills.join("multiply-add")).unwrap();
         std::os::unix::fs::symlink(&shared_team, workspace.join(TEAM_LINK_NAME)).unwrap();
 
-        let workspaces = vec![WatchedWorkspace {
-            workspace_id: "ws-symlink".to_string(),
-            workspace_path: workspace.clone(),
-        }];
+        let workspaces = vec![WatchedWorkspace::new("ws-symlink", workspace.clone(), None)];
         let canonical_skills = std::fs::canonicalize(&shared_skills).unwrap();
         let roots = watch_roots(&workspaces, None);
         assert!(roots.iter().any(|root| root.path == canonical_skills));
@@ -658,10 +683,11 @@ mod tests {
     async fn watcher_state_surfaces_through_runtime_status_with_http_workspace_id() {
         let dir = tempfile::tempdir().unwrap();
         let workspace_id = workspace_runtime_id(dir.path());
-        let workspaces = vec![WatchedWorkspace {
-            workspace_id: workspace_id.clone(),
-            workspace_path: dir.path().to_path_buf(),
-        }];
+        let workspaces = vec![WatchedWorkspace::new(
+            workspace_id.clone(),
+            dir.path().to_path_buf(),
+            None,
+        )];
         let manager = RuntimeManager::new(RuntimeManager::default_launch_configs(), None);
         let supervisor = RuntimeSupervisor::new(Arc::new(AsyncMutex::new(manager)));
         let mut debounce = RefreshDebounce::new(Duration::from_millis(250));
@@ -709,10 +735,11 @@ mod tests {
             ))),
             pool.clone(),
         );
-        let workspaces = vec![WatchedWorkspace {
-            workspace_id: workspace_id.clone(),
-            workspace_path: dir.path().to_path_buf(),
-        }];
+        let workspaces = vec![WatchedWorkspace::new(
+            workspace_id.clone(),
+            dir.path().to_path_buf(),
+            None,
+        )];
         let mut debounce = RefreshDebounce::new(Duration::from_millis(250));
 
         record_classified_changes(
@@ -752,10 +779,11 @@ mod tests {
         let coordinator = RuntimeRefreshCoordinator::new();
         let dir = tempfile::tempdir().unwrap();
         let workspace_id = workspace_runtime_id(dir.path());
-        let workspaces = vec![WatchedWorkspace {
-            workspace_id: workspace_id.clone(),
-            workspace_path: dir.path().to_path_buf(),
-        }];
+        let workspaces = vec![WatchedWorkspace::new(
+            workspace_id.clone(),
+            dir.path().to_path_buf(),
+            None,
+        )];
         let mut debounce = RefreshDebounce::new(Duration::from_millis(250));
 
         coordinator.suppress_workspace_watch(
@@ -793,10 +821,11 @@ mod tests {
     async fn suppress_after_await_covers_opencode_write_unlike_suppress_before_await() {
         let dir = tempfile::tempdir().unwrap();
         let workspace_id = workspace_runtime_id(dir.path());
-        let workspaces = vec![WatchedWorkspace {
-            workspace_id: workspace_id.clone(),
-            workspace_path: dir.path().to_path_buf(),
-        }];
+        let workspaces = vec![WatchedWorkspace::new(
+            workspace_id.clone(),
+            dir.path().to_path_buf(),
+            None,
+        )];
         let opencode = dir.path().join("opencode.json");
         let content = r#"{"$schema":"https://opencode.ai/config.json"}"#;
 
@@ -885,6 +914,28 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn snapshot_for_team_keeps_matching_and_skips_unknown() {
+        let registry = RefreshWatchRegistry::new(vec![
+            WatchedWorkspace::new("ws-1", PathBuf::from("/tmp/ws-1"), Some("team-1")),
+            WatchedWorkspace::new("ws-2", PathBuf::from("/tmp/ws-2"), Some("team-2")),
+            WatchedWorkspace::new("ws-unknown", PathBuf::from("/tmp/unknown"), None),
+        ]);
+
+        let mut team_1 = registry.snapshot_for_team("team-1").await;
+        team_1.sort_by(|a, b| a.workspace_id.cmp(&b.workspace_id));
+        assert_eq!(
+            team_1
+                .iter()
+                .map(|workspace| workspace.workspace_id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["ws-1"]
+        );
+
+        assert!(registry.snapshot_for_team("team-missing").await.is_empty());
+        assert_eq!(registry.snapshot().await.len(), 3);
+    }
+
     #[test]
     fn desired_targets_map_existing_dirs_and_skip_missing() {
         let dir = tempfile::tempdir().unwrap();
@@ -892,10 +943,7 @@ mod tests {
         // Only this recursive skill root exists; the other skill/_secrets roots do not.
         std::fs::create_dir_all(ws.join(".claude/skills")).unwrap();
 
-        let workspaces = vec![WatchedWorkspace {
-            workspace_id: "ws-1".to_string(),
-            workspace_path: ws.to_path_buf(),
-        }];
+        let workspaces = vec![WatchedWorkspace::new("ws-1", ws.to_path_buf(), None)];
 
         let targets = desired_watch_targets(&workspaces, None);
 

--- a/apps/daemon/src/runtime/supervisor.rs
+++ b/apps/daemon/src/runtime/supervisor.rs
@@ -4,6 +4,7 @@
 //! here before agent spawn, and `/v1/workspaces/:id/runtime/*` handlers
 //! delegate reload/status to the shared `RuntimeManager`.
 
+use std::collections::HashMap;
 use std::path::{Component, Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
@@ -18,6 +19,7 @@ use tracing::{info, warn};
 pub(crate) const INTROSPECT_API_PORT: u16 = 13144;
 const TEAM_SKILLS_PATH: &str = "teamclu-team/skills";
 const REMOTE_TOOLS_MCP_SERVER_NAME: &str = "amuxd-remote-tools";
+const MAX_AUTO_SKILL_REFRESHES_PER_TICK: usize = 1;
 
 /// Inherent MCP servers that older builds wrote into workspace configs under a
 /// name this build no longer maintains. Removed on sight — see the call site.
@@ -44,10 +46,10 @@ use crate::config::workspace_control::{
 use crate::proto::amux;
 use crate::runtime::{
     refresh::{
-        RefreshChangeKind, RuntimeRefreshCoordinator, WorkspaceRefreshState,
+        RefreshChangeKind, RefreshSource, RuntimeRefreshCoordinator, WorkspaceRefreshState,
         APPLY_REFRESH_SUPPRESS, INTERNAL_PREPARE_KINDS, INTERNAL_WRITE_SUPPRESS,
     },
-    AgentLaunchConfig, RuntimeManager,
+    AgentLaunchConfig, RuntimeManager, WorkspaceOccupancy,
 };
 
 struct InherentSkill {
@@ -1036,20 +1038,26 @@ pub async fn prewarm_workspace_domains(
     pool: Arc<crate::runtime::opencode_http::host_pool::OpenCodeHostPool>,
     workspaces: Vec<(String, std::collections::HashMap<String, String>)>,
 ) {
-    for (workspace_id, env) in workspaces.into_iter().take(2) {
+    use crate::runtime::opencode_http::host_pool::PrewarmOutcome;
+
+    for (workspace_id, env) in workspaces {
         let domain =
             crate::runtime::execution_context::IsolationDomainKey::Workspace(workspace_id.clone());
         let revision = crate::runtime::execution_context::ProcessEnvRevision::from_bindings(&env);
-        if let Err(error) = pool
-            .acquire(
-                domain,
-                revision,
-                env,
-                std::time::Instant::now() + Duration::from_secs(30),
-            )
-            .await
-        {
-            warn!(workspace_id, %error, "workspace host prewarm failed");
+        match pool.try_prewarm(domain, revision, env).await {
+            Ok(PrewarmOutcome::Reused(_) | PrewarmOutcome::Started(_)) => {}
+            Ok(
+                PrewarmOutcome::SkippedCapacity
+                | PrewarmOutcome::SkippedDemandQueued
+                | PrewarmOutcome::SkippedDraining,
+            ) => {
+                info!(workspace_id, "workspace host prewarm skipped");
+                break;
+            }
+            Err(error) => {
+                warn!(workspace_id, %error, "workspace host prewarm failed");
+                break;
+            }
         }
     }
 }
@@ -1064,6 +1072,9 @@ pub struct RuntimeSupervisor {
     /// evicted hosts off the critical path. Without this, the first session
     /// after a provider/env change always paid the full cold start.
     prewarm_notify: parking_lot::Mutex<Option<tokio::sync::mpsc::Sender<(String, String)>>>,
+    /// Serializes Skills auto-apply, attach barrier, and manual apply for one
+    /// workspace so concurrent callers re-read the latest pending state.
+    refresh_apply_locks: parking_lot::Mutex<HashMap<String, Arc<tokio::sync::Mutex<()>>>>,
 }
 
 impl RuntimeSupervisor {
@@ -1074,6 +1085,7 @@ impl RuntimeSupervisor {
             host_pool: None,
             context_resolver: None,
             prewarm_notify: parking_lot::Mutex::new(None),
+            refresh_apply_locks: parking_lot::Mutex::new(HashMap::new()),
         })
     }
 
@@ -1087,6 +1099,7 @@ impl RuntimeSupervisor {
             host_pool: Some(host_pool),
             context_resolver: None,
             prewarm_notify: parking_lot::Mutex::new(None),
+            refresh_apply_locks: parking_lot::Mutex::new(HashMap::new()),
         })
     }
 
@@ -1101,6 +1114,7 @@ impl RuntimeSupervisor {
             host_pool: Some(host_pool),
             context_resolver: Some(context_resolver),
             prewarm_notify: parking_lot::Mutex::new(None),
+            refresh_apply_locks: parking_lot::Mutex::new(HashMap::new()),
         })
     }
 
@@ -1775,8 +1789,93 @@ impl RuntimeSupervisor {
 
     pub async fn auto_apply_pending_refreshes(&self) -> usize {
         let pending = self.refresh.pending_workspace_states().await;
+        let occupancy_by_id = {
+            let manager = self.agents.lock().await;
+            pending
+                .iter()
+                .map(|state| {
+                    (
+                        state.workspace_id.clone(),
+                        manager.workspace_occupancy(&state.workspace_path, &state.workspace_id),
+                    )
+                })
+                .collect::<HashMap<_, _>>()
+        };
+
+        for state in &pending {
+            if !auto_applicable_refresh(state) {
+                self.refresh
+                    .set_auto_apply_blocked_by_active_runtime(&state.workspace_id, false)
+                    .await;
+                continue;
+            }
+            let occupancy = occupancy_by_id
+                .get(&state.workspace_id)
+                .copied()
+                .unwrap_or(WorkspaceOccupancy::Unknown);
+            match occupancy {
+                WorkspaceOccupancy::Active => {
+                    self.refresh
+                        .set_auto_apply_blocked_by_active_runtime(&state.workspace_id, true)
+                        .await;
+                    info!(
+                        workspace_id = %state.workspace_id,
+                        workspace_path = %state.workspace_path,
+                        change_kinds = ?state.change_kinds,
+                        "team_skill_refresh_deferred_active_turn"
+                    );
+                }
+                WorkspaceOccupancy::Cold if team_skill_reconcile_only(state) => {
+                    info!(
+                        workspace_id = %state.workspace_id,
+                        workspace_path = %state.workspace_path,
+                        "team_skill_refresh_deferred_cold"
+                    );
+                }
+                WorkspaceOccupancy::Unknown => {
+                    info!(
+                        workspace_id = %state.workspace_id,
+                        workspace_path = %state.workspace_path,
+                        "team_skill_refresh_deferred_unknown_occupancy"
+                    );
+                }
+                _ => {}
+            }
+        }
+
+        let mut candidates: Vec<WorkspaceRefreshState> = pending
+            .into_iter()
+            .filter(|state| {
+                auto_applicable_refresh(state)
+                    && auto_apply_candidate(
+                        occupancy_by_id
+                            .get(&state.workspace_id)
+                            .copied()
+                            .unwrap_or(WorkspaceOccupancy::Unknown),
+                        state,
+                    )
+            })
+            .collect();
+        candidates.sort_by(|left, right| {
+            let left_occupancy = occupancy_by_id
+                .get(&left.workspace_id)
+                .copied()
+                .unwrap_or(WorkspaceOccupancy::Unknown);
+            let right_occupancy = occupancy_by_id
+                .get(&right.workspace_id)
+                .copied()
+                .unwrap_or(WorkspaceOccupancy::Unknown);
+            auto_apply_priority(left, left_occupancy)
+                .cmp(&auto_apply_priority(right, right_occupancy))
+                .then(left.first_detected_at.cmp(&right.first_detected_at))
+                .then(left.workspace_id.cmp(&right.workspace_id))
+        });
+
         let mut applied = 0usize;
-        for state in pending {
+        for state in candidates {
+            if applied >= MAX_AUTO_SKILL_REFRESHES_PER_TICK {
+                break;
+            }
             if self.auto_apply_pending_refresh_state(state).await {
                 applied += 1;
             }
@@ -1821,7 +1920,38 @@ impl RuntimeSupervisor {
         current.fingerprint == previous.fingerprint
     }
 
+    fn refresh_apply_lock(&self, workspace_id: &str) -> Arc<tokio::sync::Mutex<()>> {
+        self.refresh_apply_locks
+            .lock()
+            .entry(workspace_id.to_string())
+            .or_insert_with(|| Arc::new(tokio::sync::Mutex::new(())))
+            .clone()
+    }
+
+    async fn latest_pending_state(
+        &self,
+        workspace_id: &str,
+        workspace_path: &str,
+    ) -> Option<WorkspaceRefreshState> {
+        self.refresh
+            .pending_workspace_states()
+            .await
+            .into_iter()
+            .find(|state| {
+                state.workspace_id == workspace_id || state.workspace_path == workspace_path
+            })
+    }
+
     async fn auto_apply_pending_refresh_state(&self, state: WorkspaceRefreshState) -> bool {
+        let lock = self.refresh_apply_lock(&state.workspace_id);
+        let _guard = lock.lock().await;
+
+        let Some(state) = self
+            .latest_pending_state(&state.workspace_id, &state.workspace_path)
+            .await
+        else {
+            return false;
+        };
         if !auto_applicable_refresh(&state) {
             self.refresh
                 .set_auto_apply_blocked_by_active_runtime(&state.workspace_id, false)
@@ -1856,21 +1986,33 @@ impl RuntimeSupervisor {
             );
             return true;
         }
-        let busy = {
+        let occupancy = {
             let manager = self.agents.lock().await;
-            manager.workspace_has_active_turn(&state.workspace_path, &state.workspace_id)
+            manager.workspace_occupancy(&state.workspace_path, &state.workspace_id)
         };
-        if busy {
-            self.refresh
-                .set_auto_apply_blocked_by_active_runtime(&state.workspace_id, true)
-                .await;
-            info!(
-                workspace_id = %state.workspace_id,
-                workspace_path = %state.workspace_path,
-                change_kinds = ?state.change_kinds,
-                "deferred runtime refresh auto-apply because workspace has active turn"
-            );
-            return false;
+        match occupancy {
+            WorkspaceOccupancy::Active => {
+                self.refresh
+                    .set_auto_apply_blocked_by_active_runtime(&state.workspace_id, true)
+                    .await;
+                info!(
+                    workspace_id = %state.workspace_id,
+                    workspace_path = %state.workspace_path,
+                    change_kinds = ?state.change_kinds,
+                    "team_skill_refresh_deferred_active_turn"
+                );
+                return false;
+            }
+            WorkspaceOccupancy::Cold if team_skill_reconcile_only(&state) => {
+                info!(
+                    workspace_id = %state.workspace_id,
+                    workspace_path = %state.workspace_path,
+                    "team_skill_refresh_deferred_cold"
+                );
+                return false;
+            }
+            WorkspaceOccupancy::Unknown => return false,
+            WorkspaceOccupancy::WarmIdle | WorkspaceOccupancy::Cold => {}
         }
 
         self.refresh
@@ -1920,12 +2062,14 @@ impl RuntimeSupervisor {
         workspace_id: &str,
         workspace_path: &Path,
     ) -> Result<SkillsRefreshApplyStatus, WorkspaceControlError> {
+        let lock = self.refresh_apply_lock(workspace_id);
+        let _guard = lock.lock().await;
+
         let workspace_path_str = workspace_path.to_string_lossy();
-        let pending = self.refresh.pending_workspace_states().await;
-        let Some(state) = pending.into_iter().find(|state| {
-            state.workspace_id == workspace_id
-                || state.workspace_path == workspace_path_str.as_ref()
-        }) else {
+        let Some(state) = self
+            .latest_pending_state(workspace_id, workspace_path_str.as_ref())
+            .await
+        else {
             return Ok(SkillsRefreshApplyStatus::Applied(ApplyOutcome::AppliedLive));
         };
         if !state
@@ -2011,6 +2155,36 @@ fn auto_applicable_refresh(state: &WorkspaceRefreshState) -> bool {
             .change_kinds
             .iter()
             .all(|kind| matches!(kind, RefreshChangeKind::Skills))
+}
+
+fn team_skill_reconcile_only(state: &WorkspaceRefreshState) -> bool {
+    !state.sources.is_empty()
+        && state
+            .sources
+            .iter()
+            .all(|source| matches!(source, RefreshSource::TeamSkillReconcile))
+}
+
+fn auto_apply_candidate(occupancy: WorkspaceOccupancy, state: &WorkspaceRefreshState) -> bool {
+    match occupancy {
+        WorkspaceOccupancy::WarmIdle => true,
+        WorkspaceOccupancy::Cold => !team_skill_reconcile_only(state),
+        WorkspaceOccupancy::Active | WorkspaceOccupancy::Unknown => false,
+    }
+}
+
+fn auto_apply_priority(state: &WorkspaceRefreshState, occupancy: WorkspaceOccupancy) -> u8 {
+    if state.sources.contains(&RefreshSource::UiMutation) {
+        0
+    } else if occupancy == WorkspaceOccupancy::WarmIdle {
+        1
+    } else if state.sources.contains(&RefreshSource::FilesystemWatch)
+        || state.sources.contains(&RefreshSource::StartupRescan)
+    {
+        2
+    } else {
+        3
+    }
 }
 
 #[cfg(test)]
@@ -3142,6 +3316,363 @@ mod tests {
             .runtime_refresh_dto(&workspace_id)
             .await;
         assert_eq!(dto.status, "clean");
+    }
+
+    #[tokio::test]
+    async fn team_skill_reconcile_cold_stays_pending_without_dispose() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/instance/dispose"))
+            .respond_with(ResponseTemplate::new(200))
+            .expect(0)
+            .mount(&server)
+            .await;
+
+        let dir = tempfile::tempdir().unwrap();
+        let workspace_id = refresh_watch::workspace_runtime_id(dir.path());
+        let pool = OpenCodeHostPool::new(Arc::new(BaseUrlFactory {
+            base_url: server.uri(),
+        }));
+        let supervisor = RuntimeSupervisor::new_with_host_pool(
+            Arc::new(AsyncMutex::new(RuntimeManager::new(
+                RuntimeManager::default_launch_configs(),
+                None,
+            ))),
+            pool.clone(),
+        );
+        let (_revision, _lease) = seed_domain(&pool, &workspace_id, "v1").await;
+
+        supervisor
+            .refresh_coordinator()
+            .record_change(
+                &workspace_id,
+                dir.path(),
+                refresh::RefreshChangeKind::Skills,
+                refresh::RefreshSource::TeamSkillReconcile,
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(supervisor.auto_apply_pending_refreshes().await, 0);
+        let dto = supervisor
+            .refresh_coordinator()
+            .runtime_refresh_dto(&workspace_id)
+            .await;
+        assert_eq!(dto.status, "pending");
+        assert!(dto.change_kinds.iter().any(|kind| kind == "skills"));
+    }
+
+    #[tokio::test]
+    async fn team_skill_reconcile_warm_idle_auto_applies_dispose() {
+        use wiremock::matchers::{method, path, query_param};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        let dir = tempfile::tempdir().unwrap();
+        let workspace_id = refresh_watch::workspace_runtime_id(dir.path());
+        let directory = dir.path().to_string_lossy().into_owned();
+        Mock::given(method("POST"))
+            .and(path("/instance/dispose"))
+            .and(query_param("directory", directory))
+            .respond_with(ResponseTemplate::new(200))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let pool = OpenCodeHostPool::new(Arc::new(BaseUrlFactory {
+            base_url: server.uri(),
+        }));
+        let supervisor = RuntimeSupervisor::new_with_host_pool(
+            Arc::new(AsyncMutex::new(RuntimeManager::new(
+                RuntimeManager::default_launch_configs(),
+                None,
+            ))),
+            pool.clone(),
+        );
+        let (_revision, _lease) = seed_domain(&pool, &workspace_id, "v1").await;
+        {
+            let mut manager = supervisor.agents.lock().await;
+            manager.add_test_workspace_runtime(
+                "rt-idle",
+                &dir.path().to_string_lossy(),
+                &workspace_id,
+                amux::AgentStatus::Idle,
+            );
+        }
+
+        supervisor
+            .refresh_coordinator()
+            .record_change(
+                &workspace_id,
+                dir.path(),
+                refresh::RefreshChangeKind::Skills,
+                refresh::RefreshSource::TeamSkillReconcile,
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(supervisor.auto_apply_pending_refreshes().await, 1);
+        let dto = supervisor
+            .refresh_coordinator()
+            .runtime_refresh_dto(&workspace_id)
+            .await;
+        assert_eq!(dto.status, "clean");
+    }
+
+    #[tokio::test]
+    async fn team_skill_reconcile_active_stays_pending_until_idle() {
+        use wiremock::matchers::{method, path, query_param};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        let dir = tempfile::tempdir().unwrap();
+        let workspace_id = refresh_watch::workspace_runtime_id(dir.path());
+        let directory = dir.path().to_string_lossy().into_owned();
+        Mock::given(method("POST"))
+            .and(path("/instance/dispose"))
+            .and(query_param("directory", directory))
+            .respond_with(ResponseTemplate::new(200))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let pool = OpenCodeHostPool::new(Arc::new(BaseUrlFactory {
+            base_url: server.uri(),
+        }));
+        let supervisor = RuntimeSupervisor::new_with_host_pool(
+            Arc::new(AsyncMutex::new(RuntimeManager::new(
+                RuntimeManager::default_launch_configs(),
+                None,
+            ))),
+            pool.clone(),
+        );
+        let (_revision, _lease) = seed_domain(&pool, &workspace_id, "v1").await;
+        {
+            let mut manager = supervisor.agents.lock().await;
+            manager.add_test_workspace_runtime(
+                "rt-busy",
+                &dir.path().to_string_lossy(),
+                &workspace_id,
+                amux::AgentStatus::Active,
+            );
+        }
+        supervisor
+            .refresh_coordinator()
+            .record_change(
+                &workspace_id,
+                dir.path(),
+                refresh::RefreshChangeKind::Skills,
+                refresh::RefreshSource::TeamSkillReconcile,
+            )
+            .await
+            .unwrap();
+        assert_eq!(supervisor.auto_apply_pending_refreshes().await, 0);
+
+        {
+            let mut manager = supervisor.agents.lock().await;
+            manager.set_test_runtime_status("rt-busy", amux::AgentStatus::Idle);
+        }
+        assert_eq!(supervisor.auto_apply_pending_refreshes().await, 1);
+        let dto = supervisor
+            .refresh_coordinator()
+            .runtime_refresh_dto(&workspace_id)
+            .await;
+        assert_eq!(dto.status, "clean");
+    }
+
+    #[tokio::test]
+    async fn repeated_team_skill_records_merge_to_one_apply() {
+        use wiremock::matchers::{method, path, query_param};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        let dir = tempfile::tempdir().unwrap();
+        let workspace_id = refresh_watch::workspace_runtime_id(dir.path());
+        let directory = dir.path().to_string_lossy().into_owned();
+        Mock::given(method("POST"))
+            .and(path("/instance/dispose"))
+            .and(query_param("directory", directory))
+            .respond_with(ResponseTemplate::new(200))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let pool = OpenCodeHostPool::new(Arc::new(BaseUrlFactory {
+            base_url: server.uri(),
+        }));
+        let supervisor = RuntimeSupervisor::new_with_host_pool(
+            Arc::new(AsyncMutex::new(RuntimeManager::new(
+                RuntimeManager::default_launch_configs(),
+                None,
+            ))),
+            pool.clone(),
+        );
+        let (_revision, _lease) = seed_domain(&pool, &workspace_id, "v1").await;
+        {
+            let mut manager = supervisor.agents.lock().await;
+            manager.add_test_workspace_runtime(
+                "rt-idle",
+                &dir.path().to_string_lossy(),
+                &workspace_id,
+                amux::AgentStatus::Idle,
+            );
+        }
+        for _ in 0..10 {
+            supervisor
+                .refresh_coordinator()
+                .record_change(
+                    &workspace_id,
+                    dir.path(),
+                    refresh::RefreshChangeKind::Skills,
+                    refresh::RefreshSource::TeamSkillReconcile,
+                )
+                .await
+                .unwrap();
+        }
+
+        assert_eq!(supervisor.auto_apply_pending_refreshes().await, 1);
+        let dto = supervisor
+            .refresh_coordinator()
+            .runtime_refresh_dto(&workspace_id)
+            .await;
+        assert_eq!(dto.status, "clean");
+    }
+
+    #[tokio::test]
+    async fn auto_apply_applies_at_most_one_workspace_per_tick() {
+        let dir_a = tempfile::tempdir().unwrap();
+        let dir_b = tempfile::tempdir().unwrap();
+        let workspace_a = refresh_watch::workspace_runtime_id(dir_a.path());
+        let workspace_b = refresh_watch::workspace_runtime_id(dir_b.path());
+        let supervisor = RuntimeSupervisor::new(Arc::new(AsyncMutex::new(RuntimeManager::new(
+            RuntimeManager::default_launch_configs(),
+            None,
+        ))));
+
+        for (workspace_id, path) in [
+            (workspace_a.as_str(), dir_a.path()),
+            (workspace_b.as_str(), dir_b.path()),
+        ] {
+            supervisor
+                .refresh_coordinator()
+                .record_change(
+                    workspace_id,
+                    path,
+                    refresh::RefreshChangeKind::Skills,
+                    refresh::RefreshSource::FilesystemWatch,
+                )
+                .await
+                .unwrap();
+        }
+
+        assert_eq!(supervisor.auto_apply_pending_refreshes().await, 1);
+        let dto_a = supervisor
+            .refresh_coordinator()
+            .runtime_refresh_dto(&workspace_a)
+            .await;
+        let dto_b = supervisor
+            .refresh_coordinator()
+            .runtime_refresh_dto(&workspace_b)
+            .await;
+        let clean = [&dto_a, &dto_b]
+            .iter()
+            .filter(|dto| dto.status == "clean")
+            .count();
+        let pending = [&dto_a, &dto_b]
+            .iter()
+            .filter(|dto| dto.status == "pending")
+            .count();
+        assert_eq!(clean, 1, "exactly one workspace should apply this tick");
+        assert_eq!(pending, 1, "the other workspace stays pending");
+    }
+
+    #[tokio::test]
+    async fn ui_mutation_priority_over_team_skill_reconcile() {
+        use wiremock::matchers::{method, path, query_param};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        let ui_dir = tempfile::tempdir().unwrap();
+        let team_dir = tempfile::tempdir().unwrap();
+        let ui_workspace = refresh_watch::workspace_runtime_id(ui_dir.path());
+        let team_workspace = refresh_watch::workspace_runtime_id(team_dir.path());
+        Mock::given(method("POST"))
+            .and(path("/instance/dispose"))
+            .and(query_param(
+                "directory",
+                ui_dir.path().to_string_lossy().into_owned(),
+            ))
+            .respond_with(ResponseTemplate::new(200))
+            .expect(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/instance/dispose"))
+            .and(query_param(
+                "directory",
+                team_dir.path().to_string_lossy().into_owned(),
+            ))
+            .respond_with(ResponseTemplate::new(200))
+            .expect(0)
+            .mount(&server)
+            .await;
+
+        let pool = OpenCodeHostPool::new(Arc::new(BaseUrlFactory {
+            base_url: server.uri(),
+        }));
+        let supervisor = RuntimeSupervisor::new_with_host_pool(
+            Arc::new(AsyncMutex::new(RuntimeManager::new(
+                RuntimeManager::default_launch_configs(),
+                None,
+            ))),
+            pool.clone(),
+        );
+        let (_revision, _ui_lease) = seed_domain(&pool, &ui_workspace, "ui").await;
+        {
+            let mut manager = supervisor.agents.lock().await;
+            manager.add_test_workspace_runtime(
+                "rt-idle",
+                &team_dir.path().to_string_lossy(),
+                &team_workspace,
+                amux::AgentStatus::Idle,
+            );
+        }
+
+        supervisor
+            .refresh_coordinator()
+            .record_change(
+                &team_workspace,
+                team_dir.path(),
+                refresh::RefreshChangeKind::Skills,
+                refresh::RefreshSource::TeamSkillReconcile,
+            )
+            .await
+            .unwrap();
+        supervisor
+            .refresh_coordinator()
+            .record_change(
+                &ui_workspace,
+                ui_dir.path(),
+                refresh::RefreshChangeKind::Skills,
+                refresh::RefreshSource::UiMutation,
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(supervisor.auto_apply_pending_refreshes().await, 1);
+        let ui_dto = supervisor
+            .refresh_coordinator()
+            .runtime_refresh_dto(&ui_workspace)
+            .await;
+        let team_dto = supervisor
+            .refresh_coordinator()
+            .runtime_refresh_dto(&team_workspace)
+            .await;
+        assert_eq!(ui_dto.status, "clean");
+        assert_eq!(team_dto.status, "pending");
     }
 
     #[tokio::test]

--- a/apps/daemon/src/runtime/team_skills.rs
+++ b/apps/daemon/src/runtime/team_skills.rs
@@ -400,44 +400,14 @@ pub async fn apply_team_skill_outcome(
         return;
     };
 
-    let mut cloud_targets = Vec::new();
-    if let Some(backend) = backend {
-        match backend
-            .get_workspaces_by_agent(team_id, backend.actor_id())
-            .await
-        {
-            Ok(rows) => {
-                for row in rows {
-                    let Some((path, _)) =
-                        crate::config::workspace_path::listable_local_workspace(&row)
-                    else {
-                        continue;
-                    };
-                    cloud_targets.push(crate::runtime::refresh::refresh_watch::WatchedWorkspace {
-                        workspace_id: row.id,
-                        workspace_path: PathBuf::from(path),
-                    });
-                }
-            }
-            Err(e) => tracing::warn!(
-                team_id,
-                error = %e,
-                "team skills changed but cloud workspace list failed; using runtime refresh targets"
-            ),
-        }
-    }
-
-    let runtime_targets = match refresh_watch_registry {
-        Some(registry) => registry.snapshot().await,
-        None => Vec::new(),
-    };
-    for target in merge_refresh_targets(cloud_targets, runtime_targets) {
+    for target in resolve_team_skill_refresh_targets(team_id, backend, refresh_watch_registry).await
+    {
         if let Err(error) = refresh
             .record_change(
                 &target.workspace_id,
                 &target.workspace_path,
                 crate::runtime::refresh::RefreshChangeKind::Skills,
-                crate::runtime::refresh::RefreshSource::UiMutation,
+                crate::runtime::refresh::RefreshSource::TeamSkillReconcile,
             )
             .await
         {
@@ -447,8 +417,113 @@ pub async fn apply_team_skill_outcome(
                 error = %error,
                 "failed to record skills refresh after team skill reconcile"
             );
+            continue;
+        }
+        tracing::info!(
+            team_id,
+            workspace_id = %target.workspace_id,
+            workspace_path = %target.workspace_path.display(),
+            "team_skill_refresh_recorded"
+        );
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CloudLookupStatus {
+    Success,
+    Failed,
+    Unavailable,
+}
+
+impl CloudLookupStatus {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Success => "success",
+            Self::Failed => "failed",
+            Self::Unavailable => "unavailable",
         }
     }
+}
+
+async fn resolve_team_skill_refresh_targets(
+    team_id: &str,
+    backend: Option<&Arc<dyn Backend>>,
+    registry: Option<&Arc<crate::runtime::refresh::refresh_watch::RefreshWatchRegistry>>,
+) -> Vec<crate::runtime::refresh::refresh_watch::WatchedWorkspace> {
+    use crate::runtime::refresh::refresh_watch::WatchedWorkspace;
+
+    let (cloud_targets, cloud_lookup_status) = match backend {
+        Some(backend) => match backend
+            .get_workspaces_by_agent(team_id, backend.actor_id())
+            .await
+        {
+            Ok(rows) => {
+                let mut cloud_targets = Vec::new();
+                for row in rows {
+                    let Some((path, _)) =
+                        crate::config::workspace_path::listable_local_workspace(&row)
+                    else {
+                        continue;
+                    };
+                    cloud_targets.push(WatchedWorkspace::new(
+                        row.id,
+                        PathBuf::from(path),
+                        Some(team_id),
+                    ));
+                }
+                (cloud_targets, CloudLookupStatus::Success)
+            }
+            Err(e) => {
+                tracing::warn!(
+                    team_id,
+                    error = %e,
+                    "team skills changed but cloud workspace list failed; using team-matched runtime refresh targets"
+                );
+                (Vec::new(), CloudLookupStatus::Failed)
+            }
+        },
+        None => (Vec::new(), CloudLookupStatus::Unavailable),
+    };
+
+    let (runtime_targets, unknown_skipped) = match registry {
+        Some(registry) => {
+            let snapshot = registry.snapshot().await;
+            let unknown_skipped = snapshot
+                .iter()
+                .filter(|workspace| workspace.team_id.is_none())
+                .count();
+            if unknown_skipped > 0 {
+                tracing::warn!(
+                    team_id,
+                    unknown_skipped,
+                    "skipping refresh-watch workspaces with unknown team_id"
+                );
+            }
+            (registry.snapshot_for_team(team_id).await, unknown_skipped)
+        }
+        None => (Vec::new(), 0),
+    };
+
+    let cloud_count = cloud_targets.len();
+    let runtime_count = runtime_targets.len();
+    let targets = merge_refresh_targets(cloud_targets, runtime_targets);
+    tracing::info!(
+        team_id,
+        cloud_count,
+        runtime_count,
+        unknown_skipped,
+        deduped_count = targets.len(),
+        cloud_lookup_status = cloud_lookup_status.as_str(),
+        "team_skill_refresh_targets_resolved"
+    );
+    if targets.is_empty() {
+        tracing::warn!(
+            team_id,
+            cloud_lookup_status = cloud_lookup_status.as_str(),
+            "team skills changed but no trusted refresh targets were found"
+        );
+    }
+    targets
 }
 
 fn merge_refresh_targets(
@@ -639,19 +714,64 @@ mod tests {
         assert!(!tmp.path().join("escaped.md").exists());
     }
 
+    fn watched(
+        id: &str,
+        path: &str,
+        team_id: Option<&str>,
+    ) -> crate::runtime::refresh::refresh_watch::WatchedWorkspace {
+        crate::runtime::refresh::refresh_watch::WatchedWorkspace::new(
+            id,
+            PathBuf::from(path),
+            team_id,
+        )
+    }
+
+    fn changed_outcome() -> TeamSkillReconcileOutcome {
+        TeamSkillReconcileOutcome {
+            installed: 1,
+            removed: 0,
+        }
+    }
+
+    async fn apply_changed(
+        team_id: &str,
+        backend: Option<&Arc<dyn Backend>>,
+        refresh: &Arc<crate::runtime::refresh::RuntimeRefreshCoordinator>,
+        registry: &Arc<crate::runtime::refresh::refresh_watch::RefreshWatchRegistry>,
+    ) {
+        apply_team_skill_outcome(
+            team_id,
+            changed_outcome(),
+            backend,
+            Some(refresh),
+            Some(registry),
+        )
+        .await;
+    }
+
+    fn seed_workspace(
+        mock: &crate::backend::mock::MockBackend,
+        id: &str,
+        team_id: &str,
+        path: &Path,
+    ) {
+        mock.state.lock().unwrap().workspaces_by_id.insert(
+            id.to_string(),
+            crate::backend::WorkspaceRow {
+                id: id.to_string(),
+                team_id: team_id.to_string(),
+                path: Some(path.display().to_string()),
+                archived: false,
+                agent_id: Some(mock.actor_id().to_string()),
+            },
+        );
+    }
+
     #[test]
     fn runtime_refresh_target_overrides_stale_cloud_path() {
-        use crate::runtime::refresh::refresh_watch::WatchedWorkspace;
-
         let targets = merge_refresh_targets(
-            vec![WatchedWorkspace {
-                workspace_id: "ws-1".into(),
-                workspace_path: PathBuf::from("/tmp/stale-cloud-path"),
-            }],
-            vec![WatchedWorkspace {
-                workspace_id: "ws-1".into(),
-                workspace_path: PathBuf::from("/tmp/actual-runtime-path"),
-            }],
+            vec![watched("ws-1", "/tmp/stale-cloud-path", Some("team-1"))],
+            vec![watched("ws-1", "/tmp/actual-runtime-path", Some("team-1"))],
         );
         assert_eq!(
             targets[0].workspace_path,
@@ -661,17 +781,70 @@ mod tests {
 
     #[tokio::test]
     async fn team_skill_change_refreshes_runtime_target_without_cloud_inventory() {
-        use crate::runtime::refresh::refresh_watch::{RefreshWatchRegistry, WatchedWorkspace};
+        use crate::runtime::refresh::refresh_watch::RefreshWatchRegistry;
 
-        let registry = RefreshWatchRegistry::new(vec![WatchedWorkspace {
-            workspace_id: "ws-runtime".into(),
-            workspace_path: PathBuf::from("/tmp/actual-runtime-path"),
-        }]);
+        let registry = RefreshWatchRegistry::new(vec![watched(
+            "ws-runtime",
+            "/tmp/actual-runtime-path",
+            Some("team-1"),
+        )]);
+        let refresh = crate::runtime::refresh::RuntimeRefreshCoordinator::new();
+        apply_changed("team-1", None, &refresh, &registry).await;
+
+        let state = refresh.workspace_state("ws-runtime").await.unwrap();
+        assert_eq!(state.workspace_path, "/tmp/actual-runtime-path");
+        assert!(state
+            .change_kinds
+            .contains(&crate::runtime::refresh::RefreshChangeKind::Skills));
+        assert!(state
+            .sources
+            .contains(&crate::runtime::refresh::RefreshSource::TeamSkillReconcile));
+    }
+
+    #[tokio::test]
+    async fn team_skill_change_skips_unknown_team_runtime_target() {
+        use crate::runtime::refresh::refresh_watch::RefreshWatchRegistry;
+
+        let registry = RefreshWatchRegistry::new(vec![watched(
+            "ws-unknown",
+            "/tmp/unknown-runtime-path",
+            None,
+        )]);
+        let refresh = crate::runtime::refresh::RuntimeRefreshCoordinator::new();
+        apply_changed("team-1", None, &refresh, &registry).await;
+
+        assert!(refresh.workspace_state("ws-unknown").await.is_none());
+    }
+
+    #[tokio::test]
+    async fn team_skill_change_does_not_refresh_other_team_workspace() {
+        use crate::runtime::refresh::refresh_watch::RefreshWatchRegistry;
+
+        let registry = RefreshWatchRegistry::new(vec![
+            watched("ws-team-1", "/tmp/team-1", Some("team-1")),
+            watched("ws-team-2", "/tmp/team-2", Some("team-2")),
+        ]);
+        let refresh = crate::runtime::refresh::RuntimeRefreshCoordinator::new();
+        apply_changed("team-1", None, &refresh, &registry).await;
+
+        assert!(refresh.workspace_state("ws-team-1").await.is_some());
+        assert!(refresh.workspace_state("ws-team-2").await.is_none());
+    }
+
+    #[tokio::test]
+    async fn unchanged_reconcile_outcome_does_not_record_refresh() {
+        use crate::runtime::refresh::refresh_watch::RefreshWatchRegistry;
+
+        let registry = RefreshWatchRegistry::new(vec![watched(
+            "ws-runtime",
+            "/tmp/actual-runtime-path",
+            Some("team-1"),
+        )]);
         let refresh = crate::runtime::refresh::RuntimeRefreshCoordinator::new();
         apply_team_skill_outcome(
             "team-1",
             TeamSkillReconcileOutcome {
-                installed: 1,
+                installed: 0,
                 removed: 0,
             },
             None,
@@ -680,11 +853,87 @@ mod tests {
         )
         .await;
 
-        let state = refresh.workspace_state("ws-runtime").await.unwrap();
-        assert_eq!(state.workspace_path, "/tmp/actual-runtime-path");
-        assert!(state
-            .change_kinds
-            .contains(&crate::runtime::refresh::RefreshChangeKind::Skills));
+        assert!(refresh.workspace_state("ws-runtime").await.is_none());
+    }
+
+    #[tokio::test]
+    async fn cloud_lookup_failure_uses_only_exact_team_match() {
+        use crate::runtime::refresh::refresh_watch::RefreshWatchRegistry;
+
+        let mock = crate::backend::mock::MockBackend::with_identity("team-1", "agent-1");
+        mock.state.lock().unwrap().get_workspaces_by_team_error = Some("cloud down".to_string());
+        let backend: Arc<dyn Backend> = Arc::new(mock);
+        let registry = RefreshWatchRegistry::new(vec![
+            watched("ws-team-1", "/tmp/team-1", Some("team-1")),
+            watched("ws-team-2", "/tmp/team-2", Some("team-2")),
+            watched("ws-unknown", "/tmp/unknown", None),
+        ]);
+        let refresh = crate::runtime::refresh::RuntimeRefreshCoordinator::new();
+        apply_changed("team-1", Some(&backend), &refresh, &registry).await;
+
+        assert!(refresh.workspace_state("ws-team-1").await.is_some());
+        assert!(refresh.workspace_state("ws-team-2").await.is_none());
+        assert!(refresh.workspace_state("ws-unknown").await.is_none());
+    }
+
+    #[tokio::test]
+    async fn backend_none_does_not_cross_team_refresh() {
+        use crate::runtime::refresh::refresh_watch::RefreshWatchRegistry;
+
+        let registry = RefreshWatchRegistry::new(vec![
+            watched("ws-team-1", "/tmp/team-1", Some("team-1")),
+            watched("ws-team-2", "/tmp/team-2", Some("team-2")),
+        ]);
+        let refresh = crate::runtime::refresh::RuntimeRefreshCoordinator::new();
+        apply_changed("team-1", None, &refresh, &registry).await;
+
+        assert!(refresh.workspace_state("ws-team-1").await.is_some());
+        assert!(refresh.workspace_state("ws-team-2").await.is_none());
+    }
+
+    #[tokio::test]
+    async fn cloud_success_overlays_runtime_path_for_same_workspace_id() {
+        use crate::runtime::refresh::refresh_watch::RefreshWatchRegistry;
+
+        let cloud_dir = tempfile::tempdir().unwrap();
+        let runtime_dir = tempfile::tempdir().unwrap();
+        let mock = crate::backend::mock::MockBackend::with_identity("team-1", "agent-1");
+        seed_workspace(&mock, "ws-1", "team-1", cloud_dir.path());
+        let backend: Arc<dyn Backend> = Arc::new(mock);
+        let registry = RefreshWatchRegistry::new(vec![watched(
+            "ws-1",
+            runtime_dir.path().to_str().unwrap(),
+            Some("team-1"),
+        )]);
+        let refresh = crate::runtime::refresh::RuntimeRefreshCoordinator::new();
+        apply_changed("team-1", Some(&backend), &refresh, &registry).await;
+
+        let state = refresh.workspace_state("ws-1").await.unwrap();
+        assert_eq!(
+            state.workspace_path,
+            runtime_dir.path().display().to_string()
+        );
+    }
+
+    #[tokio::test]
+    async fn cloud_success_does_not_refresh_other_team_runtime_target() {
+        use crate::runtime::refresh::refresh_watch::RefreshWatchRegistry;
+
+        let cloud_dir = tempfile::tempdir().unwrap();
+        let mock = crate::backend::mock::MockBackend::with_identity("team-1", "agent-1");
+        seed_workspace(&mock, "ws-cloud", "team-1", cloud_dir.path());
+        let backend: Arc<dyn Backend> = Arc::new(mock);
+        let registry =
+            RefreshWatchRegistry::new(vec![watched("ws-other", "/tmp/other-team", Some("team-2"))]);
+        let refresh = crate::runtime::refresh::RuntimeRefreshCoordinator::new();
+        apply_changed("team-1", Some(&backend), &refresh, &registry).await;
+
+        let cloud_state = refresh.workspace_state("ws-cloud").await.unwrap();
+        assert_eq!(
+            cloud_state.workspace_path,
+            cloud_dir.path().display().to_string()
+        );
+        assert!(refresh.workspace_state("ws-other").await.is_none());
     }
 
     fn seed_installed_pack(root: &Path, slug: &str, version: i64, body: &str) {


### PR DESCRIPTION
## Summary
- Team Skill reconcile no longer auto-disposes Cold workspaces. Pending stays until WarmIdle (auto-apply) or the attach barrier; Active turns keep pending. FilesystemWatch / UiMutation Cold behavior is unchanged.
- Auto-apply is capped at one Skills refresh per tick, with UiMutation first. Auto-apply, attach, and manual Skills apply share a per-workspace lock and re-read pending after taking it.
- Host prewarm uses `try_prewarm`: reuse a Ready generation, otherwise start only under the soft limit with an empty queue and no draining hosts. Skip stops the prewarm loop; user `acquire` can still take the hard-limit spare slot.

Stacked on #1223.

## Test plan
- [x] `node scripts/daemon-cargo.js test --bin amuxd team_skill_reconcile_`
- [x] `node scripts/daemon-cargo.js test --bin amuxd prewarm_`
- [x] `pnpm rust:clippy`
- [x] `pnpm daemon:test`
- [ ] Confirm a team Skill change does not `/instance/dispose` Cold workspaces
- [ ] Confirm attach of a Cold workspace with pending Skills disposes once, then proceeds
- [ ] Confirm startup prewarm still keeps two workspace currents and does not queue behind user acquires


Made with [Cursor](https://cursor.com)