### PR TITLE
fix(daemon): share one ManagedLlmResolver between HTTP and runtime

### DIFF
--- a/apps/daemon/src/daemon/server.rs
+++ b/apps/daemon/src/daemon/server.rs
@@ -853,8 +853,9 @@ impl DaemonServer {
             refresh_auto_apply_task: None,
             mqtt_connected_flag: None,
             // Built without a token source: the HTTP layer owns the TokenStore
-            // and has not started yet. It is injected below, once that store
-            // exists — see the `set_tokens` call after the http spawn.
+            // and has not started yet. HTTP spawn binds tokens + the local
+            // proxy URL onto this same Arc after the listener binds, before
+            // it accepts requests.
             managed_llm: Arc::new(crate::runtime::managed_llm::ManagedLlmResolver::new(
                 backend,
             )),
@@ -1236,31 +1237,16 @@ impl DaemonServer {
                 self.refresh_watch_registry.clone(),
                 Some(self.runtime_context.clone()),
                 session_prompt,
+                Some(self.managed_llm.clone()),
             )
             .await
             {
                 Ok(h) => {
                     info!(addr = %h.local_addr, "http listener bound");
-                    // Hand the spawn-path resolver the SAME TokenStore the HTTP
-                    // layer authenticates against. Loading a second store from
-                    // the same file is not equivalent: the file holds only the
-                    // root token, while minted session tokens live in the
-                    // instance that minted them — so a token from any other
-                    // store is rejected as "invalid or expired".
-                    //
-                    // Without this the runtimes that read their credential from
-                    // `TEAMCLU_TEAM_PROVIDER` (pi, and anything after it) get a
-                    // token nothing accepts, and every team-model call 401s.
-                    self.managed_llm.set_tokens(
-                        crate::runtime::gateway_token::GatewayTokenSource::new(h.tokens.clone()),
-                    );
-                    // ...and where to reach that proxy. Runtimes are pointed
-                    // here, not at the cloud gateway: the token above is only
-                    // valid locally, and this hop is what refreshes the cloud
-                    // credential per request so a multi-day agent never meets
-                    // its expiry.
-                    self.managed_llm
-                        .set_local_http_base(format!("http://{}", h.local_addr));
+                    // Token source + local proxy URL are attached inside HTTP
+                    // spawn, on this same Arc, before the router accepts
+                    // requests. Calling `set_tokens` again here would replace
+                    // the GatewayTokenSource and mint a second apiKey.
                     if let Err(err) = self
                         .runtime_context
                         .validate_managed_setup(&self.config.agents.local_agent)

--- a/apps/daemon/src/http/server.rs
+++ b/apps/daemon/src/http/server.rs
@@ -186,6 +186,7 @@ pub async fn spawn(
         None,
         runtime_context,
         session_prompt,
+        None,
     )
     .await
 }
@@ -215,6 +216,9 @@ pub async fn spawn_with_refresh_watch_registry(
     >,
     runtime_context: Option<Arc<crate::runtime::context_service::RuntimeContextService>>,
     session_prompt: Option<Arc<crate::runtime::session_prompt::SessionPromptService>>,
+    // Shared with the daemon spawn path. `None` in focused HTTP tests, which
+    // then fall back to a resolver built from `backend` if one is present.
+    managed_llm: Option<Arc<crate::runtime::managed_llm::ManagedLlmResolver>>,
 ) -> anyhow::Result<HttpHandle> {
     // Resolve token + port files (defaults live in DaemonConfig::config_dir).
     let token_path = http
@@ -252,16 +256,23 @@ pub async fn spawn_with_refresh_watch_registry(
     let cors_layer = cors::build(&http.allowed_origins)
         .map_err(|e| anyhow::anyhow!("cors build: {}", e.detail))?;
 
-    // Built from the same backend the routes already hold, so `get_providers`
-    // can reconcile `provider.team` against the team's current cloud LLM config
-    // before reading it back off disk.
-    let managed_llm = backend.clone().map(|b| {
-        Arc::new(
-            crate::runtime::managed_llm::ManagedLlmResolver::new(b).with_tokens(Some(
-                crate::runtime::gateway_token::GatewayTokenSource::new(tokens.clone()),
-            )),
-        )
-    });
+    // The listener owns TokenStore and the bound address, so the shared
+    // resolver is completed here — after bind, before the router accepts
+    // requests. Runtime assemble and provider GET must mint from this
+    // source and write the same local proxy URL; a second resolver would
+    // oscillate `provider.team` and roll every OpenCode host.
+    let local_http_base = loopback_runtime_context_url(addr, local_addr);
+    let managed_llm = match managed_llm {
+        Some(resolver) => {
+            bind_managed_llm_to_listener(&resolver, &tokens, local_http_base);
+            Some(resolver)
+        }
+        None => backend.clone().map(|b| {
+            let resolver = Arc::new(crate::runtime::managed_llm::ManagedLlmResolver::new(b));
+            bind_managed_llm_to_listener(&resolver, &tokens, local_http_base);
+            resolver
+        }),
+    };
     // Same shape for team MCP / team env: desktop posts after a Cloud API write
     // so the daemon cache converges immediately instead of waiting for the tick.
     let team_cloud = backend
@@ -343,6 +354,17 @@ pub async fn spawn_with_refresh_watch_registry(
         runtime_context_join,
         runtime_context_shutdown,
     })
+}
+
+fn bind_managed_llm_to_listener(
+    resolver: &crate::runtime::managed_llm::ManagedLlmResolver,
+    tokens: &TokenStore,
+    local_http_base: String,
+) {
+    resolver.set_tokens(crate::runtime::gateway_token::GatewayTokenSource::new(
+        tokens.clone(),
+    ));
+    resolver.set_local_http_base(local_http_base);
 }
 
 /// Background reaper: prunes expired session tokens every minute.
@@ -1609,9 +1631,7 @@ mod tests {
         {
             let mut mgr = manager.lock().await;
             mgr.add_test_runtime("runtime-prompt");
-            mgr.get_handle_mut("runtime-prompt")
-                .unwrap()
-                .owner_actor_id = "agent-1".into();
+            mgr.get_handle_mut("runtime-prompt").unwrap().owner_actor_id = "agent-1".into();
         }
         let prompt_service = Arc::new(SessionPromptService::new(
             Arc::clone(&manager),
@@ -1772,11 +1792,7 @@ mod tests {
             .expect("token");
 
         let backend = Arc::new(MockBackend::default());
-        seed_session_prompt_backend(
-            &backend,
-            "teamclu-z",
-            &[("agent-z", "Bot", "agent")],
-        );
+        seed_session_prompt_backend(&backend, "teamclu-z", &[("agent-z", "Bot", "agent")]);
         let manager = Arc::new(Mutex::new(RuntimeManager::new(
             std::collections::HashMap::new(),
             None,
@@ -1784,14 +1800,9 @@ mod tests {
         {
             let mut mgr = manager.lock().await;
             mgr.add_test_runtime("runtime-z");
-            mgr.get_handle_mut("runtime-z")
-                .unwrap()
-                .owner_actor_id = "agent-z".into();
+            mgr.get_handle_mut("runtime-z").unwrap().owner_actor_id = "agent-z".into();
         }
-        let prompt_service = Arc::new(SessionPromptService::new(
-            Arc::clone(&manager),
-            backend,
-        ));
+        let prompt_service = Arc::new(SessionPromptService::new(Arc::clone(&manager), backend));
 
         let meta = metadata("actor-test".into(), "test");
         let runtime = crate::http::runtime_adapter::StubRuntimeAdapter::new(256);
@@ -1809,11 +1820,14 @@ mod tests {
         .with_runtime_context(Arc::clone(&service))
         .with_session_prompt(Some(prompt_service));
 
-        let (dedicated_base, join, shutdown_tx) =
-            spawn_dedicated_runtime_context_listener(state).await.unwrap();
+        let (dedicated_base, join, shutdown_tx) = spawn_dedicated_runtime_context_listener(state)
+            .await
+            .unwrap();
         let client = reqwest::Client::new();
         let ok: serde_json::Value = client
-            .post(format!("{dedicated_base}/internal/runtime-context/session-prompt"))
+            .post(format!(
+                "{dedicated_base}/internal/runtime-context/session-prompt"
+            ))
             .bearer_auth(&token)
             .json(&ResolveRuntimeContextRequest {
                 backend_session_id: "backend-z".into(),

--- a/apps/daemon/src/http/state.rs
+++ b/apps/daemon/src/http/state.rs
@@ -152,11 +152,10 @@ pub struct HttpState {
     /// session/live MQTT publish (identical bytes incl. event_id). `None` in
     /// focused tests — the route then returns 503.
     pub live_tee: Option<tokio::sync::broadcast::Sender<super::live_events::LiveTeeEvent>>,
-    /// Shared, TTL-cached resolver for the team's cloud managed LLM. Lets
-    /// `GET /v1/workspaces/:id/providers` re-materialize `provider.team` before
-    /// reading it back off disk, so an admin's model-list change reaches a
-    /// member on a plain refresh rather than only at the next runtime spawn.
-    /// `None` in focused tests — the reconcile is then skipped.
+    /// Shared, TTL-cached resolver for the team's cloud managed LLM. The daemon
+    /// and HTTP listener must hold the same `Arc` so provider reads and runtime
+    /// assemble write one `provider.team`. `None` in focused tests — the
+    /// reconcile is then skipped, unless spawn built a fallback from `backend`.
     pub managed_llm: Option<Arc<crate::runtime::managed_llm::ManagedLlmResolver>>,
     /// Mirrors team MCP / team env from the Cloud API onto the daemon-owned
     /// cache under `~/.amuxd/teams/<id>/cloud/`. Shared with the background

--- a/apps/daemon/src/runtime/managed_llm.rs
+++ b/apps/daemon/src/runtime/managed_llm.rs
@@ -77,13 +77,34 @@ impl ManagedLlmResolver {
 
     /// Attach the token source after construction, for the resolver the daemon
     /// builds before its HTTP layer exists.
+    ///
+    /// Set-once: a second `GatewayTokenSource` would mint a different token
+    /// (each source has its own `OnceLock`) and rewrite `provider.team` forever.
     pub fn set_tokens(&self, tokens: super::gateway_token::GatewayTokenSource) {
-        *self.tokens.write() = Some(tokens);
+        let mut slot = self.tokens.write();
+        if slot.is_some() {
+            tracing::debug!(
+                "managed LLM token source already attached; ignoring a second GatewayTokenSource"
+            );
+            return;
+        }
+        *slot = Some(tokens);
     }
 
     /// Record this daemon's own HTTP origin, once its listener has an address.
     pub fn set_local_http_base(&self, base: String) {
-        *self.local_http_base.write() = Some(base);
+        let mut slot = self.local_http_base.write();
+        if slot.is_some() {
+            tracing::debug!("managed LLM local HTTP base already set; ignoring replacement");
+            return;
+        }
+        *slot = Some(base);
+    }
+
+    /// Drop cached cloud answers so the next `resolve` hits the backend.
+    #[cfg(test)]
+    pub async fn clear_cache(&self) {
+        self.cache.lock().await.clear();
     }
 
     /// The AI proxy URL a runtime should call for `team_id`, or None when this
@@ -288,7 +309,7 @@ mod tests {
             "team-x".to_string(),
             config_with_models(&["model-b", "model-c"]),
         );
-        resolver.cache.lock().await.clear();
+        resolver.clear_cache().await;
 
         resolver.reconcile_global("team-x").await;
         assert_eq!(
@@ -458,5 +479,24 @@ mod tests {
         .unwrap();
 
         assert_eq!(team_model_ids(), vec!["model-a".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn set_tokens_does_not_replace_an_existing_source() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = crate::http::tokens::TokenStore::load_or_init(&dir.path().join("t")).unwrap();
+        let resolver = ManagedLlmResolver::new(mock_resolver());
+        resolver.set_tokens(crate::runtime::gateway_token::GatewayTokenSource::new(
+            store.clone(),
+        ));
+        let first = resolver.gateway_token().expect("token after first set");
+        resolver.set_tokens(crate::runtime::gateway_token::GatewayTokenSource::new(
+            store,
+        ));
+        assert_eq!(
+            resolver.gateway_token().expect("token after second set"),
+            first,
+            "replacing GatewayTokenSource would mint a second apiKey and rewrite provider.team"
+        );
     }
 }

--- a/apps/daemon/tests/http_managed_llm_share.rs
+++ b/apps/daemon/tests/http_managed_llm_share.rs
@@ -1,0 +1,394 @@
+//! Shared `ManagedLlmResolver` between daemon runtime assemble and HTTP
+//! provider reads. Two independent resolvers mint different tokens and write
+//! different baseURLs, which marks every isolation domain for replacement.
+
+include!("support/crate_modules.rs");
+
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use async_trait::async_trait;
+use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
+use config::{HttpConfig, OpenCodeCompatStore, WorkspaceControlStore};
+use runtime::execution_context::{IsolationDomainKey, ProcessEnvRevision};
+use runtime::managed_llm::ManagedLlmResolver;
+use runtime::opencode_http::host_pool::{
+    GenerationFactory, HostGeneration, HostLease, HostLifecycle, OpenCodeHostPool,
+};
+use runtime::opencode_http::process_registry::ServeProcessRegistry;
+use runtime::opencode_http::supervisor::{ServeSupervisor, ShutdownOutcome};
+use runtime::RuntimeSupervisor;
+use tokio::sync::Mutex;
+
+fn ws_id(path: &std::path::Path) -> String {
+    URL_SAFE_NO_PAD.encode(path.to_str().unwrap())
+}
+
+fn enabled_llm(name: &str) -> backend::ManagedLlmConfig {
+    backend::ManagedLlmConfig {
+        enabled: true,
+        base_url: Some("https://gateway.example/v1".to_string()),
+        name: Some(name.to_string()),
+        models: vec![backend::ManagedLlmModelInfo {
+            id: "model-a".to_string(),
+            name: "model-a".to_string(),
+        }],
+    }
+}
+
+fn team_provider_json() -> serde_json::Value {
+    let raw = std::fs::read_to_string(
+        teamclu_runtime_env::opencode_config::global_opencode_config_path(),
+    )
+    .unwrap();
+    serde_json::from_str(&raw).unwrap()
+}
+
+fn team_provider_bytes() -> Vec<u8> {
+    std::fs::read(teamclu_runtime_env::opencode_config::global_opencode_config_path()).unwrap()
+}
+
+struct CountingFactory {
+    starts: AtomicUsize,
+}
+
+#[async_trait]
+impl GenerationFactory for CountingFactory {
+    async fn start(
+        &self,
+        generation_id: String,
+        _domain: IsolationDomainKey,
+        revision: ProcessEnvRevision,
+        env: HashMap<String, String>,
+    ) -> Result<Arc<ServeSupervisor>, String> {
+        self.starts.fetch_add(1, Ordering::SeqCst);
+        Ok(Arc::new(ServeSupervisor::new(
+            generation_id,
+            Arc::new(ServeProcessRegistry::new(
+                tempfile::tempdir().unwrap().keep().join("pgids.json"),
+            )),
+            env,
+            revision,
+        )))
+    }
+
+    fn stop(&self, _generation: &HostGeneration) -> ShutdownOutcome {
+        ShutdownOutcome::Stopped
+    }
+}
+
+struct SharedResolverApp {
+    handle: crate::http::HttpHandle,
+    client: reqwest::Client,
+    base: String,
+    session_token: String,
+    workspace_id: String,
+    resolver: Arc<ManagedLlmResolver>,
+    mock: backend::mock::MockBackend,
+    pool: Option<Arc<OpenCodeHostPool>>,
+    factory: Option<Arc<CountingFactory>>,
+    _lease: Option<HostLease>,
+    _home: test_brand_env::BrandEnvGuard,
+    _amuxd: tempfile::TempDir,
+    _http: tempfile::TempDir,
+    _workspace: tempfile::TempDir,
+}
+
+impl SharedResolverApp {
+    async fn boot(with_host_pool: bool) -> Self {
+        let amuxd = tempfile::tempdir().expect("amuxd home");
+        let home = test_brand_env::BrandEnvGuard::set_amuxd_home(amuxd.path());
+        std::fs::write(
+            amuxd.path().join("daemon.toml"),
+            "active_team = \"team-x\"\n",
+        )
+        .unwrap();
+        std::fs::create_dir_all(amuxd.path().join("teams/team-x/state")).unwrap();
+
+        let workspace = tempfile::tempdir().expect("workspace");
+        let workspace_id = ws_id(workspace.path());
+
+        let mock = backend::mock::MockBackend::with_identity("team-x", "actor-x");
+        mock.state()
+            .managed_llm_configs
+            .insert("team-x".to_string(), enabled_llm("Team"));
+        let backend: Arc<dyn backend::Backend> = Arc::new(mock.clone());
+        let resolver = Arc::new(ManagedLlmResolver::new(backend.clone()));
+
+        let http_dir = tempfile::tempdir().expect("http dir");
+        let token_path = http_dir.path().join("token");
+        let cfg = HttpConfig {
+            bind: "127.0.0.1:0".into(),
+            token_file: Some(token_path.clone()),
+            port_file: Some(http_dir.path().join("port")),
+            heartbeat_interval: Duration::from_secs(5),
+            ..HttpConfig::default()
+        };
+
+        let manager = Arc::new(Mutex::new(runtime::RuntimeManager::new(
+            HashMap::new(),
+            None,
+        )));
+        let (pool, factory, lease, runtime_supervisor) = if with_host_pool {
+            let factory = Arc::new(CountingFactory {
+                starts: AtomicUsize::new(0),
+            });
+            let pool = OpenCodeHostPool::new(factory.clone());
+            let env = HashMap::from([("SENTINEL".to_string(), "a".to_string())]);
+            let revision = ProcessEnvRevision::from_bindings(&env);
+            let lease = pool
+                .acquire(
+                    IsolationDomainKey::Workspace("ws-a".into()),
+                    revision,
+                    env,
+                    Instant::now() + Duration::from_secs(2),
+                )
+                .await
+                .unwrap();
+            let supervisor = RuntimeSupervisor::new_with_host_pool(manager.clone(), pool.clone());
+            (Some(pool), Some(factory), Some(lease), Some(supervisor))
+        } else {
+            (None, None, None, None)
+        };
+
+        let runtime = crate::http::runtime_adapter::RuntimeManagerAdapter::new(manager, 256, None);
+        let workspace_control: Arc<dyn WorkspaceControlStore> =
+            Arc::new(OpenCodeCompatStore::new());
+        let handle = crate::http::spawn_with_refresh_watch_registry(
+            cfg,
+            crate::http::server::metadata("actor".into(), "test"),
+            runtime,
+            Some(workspace_control),
+            runtime_supervisor,
+            None,
+            test_sync_dispatcher(),
+            None,
+            Some(backend),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            Some(resolver.clone()),
+        )
+        .await
+        .expect("spawn http server");
+
+        let base = format!("http://{}", handle.local_addr);
+        let root = std::fs::read_to_string(&token_path)
+            .expect("read root token")
+            .trim()
+            .to_owned();
+        let client = reqwest::Client::new();
+        let resp: serde_json::Value = client
+            .post(format!("{base}/v1/auth/exchange"))
+            .bearer_auth(&root)
+            .json(&serde_json::json!({"ttl_seconds": 3600}))
+            .send()
+            .await
+            .expect("exchange response")
+            .error_for_status()
+            .expect("exchange status")
+            .json()
+            .await
+            .expect("exchange body");
+        let session_token = resp["token"].as_str().expect("session token").to_string();
+
+        Self {
+            handle,
+            client,
+            base,
+            session_token,
+            workspace_id,
+            resolver,
+            mock,
+            pool,
+            factory,
+            _lease: lease,
+            _home: home,
+            _amuxd: amuxd,
+            _http: http_dir,
+            _workspace: workspace,
+        }
+    }
+
+    async fn get_providers(&self) {
+        self.client
+            .get(format!(
+                "{}/v1/workspaces/{}/providers",
+                self.base, self.workspace_id
+            ))
+            .bearer_auth(&self.session_token)
+            .send()
+            .await
+            .expect("providers response")
+            .error_for_status()
+            .expect("providers status");
+    }
+}
+
+#[tokio::test]
+async fn http_spawn_initializes_the_shared_resolver() {
+    let app = SharedResolverApp::boot(false).await;
+
+    let token = app
+        .resolver
+        .gateway_token()
+        .expect("shared resolver must mint after HTTP bind");
+    assert!(
+        app.handle.tokens.lookup(&token).is_some(),
+        "runtime token must authenticate against the HTTP TokenStore"
+    );
+
+    let proxy = app
+        .resolver
+        .ai_proxy_base("team-x")
+        .expect("shared resolver must know the local proxy");
+    assert_eq!(
+        proxy,
+        format!(
+            "http://127.0.0.1:{}/v1/ai/teams/team-x",
+            app.handle.local_addr.port()
+        )
+    );
+
+    app.handle.shutdown().await;
+}
+
+#[tokio::test]
+async fn repeated_provider_get_keeps_opencode_json_byte_identical() {
+    let app = SharedResolverApp::boot(false).await;
+    app.resolver.reconcile_global("team-x").await;
+    let before = team_provider_bytes();
+
+    app.get_providers().await;
+    app.resolver.reconcile_global("team-x").await;
+    app.get_providers().await;
+
+    assert_eq!(
+        team_provider_bytes(),
+        before,
+        "GET /providers must not rewrite provider.team when cloud config is unchanged"
+    );
+
+    let json = team_provider_json();
+    let token = app.resolver.gateway_token().unwrap();
+    assert_eq!(
+        json["provider"]["team"]["options"]["apiKey"].as_str(),
+        Some(token.as_str())
+    );
+    assert_eq!(
+        json["provider"]["team"]["options"]["baseURL"].as_str(),
+        Some(
+            format!(
+                "http://127.0.0.1:{}/v1/ai/teams/team-x",
+                app.handle.local_addr.port()
+            )
+            .as_str()
+        )
+    );
+
+    app.handle.shutdown().await;
+}
+
+#[tokio::test]
+async fn repeated_provider_get_does_not_replace_a_ready_host() {
+    let app = SharedResolverApp::boot(true).await;
+    let pool = app.pool.as_ref().unwrap();
+    let factory = app.factory.as_ref().unwrap();
+    let lease = app._lease.as_ref().unwrap();
+    let generation_id = lease.generation.generation_id.clone();
+    let revision = lease.generation.process_env_revision.clone();
+    assert_eq!(factory.starts.load(Ordering::SeqCst), 1);
+
+    app.resolver.reconcile_global("team-x").await;
+    app.get_providers().await;
+    app.get_providers().await;
+
+    let reused = pool
+        .acquire(
+            IsolationDomainKey::Workspace("ws-a".into()),
+            revision.clone(),
+            HashMap::from([("SENTINEL".into(), "a".into())]),
+            Instant::now() + Duration::from_secs(2),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(reused.generation.generation_id, generation_id);
+    assert_eq!(lease.generation.lifecycle(), HostLifecycle::Ready);
+    assert_eq!(factory.starts.load(Ordering::SeqCst), 1);
+
+    app.handle.shutdown().await;
+}
+
+#[tokio::test]
+async fn real_managed_llm_name_change_refreshes_once() {
+    let app = SharedResolverApp::boot(true).await;
+    let pool = app.pool.as_ref().unwrap();
+    let factory = app.factory.as_ref().unwrap();
+    let lease = app._lease.as_ref().unwrap();
+    let original_id = lease.generation.generation_id.clone();
+    let revision = lease.generation.process_env_revision.clone();
+
+    app.resolver.reconcile_global("team-x").await;
+    let before = team_provider_bytes();
+
+    app.mock
+        .state()
+        .managed_llm_configs
+        .insert("team-x".to_string(), enabled_llm("Team Renamed"));
+    app.resolver.clear_cache().await;
+    app.get_providers().await;
+
+    assert_ne!(
+        team_provider_bytes(),
+        before,
+        "a real cloud provider-name change must rewrite provider.team"
+    );
+    assert_eq!(
+        team_provider_json()["provider"]["team"]["name"].as_str(),
+        Some("Team Renamed")
+    );
+
+    let replacement = pool
+        .acquire(
+            IsolationDomainKey::Workspace("ws-a".into()),
+            revision.clone(),
+            HashMap::from([("SENTINEL".into(), "a".into())]),
+            Instant::now() + Duration::from_secs(2),
+        )
+        .await
+        .unwrap();
+    assert_ne!(replacement.generation.generation_id, original_id);
+    assert_eq!(factory.starts.load(Ordering::SeqCst), 2);
+    assert_eq!(lease.generation.lifecycle(), HostLifecycle::Draining);
+
+    let after_change = team_provider_bytes();
+    app.get_providers().await;
+    assert_eq!(team_provider_bytes(), after_change);
+
+    let stable = pool
+        .acquire(
+            IsolationDomainKey::Workspace("ws-a".into()),
+            revision,
+            HashMap::from([("SENTINEL".into(), "a".into())]),
+            Instant::now() + Duration::from_secs(2),
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        stable.generation.generation_id,
+        replacement.generation.generation_id
+    );
+    assert_eq!(factory.starts.load(Ordering::SeqCst), 2);
+
+    app.handle.shutdown().await;
+}


### PR DESCRIPTION
## Summary

- Provider GET used a second `ManagedLlmResolver` with its own gateway token and no local AI proxy URL, so `provider.team` oscillated between the cloud baseURL and the daemon proxy and every isolation domain was marked for OpenCode host replacement.
- HTTP spawn now takes the daemon's shared `Arc<ManagedLlmResolver>`, binds `TokenStore` + loopback proxy URL after listen succeeds and before the router accepts requests, and no longer mints a second `GatewayTokenSource` after spawn returns.
- `set_tokens` / `set_local_http_base` are set-once so a later `GatewayTokenSource::new()` cannot rewrite `opencode.json`.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Test plan

- [x] `node scripts/daemon-cargo.js test --test http_managed_llm_share` — shared resolver init, byte-identical repeated GET `/providers`, no host replacement, name-change still refreshes once
- [x] `node scripts/daemon-cargo.js test --bin amuxd managed_llm` — set-once token source and existing reconcile tests
- [ ] Repeat GET `/v1/workspaces/:id/providers` against a running daemon: `opencode.json` bytes stay put and host `generation_id` does not change unless cloud LLM config actually changed

## Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published


Made with [Cursor](https://cursor.com)