### PR TITLE
chore(self-host): ignore filled-in .env.* files, keep the examples tracked

### DIFF
--- a/deploy/self-host/.gitignore
+++ b/deploy/self-host/.gitignore
@@ -1,5 +1,8 @@
+# Local, filled-in env files (real secrets). Only the *.example templates are tracked.
 .env
-.env.server
+.env.*
+!.env.example
+!.env.local.example
 # podman-compose bind-mount shim (see bootstrap/link-volumes.sh)
 volumes
 caddy_data/


### PR DESCRIPTION
## 问题

`deploy/self-host/.gitignore` 只排除了 `.env`（后来又手工补了一行 `.env.server`）。真正填好的 `.env.server` —— 里面有 `JWT_SECRET`、`POSTGRES_PASSWORD`、service-role key —— 在这行补上之前，是**既没被追踪、也没被忽略**地躺在工作区里，离进仓库只差一次 `git add -A`。

而这类文件不止一个：`.env.local`、以后任何 `.env.<something>`，都会重复同一次侥幸。

## 改法

把规则放宽成 `.env.*`，再把两个**已被追踪**的模板反选回来：

```gitignore
# Local, filled-in env files (real secrets). Only the *.example templates are tracked.
.env
.env.*
!.env.example
!.env.local.example
```

main 上那行显式的 `.env.server` 被 `.env.*` 覆盖，一并删掉 —— 两条并存只会让下一个真实 env 文件被同样地忘掉。

## 验证

`git check-ignore` 实测：

| 文件 | 结果 |
|---|---|
| `.env` | 忽略 |
| `.env.server` | 忽略 |
| `.env.local` | 忽略 |
| `.env.example` | **不忽略**（仍在仓库里） |
| `.env.local.example` | **不忽略**（仍在仓库里） |

并且遍历了 `deploy/self-host/` 下所有已追踪文件，确认没有任何一个会因为这条规则变成被忽略。

原 commit 停在一个落后 main 117 个 commit 的本地分支上（从没推过），这里是 rebase 到当前 main 后的版本。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EZb9HE24tLykNiWm22ZciS
