### PR TITLE
fix(skills): refresh dirty state when opening the skills list

### DIFF
--- a/apps/daemon/src/config/knowledge_scaffold.rs
+++ b/apps/daemon/src/config/knowledge_scaffold.rs
@@ -115,7 +115,7 @@ pub fn domain_index_template() -> &'static str {
     template_source("_index.md")
 }
 
-/// Today as `YYYY-MM-DD` (UTC). Exposed for the knowledge MCP handlers
+/// Today as `YYYY-MM-DD` (local). Exposed for the knowledge MCP handlers
 /// (template stamping in `daemon::server::knowledge`).
 pub(crate) fn today_iso() -> String {
     // Local date, not UTC. These stamps are read by people — a salvage filename

--- a/apps/daemon/src/config/mod.rs
+++ b/apps/daemon/src/config/mod.rs
@@ -46,6 +46,7 @@ pub use team_skill_draft::{
 pub use roles_skills::{
     find_managed_skill_in_session_inventory, is_inherent_skill, scan_roles_skills_state,
     team_skill_roots,     };
+pub use knowledge_scaffold::{domain_index_template, scaffold_knowledge, ScaffoldReport};
 pub use session_store::{SessionBinding, SessionStore};
 pub use workspace_control::{
     decode_workspace_path, encode_workspace_path, ApplyOutcome, OpenCodeCompatStore, ProviderAuthRequest, ProviderModelConfig, WorkspaceControlStore,

--- a/packages/app/src/stores/__tests__/team-share-skill-local-state.test.ts
+++ b/packages/app/src/stores/__tests__/team-share-skill-local-state.test.ts
@@ -1,0 +1,89 @@
+import { describe, test, expect, beforeEach, vi } from 'vitest'
+
+const installCalls: unknown[] = []
+let inspectStates: Record<string, string> = {}
+
+const listTeamSkills = vi.fn(async () => [
+  {
+    slug: 'say-hi',
+    installed: true,
+    installedVersion: 1,
+    latestVersion: 1,
+    category: 'general',
+    summary: 'Say hi',
+    whenToUse: null,
+    whenNotToUse: null,
+    requires: null,
+    status: 'published',
+    supersededBy: null,
+    ownerActorId: 'actor-1',
+    hasUpdate: false,
+    createdAt: null,
+    updatedAt: null,
+    origin: 'local',
+    upstreamSlug: null,
+    upstreamSubscribed: false,
+    upstreamDetachedAt: null,
+  },
+])
+
+vi.mock('@/lib/utils', () => ({ isTauri: () => true }))
+vi.mock('@/lib/backend/provider', () => ({
+  getBackend: () => ({ teamSkills: { listTeamSkills } }),
+}))
+vi.mock('@/lib/daemon/local-daemon-identity', () => ({
+  getKnownLocalDaemonActorId: () => 'agent-1',
+}))
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: vi.fn(async (cmd: string, args: { slug?: string }) => {
+    if (cmd === 'team_skill_list_installed') {
+      return [{ slug: 'say-hi', version: '1', teamId: 'team-1' }]
+    }
+    if (cmd === 'team_skill_inspect') {
+      return {
+        slug: args.slug,
+        source: 'hosted-agent',
+        state: inspectStates[args.slug ?? ''] ?? 'clean',
+        installedVersion: '1',
+        modified: inspectStates[args.slug ?? ''] === 'dirty' ? ['SKILL.md'] : [],
+        deleted: [],
+        added: [],
+      }
+    }
+    if (cmd === 'team_skill_install') {
+      installCalls.push(args)
+      return null
+    }
+    return null
+  }),
+}))
+
+import { useTeamShareBrowserStore } from '../team-share-browser'
+import { useCurrentTeamStore } from '../current-team'
+
+const store = () => useTeamShareBrowserStore.getState()
+
+describe('refreshSkillLocalState', () => {
+  beforeEach(() => {
+    installCalls.length = 0
+    inspectStates = {}
+    listTeamSkills.mockClear()
+    useCurrentTeamStore.setState({ team: { id: 'team-1' } } as never)
+    useTeamShareBrowserStore.setState({ skillLocalState: {} })
+  })
+
+  test('records dirty from inspect without installing', async () => {
+    inspectStates = { 'say-hi': 'dirty' }
+
+    await store().refreshSkillLocalState()
+
+    expect(store().skillLocalState['say-hi']?.state).toBe('dirty')
+    expect(installCalls).toHaveLength(0)
+  })
+
+  test('leaves skillLocalState clean when inspect reports clean', async () => {
+    await store().refreshSkillLocalState()
+
+    expect(store().skillLocalState['say-hi']?.state).toBe('clean')
+  })
+})

--- a/packages/app/src/stores/team-share-browser.ts
+++ b/packages/app/src/stores/team-share-browser.ts
@@ -360,6 +360,12 @@ interface TeamShareBrowserState {
    * panel open, and after any local mutation.
    */
   reconcileSkills: () => Promise<void>
+  /**
+   * Re-read installed packs against their baselines without install/remove.
+   * The skills list calls this on open/refresh so dirty badges appear without
+   * waiting for the next auto-follow tick.
+   */
+  refreshSkillLocalState: () => Promise<void>
   /** Publish an older version's content as the new latest (undo a bad publish). */
   revertSkillVersion: (slug: string, version: number, expectedLatestVersion: number) => Promise<void>
   /** Move the edited pack aside and re-install clean. Returns the undo handle. */
@@ -1054,6 +1060,39 @@ async function inspectSkill(
 
 async function listInstalledPacks(): Promise<OnDiskSkill[]> {
   return invoke<OnDiskSkill[]>('team_skill_list_installed')
+}
+
+function knownSkillSlugs(listed: OnDiskSkill[], desired: TeamSkill[]): Set<string> {
+  return new Set<string>([
+    ...listed.map((p) => p.slug),
+    ...desired.filter((s) => s.installed).map((s) => s.slug),
+  ])
+}
+
+async function collectSkillLocalStates(
+  known: Set<string>,
+  desired: TeamSkill[],
+  teamId: string,
+): Promise<{ states: Record<string, SkillLocalState>; blocked: Set<string> }> {
+  const states: Record<string, SkillLocalState> = {}
+  const blocked = new Set<string>()
+  for (const slug of known) {
+    const row = desired.find((s) => s.slug === slug)
+    const state = await inspectSkill(
+      slug,
+      row?.installedVersion ?? null,
+      teamId,
+      row?.latestVersion ?? null,
+    ).catch(() => null)
+    if (!state) continue
+    states[slug] = state
+    // A local edit needs a decision; another registry's pack is not ours to
+    // touch at all. Both mean "auto-follow stops here".
+    if (state.state === 'dirty' || state.state === 'stale_dirty' || state.state === 'foreign') {
+      blocked.add(slug)
+    }
+  }
+  return { states, blocked }
 }
 
 /** Render a catalog row in the daemon's config shape so one detail view serves both. */
@@ -1786,30 +1825,10 @@ export const useTeamShareBrowserStore = create<TeamShareBrowserState>((set, get)
       memberDesired.filter((s) => s.installed).map((s) => s.slug),
     )
 
-    const states: Record<string, SkillLocalState> = {}
     const errors: Record<string, string> = {}
     const archived: Record<string, string> = { ...get().skillArchived }
-    const blocked = new Set<string>()
-    const known = new Set<string>([
-      ...listed.map((p) => p.slug),
-      ...desired.filter((s) => s.installed).map((s) => s.slug),
-    ])
-    for (const slug of known) {
-      const row = desired.find((s) => s.slug === slug)
-      const state = await inspectSkill(
-        slug,
-        row?.installedVersion ?? null,
-        teamId,
-        row?.latestVersion ?? null,
-      ).catch(() => null)
-      if (!state) continue
-      states[slug] = state
-      // A local edit needs a decision; another registry's pack is not ours to
-      // touch at all. Both mean "auto-follow stops here".
-      if (state.state === 'dirty' || state.state === 'stale_dirty' || state.state === 'foreign') {
-        blocked.add(slug)
-      }
-    }
+    const known = knownSkillSlugs(listed, desired)
+    const { states, blocked } = await collectSkillLocalStates(known, desired, teamId)
 
     // Re-read the disk after inspection rather than reusing the listing above.
     // Inspecting a pack that predates manifests *adopts* it — writes the origin
@@ -1925,6 +1944,29 @@ export const useTeamShareBrowserStore = create<TeamShareBrowserState>((set, get)
     if (diskChanged) {
       await get().loadSection('skills', { force: true }).catch(() => {})
     }
+  },
+
+  refreshSkillLocalState: async () => {
+    const teamId = currentTeamId()
+    if (!teamId || !isTauri()) return
+    const backend = getBackend()
+    const localAgentId = getKnownLocalDaemonActorId()
+    let desired: TeamSkill[]
+    let listed: OnDiskSkill[]
+    try {
+      ;[desired, listed] = await Promise.all([
+        localAgentId
+          ? backend.teamSkills.listTeamSkills(teamId, { actorId: localAgentId })
+          : backend.teamSkills.listTeamSkills(teamId),
+        listInstalledPacks(),
+      ])
+    } catch (e) {
+      if (isCloudAuthError(e)) throw e
+      return
+    }
+    const known = knownSkillSlugs(listed, desired)
+    const { states } = await collectSkillLocalStates(known, desired, teamId)
+    set({ skillLocalState: states })
   },
 
   discardLocalSkill: async (slug) => {
@@ -2101,6 +2143,7 @@ export const useTeamShareBrowserStore = create<TeamShareBrowserState>((set, get)
           get().subjectActorId ?? undefined,
         )
         set({ skills: { items, loading: false, loaded: true, error: registryError } })
+        await get().refreshSkillLocalState().catch(() => {})
       } else if (section === 'knowledge') {
         // The daemon's own directory, by absolute path:
         // `~/.amuxd[-brand]/teams/<id>/shared/knowledge`. That is the tree the


### PR DESCRIPTION
## Summary
- Extract shared `collectSkillLocalStates` from `reconcileSkills` so inspect logic lives in one place
- Add `refreshSkillLocalState()` — read-only inspect of installed team packs, no install/remove
- Call it at the end of `loadSection('skills')` so opening or refreshing the skills column updates row badges and nav conflict counts without waiting for the 10-minute auto-follow tick

## Context
After editing a team skill (e.g. hosted `say-hi` draft), the list could show updated content from disk while the trailing icon stayed a checkmark because `skillLocalState` was only updated during `reconcileSkills`. Plan B: refresh inspect on list open only (not live while the list stays open).

## Test plan
- [x] `pnpm test:unit src/stores/__tests__/team-share-skill-local-state.test.ts`
- [x] `pnpm test:unit src/stores/__tests__/team-share-skill-retired.test.ts`
- [ ] Edit hosted team skill → switch away from Skills → switch back → row shows warning triangle
- [ ] Click list refresh → triangle appears without triggering install/uninstall

## Known limitation
When both hosted and member copies exist, inspect still follows `effective_team_skill_dir` (hosted first). Member-only edits remain invisible until a follow-up unifies the work copy.


Made with [Cursor](https://cursor.com)