### PR TITLE
docs(adr): D1–D5 from the desktop audit, as proposed ADRs

### DIFF
--- a/docs/adr/0009-webview-fs-and-network-scope.md
+++ b/docs/adr/0009-webview-fs-and-network-scope.md
@@ -1,0 +1,72 @@
+---
+status: proposed
+---
+
+# webview 只拿它实际要用的目录，不拿整块磁盘
+
+`apps/desktop/capabilities/default.json` 的 11 条 `fs:allow-*`（读、写、删、
+改名、建目录、复制）每一条都带 `{"path": "$HOME/**"}` 和 `{"path": "/**"}`，
+`tauri.conf.json` 的 `assetProtocol.scope` 同样是 `["$HOME/**", "/**"]`。
+本 ADR 把它们收敛到**运行时按需放行的一组根**：
+
+- 用户已注册的 workspace 根（新增 workspace 时通过 `tauri-plugin-fs` 的
+  `FsExt::scope().allow_directory` 动态放行）
+- `~/.amuxd`（daemon 的家）与 `~/.agents`（skills）
+- 系统下载目录
+- 用户经 `dialog` 插件亲手选中的路径 —— 这条不需要我们做任何事，Tauri 会自动把
+  选中项加进 scope，所以「打开任意文件」的流程不受影响
+
+另外两件不依赖本决定、可以立刻做的：`connect-src` 从 `https: http: ws: wss:`
+改成逐条列举（`build.config.*.json` 里的 API / MQTT / Supabase 域名，加
+`http://127.0.0.1:*` 给本机 daemon）；`withGlobalTauri: true` 换成
+`isTauri()` 判断——**前提是先确认没有依赖 `window.__TAURI__` 的注入脚本**，
+`commands/webview.rs` 的身份注入脚本就是一个候选。
+
+## 为什么
+
+`capabilities/default.json` 自己的 description 写着 "The fs grants below are
+whole-disk."，所以这不是疏忽，是当时的取舍。今天重新算这笔账，代价的一侧变了。
+
+**同一个 origin 渲染的东西**：`packages/app/src/packages/ai/message.tsx` 渲染队友
+和 agent 的 markdown，`lib/dynamic-ui/` 渲染 agent 生成的 UI 描述，编辑器渲染
+workspace 里的任意文件。同一个 origin 持有的能力是：全盘 fs（27 个非测试文件直接
+`import '@tauri-apps/plugin-fs'`）、`connect-src https: http: ws: wss:` 的任意
+出网，以及 `lib/daemon/daemon-local-client.ts:104` 用 daemon 根 token 换来的、
+带 `admin` scope 的会话 token。
+
+**今天没有漏洞**：2026-09-02 的审计逐条查过 XSS 落点——三处
+`dangerouslySetInnerHTML` 吃的是 Shiki 输出或 `securityLevel: 'strict'` 的
+Mermaid SVG；react-markdown 没开 `rehype-raw`，原始 HTML 被丢弃，
+`javascript:` / `file:` / `asset:` 被中和；生产构建没有 `eval` / `new Function`；
+没有 `postMessage` 处理器。所以这是**爆炸半径，不是漏洞**。
+
+正因为它是爆炸半径，它的价值不在「修掉一个已知 bug」，而在把未来任何一次 XSS 的
+后果从「读 `~/.ssh/id_rsa`、改任意文件」降到「读写用户本来就在这个 app 里操作的
+目录」。SEC-5 已经先按这个方向做了一半：agent 渲染的本地图片被限定到规范化后的
+会话目录（`message.tsx` 的 `img` 组件），但那是逐个落点的补丁，补一个漏一个——
+`readFile` 本身仍然是全盘的。
+
+## 考虑过的其它方案
+
+**a. 维持全盘。** 代价 0、收益 0。在没有 XSS 落点的今天可以自洽，但它把「有没有
+漏洞」和「漏了会怎样」绑成了同一个赌注。
+
+**c. 所有 fs 访问下沉到 Rust 命令、按命令校验路径**（`commands/workspace_files.rs`
+已经是这个模式：规范化后限定 workspace 内、25 MiB 上限、不在主线程）。这是终局
+形态——前端零 fs 能力，权限判断集中在一处——但要改 27 个文件的全部路径来源，
+工程量最大。
+
+选 b 是因为它拿到 c 的绝大部分收益，而不需要一次性重写 27 个文件：scope 一收，
+webview 就已经读不到 `~/.ssh` 了。**c 仍然是长期方向**，对新代码应当直接要求：
+新的 fs 访问走 Rust 命令，不要新增 `@tauri-apps/plugin-fs` 的导入点。
+
+## 代价与已知的坑
+
+- 要逐个过那 27 个文件的路径来源，把 workspace 外的合法路径显式登记。已知的至少
+  有：Obsidian vault（`lib/knowledge/obsidian.ts`）、skill 目录、诊断包写出的位置。
+- 动态放行必须在**用户新增 workspace 的那一刻**发生，而不是在第一次读文件时，
+  否则会出现"第一次点开报错、第二次就好了"的时序 bug。
+- `assetProtocol.scope` 是编译期静态的，不能像 fs 那样运行时追加。图片预览这类
+  走 `asset:` 的路径要么改走已经存在的 `read_workspace_binary_file`（PERF-16 之后
+  它返回 base64），要么给 asset 单独留一组更宽的根。这一条要在动手前定，
+  否则收 scope 会直接打断文件预览。

--- a/docs/adr/0010-cron-belongs-to-the-daemon.md
+++ b/docs/adr/0010-cron-belongs-to-the-daemon.md
@@ -1,0 +1,59 @@
+---
+status: proposed
+---
+
+# 定时任务归 daemon，桌面端只剩 UI
+
+`apps/desktop/src/commands/cron/`（6 个文件，3,531 行）整体搬到 amuxd。调度器、
+任务存储、执行、投递都在 daemon 进程内；桌面端保留设置页 UI，通过 daemon 的
+HTTP API 增删改查任务。任务存储按 layout-v2 归 team：
+`~/.amuxd/teams/<id>/cron/`，不再是 `dirs::config_dir()/<brand>/cron-global`。
+
+搬家的同时把那份**不存在的 spec** 补上：`commands/cron/amuxd_client.rs:10` 的
+文件头引用 `docs/superpowers/specs/2026-05-17-cron-to-amuxd-design.md`，
+这个文件在仓库里不存在（已核实）。
+
+## 为什么
+
+cron 的用户价值恰恰是「人不在的时候跑」，而人不在的时候桌面 app 大概率也不在。
+今天的形态把这个价值和「app 得开着」绑死了：
+
+- 调度器跑在桌面进程里。关掉 app，定时任务就不跑。
+- 无头运行的 daemon（gateway 场景、服务器上的 amuxd）**永远没有定时能力**，
+  因为调度器根本不在那个进程里。
+- daemon 只执行回合——它的两条相关路由的注释明说是为桌面 cron 服务的。也就是说
+  daemon 已经承担了最难的部分（跑完一整个 agent turn），却拿不到触发权。
+
+存储位置也偏离了 layout-v2 的第一条：`commands/cron/mod.rs:81-84` 把全局任务放在
+`dirs::config_dir()/<brand storage dir>/cron-global`，这个路径不在任何 layout 文档
+里；workspace 任务按 workspace 路径做键。两者都不是 team-scoped，和 ADR-0006
+（daemon 状态按 team 归属）对不上。
+
+还有第三个 cron 面：`teamclu-introspect` 的 `/cron-run`
+（`crates/teamclu-introspect/src/cron.rs:161`）让 agent 自己触发任务。三个面
+并存的时候，「一个任务现在到底会不会跑」没有单一答案。
+
+## 一条必须一起搬的约束
+
+团队记忆里有一条不在审计报告里、但会决定实现对错的事实：**cron 触发的 agent
+必须默认 full access**。无人值守，等审批就等于不跑。搬到 daemon 之后这条要显式
+写进 daemon 侧的执行路径，不能指望桌面端的权限 UI 兜底——那时候没有 UI 在场。
+
+## 考虑过的其它方案
+
+**a. 桌面端继续持有。** 零成本，但上面三条问题一条都不解决，且三个 cron 面继续
+并存。
+
+**c. 云端调度**（Cloud API 定时触发 daemon）。多设备只跑一次的语义最自然——这是
+b 解决不了的：两台机器各跑一个 amuxd，同一个 team 的任务会跑两遍。但它依赖网络，
+离线场景直接丢掉，而「本机定时跑一件事」不该需要公网。
+
+选 b，把 c 留作 b 之上的可选层：调度仍在 daemon，云端只做多设备去重。先 b 后 c
+的顺序是对的，反过来（先做 c）会让离线用户从「app 开着就能跑」退化到「没网就不
+跑」。
+
+## 代价
+
+3,531 行搬家，加一份从来没写过的 spec。桌面端因此少掉一个子系统——`commands/cron/`
+整个目录，以及它牵连的 `amuxd_client.rs`（一个只为 cron 存在的 Unix socket /
+命名管道客户端）。

--- a/docs/adr/0011-one-reconciliation-point-for-agent-reply-text.md
+++ b/docs/adr/0011-one-reconciliation-point-for-agent-reply-text.md
@@ -1,0 +1,56 @@
+---
+status: proposed
+---
+
+# agent 回复文本只有一个对账点
+
+CLAUDE.md 的流式规则写着「完成阶段禁止取最长」，而
+`lib/agent/agent-reply-text.ts:7` 的 `pickCanonicalAgentReplyText` 恰恰是
+「等价则取较长」。这条例外**保留**，但收口成唯一出处：
+
+- `pickCanonicalAgentReplyText` 只允许 `lib/agent/agent-reply-transcript.ts`
+  import。
+- 该模块对外只导出 `reconcileEquivalentAgentReplyText`
+  （`agent-reply-transcript.ts:174`）和 `deriveAgentReplyContent`；
+  `stores/v2-stream-parts.ts` 的 finalize 路径走前者。
+- `lib/__tests__/agent-reply-single-reconciliation.test.ts` 扫 `src`，
+  出现第四个 importer 就让构建失败。
+- CLAUDE.md 的流式段落写明这条例外的出处和理由。
+
+以上**已经实现**（#1227）。本 ADR 记的是它为什么是决定而不是权宜，以及下一步的
+前提。
+
+## 为什么保留「取最长」
+
+代码里的理由成立，且是两条独立的事实：
+
+1. MQTT QoS0 会丢包。工具调用之后的 delta 丢一段，客户端拼出来的文本就短一截。
+2. daemon 的最终内容有时带尾巴——它不是 delta 的简单拼接。
+
+所以「等价则取较长」不是偷懒，是在两个都可能不完整的来源之间做的取舍。真正的问题
+从来不是这个规则本身，而是它当时**住在三处**（finalize、`deriveAgentReplyContent`、
+以及后者内部的第二处调用），没有单一权威，类型层面拦不住第四处。收口之后行为
+一字未变，变的是「这条例外只有一个出处，而且有测试守着」。
+
+注意 `deriveAgentReplyContent` 同时喂两条路径：`streaming-persist.ts` 的持久化
+content 和 `live-agent-stream.ts` 的实时气泡。这就是为什么它必须是**同一个**
+函数——两条路径若各自对账，用户会看到气泡和落库内容不一致。
+
+## 下一步：切到「daemon 最终内容为准」的前提
+
+真正干净的终局是：daemon 最终内容存在时一律以它为准，delta 拼接只在它缺席时兜底。
+那时 `pickCanonicalAgentReplyText` 整个删掉。切之前必须在 **daemon 侧**证实三件事：
+
+1. 最终内容是否完整覆盖工具调用之后的文本；
+2. 「尾巴」到底是什么——是 daemon 多加的，还是客户端少收的；
+3. 能否在 daemon 侧把尾巴去掉。
+
+若 daemon 内容确有缺失就切，用户会看到回复被截断——这是比「偶尔多一段」更糟的
+失败模式。所以顺序是：先核实，后切。
+
+## 明确没做的事
+
+`stores/v2-streaming-store.ts` 里 delta 与最终内容共用同一个 `outputText` 字段
+（16 处调用点散在 1,869 行里）。`docs/architecture/v2.md` 说这两者"必须"物理分离，
+从未落地。它不是一个可以收口的改动，留给切到「daemon 为准」时一起做——那时候
+分离是必然结果，而不是一次独立的重构。

--- a/docs/adr/0012-window-local-state-is-the-default.md
+++ b/docs/adr/0012-window-local-state-is-the-default.md
@@ -1,0 +1,54 @@
+---
+status: proposed
+---
+
+# 除 auth 外，一切前端状态默认窗口局部
+
+多窗口下（`create_workspace_window` 开出的 workspace 窗口、local-agent 面板），
+每个窗口有自己的 store 图和自己的 `MqttLiveWiring`。本 ADR 把这个隐含约定变成
+显式规则：
+
+- **默认：窗口局部。** 一个 store 的状态不承诺跨窗口一致，也不需要。
+- **唯一的例外是 auth。** `lib/auth/session-store.ts` 用 `BroadcastChannel`
+  （`session-store.ts:38`）跨窗口同步会话，因为「一个窗口登出、另一个窗口还拿着
+  旧 token 打 API」是安全问题，不是体验问题。
+- **6 个 `persist()` store 属于「偏好」，允许后写者赢**：
+  `agent-model-pick-store`、`agent-default-workspace-store`、
+  `automation-default-model`、`client-model-mru`、`header-preferences-store`、
+  `offline-send-preference-store`。偏好被另一个窗口覆盖，代价是用户重新选一次。
+- **新增 `localStorage` 写入点默认落在上面这条**：它是偏好，不是共享状态。
+  如果一个值不能接受"后写者赢"，那它就不该在 localStorage 里。
+
+规则写进 `AGENTS.md`，因为这是一条**别人写新代码时要遵守的约定**，不是一次性
+改动。
+
+## 为什么先写规则而不是先改代码
+
+今天没有用户报告，因为多窗口用得少。这既是"不用急"的理由，也是"现在正是时候"的
+理由——趁没有既成事实，先定下规则，比等到有人报 bug 再回头统一便宜得多。
+
+而现状正在朝错误方向漂：审计当天（2026-09-02）数到 33 处
+`localStorage.setItem`，今天是 **67 处**。翻倍的过程中没有任何人做过"这个值该不该
+跨窗口一致"的判断，因为没有规则可依。规则的价值就在这里——它让下一个写
+`localStorage.setItem` 的人必须先回答一个问题。
+
+## 之后逐个评估，而不是一次性搬家
+
+规则定下之后，对 6 个 `persist()` store 逐个问：这个值真的需要设备一致吗？只有
+答案为「是」的才做搬家（挪到 Rust 持有、以 emit 广播变更）。候选是三个：
+
+- **当前团队** —— 两个窗口显示不同团队，用户几乎一定会误操作
+- **agent 默认 workspace** —— 影响新会话落在哪
+- **模型 MRU** —— 弱候选，不一致的代价只是多选一次
+
+每挪一个都是一次小重构，收益要单独论证。**不要为了"统一"而全搬**。
+
+## 考虑过的其它方案
+
+**给每个 `persist()` store 加 `BroadcastChannel` 同步。** 实现简单，但它只解决
+6 个 store，那 67 处裸 `localStorage.setItem` 仍然各写各的——而且它把"跨窗口
+一致"变成默认行为，等于在没有判断的情况下替所有值做了决定。方向反了：默认应该是
+局部，一致性是要论证的例外。
+
+**把所有共享状态挪到 Rust。** 是终局形态，但在没有任何用户报告的今天，它的成本
+远大于收益，而且没有规则的话，挪完之后新代码还会继续往 localStorage 里写。

--- a/docs/adr/0013-ipc-errors-carry-a-code.md
+++ b/docs/adr/0013-ipc-errors-carry-a-code.md
@@ -1,0 +1,65 @@
+---
+status: proposed
+---
+
+# IPC 错误带一个稳定的 code，而不是靠子串匹配文案
+
+引入一个跨 IPC 边界的错误形状：
+
+```rust
+pub struct CommandError {
+    pub code: &'static str,        // 稳定标识，例如 "no_team_secret"
+    pub message: String,           // 给人看的，可以随便改
+    pub details: Option<Value>,    // 可选结构化上下文
+}
+```
+
+配 `impl Serialize` 和 `impl From<String>`（`code = "unknown"`），让现存的
+**430 个** `Result<_, String>` 可以**渐进**迁移而不是一次性重写；前端在 `invoke`
+封装里统一解析。
+
+第一批换码的对象是那些今天已经在被子串匹配的错误——它们是这条决定要解决的实际
+问题，其余的可以一直挂着 `"unknown"`。
+
+## 为什么
+
+`apps/desktop/src` 里 430 个 `Result<_, String>`、4 个 `thiserror` 枚举、
+**0 个错误码**。错误就是字符串，于是字符串就成了契约：
+
+- `apps/desktop/src/commands/team_sync_proxy.rs:346` —— Rust 匹配 **daemon** 的
+  文案 `contains("no OSS team secret")`，用来决定要不要重新投递团队密钥。
+  daemon 那边改一次措辞，这条自愈路径静默失效，用户看到的是"同步失败"而没有任何
+  线索说明本机其实存着密钥。
+- `packages/app/src/lib/auth/extension-oauth.ts:52-55` —— JS 匹配 OAuth 提供方的
+  英文文案（`"did not approve"`、`"canceled"`、`"cancelled"`、
+  `"closed by the user"`）来区分"用户取消"和"真失败"。四个拼写并列本身就说明
+  这个契约有多脆。
+
+反例值得记下来，因为它已经是对的方向：
+`packages/app/src/lib/telemetry/local-cache-error-report.ts:29-30` 匹配的是
+**稳定 token** `local_cache: empty_team_id` / `local_cache: team_gate_mismatch`，
+而且它们在 Rust 侧是具名常量
+（`apps/desktop/src/local_cache/commands.rs:55`），注释明写「Matched as stable
+tokens rather than prose so the two sides can't drift apart silently」。这条已经
+不会静默漂移了——本 ADR 是把这个做法从"某个模块的好习惯"提升为整个 IPC 边界的
+形状。
+
+## 迁移顺序
+
+1. `local_cache/commands.rs` 的两个 token → 真正的 `code`，前端消费方跟着换。
+   这一步风险最低，因为两侧已经是稳定标识，只是形状换了。
+2. `extension-oauth.ts` 匹配的取消/失败判定 —— 对应的 Rust 侧出错点换码。
+3. `team_sync_proxy.rs:346` 匹配的是 **daemon** 的文案，要 daemon 先给错误码。
+   属于 daemon 边界的后续任务，不在桌面端这条 ADR 的范围内，但它是这条决定最终
+   要覆盖的目标。
+
+## 考虑过的其它方案
+
+**维持字符串，约定稳定前缀**（`E_NO_TEAM_SECRET: ...`）。便宜，而且
+`local_cache` 已经在这么做了、确实有效。没选它的理由是：前缀就是新的子串匹配——
+它靠所有人自觉不去改前缀，而没有任何机制能在改坏时报错。`code` 是一个字段，
+删掉或改名会让编译或反序列化失败；前缀改错只会让一个 `if` 分支悄悄不再命中。
+
+对 430 个返回点全部立刻迁移也不现实，所以 `From<String>` 的兜底
+（`code = "unknown"`）是这个方案能落地的关键：它让"没迁移"是一个合法状态，而不是
+一次性的大爆炸。

--- a/docs/audit/2026-09-02-tauri-desktop-audit-decisions.md
+++ b/docs/audit/2026-09-02-tauri-desktop-audit-decisions.md
@@ -5,7 +5,17 @@
 可选项和建议写清楚，**只提建议，不替产品拍板**。每条末尾注明本分支（`fix/audit-2026-09-p0-p1`）
 在不预设方向的前提下已经做了什么、什么在等这个决定。
 
-定下来之后，每条各落一份 `docs/adr/00xx-*.md`（格式照 ADR-0007），本文即可删除。
+每条已各落一份 ADR，**状态是 `proposed`**——本文的建议被原样采纳写成了决定，但
+决定本身还没人签字。定稿时把对应 ADR 的 `status` 改成 `accepted`（或改掉选项），
+本文即可删除：
+
+| | ADR |
+|---|---|
+| D1 · SEC-2 | [0009 webview 只拿它实际要用的目录](../adr/0009-webview-fs-and-network-scope.md) |
+| D2 · ARCH-6 | [0010 定时任务归 daemon](../adr/0010-cron-belongs-to-the-daemon.md) |
+| D3 · ARCH-2 | [0011 agent 回复文本只有一个对账点](../adr/0011-one-reconciliation-point-for-agent-reply-text.md) |
+| D4 · ARCH-11 | [0012 除 auth 外一切状态窗口局部](../adr/0012-window-local-state-is-the-default.md) |
+| D5 · STR-4 | [0013 IPC 错误带一个 code](../adr/0013-ipc-errors-carry-a-code.md) |
 
 ---
 


### PR DESCRIPTION
> **Stacked on #1230.** Base is `fix/audit-2026-09-remaining`, not `main`,
> because these ADRs cite frontend paths that only exist after that PR's `lib/`
> reorganisation. Retarget to `main` once #1230 lands — the diff is docs-only
> and will not conflict.

`docs/audit/2026-09-02-tauri-desktop-audit-decisions.md` said each of the five
open decisions would get an ADR once decided. These are those five.

| | ADR | 采纳的选项 |
|---|---|---|
| D1 · SEC-2 | 0009 webview 只拿它实际要用的目录 | b — 收敛到已注册 workspace + `~/.amuxd` + `~/.agents` + 下载目录，运行时按需放行 |
| D2 · ARCH-6 | 0010 定时任务归 daemon | b — 调度器搬进 amuxd，桌面端只剩 UI |
| D3 · ARCH-2 | 0011 agent 回复文本只有一个对账点 | a — 已实现（#1227），本 ADR 给它书面理由 |
| D4 · ARCH-11 | 0012 除 auth 外一切状态窗口局部 | a — 先把规则写进 AGENTS.md，再逐个评估 |
| D5 · STR-4 | 0013 IPC 错误带一个 code | a — `CommandError { code, message, details }`，渐进迁移 |

## 这里需要的是签字，不是 review

**五份的 `status` 都是 `proposed`，不是 `accepted`。** 它们把决策文档里的建议原样
写成了决定，但决定本身还没人签。那份文档开头就写着「只提建议，不替产品拍板」，
所以我没有替你把五个方向定死。

定稿方式：把对应文件的 `status: proposed` 改成 `accepted`（一行），或者告诉我哪条
要换选项。**D1 值得单独想一下**——选 b 意味着有人要逐个过 27 个直接
`import '@tauri-apps/plugin-fs'` 的文件，把 workspace 外的合法路径显式登记；
选 a（维持全盘）成本为零，选 c（fs 全下沉到 Rust 命令）是终局但工程量最大。

## 写法

每份都记了**落选方案和它们输在哪**，不只是结论——照 ADR-0007 的样子，论据是
file:line 而不是主张。所有引用都按这条分支重新解析过（`lib/` 重排动了大部分前端
路径），并逐行核对过被引用的那行确实说了 ADR 里说的话。

唯一一个悬空引用是 `docs/superpowers/specs/2026-05-17-cron-to-amuxd-design.md`：
`apps/desktop/src/commands/cron/amuxd_client.rs:10` 指着它，它不在仓库里。这个缺失
本身就是 0010 的论据之一，所以留着。

## 重新核对时冒出来的两件事

- **0012** — `localStorage.setItem` 审计当天 33 处，今天 **67 处**。翻倍的过程里
  没有规则可依，这正是「先写规则、再等下一个 34」的理由。
- **0013** — `lib/telemetry/local-cache-error-report.ts` 已经在匹配稳定 token 而不是
  文案，Rust 侧（`local_cache/commands.rs:55`）还把它们具名成了常量，注释写着
  "Matched as stable tokens rather than prose so the two sides can't drift apart
  silently"。所以它在 ADR 里是**先例**，不是又一个反面案例。

## 合并之后

五份 ADR 落地后，`2026-09-02-tauri-desktop-audit-decisions.md` 就只剩「本分支刻意
没碰的 P1」一节还有用，其余内容已经被 ADR 取代——按它自己的说法，那时候整份文档
可以删掉。这条 PR 没有替你做这个删除。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S888FF7uoJUPWf9VtCAket
