### PR TITLE
fix(knowledge): 清掉 #1149 评审剩下的七条机械性问题

### DIFF
--- a/apps/daemon/assets/knowledge-templates/mcp-manifest.json
+++ b/apps/daemon/assets/knowledge-templates/mcp-manifest.json
@@ -19,7 +19,7 @@
     },
     {
       "name": "knowledge_create",
-      "description": "Create a new vault page from a template. Refuses to overwrite an existing path — use knowledge_write to edit. 从模板新建页面；已存在则拒绝，改请用 knowledge_write。 If the reply carries teamSync:\"not-syncing\", the page was saved on this device only and is not reaching the team — say so rather than reporting it as shared. 若返回 teamSync:\"not-syncing\"，说明只存在本机、没有同步给团队，要如实告知，不要说成已共享。",
+      "description": "Create a new vault page from a template. Refuses to overwrite an existing path — use knowledge_write to edit. 从模板新建页面；已存在则拒绝，改请用 knowledge_write。 If the reply carries teamSync:\"not-syncing\", the page was saved on this device only and is not reaching the team — say so rather than reporting it as shared. 若返回 teamSync:\"not-syncing\"，说明只存在本机、没有同步给团队，要如实告知，不要说成已共享。 A page written from `content` is stamped with `type` and `updated` so it counts toward knowledge_health; supply your own frontmatter (content starting with `---`) and the page is written verbatim, heading included. 用 content 写入的页面会自动盖上 type 和 updated，以便计入 knowledge_health；若 content 以 `---` 开头则视为你自带 frontmatter，整页原样写入（含标题）。",
       "inputSchema": {
         "type": "object",
         "required": ["path"],
@@ -34,7 +34,7 @@
     },
     {
       "name": "knowledge_write",
-      "description": "Write or replace a vault page. All paths are validated to stay inside the vault. 写入/覆盖页面，路径被限制在 vault 内。 If the reply carries teamSync:\"not-syncing\", the page was saved on this device only and is not reaching the team — say so rather than reporting it as shared. 若返回 teamSync:\"not-syncing\"，说明只存在本机、没有同步给团队，要如实告知，不要说成已共享。",
+      "description": "Write or replace a vault page. All paths are validated to stay inside the vault. 写入/覆盖页面，路径被限制在 vault 内。 If the reply carries teamSync:\"not-syncing\", the page was saved on this device only and is not reaching the team — say so rather than reporting it as shared. 若返回 teamSync:\"not-syncing\"，说明只存在本机、没有同步给团队，要如实告知，不要说成已共享。 A page written from `content` is stamped with `type` and `updated` so it counts toward knowledge_health; supply your own frontmatter (content starting with `---`) and the page is written verbatim, heading included. 用 content 写入的页面会自动盖上 type 和 updated，以便计入 knowledge_health；若 content 以 `---` 开头则视为你自带 frontmatter，整页原样写入（含标题）。",
       "inputSchema": {
         "type": "object",
         "required": ["path", "content"],

--- a/apps/daemon/src/config/knowledge_scaffold.rs
+++ b/apps/daemon/src/config/knowledge_scaffold.rs
@@ -118,25 +118,12 @@ pub fn domain_index_template() -> &'static str {
 /// Today as `YYYY-MM-DD` (UTC). Exposed for the knowledge MCP handlers
 /// (template stamping in `daemon::server::knowledge`).
 pub(crate) fn today_iso() -> String {
-    // Avoid pulling in chrono for one date stamp; the daemon's MSRV and dep
-    // tree are already heavy. A simple UTC date from SystemTime is fine here.
-    use std::time::{SystemTime, UNIX_EPOCH};
-    let secs = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_secs();
-    // Civil-from-days algorithm (Howard Hinnant)
-    let z = (secs / 86400) as i64 + 719468;
-    let era = if z >= 0 { z } else { z - 146096 } / 146097;
-    let doe = (z - era * 146097) as u64;
-    let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146096) / 365;
-    let y = yoe as i64 + era * 400;
-    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
-    let mp = (5 * doy + 2) / 153;
-    let d = doy - (153 * mp + 2) / 5 + 1;
-    let m = if mp < 10 { mp + 3 } else { mp - 9 };
-    let y = if m <= 2 { y + 1 } else { y };
-    format!("{:04}-{:02}-{:02}", y, m, d)
+    // Local date, not UTC. These stamps are read by people — a salvage filename
+    // and an `updated:` line — and UTC files anything done before 08:00 in
+    // China under yesterday. `chrono` is already a direct dependency of this
+    // crate (`Cargo.toml`), which the hand-rolled civil-from-days algorithm
+    // this replaces was written to avoid.
+    chrono::Local::now().format("%Y-%m-%d").to_string()
 }
 
 #[cfg(test)]

--- a/apps/daemon/src/daemon/server.rs
+++ b/apps/daemon/src/daemon/server.rs
@@ -2048,7 +2048,7 @@ impl DaemonServer {
                                 self.handle_app_git_credential(payload, reply_tx).await;
                             }
                             Some(SockCommand::Knowledge { payload, reply_tx }) => {
-                                self.handle_knowledge(payload, reply_tx).await;
+                                knowledge::spawn_knowledge(payload, reply_tx);
                             }
                             Some(SockCommand::CursorPermission { payload, reply_tx }) => {
                                 tokio::spawn(async move {
@@ -2507,7 +2507,7 @@ impl DaemonServer {
                                 self.handle_app_git_credential(payload, reply_tx).await;
                             }
                             Some(SockCommand::Knowledge { payload, reply_tx }) => {
-                                self.handle_knowledge(payload, reply_tx).await;
+                                knowledge::spawn_knowledge(payload, reply_tx);
                             }
                             Some(SockCommand::CursorPermission { payload, reply_tx }) => {
                                 tokio::spawn(async move {

--- a/apps/daemon/src/daemon/server/knowledge.rs
+++ b/apps/daemon/src/daemon/server/knowledge.rs
@@ -32,14 +32,11 @@ use crate::config::{
     layout,
 };
 
-use super::DaemonServer;
-
 const MAX_SEARCH_RESULTS: usize = 50;
 const SALVAGE_DIR: &str = "00-salvage";
 /// How far `salvage` will walk the `-2`, `-3`, … suffixes before giving up.
 /// Only a runaway caller reaches this; a human salvaging by hand never will.
 const MAX_SALVAGE_SUFFIX: usize = 50;
-const FRESH_KINDS: &[&str] = &["runbook"];
 const STALE_DAYS_RUNBOOK: i64 = 90;
 const STALE_DAYS_UPDATED: i64 = 90;
 
@@ -172,47 +169,50 @@ fn str_field<'a>(payload: &'a Value, key: &str) -> Option<&'a str> {
         .filter(|s| !s.is_empty())
 }
 
-impl DaemonServer {
-    pub(crate) async fn handle_knowledge(
-        &self,
-        payload: Value,
-        reply_tx: tokio::sync::oneshot::Sender<String>,
-    ) {
-        let reply = self.handle_knowledge_inner(payload).await;
-        let _ = reply_tx.send(reply);
-    }
+/// Run one knowledge command and answer on `reply_tx`.
+///
+/// A free function on a blocking pool, not a method awaited inline. It never
+/// touched `DaemonServer` — taking `&self` was the only thing keeping it on the
+/// socket select loop — and `search` now reads every page in the vault with
+/// blocking IO, so it is the last thing that should hold that loop. Its
+/// neighbour `CursorPermission` spawns for exactly this reason, with a comment
+/// saying it must never run inline there.
+pub(crate) fn spawn_knowledge(payload: Value, reply_tx: tokio::sync::oneshot::Sender<String>) {
+    tokio::task::spawn_blocking(move || {
+        let _ = reply_tx.send(handle_knowledge_inner(payload));
+    });
+}
 
-    async fn handle_knowledge_inner(&self, payload: Value) -> String {
-        let action = str_field(&payload, "action").unwrap_or("");
-        let team_id = match active_team_id() {
-            Ok(id) => id,
-            Err(e) => return e,
-        };
-        let root = vault_root(&team_id);
-        // Read once per command rather than per file. Cheap (one small JSON)
-        // and only for the actions that write — `search` and `health` have
-        // nothing to say about whether a page reaches the team.
-        let blocked = match action {
-            "create" | "write" | "salvage" => LocalSyncState::peek_forbidden(&team_id),
-            _ => ForbiddenPaths::default(),
-        };
-        match action {
-            "scaffold" => knowledge_scaffold(&root, &payload),
-            "create" => knowledge_create(&root, &payload, &blocked),
-            "write" => knowledge_write(&root, &payload, &blocked),
-            "salvage" => knowledge_salvage(&root, &payload, &blocked),
-            "search" => search::search(&root, &stale_index_root(&team_id), &payload),
-            "manifest_get" => manifest_get(&root),
-            "manifest_set" => manifest_set(&root, &payload),
-            "health" => health(&root),
-            other => err(
-                "unknown_action",
-                format!(
-                    "unknown knowledge action '{other}'; expected \
-                     scaffold|create|write|salvage|search|manifest_get|manifest_set|health"
-                ),
+fn handle_knowledge_inner(payload: Value) -> String {
+    let action = str_field(&payload, "action").unwrap_or("");
+    let team_id = match active_team_id() {
+        Ok(id) => id,
+        Err(e) => return e,
+    };
+    let root = vault_root(&team_id);
+    // Read once per command rather than per file. Cheap (one small JSON) and
+    // only for the actions that write — `search` and `health` have nothing to
+    // say about whether a page reaches the team.
+    let blocked = match action {
+        "create" | "write" | "salvage" => LocalSyncState::peek_forbidden(&team_id),
+        _ => ForbiddenPaths::default(),
+    };
+    match action {
+        "scaffold" => knowledge_scaffold(&root, &payload),
+        "create" => knowledge_create(&root, &payload, &blocked),
+        "write" => knowledge_write(&root, &payload, &blocked),
+        "salvage" => knowledge_salvage(&root, &payload, &blocked),
+        "search" => search::search(&root, &stale_index_root(&team_id), &payload),
+        "manifest_get" => manifest_get(&root),
+        "manifest_set" => manifest_set(&root, &payload),
+        "health" => health(&root),
+        other => err(
+            "unknown_action",
+            format!(
+                "unknown knowledge action '{other}'; expected \
+                 scaffold|create|write|salvage|search|manifest_get|manifest_set|health"
             ),
-        }
+        ),
     }
 }
 
@@ -234,17 +234,42 @@ fn knowledge_scaffold(root: &Path, payload: &Value) -> String {
 
 /// Build the page body for `create` / `salvage`. `template:` is optional;
 /// `content:` overrides the template body when given.
+/// The bytes a new page starts life with.
+///
+/// `kind` used to be accepted here as a second spelling of `template`, and the
+/// MCP manifest never mentioned it — a parameter an agent could only find by
+/// reading this file. The manifest is the contract; `template` is what it
+/// documents, so that is now the only spelling.
 fn page_body(
-    kind: &Option<Value>,
     template: Option<&str>,
     title: &str,
     content: Option<&str>,
     today: &str,
 ) -> Result<String, String> {
-    let k = template.or(kind.as_ref().and_then(Value::as_str)).unwrap_or("page");
+    let k = template.unwrap_or("page");
     // A caller-supplied body always wins — the template is only the default.
     if let Some(body) = content {
-        return Ok(format!("# {title}\n\n{body}\n"));
+        // Stamped, unless the caller brought their own frontmatter. Without a
+        // `type` and an `updated`, `health()` reads no date off the page and it
+        // never counts toward the freshness figures — and pages written through
+        // these tools are exactly the ones whose freshness is worth watching.
+        //
+        // Content that already opens with `---` is written verbatim: frontmatter
+        // is only frontmatter at the very start of the file, so prepending a
+        // `# {title}` heading would turn the block into body text and lose the
+        // very fields the caller set. Bring your own frontmatter and you own the
+        // whole page, heading included.
+        if body.trim_start().starts_with("---") {
+            let body = body.trim_start();
+            return Ok(if body.ends_with('\n') {
+                body.to_string()
+            } else {
+                format!("{body}\n")
+            });
+        }
+        return Ok(format!(
+            "---\ntype: {k}\nupdated: {today}\n---\n\n# {title}\n\n{body}\n"
+        ));
     }
     let raw = match k {
         "adr" => include_str!("../../../assets/knowledge-templates/adr-template.md"),
@@ -282,9 +307,8 @@ fn create_or_write(
     let title = str_field(payload, "title").unwrap_or("Untitled");
     let content = str_field(payload, "content");
     let template = str_field(payload, "template");
-    let kind = payload.get("kind").cloned();
     let today = today_iso();
-    let body = match page_body(&kind, template, title, content, &today) {
+    let body = match page_body(template, title, content, &today) {
         Ok(b) => b,
         Err(e) => return err("invalid_kind", e),
     };
@@ -293,6 +317,10 @@ fn create_or_write(
             return err("write_failed", format!("creating parent dirs failed: {e}"));
         }
     }
+    // Before the write: afterwards the file exists by definition, so this
+    // reported `overwritten: true` for every `write`, including one that
+    // created the page.
+    let existed = target.exists();
     match std::fs::write(&target, body) {
         Ok(()) => {
             let rel = target
@@ -301,10 +329,7 @@ fn create_or_write(
                 .unwrap_or_else(|_| target.to_string_lossy().into_owned());
             let mut body = serde_json::Map::new();
             body.insert("path".into(), Value::String(rel.clone()));
-            body.insert(
-                "overwritten".into(),
-                Value::Bool(overwrite && target.exists()),
-            );
+            body.insert("overwritten".into(), Value::Bool(overwrite && existed));
             ok(with_team_sync(body, team_sync_fields(blocked, &rel)))
         }
         Err(e) => err("write_failed", format!("write failed: {e}")),
@@ -522,6 +547,44 @@ fn yaml_scalar(value: &str) -> String {
     out
 }
 
+/// The ` # …` a line ends with, whitespace included, or `""`.
+///
+/// The rewrite replaces the whole line, and the manifest template ships its
+/// documentation *on* those lines — `visibility: private  # private | org —
+/// 默认仅团队可见`. Setting a value used to delete the sentence explaining what
+/// the value may be, in a file whose whole point is that a human edits it in
+/// Obsidian.
+///
+/// A `#` inside the old value is not a comment, so quotes are tracked rather
+/// than searched past.
+fn trailing_comment(value_part: &str) -> String {
+    let mut in_single = false;
+    let mut in_double = false;
+    let mut escaped = false;
+    // Where the run of whitespace before the current character started, so the
+    // gap separating the comment comes back with it.
+    let mut gap_start = 0usize;
+    let mut prev_was_space = true;
+    for (at, c) in value_part.char_indices() {
+        match c {
+            _ if escaped => escaped = false,
+            '\\' if in_double => escaped = true,
+            '\'' if !in_double => in_single = !in_single,
+            '"' if !in_single => in_double = !in_double,
+            // YAML wants whitespace before an inline comment; `a#b` is a value.
+            '#' if !in_single && !in_double && prev_was_space => {
+                return value_part[gap_start..].to_string();
+            }
+            _ => {}
+        }
+        if !c.is_whitespace() {
+            gap_start = at + c.len_utf8();
+        }
+        prev_was_space = c.is_whitespace();
+    }
+    String::new()
+}
+
 /// Minimal line-based YAML scalar rewriter. Handles scalar values only —
 /// `version: 1`, `visibility: private`. List/map blocks pass through
 /// unchanged; users edit those by hand in Obsidian anyway.
@@ -533,10 +596,14 @@ fn replace_lenient_yaml_scalar(raw: &str, key: &str, value: &str) -> Option<Stri
     let mut next = Vec::with_capacity(raw.lines().count());
     let mut found = false;
     for line in raw.lines() {
-        if let Some((k, _)) = line.split_once(':') {
+        if let Some((k, rest)) = line.split_once(':') {
             if !found && k.trim() == key && !line.trim_start().starts_with('#') {
                 let indent = &line[..line.len() - line.trim_start().len()];
-                next.push(format!("{indent}{key}: {}", yaml_scalar(value)));
+                next.push(format!(
+                    "{indent}{key}: {}{}",
+                    yaml_scalar(value),
+                    trailing_comment(rest)
+                ));
                 found = true;
                 continue;
             }
@@ -561,29 +628,30 @@ fn health(root: &Path) -> String {
     for (rel, abs) in &files {
         total += 1;
         let Ok(raw) = std::fs::read_to_string(abs) else { continue };
-        let (kind, owner, verified, updated) = parse_frontmatter(&raw);
-        let _ = owner;
-        let rel_str = rel.to_string_lossy();
-        let window = if FRESH_KINDS.contains(&kind.as_str()) {
+        let (kind, _owner, verified, updated) = parse_frontmatter(&raw);
+        // Asked once. `FRESH_KINDS.contains(&kind)` and `kind == "runbook"`
+        // were two spellings of the same question, three lines apart, free to
+        // drift into disagreeing.
+        let is_runbook = kind == "runbook";
+        let window = if is_runbook {
             STALE_DAYS_RUNBOOK
         } else {
             STALE_DAYS_UPDATED
         };
-        let date = if kind == "runbook" {
+        let date = if is_runbook {
             verified.as_deref().or(updated.as_deref())
         } else {
             updated.as_deref()
         };
         if let Some(d) = date {
             if days_between(d, &today).map(|n| n > window).unwrap_or(false) {
-                if kind == "runbook" {
+                if is_runbook {
                     stale_runbook += 1;
                 } else {
                     stale_updated += 1;
                 }
             }
         }
-        let _ = rel_str;
     }
     let coverage = json!({
         "hasHome": root.join("00-home.md").exists(),
@@ -982,6 +1050,92 @@ mod tests {
         let v: Value = serde_json::from_str(&reply).unwrap();
         assert_eq!(v["ok"], true);
         assert_eq!(v["result"]["teamSync"], "not-syncing", "{v}");
+    }
+
+    /// `overwritten` used to be computed after the write, when the file exists
+    /// by definition — so `write` reported it for pages it had just created.
+    #[test]
+    fn overwritten_distinguishes_a_create_from_a_replace() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        let page = json!({ "path": "20-domains/pricing.md", "title": "Pricing", "content": "x" });
+
+        let first: Value =
+            serde_json::from_str(&knowledge_write(root, &page, &ForbiddenPaths::default()))
+                .unwrap();
+        assert_eq!(first["result"]["overwritten"], false, "{first}");
+
+        let second: Value =
+            serde_json::from_str(&knowledge_write(root, &page, &ForbiddenPaths::default()))
+                .unwrap();
+        assert_eq!(second["result"]["overwritten"], true, "{second}");
+    }
+
+    /// Pages written through these tools carried no frontmatter, so `health()`
+    /// found no date on them and they never counted toward freshness.
+    #[test]
+    fn a_written_page_is_visible_to_health() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        knowledge_write(
+            root,
+            &json!({ "path": "20-domains/x.md", "title": "X", "content": "body" }),
+            &ForbiddenPaths::default(),
+        );
+        let raw = std::fs::read_to_string(root.join("20-domains/x.md")).unwrap();
+        let (kind, _owner, _verified, updated) = parse_frontmatter(&raw);
+        assert_eq!(kind, "page", "{raw}");
+        assert_eq!(updated.as_deref(), Some(today_iso().as_str()), "{raw}");
+
+        // A caller who brought their own frontmatter keeps it, and it stays at
+        // the top of the file where frontmatter is frontmatter.
+        knowledge_write(
+            root,
+            &json!({
+                "path": "20-domains/y.md",
+                "title": "Y",
+                "content": "---\ntype: runbook\nlast-verified: 2026-01-01\n---\n\nbody",
+            }),
+            &ForbiddenPaths::default(),
+        );
+        let raw = std::fs::read_to_string(root.join("20-domains/y.md")).unwrap();
+        assert!(raw.starts_with("---"), "frontmatter must lead the file: {raw}");
+        assert_eq!(raw.matches("---").count(), 2, "no second frontmatter: {raw}");
+        let (kind, _, verified, _) = parse_frontmatter(&raw);
+        assert_eq!(kind, "runbook");
+        assert_eq!(verified.as_deref(), Some("2026-01-01"));
+    }
+
+    /// The manifest template documents each value in a comment on its own line.
+    /// Rewriting the line used to take the sentence with it.
+    #[test]
+    fn setting_a_value_keeps_the_line_that_explains_it() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        std::fs::write(
+            root.join(MANIFEST),
+            "version: 1\nvisibility: private  # private | org — 默认仅团队可见\n",
+        )
+        .unwrap();
+
+        let reply = manifest_set(root, &json!({ "visibility": "org", "confirm": true }));
+        assert!(reply.contains("\"ok\":true"), "{reply}");
+        let raw = std::fs::read_to_string(root.join(MANIFEST)).unwrap();
+        assert!(raw.contains("visibility: org"), "{raw}");
+        assert!(
+            raw.contains("# private | org — 默认仅团队可见"),
+            "the explanation must survive: {raw}"
+        );
+    }
+
+    #[test]
+    fn a_hash_inside_a_value_is_not_a_comment() {
+        // ` #` starts a comment; `a#b` does not, and neither does one in quotes.
+        assert_eq!(trailing_comment(" private  # why"), "  # why");
+        assert_eq!(trailing_comment(" tag#1"), "");
+        assert_eq!(trailing_comment(" \"a # b\""), "");
+        assert_eq!(trailing_comment(" \"a # b\"  # real"), "  # real");
+        assert_eq!(trailing_comment(" plain"), "");
     }
 
     #[test]


### PR DESCRIPTION
#1149 评审里剩下的机械性条目，一次清完。**需要拍板的两条（`visibility` 的真人审批、补 `read`）刻意不在里面。**

| # | 问题 | 现在 |
|---|---|---|
| 1 | `overwritten` 恒为 true | 改到写之前判断 |
| 2 | agent 写的页对 `health()` 隐形 | 盖 `type` + `updated` |
| 3 | 改 manifest 值会抹掉解释它的注释 | 注释带过去 |
| 4 | `today_iso()` 是 UTC | 改成本地日期 |
| 5 | handler 在 socket select loop 上 inline await | 挪到 `spawn_blocking` |
| 6 | `kind` 是未写进契约的隐藏别名 | 删掉 |
| 7 | 同一个问题两种问法 + 两行 `let _ = …` | 合一、清掉 |

## 几条值得单独说的

**第 2 条不只是「加个 frontmatter」。** 自带 frontmatter 的 content 现在**整页原样写入** —— 因为 frontmatter 只有在文件最开头才算 frontmatter，在它前面拼一个 `# {title}` 会把整块变成正文，**调用方费力设置的字段全部静默丢失**。这个错误就出现在本 commit 的初稿里，是新加的测试抓出来的。契约因此变成「你带了 frontmatter，这一页就归你，标题也归你」，mcp-manifest 里写明了。

**第 4 条附带一个事实更正。** 原注释写着「避免为一个日期戳引入 chrono，daemon 的依赖树已经很重」—— 但 `chrono` 一直就是这个 crate 的**直接依赖**（`apps/daemon/Cargo.toml:45`）。那套手写的 civil-from-days 是为了躲一个早就在树里的东西。

**第 5 条在 #1217 之后更要紧。** `search` 现在同步读整棵树，正是最不该占着 select loop 的那种活。而且它从来没用过 `self` —— `&self` 是唯一把它钉在循环上的东西。紧挨着的 `CursorPermission` 早就在 spawn，注释还写着「must never run inline on this loop」。

**第 3 条的注释判定要小心引号。** ` #` 才开注释，`a#b` 不是，引号里的 `#` 也不是 —— 单独有测试覆盖这四种形状。

## 验证

`cargo test -p amuxd --bin amuxd`：**1739 passed, 0 failed**（新增 4 条测试）。三个文件的 rustfmt 差异与 main 基线完全一致（2 / 0 / 19，无新增）—— 用一次性 worktree 对比的。

## 还欠着的两条（需要你定方向）

- **`visibility` 的 confirm 不构成人工确认** —— `confirm: true` 和 `visibility: "org"` 由同一个 agent 在同一个 payload 里填。要真是「发布到全公司」，得走 `cursor-permission` 那种真人审批通道。
- **缺 `read`** —— agent 只能 search 拿片段、`write` 是整篇覆盖，改一页只能凭片段重写全文。补 `knowledge_read` 还是让 `write` 支持 append/patch，是个 API 形状问题。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NSLRgWQJVe4uVJ824WdBdE
