### PR TITLE
docs: 签掉审计的五个决定（ADR-0009~0013 全部 accepted）

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -303,6 +303,33 @@ The user-facing rule is "适度区分 — 清晰但不抢眼". Concretely:
   panel, background, or selected? If you can't answer, you probably need a
   new token; raise it before adding ad-hoc colors.
 
+### Which state is shared between windows
+
+**Default: window-local.** Every workspace window and the local-agent panel gets
+its own store graph and its own `MqttLiveWiring`. A store's state is not
+promised to be consistent across windows, and does not need to be.
+
+**The one exception is auth.** `lib/auth/session-store.ts` syncs the session
+across windows over a `BroadcastChannel`, because "one window signed out while
+another still holds a token" is a security problem, not a cosmetic one.
+
+**Everything persisted today is a preference, and last-writer-wins is fine for
+it.** Five stores use the zustand `persist()` middleware —
+`agent-default-workspace-store`, `agent-model-pick-store`,
+`automation-default-model`, `client-model-mru`,
+`offline-send-preference-store` — and a few more hand-roll the same thing over
+`localStorage` (`header-preferences-store`, `git-settings`). The cost of another
+window overwriting any of them is that the user picks again.
+
+**So a new `localStorage.setItem` is a preference by default.** If a value
+cannot tolerate last-writer-wins, it does not belong in `localStorage` — raise
+it instead of reaching for a `BroadcastChannel`. Making cross-window
+consistency the default would decide, for every value, a question nobody asked.
+
+See [ADR-0012](docs/adr/0012-window-local-state-is-the-default.md). It also
+records which values are worth promoting to device-shared state (current team,
+agent default workspace) — one at a time, each argued on its own.
+
 ### `packages/app/src/lib` layout
 
 `lib/` is one directory per domain. Put a new module in the domain it belongs

--- a/docs/adr/0009-webview-fs-and-network-scope.md
+++ b/docs/adr/0009-webview-fs-and-network-scope.md
@@ -1,5 +1,5 @@
 ---
-status: proposed
+status: accepted
 ---
 
 # webview 只拿它实际要用的目录，不拿整块磁盘

--- a/docs/adr/0010-cron-belongs-to-the-daemon.md
+++ b/docs/adr/0010-cron-belongs-to-the-daemon.md
@@ -1,10 +1,10 @@
 ---
-status: proposed
+status: accepted
 ---
 
 # 定时任务归 daemon，桌面端只剩 UI
 
-`apps/desktop/src/commands/cron/`（6 个文件，3,531 行）整体搬到 amuxd。调度器、
+`apps/desktop/src/commands/cron/`（7 个文件，3,531 行）整体搬到 amuxd。调度器、
 任务存储、执行、投递都在 daemon 进程内；桌面端保留设置页 UI，通过 daemon 的
 HTTP API 增删改查任务。任务存储按 layout-v2 归 team：
 `~/.amuxd/teams/<id>/cron/`，不再是 `dirs::config_dir()/<brand>/cron-global`。
@@ -30,7 +30,7 @@ cron 的用户价值恰恰是「人不在的时候跑」，而人不在的时候
 （daemon 状态按 team 归属）对不上。
 
 还有第三个 cron 面：`teamclu-introspect` 的 `/cron-run`
-（`crates/teamclu-introspect/src/cron.rs:161`）让 agent 自己触发任务。三个面
+（`apps/desktop/crates/teamclu-introspect/src/cron.rs:161`）让 agent 自己触发任务。三个面
 并存的时候，「一个任务现在到底会不会跑」没有单一答案。
 
 ## 一条必须一起搬的约束

--- a/docs/adr/0011-one-reconciliation-point-for-agent-reply-text.md
+++ b/docs/adr/0011-one-reconciliation-point-for-agent-reply-text.md
@@ -1,5 +1,5 @@
 ---
-status: proposed
+status: accepted
 ---
 
 # agent 回复文本只有一个对账点
@@ -14,7 +14,7 @@ CLAUDE.md 的流式规则写着「完成阶段禁止取最长」，而
   （`agent-reply-transcript.ts:174`）和 `deriveAgentReplyContent`；
   `stores/v2-stream-parts.ts` 的 finalize 路径走前者。
 - `lib/__tests__/agent-reply-single-reconciliation.test.ts` 扫 `src`，
-  出现第四个 importer 就让构建失败。
+  唯一合法 importer 就是上面那个模块，**出现第二个就让构建失败**。
 - CLAUDE.md 的流式段落写明这条例外的出处和理由。
 
 以上**已经实现**（#1227）。本 ADR 记的是它为什么是决定而不是权宜，以及下一步的

--- a/docs/adr/0012-window-local-state-is-the-default.md
+++ b/docs/adr/0012-window-local-state-is-the-default.md
@@ -1,5 +1,5 @@
 ---
-status: proposed
+status: accepted
 ---
 
 # 除 auth 外，一切前端状态默认窗口局部
@@ -12,10 +12,11 @@ status: proposed
 - **唯一的例外是 auth。** `lib/auth/session-store.ts` 用 `BroadcastChannel`
   （`session-store.ts:38`）跨窗口同步会话，因为「一个窗口登出、另一个窗口还拿着
   旧 token 打 API」是安全问题，不是体验问题。
-- **6 个 `persist()` store 属于「偏好」，允许后写者赢**：
-  `agent-model-pick-store`、`agent-default-workspace-store`、
-  `automation-default-model`、`client-model-mru`、`header-preferences-store`、
-  `offline-send-preference-store`。偏好被另一个窗口覆盖，代价是用户重新选一次。
+- **今天所有被持久化的值都属于「偏好」，允许后写者赢**：走 zustand `persist()`
+  中间件的 5 个是 `agent-default-workspace-store`、`agent-model-pick-store`、
+  `automation-default-model`、`client-model-mru`、`offline-send-preference-store`；
+  另有几个自己手写 `localStorage`（`header-preferences-store`、`git-settings`），
+  性质相同。偏好被另一个窗口覆盖，代价是用户重新选一次。
 - **新增 `localStorage` 写入点默认落在上面这条**：它是偏好，不是共享状态。
   如果一个值不能接受"后写者赢"，那它就不该在 localStorage 里。
 
@@ -34,7 +35,7 @@ status: proposed
 
 ## 之后逐个评估，而不是一次性搬家
 
-规则定下之后，对 6 个 `persist()` store 逐个问：这个值真的需要设备一致吗？只有
+规则定下之后，对这些持久化的值逐个问：这个值真的需要设备一致吗？只有
 答案为「是」的才做搬家（挪到 Rust 持有、以 emit 广播变更）。候选是三个：
 
 - **当前团队** —— 两个窗口显示不同团队，用户几乎一定会误操作
@@ -46,7 +47,7 @@ status: proposed
 ## 考虑过的其它方案
 
 **给每个 `persist()` store 加 `BroadcastChannel` 同步。** 实现简单，但它只解决
-6 个 store，那 67 处裸 `localStorage.setItem` 仍然各写各的——而且它把"跨窗口
+那 5 个 store，其余手写持久化和 67 处裸 `localStorage.setItem` 仍然各写各的——而且它把"跨窗口
 一致"变成默认行为，等于在没有判断的情况下替所有值做了决定。方向反了：默认应该是
 局部，一致性是要论证的例外。
 

--- a/docs/adr/0013-ipc-errors-carry-a-code.md
+++ b/docs/adr/0013-ipc-errors-carry-a-code.md
@@ -1,5 +1,5 @@
 ---
-status: proposed
+status: accepted
 ---
 
 # IPC 错误带一个稳定的 code，而不是靠子串匹配文案
@@ -15,7 +15,7 @@ pub struct CommandError {
 ```
 
 配 `impl Serialize` 和 `impl From<String>`（`code = "unknown"`），让现存的
-**430 个** `Result<_, String>` 可以**渐进**迁移而不是一次性重写；前端在 `invoke`
+**510 个** `Result<_, String>` 可以**渐进**迁移而不是一次性重写；前端在 `invoke`
 封装里统一解析。
 
 第一批换码的对象是那些今天已经在被子串匹配的错误——它们是这条决定要解决的实际
@@ -23,8 +23,9 @@ pub struct CommandError {
 
 ## 为什么
 
-`apps/desktop/src` 里 430 个 `Result<_, String>`、4 个 `thiserror` 枚举、
-**0 个错误码**。错误就是字符串，于是字符串就成了契约：
+`apps/desktop/src` 里 510 个 `Result<_, String>`
+（`grep -rE "Result<[^,]*, *String>" apps/desktop/src --include='*.rs'`，签字时重数；
+审计当时是 430，这个数只会涨）、4 个 `thiserror` 枚举、**0 个错误码**。错误就是字符串，于是字符串就成了契约：
 
 - `apps/desktop/src/commands/team_sync_proxy.rs:346` —— Rust 匹配 **daemon** 的
   文案 `contains("no OSS team secret")`，用来决定要不要重新投递团队密钥。

--- a/docs/audit/2026-09-02-tauri-desktop-audit-decisions.md
+++ b/docs/audit/2026-09-02-tauri-desktop-audit-decisions.md
@@ -5,16 +5,16 @@
 可选项和建议写清楚，**只提建议，不替产品拍板**。每条末尾注明本分支（`fix/audit-2026-09-p0-p1`）
 在不预设方向的前提下已经做了什么、什么在等这个决定。
 
-每条已各落一份 ADR，**状态是 `proposed`**——本文的建议被原样采纳写成了决定，但
-决定本身还没人签字。定稿时把对应 ADR 的 `status` 改成 `accepted`（或改掉选项），
-本文即可删除：
+每条已各落一份 ADR。**D1 与 D4 已签字（`accepted`），另外三条仍是 `proposed`**——
+后者是本文的建议被原样写成了决定，但还没人拍板。定稿时把对应 ADR 的 `status` 改成
+`accepted`（或改掉选项）；五条都签完，本文即可删除：
 
 | | ADR |
 |---|---|
-| D1 · SEC-2 | [0009 webview 只拿它实际要用的目录](../adr/0009-webview-fs-and-network-scope.md) |
+| D1 · SEC-2 | ✅ **accepted** — [0009 webview 只拿它实际要用的目录](../adr/0009-webview-fs-and-network-scope.md) |
 | D2 · ARCH-6 | [0010 定时任务归 daemon](../adr/0010-cron-belongs-to-the-daemon.md) |
 | D3 · ARCH-2 | [0011 agent 回复文本只有一个对账点](../adr/0011-one-reconciliation-point-for-agent-reply-text.md) |
-| D4 · ARCH-11 | [0012 除 auth 外一切状态窗口局部](../adr/0012-window-local-state-is-the-default.md) |
+| D4 · ARCH-11 | ✅ **accepted** — [0012 除 auth 外一切状态窗口局部](../adr/0012-window-local-state-is-the-default.md)，规则已写进 AGENTS.md |
 | D5 · STR-4 | [0013 IPC 错误带一个 code](../adr/0013-ipc-errors-carry-a-code.md) |
 
 ---

--- a/docs/audit/2026-09-02-tauri-desktop-audit-decisions.md
+++ b/docs/audit/2026-09-02-tauri-desktop-audit-decisions.md
@@ -1,21 +1,22 @@
-# 桌面端审计（2026-09-02）——待拍板的五个决定
+# 桌面端审计（2026-09-02）——五个决定（已全部签字）
 
 配套 `2026-09-02-tauri-desktop-audit.md`「建议动手顺序」第 8 条。审计里有五条 P0/P1
-不是改代码就能关的：它们各自要先定一个方向，代码才知道往哪改。本文把每条的现状、
-可选项和建议写清楚，**只提建议，不替产品拍板**。每条末尾注明本分支（`fix/audit-2026-09-p0-p1`）
-在不预设方向的前提下已经做了什么、什么在等这个决定。
+不是改代码就能关的：它们各自要先定一个方向，代码才知道往哪改。本文写的是每条的现状、
+可选项和建议——**它当时只提建议，不替产品拍板**。
 
-每条已各落一份 ADR。**D1 与 D4 已签字（`accepted`），另外三条仍是 `proposed`**——
-后者是本文的建议被原样写成了决定，但还没人拍板。定稿时把对应 ADR 的 `status` 改成
-`accepted`（或改掉选项）；五条都签完，本文即可删除：
+**五条现已全部签字，方向以 ADR 为准，本文只作为当时的分析留档。** 下面每条末尾还注明了
+本分支（`fix/audit-2026-09-p0-p1`）在不预设方向的前提下已经做了什么、什么在等这个决定。
 
-| | ADR |
+| | ADR（全部 `accepted`） |
 |---|---|
-| D1 · SEC-2 | ✅ **accepted** — [0009 webview 只拿它实际要用的目录](../adr/0009-webview-fs-and-network-scope.md) |
+| D1 · SEC-2 | [0009 webview 只拿它实际要用的目录](../adr/0009-webview-fs-and-network-scope.md) |
 | D2 · ARCH-6 | [0010 定时任务归 daemon](../adr/0010-cron-belongs-to-the-daemon.md) |
 | D3 · ARCH-2 | [0011 agent 回复文本只有一个对账点](../adr/0011-one-reconciliation-point-for-agent-reply-text.md) |
-| D4 · ARCH-11 | ✅ **accepted** — [0012 除 auth 外一切状态窗口局部](../adr/0012-window-local-state-is-the-default.md)，规则已写进 AGENTS.md |
+| D4 · ARCH-11 | [0012 除 auth 外一切状态窗口局部](../adr/0012-window-local-state-is-the-default.md) —— 规则已写进 AGENTS.md |
 | D5 · STR-4 | [0013 IPC 错误带一个 code](../adr/0013-ipc-errors-carry-a-code.md) |
+
+本文当初写着「五条都签完即可删除」，现在不删：末尾两节（**本分支已关闭的条目**、
+**本分支刻意没碰的 P1**）是 ADR 不承载的分支留档，删掉会真丢东西。
 
 ---
 

--- a/docs/audit/2026-09-02-tauri-desktop-audit.md
+++ b/docs/audit/2026-09-02-tauri-desktop-audit.md
@@ -325,9 +325,14 @@ delta 和最终内容；`docs/architecture/v2.md:848` 说"必须做"的物理分
    的 token、请求/响应结构体进两边共编的 `teamclu-types`；`/v1/setup/status` 替换
    `read_daemon_actor_id`（ARCH-4/5，PERF-10）。TS 侧 lint 把 `@tauri-apps/api/core`
    限制在 `lib/`，收拢 16 条双重封装命令（ARCH-8）。
-8. **要落成 ADR 的决定**：cron 归谁（ARCH-6）；agent 回复文本唯一对账点（ARCH-2）；产品真正
-   需要的 fs/asset 范围（SEC-2）；窗口局部 vs 设备共享状态（ARCH-11）；稳定 IPC 错误码形状
-   （STR-4）。然后对照代码修 CLAUDE.md / AGENTS.md（ARCH-7）。
+8. **~~要落成 ADR 的决定~~ 已全部落成并签字**（`accepted`）：cron 归 daemon（ARCH-6 →
+   [ADR-0010](../adr/0010-cron-belongs-to-the-daemon.md)）；agent 回复文本唯一对账点
+   （ARCH-2 → [0011](../adr/0011-one-reconciliation-point-for-agent-reply-text.md)，已实现）；
+   webview 的 fs/asset 范围（SEC-2 → [0009](../adr/0009-webview-fs-and-network-scope.md)）；
+   窗口局部 vs 设备共享状态（ARCH-11 → [0012](../adr/0012-window-local-state-is-the-default.md)，
+   规则已写进 AGENTS.md）；稳定 IPC 错误码形状（STR-4 →
+   [0013](../adr/0013-ipc-errors-carry-a-code.md)）。剩下的是照 ADR 施工，以及对照代码修
+   CLAUDE.md / AGENTS.md（ARCH-7）。
 9. **CI 守卫**：`cargo audit` + `pnpm audit`、`rust-toolchain.toml`、
    `cargo test --all-targets --no-run`、`vitest-setup.ts` 统一测试重置注册表（STR-3/5，SEC-13）。
 


### PR DESCRIPTION
`2026-09-02` 桌面端审计里有五条 P0/P1 不是改代码就能关的——它们各自要先定方向。五份 ADR
都已写好，本 PR 把它们**全部签字**：`status: proposed` → `accepted`。签完之后
`docs/adr/` 的 13 份 ADR 全是 `accepted`。

| | ADR |
|---|---|
| D1 · SEC-2 | 0009 webview 只拿它实际要用的目录 |
| D2 · ARCH-6 | 0010 定时任务归 daemon |
| D3 · ARCH-2 | 0011 agent 回复文本只有一个对账点（已实现于 #1227） |
| D4 · ARCH-11 | 0012 除 auth 外一切状态窗口局部 |
| D5 · STR-4 | 0013 IPC 错误带一个 code |

## 不只是改五个词

**0012 的决定内容本身就是「把规则写下来」**——它选的是「先定约定，再逐个值去问要不要提升
为设备共享」，而不是「给每个 store 加 `BroadcastChannel`」。所以签掉它就得把规则落到
`AGENTS.md`，否则这条 accepted 的 ADR 等于没执行。新增一节
**Which state is shared between windows**（挨着 lib 布局那节）：

- 默认窗口局部：每个 workspace 窗口和本地 agent 面板各有一套 store 图和自己的
  `MqttLiveWiring`，store 状态不承诺跨窗口一致
- 唯一例外是 auth：`lib/auth/session-store.ts` 用 `BroadcastChannel` 同步会话，因为
  「一个窗口登出、另一个还拿着旧 token」是安全问题，不是体验问题
- 今天所有被持久化的值都是偏好，允许后写者赢
- 新增 `localStorage.setItem` 默认按偏好算；不能接受后写者赢的值就不该放 localStorage

## 签字前逐条重核，查出四处错

一份 `accepted` 的 ADR 不该带着错数字，所以核实后一并修正。**五个决定本身一条没改。**

| ADR | 原文 | 实际 |
|---|---|---|
| 0012 | 「6 个 `persist()` store」，含 `header-preferences-store` | 走 zustand `persist()` 中间件的是 **5 个**；`header-preferences-store` 和 `git-settings` 是手写 `localStorage`，性质相同但不是一回事 |
| 0010 | `commands/cron/` **6** 个文件 | **7** 个（3,531 行是对的） |
| 0010 | `crates/teamclu-introspect/src/cron.rs` | 该 crate 在 **`apps/desktop/crates/`** 下，原路径不存在 |
| 0011 | 「出现**第四个** importer 就让构建失败」 | 守卫只有一个 `ALLOWED_IMPORTER`，**第二个**就失败（与 CLAUDE.md 一致）。原文把 importer 文件和「规则原先住的三处调用点」混为一谈 |
| 0013 | **430** 个 `Result<_, String>` | 签字时重数 **510**，树长了。已把 grep 写进正文让数字可复现 |

被否选项的论证不受影响：0012 那条（「只覆盖这几个 store，其余手写持久化和 67 处裸
`setItem` 照样各写各的」）两种数法都成立；0013 的数越大，`From<String>` 渐进迁移的理由
只会更强。

## 核实无误的部分

- **0009**：27 个非测试文件 `import @tauri-apps/plugin-fs`；`withGlobalTauri: true`
  （`tauri.conf.json:13`）；`capabilities/default.json` 对 **11 个 fs 操作**各给 `/**`
  （22 条 = 11 op × `$HOME/**` + `/**`）
- **0010**：`cron-global` 路径（`mod.rs:81-84`）；`/cron-run`（`cron.rs:161`）；它点名要补的
  那份 spec（`docs/superpowers/specs/2026-05-17-cron-to-amuxd-design.md`，被
  `amuxd_client.rs:10` 引用）**确实至今不存在**
- **0011**：`v2-streaming-store.ts` 1,869 行 / 16 处 `outputText`；
  `agent-reply-transcript.ts:174`
- **0013**：4 个 `thiserror` 枚举；`team_sync_proxy.rs:346` 的
  `contains("no OSS team secret")`；`extension-oauth.ts:52-55` 的四种取消拼写；
  `local_cache/commands.rs:55` 与 `local-cache-error-report.ts:29-30` 的稳定 token

## 动手做 SEC-2 前必须先定的一件事

0009「代价与已知的坑」里写着，这里再强调一遍，因为它决定动手顺序：

> `assetProtocol.scope` 是**编译期静态的**，不能像 fs 那样运行时追加。

图片预览走 `asset:`，所以要么改走已经存在的 `read_workspace_binary_file`（PERF-16 之后它
返回 base64），要么给 asset 单独留一组更宽的根。**不定这条就去收 scope，文件预览会直接断。**

## 决定文档没删

它自己写着「五条都签完即可删除」，但末尾两节（**本分支已关闭的条目**、**本分支刻意没碰的
P1**）是 ADR 不承载的分支留档，删掉会真丢东西。改成留档定位，并在文里写明了为什么不删。
审计正文第 8 条「要落成 ADR 的决定」也改成指向五份 ADR，免得读的人再去找已经定了的事。

## 影响面

纯文档，两个 commit。没有代码路径改动，没有测试改动。文档内相对链接已校验全部可解析。

签完解锁 SEC-2、ARCH-8、ARCH-9，以及 cron 搬家（ARCH-6）。

---

注：`main` 当前是红的，与本 PR 无关——#1233 漏了两个 `export`
（`DaemonInfoBody`、`LocalDaemonCatalogOutcome`）加两处无用 import，四行的事，目前没有
PR 在修。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S888FF7uoJUPWf9VtCAket