### PR TITLE
fix(ci): unbreak Windows Tauri signing verification in release workflows

### DIFF
--- a/.github/workflows/release-oss.yml
+++ b/.github/workflows/release-oss.yml
@@ -461,22 +461,30 @@ jobs:
           cdn-base-default: ${{ env.CDN_BASE_DEFAULT }}
           cdn-refresh-region-default: ${{ env.CDN_REFRESH_REGION_DEFAULT }}
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: lts/*
+
       - name: Verify Tauri signing key
         env:
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         shell: bash
         run: |
-          npm install --no-save @tauri-apps/cli
-          echo "test" > "$RUNNER_TEMP/test_sign_file"
-          npx @tauri-apps/cli signer sign --private-key "$TAURI_SIGNING_PRIVATE_KEY" --password "$TAURI_SIGNING_PRIVATE_KEY_PASSWORD" "$RUNNER_TEMP/test_sign_file"
+          # npm install in the pnpm monorepo root crashes on Windows runners with
+          # "Cannot read properties of null (reading 'edgesOut')". Install the CLI
+          # in an isolated dir instead (see mirror-pi-oss.yml for the same npm bug).
+          SIGN_DIR="${RUNNER_TEMP}/tauri-sign-verify"
+          mkdir -p "$SIGN_DIR"
+          (
+            cd "$SIGN_DIR"
+            npm install --no-save @tauri-apps/cli
+            echo "test" > "$RUNNER_TEMP/test_sign_file"
+            npx @tauri-apps/cli signer sign --private-key "$TAURI_SIGNING_PRIVATE_KEY" --password "$TAURI_SIGNING_PRIVATE_KEY_PASSWORD" "$RUNNER_TEMP/test_sign_file"
+          )
           echo "✅ Signing key verified successfully"
           rm -f "$RUNNER_TEMP/test_sign_file" "$RUNNER_TEMP/test_sign_file.sig"
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v7
-        with:
-          node-version: lts/*
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v6.0.10

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -340,22 +340,30 @@ jobs:
           echo "Official build config:"
           cat build.config.json
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: lts/*
+
       - name: Verify Tauri signing key
         env:
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         shell: bash
         run: |
-          npm install --no-save @tauri-apps/cli
-          echo "test" > "$RUNNER_TEMP/test_sign_file"
-          npx @tauri-apps/cli signer sign --private-key "$TAURI_SIGNING_PRIVATE_KEY" --password "$TAURI_SIGNING_PRIVATE_KEY_PASSWORD" "$RUNNER_TEMP/test_sign_file"
+          # npm install in the pnpm monorepo root crashes on Windows runners with
+          # "Cannot read properties of null (reading 'edgesOut')". Install the CLI
+          # in an isolated dir instead (see mirror-pi-oss.yml for the same npm bug).
+          SIGN_DIR="${RUNNER_TEMP}/tauri-sign-verify"
+          mkdir -p "$SIGN_DIR"
+          (
+            cd "$SIGN_DIR"
+            npm install --no-save @tauri-apps/cli
+            echo "test" > "$RUNNER_TEMP/test_sign_file"
+            npx @tauri-apps/cli signer sign --private-key "$TAURI_SIGNING_PRIVATE_KEY" --password "$TAURI_SIGNING_PRIVATE_KEY_PASSWORD" "$RUNNER_TEMP/test_sign_file"
+          )
           echo "✅ Signing key verified successfully"
           rm -f "$RUNNER_TEMP/test_sign_file" "$RUNNER_TEMP/test_sign_file.sig"
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v7
-        with:
-          node-version: lts/*
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v6.0.10


### PR DESCRIPTION
## Summary
- Fix Windows `build-windows` jobs failing at **Verify Tauri signing key** with `npm error Cannot read properties of null (reading 'edgesOut')`.
- Move `Setup Node.js` before the signing check and install `@tauri-apps/cli` in an isolated temp dir so npm does not try to resolve the pnpm monorepo root on Windows runners.
- Apply the same fix to both `release-oss.yml` and `release.yml`.

## Test plan
- [ ] Merge to `main`
- [ ] Re-dispatch OSS release for `teamclu` (`v0.4.1-beta.41`) and `copilot361` (`v0.4.1-beta.42`)
- [ ] Confirm `build-windows` passes the signing verification step


Made with [Cursor](https://cursor.com)