### PR TITLE
fix(skills): treat hosted cloud/skills as a comparison cache

### DIFF
--- a/apps/daemon/src/config/roles_skills.rs
+++ b/apps/daemon/src/config/roles_skills.rs
@@ -297,25 +297,11 @@ fn remap_team_skill_path(workspace_path: &Path, path: PathBuf, team_id: &str) ->
 /// Code, and an empty list makes the bridge prune every team symlink it had.
 pub fn team_skill_roots(workspace_path: &Path) -> Vec<PathBuf> {
     let mut roots = collect_team_skill_paths(workspace_path);
-    // The daemon's own install root, for skills an admin assigned to this
-    // hosted agent. Separate from `~/.agents/skills` because that one belongs
-    // to the desktop's member-side reconcile — see `runtime::team_skills` for
-    // why sharing it would make the two loops delete each other's packs.
-    //
-    // Ordered *before* `~/.agents/skills`, and that ordering is the whole
-    // point: consumers resolve a slug collision by taking the first root that
-    // has it. On a machine that both hosts a shared agent and is signed in as a
-    // member, the same slug exists twice — once at the version an admin
-    // assigned to the agent, once at whatever the member happens to have,
-    // possibly edited and held back by a conflict. Putting the member's copy
-    // first would let a private edit decide what a team agent executes, which
-    // is exactly the veto the agent-side reconcile refuses to grant.
-    if let Some(team_id) = onboarded_team_id() {
-        let agent_dir = crate::runtime::team_skills::team_cloud_skills_dir(&team_id);
-        if agent_dir.is_dir() && !roots.contains(&agent_dir) {
-            roots.push(agent_dir);
-        }
-    }
+    // Hosted `cloud/skills` is a remote snapshot cache, not a runtime root.
+    // OpenCode loads `~/.agents/skills` only; putting the cache on
+    // `skills.paths` made the agent (and the Skills list) prefer it over the
+    // working copy, so drafts landed in a directory the next reconcile could
+    // overwrite.
     if let Some(home) = dirs::home_dir() {
         let registry_dir = home.join(".agents/skills");
         if registry_dir.is_dir() && !roots.contains(&registry_dir) {

--- a/apps/daemon/src/config/team_skill_draft.rs
+++ b/apps/daemon/src/config/team_skill_draft.rs
@@ -28,6 +28,8 @@ use super::managed_skill_writer::{
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum EffectiveSkillSource {
+    /// Legacy: drafts no longer target the cache.
+    #[allow(dead_code)]
     HostedAgent,
     Member,
 }
@@ -41,19 +43,16 @@ impl EffectiveSkillSource {
     }
 }
 
-/// Resolve the pack directory OpenCode actually loads for one team slug.
+/// The working copy OpenCode and the Skills list must use: `~/.agents/skills`.
 ///
-/// Hosted-agent projection wins when present — same ordering as
-/// `team_skill_roots` and the desktop `effective_team_skill_dir`.
+/// `cloud/skills` is a remote snapshot cache. Drafts, inspect, and publish
+/// never write it.
 pub fn effective_team_skill_dir(
     team_id: &str,
     slug: &str,
     home: &Path,
 ) -> (PathBuf, EffectiveSkillSource) {
-    let hosted = team_cloud_skills_dir(team_id).join(slug);
-    if hosted.is_dir() {
-        return (hosted, EffectiveSkillSource::HostedAgent);
-    }
+    let _ = team_id;
     (
         home.join(".agents/skills").join(slug),
         EffectiveSkillSource::Member,
@@ -459,7 +458,7 @@ mod tests {
     }
 
     #[test]
-    fn effective_path_prefers_hosted_projection() {
+    fn effective_path_is_always_the_member_working_copy() {
         let home = tempfile::tempdir().unwrap();
         let _guard = crate::test_brand_env::BrandEnvGuard::set_with_home("teamclu", home.path());
         let team = "team-a";
@@ -473,8 +472,8 @@ mod tests {
         );
 
         let (path, source) = effective_team_skill_dir(team, slug, home.path());
-        assert_eq!(source, EffectiveSkillSource::HostedAgent);
-        assert_eq!(path, hosted);
+        assert_eq!(source, EffectiveSkillSource::Member);
+        assert_eq!(path, member);
     }
 
     #[test]

--- a/apps/daemon/src/daemon/server/rpc.rs
+++ b/apps/daemon/src/daemon/server/rpc.rs
@@ -38,7 +38,9 @@ async fn skill_inventory(
         .team_skills(team_id)
         .await
         .map_err(|e| e.to_string())?;
-    let root = crate::runtime::team_skills::team_cloud_skills_dir(team_id);
+    let root = dirs::home_dir()
+        .map(|home| home.join(".agents").join("skills"))
+        .unwrap_or_else(|| crate::runtime::team_skills::team_cloud_skills_dir(team_id));
     let mut items = Vec::new();
     let claimed = claimed_slugs(&desired);
     for row in desired.into_iter().filter(|row| row.installed) {

--- a/apps/daemon/src/runtime/supervisor.rs
+++ b/apps/daemon/src/runtime/supervisor.rs
@@ -646,12 +646,10 @@ pub(crate) fn is_hosted_team_skills_path(path: &str, teams_root: &Path) -> bool 
     }
 }
 
-/// Put the two system-managed skill roots first, in the order OpenCode must
-/// search them, then keep any user-defined extras.
+/// Put the system-managed skill root first, then keep any user-defined extras.
 ///
-/// Hosted (current team) before `~/.agents/skills`. Every hosted root for a
-/// *different* team is dropped so a team switch cannot leave the previous
-/// team's packs in the search path.
+/// Runtime path is `~/.agents/skills`. Hosted `cloud/skills` is a comparison
+/// cache and is stripped from `skills.paths` so OpenCode never loads it.
 pub fn normalize_managed_skill_paths(
     existing: &[String],
     hosted: Option<&str>,
@@ -662,15 +660,11 @@ pub fn normalize_managed_skill_paths(
     let is_member =
         |path: &str| path_eq(path, "~/.agents/skills") || member.is_some_and(|m| path_eq(path, m));
     let is_managed = |path: &str| is_hosted_team_skills_path(path, teams_root) || is_member(path);
+    let _ = hosted;
 
     let mut out = Vec::new();
-    if let Some(hosted) = hosted.filter(|p| !p.is_empty()) {
-        out.push(hosted.to_string());
-    }
     if let Some(member) = member.filter(|p| !p.is_empty()) {
-        if !out.iter().any(|p| path_eq(p, member)) {
-            out.push(member.to_string());
-        }
+        out.push(member.to_string());
     }
     for path in existing {
         if path.trim().is_empty() || is_managed(path) {
@@ -684,16 +678,11 @@ pub fn normalize_managed_skill_paths(
     out
 }
 
-/// Seed the real skill roots into the active team's global config, absolutely —
-/// so no workspace has to be standing in the right place for them to resolve.
+/// Seed `~/.agents/skills` into the active team's global config.
 ///
-/// The two roots that actually receive skills, in the same order
-/// `config::team_skill_roots` uses:
-///
-/// 1. `~/.amuxd/teams/<id>/state/cloud/skills` — what an admin assigned to this
-///    hosted agent. First, so a member's private edit of the same slug cannot
-///    decide what a team agent executes.
-/// 2. `~/.agents/skills` — the member-side registry install dir.
+/// Hosted `cloud/skills` is a comparison cache, not a runtime root — it is
+/// stripped from `skills.paths` rather than registered. OpenCode loads the
+/// working copy only.
 ///
 /// Notably NOT the team share's `teamclu-team/skills`: file sync carries
 /// documents only, so nothing is ever installed there (see the note on
@@ -4194,30 +4183,30 @@ mod skill_path_normalize_tests {
     }
 
     #[test]
-    fn empty_config_emits_hosted_then_member() {
+    fn empty_config_emits_member_only() {
         assert_eq!(
             normalize(&[], Some(HOSTED_A), Some(MEMBER)),
-            vec![HOSTED_A.to_string(), MEMBER.to_string()]
+            vec![MEMBER.to_string()]
         );
     }
 
     #[test]
-    fn member_only_existing_puts_hosted_first() {
+    fn member_only_existing_stays_member() {
         assert_eq!(
             normalize(&[MEMBER.to_string()], Some(HOSTED_A), Some(MEMBER)),
-            vec![HOSTED_A.to_string(), MEMBER.to_string()]
+            vec![MEMBER.to_string()]
         );
     }
 
     #[test]
-    fn reverses_member_before_hosted() {
+    fn drops_hosted_even_when_listed_first() {
         assert_eq!(
             normalize(
-                &[MEMBER.to_string(), HOSTED_A.to_string()],
+                &[HOSTED_A.to_string(), MEMBER.to_string()],
                 Some(HOSTED_A),
                 Some(MEMBER)
             ),
-            vec![HOSTED_A.to_string(), MEMBER.to_string()]
+            vec![MEMBER.to_string()]
         );
     }
 
@@ -4234,7 +4223,7 @@ mod skill_path_normalize_tests {
                 Some(HOSTED_A),
                 Some(MEMBER)
             ),
-            vec![HOSTED_A.to_string(), MEMBER.to_string()]
+            vec![MEMBER.to_string()]
         );
     }
 
@@ -4248,7 +4237,6 @@ mod skill_path_normalize_tests {
                 Some(MEMBER)
             ),
             vec![
-                HOSTED_A.to_string(),
                 MEMBER.to_string(),
                 CUSTOM.to_string(),
                 extra.to_string()
@@ -4264,7 +4252,7 @@ mod skill_path_normalize_tests {
                 Some(HOSTED_B),
                 Some(MEMBER)
             ),
-            vec![HOSTED_B.to_string(), MEMBER.to_string()]
+            vec![MEMBER.to_string()]
         );
     }
 
@@ -4288,7 +4276,7 @@ mod skill_path_normalize_tests {
                 Some(HOSTED_A),
                 Some(MEMBER)
             ),
-            vec![HOSTED_A.to_string(), MEMBER.to_string(), CUSTOM.to_string()]
+            vec![MEMBER.to_string(), CUSTOM.to_string()]
         );
     }
 
@@ -4338,11 +4326,7 @@ mod skill_path_normalize_tests {
                 Some(HOSTED_A),
                 Some(MEMBER)
             ),
-            vec![
-                HOSTED_A.to_string(),
-                MEMBER.to_string(),
-                LOOKALIKE.to_string()
-            ]
+            vec![MEMBER.to_string(), LOOKALIKE.to_string()]
         );
     }
 }

--- a/apps/daemon/src/runtime/team_skills.rs
+++ b/apps/daemon/src/runtime/team_skills.rs
@@ -1,41 +1,9 @@
 //! Materialises the team skills a shared agent is supposed to have.
 //!
-//! Design: `docs/architecture/team-skills-registry.md` §8.1 / §8.2.
-//!
-//! An admin installing a skill onto a `visibility='team'` agent writes a server
-//! record and nothing else — their machine is not the machine that runs the
-//! agent. This is the other half: the daemon that *does* host the agent pulls
-//! the set it should have and makes the disk match.
-//!
-//! # Why a full diff and not an event feed
-//!
-//! Notifications get lost, daemons go offline, and an install can land while
-//! this process is not running at all. Anything that applies deltas drifts, and
-//! drift here means an agent quietly executing a version of a team procedure
-//! the team has retired. Recomputing the whole set costs a directory listing
-//! and cannot drift by construction; a lost notification only means the change
-//! lands on the next tick instead of immediately.
-//!
-//! # Why not `~/.agents/skills`
-//!
-//! That directory is the *desktop's* install root, and on a desktop machine the
-//! desktop is simultaneously reconciling it against the signed-in **member's**
-//! install set. This daemon reconciles against the **agent's** set. Two owners,
-//! one directory, and both remove packs that are not in their own desired set —
-//! they would delete each other's skills on alternating ticks, forever.
-//!
-//! So the daemon gets its own root under `~/.amuxd/teams/<id>/cloud/skills`,
-//! a sibling of the team MCP and env caches and outside every git worktree, and
-//! that root is added to [`crate::config::team_skill_roots`] so OpenCode and the
-//! Claude symlink bridge still see the packs.
-//!
-//! # No dirty protection here
-//!
-//! The desktop refuses to overwrite a pack a member edited locally. This does
-//! the opposite and overwrites unconditionally. Nobody on the host machine has
-//! standing to veto a team-level decision about a shared agent, and there is no
-//! one to ask — the admin who made the change is elsewhere and the daemon has
-//! no UI. The server record is the desired state, full stop (§4).
+//! `cloud/skills` is a **remote snapshot cache**: pull the registry zip, keep
+//! it for dirty comparison. The working copy OpenCode loads is
+//! `~/.agents/skills`. Cache updates overwrite unconditionally. Working-copy
+//! updates skip a dirty pack so a local draft is not clobbered.
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
@@ -185,19 +153,10 @@ impl TeamSkillReconciler {
         for row in rows.iter().filter(|r| r.installed) {
             let want = desired_version(row);
             let target = root.join(&row.slug);
-            // A pack whose recorded version we cannot read is reinstalled
-            // rather than trusted: one redundant download beats leaving content
-            // of unknown provenance in front of an agent.
+            // The cache is a remote snapshot: always match the server, even if
+            // something mutated the files. Dirty protection belongs on the
+            // working copy (`~/.agents/skills`), not here.
             if on_disk.get(&row.slug).copied() != Some(want) {
-                if is_dirty_pack(&target) {
-                    tracing::info!(
-                        team_id,
-                        slug = %row.slug,
-                        want,
-                        "team skill auto-follow held back by local draft"
-                    );
-                    continue;
-                }
                 match self.install(team_id, root, row, want).await {
                     Ok(()) => {
                         outcome.installed += 1;
@@ -209,6 +168,7 @@ impl TeamSkillReconciler {
                     }
                 }
             }
+            sync_working_copy_from_cache(team_id, &row.slug, &target);
 
             // Report the version actually on disk back to the server. Auto-follow
             // moves packs on its own, so nothing else ever advances
@@ -240,21 +200,13 @@ impl TeamSkillReconciler {
                 continue;
             }
             let dir = root.join(slug);
-            if is_dirty_pack(&dir) {
-                match archive_removed_pack(team_id, &dir, slug) {
-                    Ok(()) => outcome.removed += 1,
-                    Err(e) => {
-                        tracing::warn!(team_id, slug = %slug, error = %e, "team skill archive failed");
-                    }
-                }
-                continue;
-            }
             match std::fs::remove_dir_all(&dir) {
                 Ok(()) => outcome.removed += 1,
                 Err(e) => {
                     tracing::warn!(team_id, slug = %slug, error = %e, "team skill removal failed");
                 }
             }
+            remove_working_copy_if_ours(team_id, slug);
         }
 
         outcome
@@ -543,6 +495,72 @@ fn merge_refresh_targets(
 
 /// Which packs are in this root, and at what version, from each pack's own
 /// `origin.json`.
+fn working_copy_dir(slug: &str) -> Option<PathBuf> {
+    dirs::home_dir().map(|home| home.join(".agents").join("skills").join(slug))
+}
+
+/// Mirror the cache into `~/.agents/skills` when that working copy is not a
+/// local draft. Personal / foreign packs are left alone.
+fn sync_working_copy_from_cache(team_id: &str, slug: &str, cache: &Path) {
+    if !cache.is_dir() {
+        return;
+    }
+    let Some(work) = working_copy_dir(slug) else {
+        return;
+    };
+    if work.is_dir() {
+        if is_dirty_pack(&work) {
+            return;
+        }
+        match read_origin(&work) {
+            Some(origin)
+                if origin.registry != SOURCE_TEAM
+                    || origin
+                        .team_id
+                        .as_deref()
+                        .is_some_and(|have| have != team_id) =>
+            {
+                return;
+            }
+            None => return,
+            Some(_) => {}
+        }
+    }
+    if let Err(e) = commit_staged_pack(&work, cache) {
+        tracing::warn!(
+            team_id,
+            slug,
+            error = %e,
+            "failed to sync team skill working copy from cache"
+        );
+    }
+}
+
+fn remove_working_copy_if_ours(team_id: &str, slug: &str) {
+    let Some(work) = working_copy_dir(slug) else {
+        return;
+    };
+    if !work.is_dir() {
+        return;
+    }
+    let Some(origin) = read_origin(&work) else {
+        return;
+    };
+    if origin.registry != SOURCE_TEAM || origin.team_id.as_deref().is_some_and(|have| have != team_id)
+    {
+        return;
+    }
+    if is_dirty_pack(&work) {
+        if let Err(e) = archive_removed_pack(team_id, &work, slug) {
+            tracing::warn!(team_id, slug, error = %e, "team skill working-copy archive failed");
+        }
+        return;
+    }
+    if let Err(e) = std::fs::remove_dir_all(&work) {
+        tracing::warn!(team_id, slug, error = %e, "team skill working-copy removal failed");
+    }
+}
+
 fn installed_versions(root: &Path) -> HashMap<String, i64> {
     let mut out = HashMap::new();
     let Ok(entries) = std::fs::read_dir(root) else {

--- a/apps/desktop/src/commands/agents_skills.rs
+++ b/apps/desktop/src/commands/agents_skills.rs
@@ -96,9 +96,8 @@ pub fn ensure_agents_skills_paths(workspace_path: Option<String>) -> Result<Stri
         .filter(|s| !s.is_empty())
     {
         // Workspace `opencode.json` used to get `~/.agents/skills` prepended here.
-        // That copy outranks the team's global hosted-first `skills.paths`, so
-        // an older member pack shadowed the hosted team skill. Claude still
-        // needs the member root; OpenCode reads it from the global config.
+        // The working copy now lives there exclusively; the hosted cache is not
+        // a runtime path. Claude still needs the member root registered.
         let claude_ws = Path::new(ws).join(".claude").join("settings.json");
         if patch_config_file(&claude_ws, &agents_str)? {
             touched.push(claude_ws.display().to_string());

--- a/apps/desktop/src/commands/team_skills/inspect.rs
+++ b/apps/desktop/src/commands/team_skills/inspect.rs
@@ -45,6 +45,8 @@ fn team_skill_list_installed_blocking() -> Result<Vec<InstalledTeamSkill>, Strin
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum EffectiveSkillSource {
+    /// Legacy: inspect no longer targets the cache. Kept so old payloads decode.
+    #[allow(dead_code)]
     HostedAgent,
     Member,
 }
@@ -64,49 +66,50 @@ pub(super) fn hosted_team_skills_dir(team_id: &str) -> std::path::PathBuf {
         .join("skills")
 }
 
-/// Resolve the copy OpenCode actually sees for this slug. The daemon registers
-/// its hosted-Agent root before `~/.agents/skills`, so the first existing
-/// directory wins. A cloud directory for another (non-active) team is ignored:
-/// this desktop cannot be running it through the local daemon.
+/// The working copy: `~/.agents/skills/<slug>`.
+///
+/// `cloud/skills` is a remote snapshot cache used as the dirty baseline. It is
+/// never the directory inspect / edit / publish / restore should touch.
 pub(super) fn effective_team_skill_dir(
     slug: &str,
-    team_id: Option<&str>,
+    _team_id: Option<&str>,
 ) -> Result<(std::path::PathBuf, EffectiveSkillSource), String> {
-    let hosted = team_id
-        .map(str::trim)
-        .filter(|id| !id.is_empty())
-        .filter(|id| crate::commands::amuxd_active_team().as_deref() == Some(*id))
-        .map(|id| hosted_team_skills_dir(id).join(slug));
-    if let Some(path) = hosted.filter(|path| path.is_dir()) {
-        return Ok((path, EffectiveSkillSource::HostedAgent));
-    }
     Ok((
         global_skills_dir()?.join(slug),
         EffectiveSkillSource::Member,
     ))
 }
 
-/// Restore targets differ from reads: after a hosted copy was moved aside its
-/// directory no longer exists, but undo must put it back into the higher-ranked
-/// hosted root rather than silently restoring it as a member copy.
+/// Restore always returns the working copy. The hosted cache is not a draft.
 pub(super) fn preferred_team_skill_dir(
     slug: &str,
-    team_id: Option<&str>,
+    _team_id: Option<&str>,
 ) -> Result<std::path::PathBuf, String> {
-    if let Some(id) = team_id
-        .map(str::trim)
-        .filter(|id| !id.is_empty())
-        .filter(|id| crate::commands::amuxd_active_team().as_deref() == Some(*id))
-    {
-        return Ok(hosted_team_skills_dir(id).join(slug));
-    }
     Ok(global_skills_dir()?.join(slug))
 }
 
-/// Where the effective installed pack lives. The publish-a-new-version flow
-/// packs this directory rather than a hardcoded member projection — after a
-/// Hosted Agent edits its higher-priority cloud copy, that is the content the
-/// team expects to ship.
+/// Remote snapshot for this slug, when the cache is present and is ours.
+///
+/// Used only as the inspect baseline. Hosted files themselves are not hashed
+/// live: if the cache was mutated, `origin.json` still describes the last pull.
+fn hosted_snapshot(
+    slug: &str,
+    team_id: Option<&str>,
+) -> Option<(String, teamclu_skillpack::FileManifest)> {
+    let id = team_id.map(str::trim).filter(|s| !s.is_empty())?;
+    let hosted = hosted_team_skills_dir(id).join(slug);
+    if !hosted.is_dir() {
+        return None;
+    }
+    let origin = read_origin(&hosted)?;
+    if origin.registry != SOURCE_TEAM || belongs_to_another_team(&origin, Some(id)) {
+        return None;
+    }
+    Some((origin.installed_version, origin.files?))
+}
+
+/// Where the working copy lives (`~/.agents/skills/<slug>`). Publish packs this
+/// directory. The hosted cache is never the source.
 #[tauri::command]
 pub async fn team_skill_installed_dir(
     slug: String,
@@ -196,6 +199,7 @@ pub(crate) fn inspect_team_skill(
     let slug = slug.trim().to_string();
     validate_slug(&slug)?;
     let (target, source) = effective_team_skill_dir(&slug, team_id.as_deref())?;
+    let hosted = hosted_snapshot(&slug, team_id.as_deref());
 
     let missing = |slug: String| TeamSkillInspectResult {
         slug,
@@ -243,7 +247,7 @@ pub(crate) fn inspect_team_skill(
         });
     }
 
-    if origin.as_ref().and_then(|o| o.files.as_ref()).is_none() {
+    if origin.as_ref().and_then(|o| o.files.as_ref()).is_none() && hosted.is_none() {
         return Ok(missing(slug));
     }
 
@@ -254,7 +258,18 @@ pub(crate) fn inspect_team_skill(
         .unwrap_or(0);
     let registry_latest = registry_latest_version.unwrap_or(base_version);
 
-    let baseline = origin.and_then(|o| o.files);
+    // Prefer the hosted snapshot when it is the same installed version. A
+    // cache that has already moved to a newer pull must not paint "behind"
+    // as local edits — that is `stale_dirty` via registry_latest, not dirty.
+    let hosted_same_version = hosted
+        .as_ref()
+        .and_then(|(version, _)| version.parse::<i64>().ok())
+        == Some(base_version);
+    let baseline = if hosted_same_version {
+        hosted.map(|(_, files)| files)
+    } else {
+        origin.and_then(|o| o.files)
+    };
     match inspect(&target, baseline.as_ref()) {
         DirtyState::Dirty {
             modified,

--- a/apps/desktop/src/commands/team_skills/tests.rs
+++ b/apps/desktop/src/commands/team_skills/tests.rs
@@ -91,7 +91,7 @@ fn write_installed_skill(path: &std::path::Path, team_id: &str, version: i64) {
 }
 
 #[test]
-fn effective_copy_prefers_the_active_hosted_agent_projection() {
+fn effective_copy_is_always_the_member_working_copy() {
     let home = tempfile::tempdir().expect("tempdir");
     let _home = crate::test_home::HomeGuard::set(home.path());
     set_active_team("team-a");
@@ -101,12 +101,12 @@ fn effective_copy_prefers_the_active_hosted_agent_projection() {
     write_installed_skill(&hosted, "team-a", 2);
 
     let (resolved, source) = effective_team_skill_dir("say-hello", Some("team-a")).unwrap();
-    assert_eq!(resolved, hosted);
-    assert_eq!(source, EffectiveSkillSource::HostedAgent);
+    assert_eq!(resolved, member);
+    assert_eq!(source, EffectiveSkillSource::Member);
 }
 
 #[test]
-fn inspection_and_rebaseline_use_the_same_hosted_copy() {
+fn inspect_ignores_hosted_cache_edits_and_tracks_the_working_copy() {
     let home = tempfile::tempdir().expect("tempdir");
     let _home = crate::test_home::HomeGuard::set(home.path());
     set_active_team("team-a");
@@ -120,18 +120,29 @@ fn inspection_and_rebaseline_use_the_same_hosted_copy() {
     )
     .unwrap();
 
-    let before = inspect_team_skill("say-hello".into(), Some(2), Some("team-a".into()), None)
-        .expect("inspect hosted edit");
-    assert_eq!(before.state, "dirty");
-    assert_eq!(before.source, "hosted-agent");
-    assert_eq!(before.modified, vec!["SKILL.md"]);
+    let hosted_only = inspect_team_skill("say-hello".into(), Some(2), Some("team-a".into()), None)
+        .expect("inspect after hosted-only edit");
+    assert_eq!(hosted_only.state, "clean");
+    assert_eq!(hosted_only.source, "member");
+    assert!(hosted_only.modified.is_empty());
+
+    std::fs::write(
+        member.join("SKILL.md"),
+        "---\nname: say-hello\n---\nhello, bertrand\n",
+    )
+    .unwrap();
+    let local_edit = inspect_team_skill("say-hello".into(), Some(2), Some("team-a".into()), None)
+        .expect("inspect after working-copy edit");
+    assert_eq!(local_edit.state, "dirty");
+    assert_eq!(local_edit.source, "member");
+    assert_eq!(local_edit.modified, vec!["SKILL.md"]);
 
     let result = team_skill_rebaseline_blocking(rebaseline_request("say-hello", 3))
-        .expect("rebaseline hosted edit");
-    assert_eq!(std::path::PathBuf::from(result.path), hosted);
-    assert_eq!(read_origin(&hosted).unwrap().installed_version, "3");
-    assert_eq!(installed_state(&hosted), DirtyState::Clean);
-    assert_eq!(read_origin(&member).unwrap().installed_version, "2");
+        .expect("rebaseline working copy");
+    assert_eq!(std::path::PathBuf::from(result.path), member);
+    assert_eq!(read_origin(&member).unwrap().installed_version, "3");
+    assert_eq!(installed_state(&member), DirtyState::Clean);
+    assert_eq!(read_origin(&hosted).unwrap().installed_version, "2");
 }
 
 /// A workspace `opencode.json` carrying a decision about `deploy-check`.

--- a/apps/desktop/src/commands/team_skills/types.rs
+++ b/apps/desktop/src/commands/team_skills/types.rs
@@ -158,8 +158,8 @@ pub struct TeamSkillInspectResult {
     /// its own right: the publish path measures the whole directory, so these
     /// ship with the next version.
     pub added: Vec<String>,
-    /// `hosted-agent` when this is the daemon projection OpenCode ranks first;
-    /// `member` for `~/.agents/skills`.
+    /// `member` for the working copy at `~/.agents/skills`. `hosted-agent` is
+    /// legacy: the cloud cache is no longer inspect's target.
     pub source: String,
 }
 

--- a/docs/architecture/team-skills-agent-install-explicit-update.md
+++ b/docs/architecture/team-skills-agent-install-explicit-update.md
@@ -1,0 +1,61 @@
+# 团队 Skill：工作副本、hosted 缓存、安装 / 改 / 发
+
+> 状态：**现行模型**（实现与本文对齐）。
+> 对照：[`team-skills-registry.md`](./team-skills-registry.md) 里曾把 `cloud/skills` 写成 Agent 的运行时安装根——那是错的。
+
+## 1. 两份磁盘的角色
+
+| 路径 | 角色 | 谁可以写 |
+|---|---|---|
+| `~/.agents/skills/<slug>` | **工作副本**。列表展示、人改、`update_draft`、发布打包、OpenCode 加载、dirty 的「本地」一侧 | 人、Agent 草稿、桌面对账（dirty 则停） |
+| `~/.amuxd-…/teams/<id>/state/cloud/skills/<slug>` | **远端快照缓存**。把团队包拉下来，inspect 用它的 `origin.json` 当 baseline，免去每次下 zip | **只有** daemon 对账（无条件覆盖成远端） |
+
+hosted **不是**第二份可编辑副本，**不进** Skills 列表，**不进** `skills.paths`。
+
+dirty = 工作副本相对「同版本的 hosted `origin.json` 哈希」（没有缓存时退回工作副本自己的 origin）。只改 hosted 文件、不动工作副本 → **不脏**。
+
+## 2. 安装
+
+```text
+人在列表选中 Agent → 点安装
+  → PUT /v1/teams/:id/skills/:slug/install  { actorId }
+  → 桌面把 zip 解到 ~/.agents/skills/<slug>，写 origin.json
+  → daemon 对账把同一份远端包写入 cloud/skills 缓存
+  → 列表：已安装，对勾；dirPath 是 ~/.agents/skills
+```
+
+无头 daemon：缓存照常刷新；工作副本仅在 **不 dirty** 时从缓存同步过去。个人 skill（无 team origin）不会被覆盖或删除。
+
+## 3. 修改
+
+```text
+改 SKILL.md / update_draft
+  → 只写 ~/.agents/skills/<slug>
+  → hosted 缓存不动
+  → inspect(工作副本, hosted origin) → dirty → 列表三角
+  → 新会话用工作副本；别人看不到草稿
+```
+
+## 4. 发布
+
+```text
+打包 ~/.agents/skills/<slug> → POST .../versions
+  → 本机 rebaseline 工作副本 origin
+  → daemon 下次对账刷新 hosted 缓存到新 latest
+```
+
+## 5. 和旧实现的差别（已拆掉的）
+
+| | 旧（错） | 现在 |
+|---|---|---|
+| `effective_team_skill_dir` | hosted 目录在就用 hosted | 永远 `~/.agents/skills` |
+| OpenCode `skills.paths` | hosted 在前 | 只有工作副本；旧 hosted 路径会被清掉 |
+| 技能列表 `dirPath` | daemon 扫描 first-wins，hosted 先到 | 跳过 `…/state/cloud/skills` |
+| inspect | 对「有效目录」相对自己的 origin | 对工作副本，baseline 来自 hosted origin（同版本时） |
+| daemon 对账 | 把 hosted 当运行时根；脏了就跳过缓存更新 | 缓存无条件对齐远端；工作副本 dirty 则不同步 |
+
+## 6. 明确不做
+
+- 把 hosted 再加回 `skills.paths` 或列表。
+- 在草稿 / 发布 / restore 路径上写 hosted。
+- 用「hosted 活文件的 hash」当 baseline（缓存被误改时会误报 dirty）。

--- a/packages/app/src/components/workspace/__tests__/RuntimeRefreshBanner.test.tsx
+++ b/packages/app/src/components/workspace/__tests__/RuntimeRefreshBanner.test.tsx
@@ -1,6 +1,5 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest'
 import { render, screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
 import { RuntimeRefreshWorkspaceBanner } from '../RuntimeRefreshBanner'
 import { useWorkspaceRuntimeRefreshStore } from '@/stores/workspace-runtime-refresh'
 
@@ -25,27 +24,20 @@ describe('RuntimeRefreshWorkspaceBanner', () => {
     expect(container).toBeEmptyDOMElement()
   })
 
-  it('shows informational pending banner without apply action', async () => {
-    const dismissBanner = vi.fn()
+  it('does not show the informational pending banner', () => {
     useWorkspaceRuntimeRefreshStore.setState({
       refresh: {
         status: 'pending',
-        change_kinds: ['skills', 'mcp'],
+        change_kinds: ['opencode_json'],
         recommended_action: 'none',
         auto_apply_blocked_by_active_runtime: false,
         last_detected_at: '2026-06-03T00:00:00Z',
         last_error: null,
       },
-      dismissBanner,
     })
 
-    render(<RuntimeRefreshWorkspaceBanner />)
-
-    expect(screen.getByTestId('runtime-refresh-workspace-banner')).toBeInTheDocument()
-    expect(screen.getByText(/Updated: skills, MCP/i)).toBeInTheDocument()
-    expect(screen.queryByTestId('runtime-refresh-apply')).not.toBeInTheDocument()
-
-    await userEvent.click(screen.getByTestId('runtime-refresh-dismiss'))
-    expect(dismissBanner).toHaveBeenCalled()
+    const { container } = render(<RuntimeRefreshWorkspaceBanner />)
+    expect(container).toBeEmptyDOMElement()
+    expect(screen.queryByTestId('runtime-refresh-workspace-banner')).not.toBeInTheDocument()
   })
 })

--- a/packages/app/src/lib/agent/__tests__/workspace-runtime-refresh-labels.test.ts
+++ b/packages/app/src/lib/agent/__tests__/workspace-runtime-refresh-labels.test.ts
@@ -12,7 +12,7 @@ describe('workspace-runtime-refresh-labels', () => {
   })
 
   it('detects banner-worthy statuses', () => {
-    expect(runtimeRefreshNeedsBanner('pending')).toBe(true)
+    expect(runtimeRefreshNeedsBanner('pending')).toBe(false)
     expect(runtimeRefreshNeedsBanner('failed')).toBe(true)
     expect(runtimeRefreshNeedsBanner('applying')).toBe(false)
     expect(runtimeRefreshNeedsBanner('clean')).toBe(false)

--- a/packages/app/src/lib/agent/workspace-runtime-refresh-labels.ts
+++ b/packages/app/src/lib/agent/workspace-runtime-refresh-labels.ts
@@ -29,5 +29,5 @@ export function formatRuntimeRefreshChangeKinds(kinds: string[]): string {
 export function runtimeRefreshNeedsBanner(
   status: DaemonRuntimeRefreshStatus | null | undefined,
 ): boolean {
-  return status === 'pending' || status === 'failed'
+  return status === 'failed'
 }

--- a/packages/app/src/stores/__tests__/team-share-skill-dir.test.ts
+++ b/packages/app/src/stores/__tests__/team-share-skill-dir.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { teamPackOnDisk } from '../team-share-browser'
+import { isHostedTeamSkillsDir, teamPackOnDisk } from '../team-share-browser'
 
 describe('teamPackOnDisk', () => {
   it('is true when the local scan found a team pack', () => {
@@ -19,5 +19,21 @@ describe('teamPackOnDisk', () => {
 
   it('is false when sync health is drift but nothing is on disk yet', () => {
     expect(teamPackOnDisk('seatalk-webhook', new Map())).toBe(false)
+  })
+})
+
+describe('isHostedTeamSkillsDir', () => {
+  it('matches the daemon cloud cache root', () => {
+    expect(
+      isHostedTeamSkillsDir(
+        '/Users/me/.amuxd-teamclaw/teams/30b7006d-4225-4160-8c12-0a057268a914/state/cloud/skills',
+      ),
+    ).toBe(true)
+  })
+
+  it('rejects the working copy and lookalike company paths', () => {
+    expect(isHostedTeamSkillsDir('/Users/me/.agents/skills')).toBe(false)
+    expect(isHostedTeamSkillsDir('/opt/company/teams/team-a/state/cloud/skills')).toBe(false)
+    expect(isHostedTeamSkillsDir('/Users/me/.amuxd/teams/team-a/shared/skills')).toBe(false)
   })
 })

--- a/packages/app/src/stores/team-share-browser.ts
+++ b/packages/app/src/stores/team-share-browser.ts
@@ -471,6 +471,12 @@ async function listTeamKnowledge(knowledgeDir: string): Promise<TeamKnowledgeIte
 
 type OnDisk = { content: string; dirPath: string; invocationName: string; source: SkillSource }
 
+/** The daemon's remote snapshot cache — not a working copy, not a list row. */
+export function isHostedTeamSkillsDir(dirPath: string): boolean {
+  const normalized = dirPath.replace(/\\/g, '/').replace(/\/+$/, '')
+  return /\/\.amuxd(?:-[^/]+)?\/teams\/[^/]+\/state\/cloud\/skills$/.test(normalized)
+}
+
 /** Whether a team pack row should borrow on-disk paths from the local scan. */
 export function teamPackOnDisk(slug: string, onDisk: Map<string, OnDisk>): boolean {
   return onDisk.has(slug)
@@ -585,7 +591,8 @@ async function localSkillFiles(
   const skills = await getDaemonSkills(encodeWorkspaceId(wsPath)).catch(() => null)
   const byFilename = new Map<string, OnDisk>()
   for (const skill of skills ?? []) {
-    // First wins: the daemon returns roots in resolution order.
+    if (isHostedTeamSkillsDir(skill.dirPath)) continue
+    // First wins among working-copy roots.
     if (byFilename.has(skill.filename)) continue
     byFilename.set(skill.filename, {
       content: skill.content,


### PR DESCRIPTION
## Description

Team skills were treating `~/.amuxd-…/cloud/skills/<slug>` as the working copy (list, edit, publish, OpenCode `skills.paths`). That directory is only a remote snapshot cache for dirty comparison.

This PR makes `~/.agents/skills` the only working copy. Hosted packs are no longer shown in the Skills list, loaded by OpenCode, or written by drafts. The daemon still pulls remote zips into the cache (overwrite is fine) and syncs the working copy only when it is not dirty.

Also hides the informational “workspace configuration updated” banner (`pending`). `skills.paths` rewrites were firing it on every reconcile; the failed-state banner is unchanged.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Test plan

- [ ] Install a team skill, edit `SKILL.md` under `~/.agents/skills/<slug>`, confirm the list shows the warning triangle
- [ ] Confirm the Skills list `dirPath` / folder tree is `~/.agents/skills`, not `…/state/cloud/skills`
- [ ] Publish a dirty pack and confirm the zip comes from the working copy
- [ ] Confirm changing OpenCode config / skills.paths no longer shows “工作区配置已更新”
- [ ] Confirm a genuine runtime-refresh **failure** still shows the error banner

## Additional Notes

`docs/architecture/team-skills-agent-install-explicit-update.md` records the working-copy vs cache split.