### PR TITLE
fix(chat): 修掉 tauri drag-drop 的 double unlisten，并修正 Sentry 上报去向

### DIFF
--- a/apps/desktop/src/main.rs
+++ b/apps/desktop/src/main.rs
@@ -25,9 +25,37 @@ fn scrub_pii(
     Some(event)
 }
 
+const SENTRY_DSN: &str =
+    "https://f7626cc6e80f4561b1673dd027742714@o60909.ingest.us.sentry.io/4511110362169344";
+
+/// The DSN this build reports to, or `None` to report nowhere.
+///
+/// Debug builds share the shipped project, and the org is on the free tier:
+/// 5,000 errors per *month* with no on-demand budget. On the webview side
+/// `environment:development` was 1,507 of 4,930 events over one billing
+/// period — enough to exhaust the quota and blackhole production reporting for
+/// the rest of it. The same policy applies here so a `pnpm tauri:dev` session
+/// cannot spend the budget that shipped crashes need. `TEAMCLU_SENTRY_DEBUG=1`
+/// opts a debug run back in; it is the counterpart of `VITE_SENTRY_DEBUG` in
+/// `packages/app/src/main.tsx`.
+///
+/// `None` still constructs the client — it just gets no transport, so every
+/// `capture_*` call behaves as it does in production and simply drops. The
+/// `debug_assertions` check is shared with `environment` below so the two
+/// cannot drift.
+fn sentry_dsn() -> Option<&'static str> {
+    if !cfg!(debug_assertions) {
+        return Some(SENTRY_DSN);
+    }
+    match std::env::var("TEAMCLU_SENTRY_DEBUG") {
+        Ok(value) if value == "1" => Some(SENTRY_DSN),
+        _ => None,
+    }
+}
+
 fn main() {
     let _sentry_guard = sentry::init((
-        "https://f7626cc6e80f4561b1673dd027742714@o60909.ingest.us.sentry.io/4511110362169344",
+        sentry_dsn(),
         sentry::ClientOptions {
             release: sentry::release_name!(),
             // Crash reports need a stack and a release, not who was at the

--- a/apps/desktop/src/main.rs
+++ b/apps/desktop/src/main.rs
@@ -25,8 +25,14 @@ fn scrub_pii(
     Some(event)
 }
 
+/// `ucar-inc/teamclu-rust` (project 4512025501237248).
+///
+/// The previous DSN pointed at project 4511110362169344, which had been deleted
+/// from the org — desktop crash reports went nowhere for however long that had
+/// been true, and nothing surfaced the loss because a dead DSN fails silently
+/// at ingest rather than erroring in the client.
 const SENTRY_DSN: &str =
-    "https://f7626cc6e80f4561b1673dd027742714@o60909.ingest.us.sentry.io/4511110362169344";
+    "https://53fd6d3ad645819bb83e0a9404750690@o60909.ingest.us.sentry.io/4512025501237248";
 
 /// The DSN this build reports to, or `None` to report nowhere.
 ///
@@ -60,6 +66,13 @@ fn main() {
             release: sentry::release_name!(),
             // Crash reports need a stack and a release, not who was at the
             // keyboard. Default PII includes the OS username and the client IP.
+            //
+            // Sentry's onboarding snippet for a new Rust project ships
+            // `send_default_pii: true`. Do not paste that over this: SEC-4
+            // decided the desktop app does not send identity, and `scrub_pii`
+            // below exists to enforce it even for events an integration builds
+            // on its own. Flipping this is a privacy decision, not a config
+            // detail.
             send_default_pii: false,
             before_send: Some(std::sync::Arc::new(scrub_pii)),
             environment: Some(

--- a/packages/app/src/main.tsx
+++ b/packages/app/src/main.tsx
@@ -45,6 +45,21 @@ void initSentry({
   dsn: 'https://87ad99c36806946fe743be71ed87fffe@o60909.ingest.us.sentry.io/4511110370295808',
   release: `teamclu-web@${import.meta.env.PACKAGE_VERSION ?? '0.0.0'}`,
   environment: import.meta.env.DEV ? 'development' : 'production',
+  // Dev builds report into the same Sentry project as shipped ones, and the
+  // org is on the free tier: 5,000 errors per *month*, no on-demand budget.
+  // Over 2026-08-19..09-18, `environment:development` was 1,507 of 4,930
+  // events (31%) — enough that the quota ran out on 09-02 and every
+  // production report was dropped for the rest of the period. A dev error is
+  // already visible in the console and in Settings → Diagnostics, so it does
+  // not need to cost quota.
+  //
+  // `enabled` is Sentry's own switch: the client is still constructed, so
+  // every capture path behaves exactly as in production, it just never
+  // transmits. `VITE_SENTRY_DEBUG=1` opts a dev run back in to verify the
+  // pipeline end-to-end without cutting a release build — same escape hatch,
+  // same reasoning as `EXPO_PUBLIC_SENTRY_DEBUG` in
+  // `apps/expo/src/lib/telemetry/sentry.ts`.
+  enabled: !import.meta.env.DEV || import.meta.env.VITE_SENTRY_DEBUG === '1',
   // SEC-4: no IP / user identity by default, and every breadcrumb (console
   // arguments, fetch URLs) goes through the same redaction the Diagnostics
   // viewer uses. The Rust process applies the same policy in main.rs.

--- a/packages/app/src/packages/ai/__tests__/prompt-input-tauri-dragdrop.test.tsx
+++ b/packages/app/src/packages/ai/__tests__/prompt-input-tauri-dragdrop.test.tsx
@@ -1,0 +1,232 @@
+/**
+ * Teardown contract for the `tauri://drag-*` subscription in `PromptInput`.
+ *
+ * The effect registers three listeners with three sequential `await listen(...)`
+ * calls, so an unmount can land between any two of them. Every interleaving must
+ * unlisten each registered handler exactly once:
+ *
+ *   - twice throws. `_unlisten` calls `unregisterListener(event, eventId)`, and
+ *     the second call reaches an eventId Tauri has already dropped, so
+ *     `listeners[eventId].handlerId` raises a TypeError. Nothing awaits
+ *     `unlisten()`, so that surfaced as an unhandled rejection and became the
+ *     largest error group in the app (TEAMCLU-REACT-7Q/99/6F, ~2.5k events).
+ *   - zero times leaks: a listener registered after cleanup already ran stays
+ *     attached for the lifetime of the window and fires into a dead closure.
+ *
+ * The mock `listen` hands out promises this file resolves by hand, which is what
+ * makes each interleaving deterministic rather than a race.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render } from '@testing-library/react'
+import React from 'react'
+
+vi.mock('@/lib/utils', () => ({
+  cn: (...args: unknown[]) => args.filter(Boolean).join(' '),
+  isTauri: () => true,
+}))
+
+vi.mock('@/packages/ai/editable-with-file-chips', () => ({
+  EditableWithFileChips: React.forwardRef(
+    (props: Record<string, unknown>, ref: React.Ref<HTMLDivElement>) =>
+      React.createElement('div', { ref, 'data-testid': 'editable', role: 'textbox' })
+  ),
+}))
+
+vi.mock('@/packages/ai/prompt-input-ui', () => ({
+  PromptInputTools: ({ children }: React.PropsWithChildren) => React.createElement('div', null, children),
+  PromptInputButton: ({ children }: React.PropsWithChildren) => React.createElement('button', null, children),
+  PromptInputSubmit: ({ children }: React.PropsWithChildren) => React.createElement('button', { type: 'submit' }, children),
+  PromptInputActionMenu: ({ children }: React.PropsWithChildren) => React.createElement('div', null, children),
+  PromptInputActionMenuTrigger: ({ children }: React.PropsWithChildren) => React.createElement('div', null, children),
+  PromptInputActionMenuContent: ({ children }: React.PropsWithChildren) => React.createElement('div', null, children),
+  PromptInputAttachment: () => null,
+  createAttachmentComponents: () => ({
+    PromptInputActionAddAttachments: () => null,
+    PromptInputAttachments: () => null,
+    PromptInputMentions: () => null,
+  }),
+}))
+
+vi.mock('@/packages/ai/prompt-input-types', () => ({}))
+
+vi.mock('@/packages/ai/prompt-input-insert-hooks', () => ({
+  useInsertMentionHook: () => vi.fn(),
+  useInsertFileMentionHook: () => vi.fn(),
+  useInsertSkillMentionHook: () => vi.fn(),
+}))
+
+/** One pending `listen()` call: the event name plus the resolver for its promise. */
+type PendingListen = {
+  event: string
+  resolve: (unlisten: () => void) => void
+}
+
+const pending: PendingListen[] = []
+
+vi.mock('@tauri-apps/api/event', () => ({
+  listen: (event: string) =>
+    new Promise<() => void>((resolve) => {
+      pending.push({ event, resolve })
+    }),
+}))
+
+/**
+ * Per-listener unlisten call counts, keyed by event name.
+ *
+ * The real unlisten returns a promise; returning one here keeps the production
+ * `Promise.resolve(unlisten())` path under test rather than a synchronous stub.
+ */
+const unlistenCalls = new Map<string, number>()
+
+function makeUnlisten(event: string): () => void {
+  unlistenCalls.set(event, 0)
+  return () => {
+    unlistenCalls.set(event, (unlistenCalls.get(event) ?? 0) + 1)
+    return Promise.resolve() as unknown as void
+  }
+}
+
+/**
+ * Let the effect advance. The first `import('@tauri-apps/api/event')` settles on
+ * a macrotask, so draining microtasks alone would leave the body parked before
+ * the first `listen()` and every `settleNextListen` would find nothing pending.
+ */
+async function flush(): Promise<void> {
+  for (let i = 0; i < 4; i += 1) {
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    for (let j = 0; j < 4; j += 1) await Promise.resolve()
+  }
+}
+
+/**
+ * Resolve the oldest outstanding `listen()` and let the effect body advance to
+ * the next `await`. Returns the event name that was settled.
+ */
+async function settleNextListen(): Promise<string> {
+  const next = pending.shift()
+  if (!next) throw new Error('no outstanding listen() to settle')
+  next.resolve(makeUnlisten(next.event))
+  await flush()
+  return next.event
+}
+
+let unhandled: unknown[] = []
+function recordUnhandled(event: PromiseRejectionEvent) {
+  event.preventDefault()
+  unhandled.push(event.reason)
+}
+
+beforeEach(() => {
+  pending.length = 0
+  unlistenCalls.clear()
+  unhandled = []
+  window.addEventListener('unhandledrejection', recordUnhandled)
+})
+
+afterEach(() => {
+  window.removeEventListener('unhandledrejection', recordUnhandled)
+})
+
+async function renderInput() {
+  const { PromptInput } = await import('@/packages/ai/prompt-input')
+  const view = render(
+    React.createElement(PromptInput, { onFilesChange: () => {} }, null)
+  )
+  await flush()
+  return view
+}
+
+describe('PromptInput tauri drag-drop teardown', () => {
+  it('unlistens each registered handler exactly once when unmounted mid-registration', async () => {
+    const { unmount } = await renderInput()
+
+    // First listener registered and remembered; the effect is now parked on the
+    // second `await listen(...)`. This is the window the double-unlisten needed.
+    const first = await settleNextListen()
+    expect(unlistenCalls.get(first)).toBe(0)
+
+    unmount()
+    await flush()
+    expect(unlistenCalls.get(first)).toBe(1)
+
+    // The in-flight second `listen` resolves after cleanup already drained.
+    // Before the fix this re-drained the same array and called `first` again.
+    const second = await settleNextListen()
+
+    expect(unlistenCalls.get(first)).toBe(1)
+    expect(unlistenCalls.get(second)).toBe(1)
+  })
+
+  it('unlistens a handler that resolves after cleanup instead of leaking it', async () => {
+    const { unmount } = await renderInput()
+
+    // Unmount before anything resolved: cleanup drains an empty array, so the
+    // registration that lands afterwards has nothing to be collected by.
+    unmount()
+    await flush()
+
+    const first = await settleNextListen()
+    expect(unlistenCalls.get(first)).toBe(1)
+  })
+
+  it('unlistens all three handlers exactly once on a clean unmount', async () => {
+    const { unmount } = await renderInput()
+
+    const events = [
+      await settleNextListen(),
+      await settleNextListen(),
+      await settleNextListen(),
+    ]
+    expect(events).toEqual([
+      'tauri://drag-over',
+      'tauri://drag-leave',
+      'tauri://drag-drop',
+    ])
+    expect(events.map((e) => unlistenCalls.get(e))).toEqual([0, 0, 0])
+
+    unmount()
+    await flush()
+
+    expect(events.map((e) => unlistenCalls.get(e))).toEqual([1, 1, 1])
+  })
+
+  it('does not re-register when the parent passes a fresh onFilesChange each render', async () => {
+    const { PromptInput } = await import('@/packages/ai/prompt-input')
+    const { rerender } = render(
+      React.createElement(PromptInput, { onFilesChange: () => {} }, null)
+    )
+    await flush()
+    await settleNextListen()
+    await settleNextListen()
+    await settleNextListen()
+    expect(pending).toHaveLength(0)
+
+    // A new closure identity must not tear the subscription down: the drop
+    // handler reads the ref, so re-registering only churns Tauri listeners and
+    // widens the teardown window this file exists to close.
+    rerender(React.createElement(PromptInput, { onFilesChange: () => {} }, null))
+    await flush()
+
+    expect(pending).toHaveLength(0)
+    expect([...unlistenCalls.values()]).toEqual([0, 0, 0])
+  })
+
+  it('never lets an unlisten rejection escape as an unhandled rejection', async () => {
+    const { unmount } = await renderInput()
+    const next = pending.shift()
+    if (!next) throw new Error('no outstanding listen() to settle')
+    next.resolve(() => {
+      // Mirrors the real failure: `listeners[eventId].handlerId` on an eventId
+      // Tauri already dropped.
+      return Promise.reject(
+        new TypeError("undefined is not an object (evaluating 'listeners[eventId].handlerId')")
+      ) as unknown as void
+    })
+    await flush()
+
+    unmount()
+    await flush()
+
+    expect(unhandled).toEqual([])
+  })
+})

--- a/packages/app/src/packages/ai/prompt-input.tsx
+++ b/packages/app/src/packages/ai/prompt-input.tsx
@@ -206,15 +206,66 @@ export function PromptInput({
 
   // Tauri with dragDropEnabled steals HTML5 dataTransfer.files. Attach OS drops
   // that land on the chat input via the native tauri://drag-drop event instead.
+  //
+  // Subscribe on whether a handler exists, not on its identity: the drop handler
+  // below reads `onFilesChangeRef.current`, so a caller that passes a fresh
+  // closure each render would otherwise tear down and re-register three Tauri
+  // listeners on every parent render — which is what turned the teardown race
+  // handled by `track` into the app's largest error group rather than a rarity.
+  const hasFilesChangeHandler = Boolean(onFilesChange)
   React.useEffect(() => {
-    if (!onFilesChange || !isTauri()) return
+    if (!hasFilesChangeHandler || !isTauri()) return
     let cancelled = false
     const unlisteners: Array<() => void> = []
+
+    /**
+     * `unlisten()` is async and nothing awaits it, so a rejection would surface
+     * as an unhandled rejection and be captured as an error — that is how the
+     * double-unlisten TypeError reached Sentry at all instead of being dropped.
+     */
+    const undo = (unlisten: () => void) => {
+      try {
+        void Promise.resolve(unlisten()).catch(() => {
+          // fail-soft: teardown must not break unmount, and a listener the
+          // webview already dropped needs no further cleanup.
+        })
+      } catch {
+        // fail-soft: same, for an unlisten that throws synchronously.
+      }
+    }
+
+    /**
+     * Unlisten everything registered so far, at most once each.
+     *
+     * The cleanup below and the mid-flight `cancelled` checks used to each run
+     * `unlisteners.forEach(...)` over the same array, so unmounting between two
+     * `await listen(...)` calls unlistened the earlier handlers twice. The
+     * second `_unlisten` hands Tauri an eventId it has already unregistered and
+     * `listeners[eventId].handlerId` throws. Draining with `splice` makes a
+     * second drain a no-op.
+     */
+    const drainUnlisteners = () => {
+      for (const unlisten of unlisteners.splice(0)) undo(unlisten)
+    }
+
+    /**
+     * Remember an unlistener, or undo it immediately when teardown already
+     * happened while its `listen` was in flight — pushing onto an array the
+     * cleanup has finished draining would leak the handler for the lifetime of
+     * the window.
+     */
+    const track = (unlisten: () => void) => {
+      if (cancelled) {
+        undo(unlisten)
+        return
+      }
+      unlisteners.push(unlisten)
+    }
 
     void import('@tauri-apps/api/event').then(async ({ listen }) => {
       if (cancelled) return
 
-      unlisteners.push(
+      track(
         await listen<{ paths: string[]; position: { x: number; y: number } }>(
           'tauri://drag-over',
           (event) => {
@@ -222,22 +273,16 @@ export function PromptInput({
           },
         ),
       )
-      if (cancelled) {
-        unlisteners.forEach((fn) => fn())
-        return
-      }
+      if (cancelled) return
 
-      unlisteners.push(
+      track(
         await listen('tauri://drag-leave', () => {
           setIsDragging(false)
         }),
       )
-      if (cancelled) {
-        unlisteners.forEach((fn) => fn())
-        return
-      }
+      if (cancelled) return
 
-      unlisteners.push(
+      track(
         await listen<{ paths: string[]; position: { x: number; y: number } }>(
           'tauri://drag-drop',
           async (event) => {
@@ -279,9 +324,9 @@ export function PromptInput({
 
     return () => {
       cancelled = true
-      unlisteners.forEach((fn) => fn())
+      drainUnlisteners()
     }
-  }, [onFilesChange, dropHitTarget])
+  }, [hasFilesChangeHandler, dropHitTarget])
 
   const handleDrop = (event: React.DragEvent) => {
     event.preventDefault()

--- a/packages/app/src/vite-env.d.ts
+++ b/packages/app/src/vite-env.d.ts
@@ -17,6 +17,8 @@ interface ImportMetaEnv {
   readonly VITE_TEAMCLU_E2E?: string;
   /** Extension embed build: force chat-only shell (apps/extension/build.mjs). */
   readonly VITE_FORCE_EMBED?: string;
+  /** '1' opts a dev run back into Sentry reporting, which is off by default. */
+  readonly VITE_SENTRY_DEBUG?: string;
 }
 
 interface ImportMeta {


### PR DESCRIPTION
## Description

两个 Sentry issue 家族的修复，合计约占月度配额的 70%；外加把 Rust 进程的崩溃上报接回一个真实存在的项目。

背景：org 是 Sentry 免费版（5,000 errors/月，无 on-demand 预算）。本计费周期（08-19 ~ 09-18）用量 5,169/5,000，**09-02 打满，09-03 起 `accepted` 归零**，所有生产上报被丢弃至今。`teamclu-react` 最后一条被接收的事件是 09-02 08:42 UTC。

> 工具链侧的修复（两个 Sentry skill + pre-commit hook）拆到了 #1243 — 那些不含产品代码，可以独立审。

### 1. Tauri drag-drop 的 double unlisten（TEAMCLU-REACT-7Q / 99 / 6F，约 2,467 事件 / 99 用户）

`PromptInput` 用三次顺序 `await listen(...)` 注册 `tauri://drag-*`，所以卸载可能落在任意两次之间。cleanup 和中途的 `cancelled` 检查**各自对同一个数组跑 `forEach`**，导致卸载前已注册的 handler 被 unlisten 两次。第二次 `_unlisten` 拿着 Tauri 已经注销的 eventId，`listeners[eventId].handlerId` 抛 TypeError；而 `unlisten()` 是 async 且无人 await，于是以未处理拒绝的形式冒出去，被当 error 上报。

改成三个辅助函数：

- `undo` —— 吞掉异步拒绝（teardown 不该打断 unmount）
- `drainUnlisteners` —— 用 `splice` 排空，第二次 drain 变 no-op
- `track` —— 注册结果落在 cleanup 之后就地撤销

`track` 顺带修掉一个**独立的泄漏**：原代码第三个 listener（`tauri://drag-drop`）后面根本没有 `cancelled` 检查，它 resolve 时若 cleanup 已排空数组，该 listener 会一直挂到窗口关闭，对着已卸载组件的闭包触发。

另外 effect 的依赖写的是 `onFilesChange`，但 handler 内部读的是 `onFilesChangeRef.current`——依赖的是闭包身份而非值。调用方每次 render 传新箭头函数就会拆掉重订阅三个 Tauri listener。改成 `Boolean(onFilesChange)`。**这是把偶发竞态放大成全应用最大错误组的原因**，本身不是 bug，但没有它前一条不会有这个量级。

### 2. dev 环境上报（1,507 / 4,930 事件，31%）

web 与 Rust 两端都改为只在正式构建上报，逃生口对齐 `apps/expo`（那边早就是 `enabled: !__DEV__ || DEBUG_REPORTING`）：

| 端 | 开关 | 逃生口 |
|---|---|---|
| webview | `enabled: !import.meta.env.DEV` | `VITE_SENTRY_DEBUG=1` |
| Rust 主进程 | `sentry_dsn()` 返回 `Option` | `TEAMCLU_SENTRY_DEBUG=1` |

用的是各自 SDK 官方支持的关法，不是 `beforeSend` 返回 null——`@sentry/core` 的 `initAndBind` 无条件构造并绑定 client（只有 `_isEnabled()` 看 `enabled`），所以 `capture.ts` 里 `sentryReady` 那套编排行为完全不变；sentry-rust 同理，`dsn: None` 时 client 照常构造、只是没有 transport。

### 3. Rust 的 DSN 指向一个已删除的项目

`apps/desktop/src/main.rs` 原本指向项目 `4511110362169344`，该项目已从 org 删除——也就是说**桌面端 Rust 崩溃一直发到虚空**。死 DSN 在 ingest 侧静默失败、客户端不报错，所以没人发现。已改指新建的 `ucar-inc/teamclu-rust`（`4512025501237248`）。

**保留 `send_default_pii: false`。** Sentry 给新 Rust 项目的 onboarding 片段里是 `true`，还附了"捕获用户 IP"的注释；但 SEC-4 已经决定桌面端不发送身份信息，`scrub_pii` 就是为此存在的。已在调用处加注释防止以后被粘贴覆盖。**这是隐私决定，不是配置细节。**

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Performance improvement
- [x] Test update

## Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## 验证

新增 `prompt-input-tauri-dragdrop.test.tsx`，用受控 promise 手工摆出每种 unmount 交错顺序（不靠竞态碰运气）。**先验证它在修复前是红的**，正好挂在该挂的两条：

```
× unlistens each registered handler exactly once when unmounted mid-registration
  AssertionError: expected 2 to be 1          ← 重复 unlisten
× does not re-register when the parent passes a fresh onFilesChange each render
  AssertionError: expected [ Array(1) ] to have a length of +0
```

| 检查 | 结果 |
|---|---|
| 新测试（5 条） | 撤掉修复红 2 条，加回全绿 |
| `src/packages/ai/` 全量（6 文件 51 条） | 全绿 |
| `pnpm typecheck` | exit 0 |
| eslint | 0 error，4 warning——**与改动前逐条相同**（`setFiles` 那条本来就在，只是行号从 284 变 329） |
| `cargo fmt --check`（desktop） | 通过 |
| `pnpm rust:check` | exit 0（7m27s 全量 + 9.86s 增量各一次，零错误） |

`pnpm rust:check` 起初跑不了，但**与本 PR 无关**：`build.rs` 读 tauri 插件权限时指向 `.worktrees/audit-p0p1`——一个早已删除的 worktree，其绝对路径被烘死在共享 `CARGO_TARGET_DIR` 的缓存里。该目录下有 22 份 `tauri-plugin-mcp` 构建产物，分别指向 4 个不同的已删 worktree，选中哪份取决于 fingerprint 哈希，所以是个随构建配置随机引爆的地雷。已用 `cargo clean -p tauri-plugin-mcp` 清掉（9110 文件 / 1.8 GiB，`--dry-run -v` 确认过范围内非本插件条目为 0）。**如果你的 checkout 也撞到这个报错，跑同一条命令即可。**

## Additional Notes

**这些修复的效果要到 09-18 配额重置后才能在数据上看见** —— 在那之前 Sentry 仍在丢弃全部事件。

修完后预计从约 11,000/月 降到约 2,600/月，落回 5,000 免费额度内：

| 家族 | 14d 事件 | 状态 |
|---|---:|---|
| `listeners[eventId].handlerId` | 2,467 | 本 PR 修掉 |
| `environment:development` | 1,507 | 本 PR 关掉 |
| `runtime_start_failure` | 1,046 | **未处理**，见下 |

一个后续（不在本 PR 范围）：**`runtime_start_failure` 是噪声不是缺陷。** `device_offline`(480) 和 `transport_offline`(30) 是预期的运行状态，不该进 Sentry；且 `runtime-error-report.ts` 的节流键 `runtime_start_failure|code|agentActorId` 按 agent 分桶，agent 一多节流就形同虚设。底下真正值得查的是 `TEAMCLU-REACT-9G: rpc timeout after 20000ms`（仅 4 条）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SFGLpfbhYK1ciRgHuUP5Jq
