### PR TITLE
fix(skills): 修好两个 Sentry skill 的项目配置，并解开 pre-commit 对 .claude 的误拦

### DIFF
--- a/.claude/skills/sentry-fix/SKILL.md
+++ b/.claude/skills/sentry-fix/SKILL.md
@@ -3,66 +3,120 @@ name: sentry-fix
 description: Use when the user wants to fix a Sentry issue, auto-repair a bug from Sentry, or create a fix PR for a Sentry error. Triggers on "修复 sentry", "fix sentry issue", "sentry 修复", "sentry fix".
 ---
 
-# Sentry Fix — Auto-Fix Issue with Test and PR
+# Sentry Fix — Auto-Fix Issue with Test
 
-Fix a specific Sentry issue: gather context, confirm with user, implement fix, write regression test, verify, and create PR.
+Fix a specific Sentry issue: gather context, confirm with user, implement fix,
+write regression test, verify, commit.
 
 ## Arguments
 
-- `<ISSUE-ID>` (required): Sentry issue short ID, e.g., `TEAMCLU-3` or `TEAMCLU-REACT-2G`
+- `<ISSUE-ID>` (required): Sentry issue short ID, e.g. `TEAMCLU-REACT-7Q`
 
-The issue ID is passed as the skill argument. Example: `/sentry-fix TEAMCLU-3`
+The issue ID is passed as the skill argument: `/sentry-fix TEAMCLU-REACT-7Q`
 
 ## Projects
 
-| Project | Sentry Slug | Platform | Test Command | Lint Command |
-|---------|-------------|----------|--------------|--------------|
-| Rust backend | `ucar-inc/teamclu` | Rust | `cargo test --manifest-path src-tauri/Cargo.toml` | `cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings` |
-| React frontend | `ucar-inc/teamclu-react` | React | `pnpm test:unit` | `pnpm typecheck && pnpm lint` |
+Route on the issue ID prefix. Every project's short ID carries its own segment,
+so the prefix alone identifies the codebase:
 
-Determine which project based on the issue ID prefix:
-- `TEAMCLU-<suffix>` (no "REACT") → Rust backend
-- `TEAMCLU-REACT-<suffix>` → React frontend
+| Prefix | Sentry Slug | Code | Test | Lint / typecheck |
+|---|---|---|---|---|
+| `TEAMCLU-REACT-` | `ucar-inc/teamclu-react` | `packages/app/` | `pnpm test:unit` | `pnpm typecheck && pnpm lint` |
+| `TEAMCLU-RUST-` | `ucar-inc/teamclu-rust` | `apps/desktop/` | see **Rust tests** below | `pnpm rust:clippy` |
+| `TEAMCLU-IOS-` | `ucar-inc/teamclu-ios` | `apps/ios/` | `pnpm ios:test:core` | — |
+| `TEAMCLU-EXPO-` | `ucar-inc/teamclu-expo` | `apps/expo/` | `pnpm expo:test` | `pnpm typecheck:expo` |
+
+`ucar-inc/teamclu` (a bare `TEAMCLU-` prefix with no platform segment) is the
+**old, deleted** project. An issue ID in that shape is from before 2026-09-04 and
+cannot be fetched; ask the user for a current one.
+
+`teamclu-react` covers both the web app and the desktop webview — the desktop
+Rust process reports separately under `teamclu-rust`.
+
+### Rust tests
+
+Do **not** run bare `cargo test`. It exits 101 on
+`teamclu-introspect sidecar binary not found`: `check`/`clippy` are analysis
+paths, but `test` is a real build and runs `apps/desktop/build.rs`, which panics
+when `binaries/` (entirely gitignored) has no sidecar and `CI` is unset.
+
+Main checkout — the wrapper builds the sidecar first:
+
+```bash
+node scripts/rust-cli.js test --manifest-path apps/desktop/Cargo.toml --lib <filter>
+```
+
+Fresh worktree — `CI=1` alone is not enough, because tauri-build still globs
+`bundle.resources` paths that do not exist there:
+
+```bash
+CI=1 TAURI_CONFIG='{"bundle":{"externalBin":[],"resources":[]}}' \
+  node scripts/rust-cli.js test --manifest-path apps/desktop/Cargo.toml --lib <filter>
+```
+
+Always go through `pnpm rust:*` / `scripts/rust-cli.js` rather than bare cargo —
+bare `cargo clippy` fails on a fresh checkout for the same reason.
 
 ## Execution Steps
 
 ### Phase 1: Gather Context
 
-1. Fetch issue details with stack trace:
+1. Fetch issue details with stack trace. `issue view` resolves a short ID across
+   projects, so no slug is needed:
 
 ```bash
 sentry issue view <ISSUE-ID> --json
 ```
 
-2. From the stack trace and error message, identify the relevant source files and functions in the codebase.
+This is also the only place volume numbers come from — `count`, `userCount`,
+`firstSeen` and `lastSeen` are silently dropped from `issue list --fields` on
+CLI 0.26.1.
 
-3. Read those source files to understand the code context around the crash/error site.
+2. From the stack trace and error message, identify the relevant source files
+   and functions in the codebase.
 
-4. Perform local root cause analysis based on the stack trace + source code. Produce a clear root cause summary.
+3. Read those source files to understand the code context around the error site.
 
-**If the stack trace is insufficient to identify the root cause:** Stop and ask the user for additional context about the issue before proceeding. Do NOT guess.
+4. Perform local root cause analysis. Produce a clear root cause summary.
+
+Two checks worth making before writing it up:
+
+- **Is this one of several groups for the same defect?** A sourcemapped build
+  and a minified one group separately. Search sibling issues for the same
+  `metadata.value`; if they match, one fix closes all of them, and the plan
+  should say so.
+- **Is there a group with a sourcemapped frame?** Prefer analyzing the one whose
+  `culprit` is a repo path (`/src/...`) over a bundle (`assets/index-*.js`) — it
+  names the file directly instead of needing to be reverse-engineered.
+
+**If the stack trace is insufficient to identify the root cause:** Stop and ask
+the user for additional context. Do NOT guess.
 
 ### Phase 2: Confirm with User
 
-Present a fix plan to the user in the terminal. The plan MUST include:
+Present a fix plan in the terminal. It MUST include:
 
-1. **Root cause** — one-paragraph summary from local analysis
-2. **Files to modify** — exact file paths and what changes in each
+1. **Root cause** — one paragraph from local analysis
+2. **Files to modify** — exact paths and what changes in each
 3. **Proposed fix** — description of the code changes
-4. **Regression test plan** — what test will be added and what it verifies
-5. **Verification commands** — which commands will be run to validate
+4. **Regression test plan** — what test is added and what it verifies
+5. **Verification commands** — which commands will be run
 
-**STOP HERE and wait for user confirmation.** Do NOT proceed until the user says yes.
+**STOP HERE and wait for user confirmation.** Do NOT proceed until the user says
+yes. This applies even when the root cause looks obvious.
 
 ### Phase 3: Implement Fix
 
-1. Create a new branch from current HEAD:
+1. Branch. Never work on `main` (see the Git Workflow section of `CLAUDE.md`):
 
 ```bash
 git checkout -b sentry-fix/<issue-id-lowercase>
 ```
 
-Example: `sentry-fix/teamclu-3` or `sentry-fix/teamclu-react-2g`
+This checkout is often shared with other sessions. Before branching, run
+`git status --short` and confirm the tree is clean — a dirty tree means someone
+else's work in progress, and carrying it onto your branch (or committing it) has
+happened before. Never `git reset --hard` here.
 
 2. Implement the fix:
    - Follow existing code patterns and style
@@ -70,49 +124,74 @@ Example: `sentry-fix/teamclu-3` or `sentry-fix/teamclu-react-2g`
    - No gratuitous refactoring
 
 3. Write a regression test:
-   - **Rust issues:** Add `#[test]` in the relevant module's test section, or create a test file in the same directory. The test must reproduce the scenario that caused the original error.
-   - **React issues:** Add a vitest test in the corresponding `.test.ts` or `.test.tsx` file (create one if none exists, following existing test file patterns in the codebase). The test must verify the fix prevents the original error.
+   - **Rust:** `#[test]` in the relevant module's test section, or a test file in
+     the same directory.
+   - **React / Expo:** a vitest test in the corresponding `.test.ts(x)`, creating
+     one if none exists and following neighbouring test files.
+   - **iOS:** a SwiftPM test under `apps/ios/Packages/AMUXCore/Tests/`.
+
+   The test must reproduce the scenario that caused the original error.
+
+4. **Prove the test catches the bug.** Stash or revert the fix, run the new test,
+   and confirm it fails for the expected reason; then restore the fix and confirm
+   it passes. A regression test that was never seen red is not evidence. Use a
+   file copy plus `git checkout -- <path>` rather than `git stash` on a shared
+   checkout.
 
 ### Phase 4: Verify
 
-Run the verification suite for the relevant platform:
+Run the full suite for the platform, **including the test just written** — not
+just the linter:
 
-**Rust backend:**
-```bash
-cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings
-```
+- **React:** `pnpm test:unit && pnpm typecheck && pnpm lint`
+- **Rust:** the `rust-cli.js test` command above, plus `pnpm rust:clippy` and
+  `cargo fmt --check --manifest-path apps/desktop/Cargo.toml`
+- **Expo:** `pnpm expo:test && pnpm typecheck:expo`
+- **iOS:** `pnpm ios:test:core` (`pnpm ios:test` additionally needs a booted
+  simulator; skip it unless the fix is UI-level and say that you did)
 
-**React frontend:**
-```bash
-pnpm test:unit && pnpm typecheck && pnpm lint
-```
+Never pipe these through `tail`/`head` when you care about the result — the
+pipeline's exit code is the pager's, so a failure reads as exit 0. Redirect to a
+file and check `$?`.
+
+Compare lint output against the pre-change baseline rather than counting
+warnings in the absolute: this repo carries known warnings, and "0 errors" with
+an unchanged warning set is the bar.
 
 If verification fails:
 1. Read the error output
 2. Fix the issue
 3. Re-run verification
-4. Maximum 2 retry rounds. If still failing after 2 retries, stop and report the failure to the user.
+4. Maximum 2 retry rounds. If still failing, stop and report to the user.
 
-### Phase 5: Submit
+If a failure looks unrelated to the change, check it against the known-flaky and
+known-broken memories before assuming you caused it — several suites in this
+repo fail on a clean `main` for environmental reasons.
 
-1. Stage and commit:
+### Phase 5: Commit, then stop
+
+1. Stage only the files you changed, by explicit path. Never `git add -A` — an
+   unscoped add on this shared checkout is what put a private document into a
+   public commit once already:
 
 ```bash
 git add <changed-files>
 git commit -m "fix(<scope>): <description> (Sentry <ISSUE-ID>)"
 ```
 
-Where `<scope>` is the module/component name (e.g., `rag`, `p2p`, `settings`, `editor`).
+`<scope>` is the module/component (e.g. `chat`, `settings`, `daemon`, `editor`).
 
-2. Push the branch:
+2. **Stop here and report back.** Per `CLAUDE.md`, do not `git push` or run
+   `gh pr create` on your own initiative, even when everything is green. Wait for
+   an explicit "open the PR" / "ship it" / "提 PR" / "可以提 PR 了".
+
+Report: what was fixed, the verification results (including the red-then-green
+evidence for the regression test), and anything left unverified.
+
+### Phase 6: PR — only when the user asks
 
 ```bash
 git push -u origin sentry-fix/<issue-id-lowercase>
-```
-
-3. Create the PR:
-
-```bash
 gh pr create --title "fix(<scope>): <short description>" --body "$(cat <<'PREOF'
 ## Sentry Issue
 
@@ -128,22 +207,23 @@ Fixes [<ISSUE-ID>](<sentry-issue-permalink>)
 
 ## Test Coverage
 
-<description of regression test added>
+<the regression test, and the failure it produces without the fix>
 
 ## Verification
 
-- [ ] cargo clippy / pnpm lint passes
-- [ ] Tests pass including new regression test
+<commands run and their results; name anything not verified and why>
 PREOF
 )"
 ```
 
-4. Print the PR URL for the user.
+State verification honestly in the PR body — if something could not be run, say
+which and why rather than omitting it.
 
 ## Constraints
 
-- NEVER modify code before user confirms the fix plan (Phase 2)
+- NEVER modify code before the user confirms the fix plan (Phase 2)
 - NEVER modify files unrelated to the issue
-- ALWAYS write a regression test — no exceptions
+- ALWAYS write a regression test, and always see it fail before it passes
+- NEVER push or open a PR without an explicit request (Phase 5/6)
 - If `sentry` CLI is not authenticated, prompt the user to run `sentry auth login`
 - If `gh` CLI is not authenticated, prompt the user to run `gh auth login`

--- a/.claude/skills/sentry-monitor/SKILL.md
+++ b/.claude/skills/sentry-monitor/SKILL.md
@@ -5,85 +5,155 @@ description: Use when the user wants to check Sentry issues, run a Sentry daily 
 
 # Sentry Monitor — Daily Issue Report
 
-Scan both TeamClu Sentry projects for unresolved fatal/high issues, analyze root causes, and push a summary report to WeCom.
+Scan the TeamClu Sentry projects for unresolved fatal/high issues, analyze root
+causes, and report.
 
 ## Projects
 
 | Project | Sentry Slug | Platform |
 |---------|-------------|----------|
-| Rust backend | `ucar-inc/teamclu` | Rust |
-| React frontend | `ucar-inc/teamclu-react` | JavaScript React |
+| Web / desktop frontend | `ucar-inc/teamclu-react` | JavaScript React |
+| Desktop Rust process | `ucar-inc/teamclu-rust` | Rust |
+| iOS | `ucar-inc/teamclu-ios` | apple-ios |
+| Expo | `ucar-inc/teamclu-expo` | react-native |
+
+`ucar-inc/teamclu` (the old Rust slug) **does not exist** — it was deleted, and
+`sentry issue list` 404s on it. `teamclu-rust` replaced it on 2026-09-04, so
+that project has no history before then; an empty result there is expected for a
+while rather than a signal. Re-verify with `sentry project list ucar-inc/ --json`
+if a scan errors on an unknown project.
 
 ## Execution Steps
 
+### 0. Quota gate — do this FIRST
+
+The org is on Sentry's free tier: **5,000 errors/month, `onDemandMaxSpend = 0`**,
+billing period resetting on the **19th**. When the quota runs out Sentry drops
+every incoming event **silently** — from the issue list that looks identical to
+"no new errors." This has already happened twice (2026-08-17 and 2026-09-02),
+and the second time the projects sat blind for over two weeks.
+
+Never report "全部正常" without clearing this check.
+
+```bash
+sentry api "/organizations/ucar-inc/stats_v2/?field=sum(quantity)&groupBy=outcome&category=error&statsPeriod=7d&interval=1d"
+```
+
+Read the `accepted` and `rate_limited` series:
+
+- `accepted` non-zero for the most recent day → ingestion is healthy, continue.
+- `accepted` at 0 with `rate_limited` climbing → **quota exhausted**. Stop the
+  normal report. Lead with this instead, get the exact numbers from
+  `sentry api "/customers/ucar-inc/"` (`categories.errors`: `usage` /
+  `reserved` / `usageExceeded`, plus `billingPeriodEnd`), and say plainly that
+  the issue list below is stale as of the last accepted event.
+
 ### 1. Scan Issues
 
-Run these two commands in parallel:
+Run these in parallel, one per project:
 
 ```bash
-sentry issue list ucar-inc/teamclu --query "is:unresolved" --json --fields shortId,title,priority,level,status --limit 20
+sentry issue list ucar-inc/teamclu-react --query "is:unresolved" --period 48h --json --fields shortId,title,priority,level,status --limit 30
+sentry issue list ucar-inc/teamclu-rust  --query "is:unresolved" --period 48h --json --fields shortId,title,priority,level,status --limit 30
+sentry issue list ucar-inc/teamclu-ios   --query "is:unresolved" --period 48h --json --fields shortId,title,priority,level,status --limit 30
+sentry issue list ucar-inc/teamclu-expo  --query "is:unresolved" --period 48h --json --fields shortId,title,priority,level,status --limit 30
 ```
 
-```bash
-sentry issue list ucar-inc/teamclu-react --query "is:unresolved" --json --fields shortId,title,priority,level,status --limit 20
-```
+Use `--period` for the time window (`24h` / `48h` / `14d`), not a `lastSeen:`
+clause. Default is 90 days, which is far wider than a daily report wants.
 
-Filter results: keep only issues where `level` is `fatal` OR `priority` is `high`.
+Filter results: keep only issues where `level` is `fatal` OR `priority` is
+`high`.
 
-If no issues match, skip to step 4 with "全部正常" message.
+**`--fields` gotcha (CLI 0.26.1):** `count`, `userCount`, `firstSeen` and
+`lastSeen` are listed in `--help` but are silently dropped from `issue list`
+output — you get the key omitted, not an error. Volume and recency have to come
+from `sentry issue view <shortId> --json`, which does return them. Do not report
+event counts sourced from `issue list`.
+
+If no issues match **and step 0 was clean**, skip to step 4 with the "全部正常"
+message. If step 0 was not clean, say so instead — an empty list under an
+exhausted quota means nothing.
 
 ### 2. Analyze Root Causes (Local)
 
 For each filtered issue (max 10 total), perform local root cause analysis:
 
-1. Fetch issue details with stack trace:
+1. Fetch issue details with stack trace, which also carries the volume numbers:
 
 ```bash
 sentry issue view <shortId> --json
 ```
 
-2. From the stack trace / error message, identify the relevant source files and functions in the codebase.
+2. From the stack trace / error message, identify the relevant source files and
+   functions in the codebase.
 
-3. Read those source files to understand the code context around the crash/error site.
+3. Read those source files to understand the code context around the error site.
 
-4. Produce a one-sentence root cause summary based on the stack trace + source code analysis.
+4. Produce a one-sentence root cause summary based on the stack trace + source.
 
-Run analyses in parallel where possible (use Agent tool with parallel subagents). Each subagent should:
-- Run `sentry issue view <shortId> --json`
-- Read the relevant source files from the codebase
-- Return a one-sentence root cause summary
+Two things worth checking before writing the summary:
 
-If analysis cannot determine a root cause, use the error title as-is.
+- **Group splits.** The same defect often appears as several issues — a
+  sourcemapped build and a minified one group separately. Compare `metadata.value`
+  across the filtered set and treat identical values as one root cause rather
+  than reporting the same bug three times.
+- **Prefer a sourcemapped frame.** When several groups share a value, analyze
+  the one whose `culprit` is a repo path (`/src/...`) rather than a bundle
+  (`assets/index-*.js`) — it names the file directly.
+
+When there are more than ~4 issues to analyze, run them as parallel subagents
+via the Agent tool; each runs `sentry issue view`, reads the relevant sources,
+and returns one sentence. For fewer than that, just do it inline — spawning
+agents costs more than it saves.
+
+If analysis cannot determine a root cause, use the error title as-is and say the
+root cause is undetermined. Do not guess.
 
 ### 3. Format Report
-
-Build a report in this exact format:
 
 ```
 Sentry 日报 <YYYY-MM-DD>
 
-【Rust 后端】N 个高优 issue
+【Web / 桌面】N 个高优 issue
 • <shortId> [<level>] <title> — 根因：<root cause summary>
 • ...
 
-【React 前端】N 个高优 issue
-• <shortId> [<level>] <title> — 根因：<root cause summary>
+【桌面 Rust】N 个高优 issue
+• ...
+
+【iOS】N 个高优 issue
+• ...
+
+【Expo】N 个高优 issue
 • ...
 
 修复命令：/sentry-fix <top-issue-id>
 ```
 
-If a project has zero matching issues, omit that section entirely.
+Omit any project section with zero matching issues. When step 0 found the quota
+exhausted, put that first, above every section:
 
-### 4. Push to WeCom
+```
+⚠️ Sentry 配额已耗尽（<usage>/<reserved>），<date> 起事件全部被丢弃，<billingPeriodEnd> 重置。
+以下列表停留在最后一条被接收的事件，不代表当前状态。
+```
 
-Send the formatted report to the **TeamClu** group chat:
+### 4. Report Out
+
+Present the report in the conversation.
+
+**Pushing to WeCom is a separate step that needs the user's go-ahead**, unless
+this run is the scheduled daily report (`/loop 24h /sentry-monitor`), where
+pushing is the whole point. When the user asked for an analysis rather than a
+daily report, show the report and offer to push — do not push unasked, since it
+posts to a group chat.
 
 ```bash
 wecom-cli msg send_message '{"chat_type": 2, "chatid": "wrOOClYgAA5gMJijxEUfWC6M0RAjwlWQ", "msgtype": "text", "text": {"content": "<report text>"}}'
 ```
 
-If no fatal/high issues exist across both projects, send:
+If no fatal/high issues exist anywhere **and the quota gate was clean**:
 
 ```
 Sentry 日报 <YYYY-MM-DD> — 全部正常，无高优 issue
@@ -99,3 +169,6 @@ Sentry 日报 <YYYY-MM-DD> — 全部正常，无高优 issue
 - This skill is READ-ONLY. Never modify any code files.
 - Do not attempt to fix issues. Only report them.
 - If `sentry` CLI is not authenticated, prompt the user to run `sentry auth login`.
+- Never pipe a `sentry` command through `tail`/`head` when you care about
+  success — the pipeline's exit code is the pager's, so a failed call reads as
+  exit 0. Redirect to a file and check `$?`.

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -41,7 +41,16 @@ if [ -n "$docs" ]; then
 fi
 
 # ── 2. Known scratch directories, even if force-added past .gitignore ────────
-scratch=$(echo "$staged" | grep -E '^(\.playwright-mcp|test-results|playwright-report|screenshots|tmp|\.claude)/' || true)
+# `.claude/` is scratch by default, but `.gitignore` deliberately re-includes
+# four paths under it — settings.json, skills/, agents/, workflows/ — which are
+# checked-in project config rather than tool output. Without this carve-out the
+# hook blocks every edit to a shared skill, which is a normal commit (see
+# 674b5c7a2, and the .gitignore comment explaining the same re-includes). Keep
+# this list in sync with the `!.claude/...` lines there.
+scratch=$(echo "$staged" \
+  | grep -E '^(\.playwright-mcp|test-results|playwright-report|screenshots|tmp|\.claude)/' \
+  | grep -vE '^\.claude/(settings\.json$|skills/|agents/|workflows/)' \
+  || true)
 if [ -n "$scratch" ]; then
   echo "${RED}✗ Tool scratch output is not source:${RESET}"
   echo "$scratch" | sed 's/^/    /'


### PR DESCRIPTION
## Description

两个 Sentry skill 的项目配置全是坏的，外加一个挡住它们被提交的 pre-commit 缺口。纯工具链，不含产品代码。

配套的产品修复在 #1242（double unlisten、dev 上报、Rust DSN），两边互不依赖，可以独立合。

### `fix(hooks)` — pre-commit 挡住了 gitignore 明确追踪的路径

规则 2 一刀切匹配 `^\.claude/`，但 `.gitignore` 明确 re-include 了 `settings.json` / `skills/` / `agents/` / `workflows/`——这些是签入的项目配置，不是工具草稿。两者矛盾的结果是**每次改共享 skill 都只能靠 `--no-verify`**，而那恰恰是这个 hook 想杜绝的习惯。

「改共享 skill 是正常提交」不是猜的：`674b5c7a2` 就是一次，发生在这个 hook 存在之前。

carve-out 严格镜像 `.gitignore` 的四条，不多一分。12 条路径验证过：四条放行；`.playwright-mcp/`、`test-results/`、`screenshots/`、`tmp/`、`.claude/session-context/`、`.claude/settings.local.json`、`.claude/skills-backup/` 全部仍被拦（`skills/` 要求分隔符，所以 `skills-backup` 这种前缀不会误放）。

### `fix(skills)` — sentry-monitor

引用的 `ucar-inc/teamclu` 是已删除的项目，`sentry issue list` 直接 404，**skill 第一条命令就失败**。

- 项目表改成实际存在的四个（react / rust / ios / expo），对着 `sentry project list` 核过
- **新增 step 0 配额闸门**，在任何扫描之前跑。免费版配额耗尽后 Sentry 静默丢弃事件，在 issue 列表里和"没有新错误"完全无法区分——已经发生两次，第二次瞎了两周多。skill 不得在未通过该检查时报「全部正常」
- 记录 `count` / `userCount` / `firstSeen` / `lastSeen` 被 `issue list --fields` **静默丢弃**（CLI 0.26.1，省略 key 而不报错），量级只能从 `issue view` 取。原指令会让人报出根本没返回过的数字
- 时间窗改用 `--period`（默认 90 天，对日报太宽）
- group split 当同一根因（sourcemap 版和压缩版会分成不同 group），优先分析 culprit 是仓库路径的那个
- 超过约 4 个 issue 才用 subagent
- 企微推送改为需用户确认（除非是 `/loop 24h` 定时日报）——它是往群里发

### `fix(skills)` — sentry-fix

同一个死 slug，而且 Rust 那几条命令**全是错的**，照着走还会违反仓库自己的 git 规则。

| 原本写的 | 实际 |
|---|---|
| `src-tauri/Cargo.toml` | 本仓库没有，是 `apps/desktop/` |
| `cargo test --manifest-path ...` | 必挂 exit 101 —— `test` 是真实构建路径会跑 build.rs，而 `binaries/` 全被 gitignore |
| `cargo clippy --manifest-path ...` | 同类原因在新 checkout 上失败；CLAUDE.md 早写了要用 `pnpm rust:clippy` |

- 路由规则「`TEAMCLU-` 不带 REACT → Rust」已失效，因为现在每个项目的 short ID 都带平台段；补齐了 iOS 和 Expo（原本完全没有条目，尽管两端都在上报）
- **Phase 4 只跑 clippy** —— Phase 3 要求写回归测试，然后从不执行它。现在会跑，且要求先看到测试变红再接受
- **Phase 5 无条件 push + 开 PR**，与 CLAUDE.md「提交后停下、等明确指令」直接冲突。拆成 commit-then-stop 加一个需用户点头的 Phase 6

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update

## Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## 验证

命令和断言都实跑核对，不是照文档推测：

| 断言 | 验证方式 |
|---|---|
| 四个 slug 可用 | `sentry issue list` 逐个跑，全部 exit 0 |
| short ID 前缀 | 线上数据确认 `TEAMCLU-{REACT,RUST,IOS,EXPO}-` |
| `issue view` 跨项目免 slug | `sentry issue view TEAMCLU-IOS-B` → `project=teamclu-ios` |
| `--period` 真的生效 | `24h`→0、`48h`→10、`14d`→60 |
| `--fields` 丢字段 | 请求 `count,userCount,lastSeen`，返回里 key 直接不存在 |
| `rust-cli.js` 对 `test` 走完整构建 | `isAnalysisOnly` 只含 check/clippy，非分析命令走 `ensureTeamcluIntrospectSidecar` |
| 文中每条 pnpm script 存在 | 对照 `package.json` |
| hook carve-out | 12 条路径逐个过（4 放行 / 8 拦截），见上 |

hook 的改动本身就被这个 PR 用上了：后两个提交是在 carve-out 生效后正常提交的，没有用 `--no-verify`。

## Additional Notes

`.claude/skills/` 下目前只有这两个 skill 被追踪。hook 的 carve-out 同时覆盖了 `.claude/agents/` 和 `.claude/workflows/`，那两个目录现在是空的，但 `.gitignore` 已经为它们留了位置。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SFGLpfbhYK1ciRgHuUP5Jq
