### PR TITLE
新会话入口重做：高级会话选工作目录，文件树跟着会话走

### DIFF
--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -47,6 +47,7 @@ import { RuntimeRefreshWorkspaceBanner } from "@/components/workspace/RuntimeRef
 import { useSessionStore } from "@/stores/session-store";
 import { useSessionListStore } from "@/stores/session-list-store";
 import { useSessionSelectionStore } from "@/stores/session-selection-store";
+import { useSessionLocalWorkspace } from "@/hooks/use-session-local-workspace";
 import { useAuthStore } from "@/stores/auth-store";
 import { useOutboxStore } from "@/stores/outbox-store";
 import { startOutboxSender } from "@/services/outbox-sender";
@@ -192,6 +193,12 @@ function AppContent() {
     isPanelOpen &&
     activeTab === "shortcuts";
   const showAppControlPanel = appControlPanelOpen && !!controlPanelApp;
+  // The file tree and the terminal both reach this machine's filesystem, so
+  // they only mean something for a session the local agent is in. Without this
+  // gate they kept showing the previous session's directory: the workspace
+  // store is ambient and only moves when a session resolving to a local path
+  // is opened.
+  const { hasLocalAgent: sessionHasLocalAgent } = useSessionLocalWorkspace();
   const showRightWorkspacePanel = isPanelOpen && !leftDockActive && !showAppControlPanel;
   const showRightSidePanel = showRightWorkspacePanel || showAppControlPanel;
   const settingsOpen = currentView === "settings";
@@ -659,7 +666,7 @@ function AppContent() {
                   <AppWindow className="h-4 w-4" />
                 </button>
               )}
-              {capabilities.workspace && workspacePath && showTerminalToggle && (
+              {capabilities.workspace && workspacePath && showTerminalToggle && sessionHasLocalAgent && (
                 <TerminalToggleButton workspacePath={workspacePath} />
               )}
               {activeSession && hasCurrentSession && (
@@ -673,11 +680,11 @@ function AppContent() {
                   onClick={() => isPanelOpen && activeTab === "actors" ? closePanel() : openPanel("actors")}
                 />
               )}
-              {/* Workspace file tree. Restored as a header entry that opens the
-                  right-panel `files` tab (rendered by the existing FileBrowser,
-                  not the deleted RAG KnowledgeBrowser). Gate mirrors the
-                  pre-#1054 condition: desktop + a workspace path. */}
-              {capabilities.workspace && (
+              {/* Workspace file tree — the folder the local agent works in for
+                  the open session. No local agent in it, no folder to show, so
+                  the entry disappears rather than pointing at whatever was open
+                  before. */}
+              {capabilities.workspace && sessionHasLocalAgent && (
                 <HeaderPanelTab
                   icon={BookOpen}
                   label={t("navigation.files", "files")}

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -198,7 +198,10 @@ function AppContent() {
   // gate they kept showing the previous session's directory: the workspace
   // store is ambient and only moves when a session resolving to a local path
   // is opened.
-  const { hasLocalAgent: sessionHasLocalAgent } = useSessionLocalWorkspace();
+  const {
+    hasLocalAgent: sessionHasLocalAgent,
+    path: sessionWorkspacePath,
+  } = useSessionLocalWorkspace();
   const showRightWorkspacePanel = isPanelOpen && !leftDockActive && !showAppControlPanel;
   const showRightSidePanel = showRightWorkspacePanel || showAppControlPanel;
   const settingsOpen = currentView === "settings";
@@ -666,8 +669,12 @@ function AppContent() {
                   <AppWindow className="h-4 w-4" />
                 </button>
               )}
-              {capabilities.workspace && workspacePath && showTerminalToggle && sessionHasLocalAgent && (
-                <TerminalToggleButton workspacePath={workspacePath} />
+              {/* `sessionWorkspacePath`, not the ambient `workspacePath`: the
+                  store lags a session switch by a background round trip, and a
+                  PTY opened in that window lands in the previous session's
+                  folder — which a terminal, unlike a tree, then keeps. */}
+              {capabilities.workspace && sessionWorkspacePath && showTerminalToggle && (
+                <TerminalToggleButton workspacePath={sessionWorkspacePath} />
               )}
               {activeSession && hasCurrentSession && (
                 <SessionThreadsHeaderButton sessionId={activeSession.id} />

--- a/packages/app/src/components/chat/NewSessionDialog.tsx
+++ b/packages/app/src/components/chat/NewSessionDialog.tsx
@@ -24,6 +24,7 @@ import {
   setAgentDefaultWorkspace,
   type DaemonWorkspace,
 } from '@/lib/daemon/daemon-workspaces'
+import { shortenWorkspacePath } from '@/lib/workspace/shorten-path'
 import { computeInitialSelection } from './new-session-prefill'
 
 type Candidate = {
@@ -511,11 +512,10 @@ export function NewSessionDialog() {
             )}
             {selectedWorkspace?.path && (
               <div
-                className="truncate pt-1.5 text-left text-[11.5px] text-faint"
-                dir="rtl"
+                className="truncate pt-1.5 text-[11.5px] text-faint"
                 title={selectedWorkspace.path}
               >
-                {selectedWorkspace.path}
+                {shortenWorkspacePath(selectedWorkspace.path)}
               </div>
             )}
             {selectedWorkspace && selectedWorkspace.id !== localAgentDefaultWorkspaceId && (

--- a/packages/app/src/components/chat/NewSessionDialog.tsx
+++ b/packages/app/src/components/chat/NewSessionDialog.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import { useTranslation } from 'react-i18next'
-import { Loader2, Pencil, Search, X } from 'lucide-react'
+import { FolderOpen, Loader2, Pencil, Search, Star, X } from 'lucide-react'
 import {
   Dialog, DialogContent, DialogTitle,
 } from '@/components/ui/dialog'
@@ -15,14 +15,26 @@ import { actorAvatarColor } from '@/lib/actor/actor-color'
 import { createSessionWithFirstMessage } from '@/lib/session/session-create'
 import { promoteCreatedSessionToUi } from '@/lib/session/promote-created-session'
 import { useEngagedAgentStore } from '@/stores/engaged-agent-store'
-import { cn } from '@/lib/utils'
+import { cn, isTauri } from '@/lib/utils'
 import { useMemberPreferencesStore } from '@/stores/member-preferences-store'
+import { rememberDefaultWorkspaceId } from '@/stores/agent-default-workspace-store'
+import {
+  createDaemonWorkspace,
+  listDaemonWorkspaces,
+  setAgentDefaultWorkspace,
+  type DaemonWorkspace,
+} from '@/lib/daemon/daemon-workspaces'
 import { computeInitialSelection } from './new-session-prefill'
 
 type Candidate = {
   id: string
   actor_type: 'member' | 'agent'
   display_name: string
+}
+
+function workspaceNameFromPath(path: string): string {
+  const trimmed = path.replace(/\/+$/, '')
+  return trimmed.split('/').pop() || trimmed
 }
 
 export function NewSessionDialog() {
@@ -48,9 +60,34 @@ export function NewSessionDialog() {
   const [message, setMessage] = React.useState('')
   const [submitting, setSubmitting] = React.useState(false)
 
+  // The agent running on THIS machine. Resolved from the local daemon's own
+  // `/v1/info`, not from the directory — several agents in a team can share a
+  // display name (three rows reading `liziliudeMacBook-Air` is the normal
+  // case), so the badge and the workspace picker cannot be driven by name.
+  const [localAgentId, setLocalAgentId] = React.useState<string | null>(null)
+  const [workspaces, setWorkspaces] = React.useState<DaemonWorkspace[]>([])
+  const [workspacesLoading, setWorkspacesLoading] = React.useState(false)
+  const [selectedWorkspaceId, setSelectedWorkspaceId] = React.useState<string>('')
+  const [workspaceBusy, setWorkspaceBusy] = React.useState(false)
+
   React.useEffect(() => {
     if (open) setMessage(initialMessage ?? '')
   }, [open, initialMessage])
+
+  React.useEffect(() => {
+    if (!open || !isTauri()) return
+    let cancelled = false
+    void (async () => {
+      try {
+        const { getLocalDaemonActorId } = await import('@/lib/daemon/daemon-agent-admin')
+        const id = await getLocalDaemonActorId()
+        if (!cancelled) setLocalAgentId(id?.trim() || null)
+      } catch {
+        if (!cancelled) setLocalAgentId(null)
+      }
+    })()
+    return () => { cancelled = true }
+  }, [open])
 
   // On open: reset the picker, pull a fresh reconcile, kick a full background
   // sync, and trigger a load of the effective default agent.
@@ -95,6 +132,112 @@ export function NewSessionDialog() {
     [candidates, picked],
   )
 
+  // A workspace is a folder on one machine, so the picker only means anything
+  // when the agent that would run there is in the session. Deselect it and the
+  // choice is dropped rather than left dangling on an absent agent.
+  const localAgentPicked = !!localAgentId && picked.has(localAgentId)
+
+  const localAgentDefaultWorkspaceId = React.useMemo(() => {
+    if (!localAgentId) return ''
+    const row = actors.find((a) => a.id === localAgentId)
+    return row?.default_workspace_id?.trim() ?? ''
+  }, [actors, localAgentId])
+
+  const loadWorkspaces = React.useCallback(async () => {
+    if (!teamId || !localAgentId) return
+    setWorkspacesLoading(true)
+    try {
+      const rows = await listDaemonWorkspaces(teamId, localAgentId)
+      setWorkspaces(rows.filter((w) => !w.archived && !!w.path))
+    } catch (e) {
+      console.warn('[NewSessionDialog] workspace load failed (non-fatal):', e)
+      setWorkspaces([])
+    } finally {
+      setWorkspacesLoading(false)
+    }
+  }, [teamId, localAgentId])
+
+  React.useEffect(() => {
+    if (!open || !localAgentPicked) {
+      setWorkspaces([])
+      setSelectedWorkspaceId('')
+      return
+    }
+    void loadWorkspaces()
+  }, [open, localAgentPicked, loadWorkspaces])
+
+  // Land on the agent's own default; fall back to its first folder so the
+  // picker is never empty-but-populated.
+  React.useEffect(() => {
+    if (!localAgentPicked || workspaces.length === 0) return
+    setSelectedWorkspaceId((current) => {
+      if (current && workspaces.some((w) => w.id === current)) return current
+      const preferred = workspaces.find((w) => w.id === localAgentDefaultWorkspaceId)
+      return (preferred ?? workspaces[0]).id
+    })
+  }, [localAgentPicked, workspaces, localAgentDefaultWorkspaceId])
+
+  const selectedWorkspace = React.useMemo(
+    () => workspaces.find((w) => w.id === selectedWorkspaceId) ?? null,
+    [workspaces, selectedWorkspaceId],
+  )
+
+  const handleBrowseWorkspace = async () => {
+    if (!teamId || !localAgentId) return
+    setWorkspaceBusy(true)
+    try {
+      const { open: openDialog } = await import('@tauri-apps/plugin-dialog')
+      const selected = await openDialog({
+        directory: true,
+        multiple: false,
+        title: t('chat.newSessionDialog.workspaceBrowse', '选择工作目录'),
+      })
+      const path = typeof selected === 'string' ? selected.trim() : ''
+      if (!path) return
+      const created = await createDaemonWorkspace({
+        teamId,
+        agentId: localAgentId,
+        createdByMemberId: currentMemberId,
+        name: workspaceNameFromPath(path),
+        path,
+      })
+      await loadWorkspaces()
+      setSelectedWorkspaceId(created.id)
+    } catch (e) {
+      const { toast } = await import('sonner')
+      toast.error(
+        t('chat.newSessionDialog.workspaceAddFailed', '添加工作目录失败：{{msg}}', {
+          msg: e instanceof Error ? e.message : String(e),
+        }),
+      )
+    } finally {
+      setWorkspaceBusy(false)
+    }
+  }
+
+  const handleSetDefaultWorkspace = async () => {
+    if (!localAgentId || !selectedWorkspace) return
+    setWorkspaceBusy(true)
+    try {
+      await setAgentDefaultWorkspace(localAgentId, selectedWorkspace.id)
+      // Keep the send-path fast cache in step with what we just wrote; a stale
+      // entry here is what makes the next first message cold-start twice.
+      rememberDefaultWorkspaceId([localAgentId], selectedWorkspace.id)
+      refetch()
+      const { toast } = await import('sonner')
+      toast.success(t('chat.newSessionDialog.workspaceDefaultSet', '已设为默认工作目录'))
+    } catch (e) {
+      const { toast } = await import('sonner')
+      toast.error(
+        t('chat.newSessionDialog.workspaceDefaultFailed', '设置默认工作目录失败：{{msg}}', {
+          msg: e instanceof Error ? e.message : String(e),
+        }),
+      )
+    } finally {
+      setWorkspaceBusy(false)
+    }
+  }
+
   // One-shot prefill: once per open, apply effective default agent selection.
   // Waits until the effective default has finished loading for this team before
   // applying, so we don't prematurely lock in an empty selection.
@@ -118,7 +261,7 @@ export function NewSessionDialog() {
 
   const clearPicks = () => setPicked(new Set())
 
-  const canSubmit = message.trim().length > 0 && !submitting
+  const canSubmit = message.trim().length > 0 && !submitting && !!teamId
 
   const handleClose = () => {
     if (submitting) return
@@ -153,6 +296,10 @@ export function NewSessionDialog() {
         additionalActorIds,
         agentActorIds,
         messageText: trimmed,
+        localWorkspace:
+          localAgentPicked && selectedWorkspace?.path
+            ? { workspaceId: selectedWorkspace.id, path: selectedWorkspace.path }
+            : null,
       })
       const agentPicks = pickedActors.filter((p) => p.actor_type === 'agent')
       if (agentPicks.length > 0) {
@@ -217,6 +364,29 @@ export function NewSessionDialog() {
           </button>
         </div>
 
+        {/*
+          No team, no session: the participant list, the creator actor and the
+          session row all hang off a team id. The advanced button stays live in
+          this state on purpose — it is the escape hatch when quick chat is
+          dead — so it has to land somewhere that says what is missing.
+        */}
+        {!teamId ? (
+          <div
+            data-testid="new-session-no-team"
+            className="border-t border-border px-5 py-10 text-center"
+          >
+            <div className="text-[13px] font-medium text-foreground">
+              {t('chat.newSessionDialog.noTeamTitle', '还没有团队')}
+            </div>
+            <div className="pt-1.5 text-[12.5px] text-muted-foreground">
+              {t(
+                'chat.newSessionDialog.noTeamHint',
+                '先创建或加入一个团队，才能发起会话。',
+              )}
+            </div>
+          </div>
+        ) : (
+        <>
         {/* Participants chips */}
         <div className="px-5 pt-2 pb-3">
           <div className="flex items-center justify-between pb-2">
@@ -280,10 +450,91 @@ export function NewSessionDialog() {
               key={c.id}
               candidate={c}
               checked={picked.has(c.id)}
+              isLocal={c.id === localAgentId}
               onToggle={() => togglePick(c.id)}
             />
           ))}
         </div>
+
+        {/* Workspace — only once the agent on this machine is in the session */}
+        {localAgentPicked && (
+          <div
+            data-testid="new-session-workspace"
+            className="border-b border-border px-5 pt-4 pb-3"
+          >
+            <div className="flex items-baseline justify-between pb-2">
+              <label className="text-[12px] text-muted-foreground">
+                {t('chat.newSessionDialog.workspaceLabel', '工作目录')}
+              </label>
+              <span className="text-[11.5px] text-faint">
+                {t('chat.newSessionDialog.workspaceScope', '仅对本机 Agent 生效')}
+              </span>
+            </div>
+            {workspacesLoading ? (
+              <div className="flex items-center gap-2 py-1.5 text-[12.5px] text-muted-foreground">
+                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                {t('chat.newSessionDialog.loading', '加载中…')}
+              </div>
+            ) : (
+              <div className="flex items-center gap-2">
+                <select
+                  value={selectedWorkspaceId}
+                  onChange={(e) => setSelectedWorkspaceId(e.target.value)}
+                  disabled={workspaceBusy || workspaces.length === 0}
+                  aria-label={t('chat.newSessionDialog.workspaceLabel', '工作目录')}
+                  className="h-9 min-w-0 flex-1 rounded-lg border border-border bg-muted/30 px-2.5 text-[13px] outline-none focus:border-foreground/30 disabled:opacity-50"
+                >
+                  {workspaces.length === 0 && (
+                    <option value="">
+                      {t('chat.newSessionDialog.workspaceNone', '本机还没有工作目录')}
+                    </option>
+                  )}
+                  {workspaces.map((w) => (
+                    <option key={w.id} value={w.id}>
+                      {w.id === localAgentDefaultWorkspaceId
+                        ? `${w.name} · ${t('chat.newSessionDialog.workspaceDefaultTag', '默认')}`
+                        : w.name}
+                    </option>
+                  ))}
+                </select>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="h-9 shrink-0 gap-1.5"
+                  disabled={workspaceBusy}
+                  onClick={() => void handleBrowseWorkspace()}
+                >
+                  <FolderOpen className="h-3.5 w-3.5" />
+                  {t('chat.newSessionDialog.workspaceBrowseAction', '浏览…')}
+                </Button>
+              </div>
+            )}
+            {selectedWorkspace?.path && (
+              <div
+                className="truncate pt-1.5 text-left text-[11.5px] text-faint"
+                dir="rtl"
+                title={selectedWorkspace.path}
+              >
+                {selectedWorkspace.path}
+              </div>
+            )}
+            {selectedWorkspace && selectedWorkspace.id !== localAgentDefaultWorkspaceId && (
+              <button
+                type="button"
+                disabled={workspaceBusy}
+                onClick={() => void handleSetDefaultWorkspace()}
+                className="mt-2 inline-flex items-center gap-1.5 text-[12px] text-muted-foreground hover:text-foreground disabled:opacity-50"
+                title={t(
+                  'chat.newSessionDialog.workspaceDefaultWarning',
+                  '将改变该 Agent 今后所有会话与定时任务的默认目录',
+                )}
+              >
+                <Star className="h-3 w-3" />
+                {t('chat.newSessionDialog.workspaceSetDefault', '设为默认')}
+              </button>
+            )}
+          </div>
+        )}
 
         {/* Opening message */}
         <div className="px-5 pt-4 pb-3">
@@ -302,6 +553,8 @@ export function NewSessionDialog() {
             className="w-full resize-none rounded-lg border border-border bg-muted/20 px-3 py-2.5 text-[13px] leading-[1.5] outline-none placeholder:text-muted-foreground focus:border-foreground/30"
           />
         </div>
+        </>
+        )}
 
         {/* Footer */}
         <div className="flex items-center justify-end gap-2 border-t border-border bg-muted/30 px-5 py-3">
@@ -377,12 +630,16 @@ function ParticipantChip({
 function CandidateRow({
   candidate,
   checked,
+  isLocal,
   onToggle,
 }: {
   candidate: Candidate
   checked: boolean
+  /** The agent running on this machine — the only one the workspace picker applies to. */
+  isLocal: boolean
   onToggle: () => void
 }) {
+  const { t } = useTranslation()
   const isAgent = candidate.actor_type === 'agent'
   const c = actorAvatarColor(candidate.id)
   return (
@@ -411,6 +668,16 @@ function CandidateRow({
           {isAgent && (
             <span className="shrink-0 rounded border border-coral/40 bg-coral/10 px-1 py-px font-mono text-[9px] font-semibold tracking-wider text-coral">
               AI
+            </span>
+          )}
+          {/* Several agents in a team commonly share a display name, so this
+              badge is the only way to tell which row is the machine you are on. */}
+          {isLocal && (
+            <span
+              data-testid="candidate-local-badge"
+              className="shrink-0 rounded border border-border bg-muted px-1 py-px text-[9.5px] font-semibold tracking-wide text-muted-foreground"
+            >
+              {t('chat.newSessionDialog.localAgentBadge', '本机')}
             </span>
           )}
         </div>

--- a/packages/app/src/components/chat/NewSessionDialog.tsx
+++ b/packages/app/src/components/chat/NewSessionDialog.tsx
@@ -24,7 +24,7 @@ import {
   setAgentDefaultWorkspace,
   type DaemonWorkspace,
 } from '@/lib/daemon/daemon-workspaces'
-import { shortenWorkspacePath } from '@/lib/workspace/shorten-path'
+import { shortenWorkspacePath, workspaceNameFromPath } from '@/lib/workspace/shorten-path'
 import { computeInitialSelection } from './new-session-prefill'
 
 type Candidate = {
@@ -33,10 +33,6 @@ type Candidate = {
   display_name: string
 }
 
-function workspaceNameFromPath(path: string): string {
-  const trimmed = path.replace(/\/+$/, '')
-  return trimmed.split('/').pop() || trimmed
-}
 
 export function NewSessionDialog() {
   const { t } = useTranslation()
@@ -144,22 +140,30 @@ export function NewSessionDialog() {
     return row?.default_workspace_id?.trim() ?? ''
   }, [actors, localAgentId])
 
+  // A load started for one (team, agent) must not land after the selection has
+  // moved on: deselecting the local agent clears the list, and a late response
+  // would repopulate it with the old agent's folders.
+  const loadGenerationRef = React.useRef(0)
+
   const loadWorkspaces = React.useCallback(async () => {
     if (!teamId || !localAgentId) return
+    const generation = ++loadGenerationRef.current
     setWorkspacesLoading(true)
     try {
       const rows = await listDaemonWorkspaces(teamId, localAgentId)
+      if (generation !== loadGenerationRef.current) return
       setWorkspaces(rows.filter((w) => !w.archived && !!w.path))
     } catch (e) {
       console.warn('[NewSessionDialog] workspace load failed (non-fatal):', e)
-      setWorkspaces([])
+      if (generation === loadGenerationRef.current) setWorkspaces([])
     } finally {
-      setWorkspacesLoading(false)
+      if (generation === loadGenerationRef.current) setWorkspacesLoading(false)
     }
   }, [teamId, localAgentId])
 
   React.useEffect(() => {
     if (!open || !localAgentPicked) {
+      loadGenerationRef.current += 1
       setWorkspaces([])
       setSelectedWorkspaceId('')
       return
@@ -202,8 +206,25 @@ export function NewSessionDialog() {
         name: workspaceNameFromPath(path),
         path,
       })
-      await loadWorkspaces()
+      // Seat the created row directly rather than waiting for the reload to
+      // produce it. A transient list failure used to empty the picker while
+      // leaving the id selected, so the session was created in the agent's
+      // default folder instead of the one the user had just chosen — silently.
+      // The server also dedupes by (teamId, path), which can return an archived
+      // row that the reload filters out.
+      setWorkspaces((prev) => {
+        const rest = prev.filter((w) => w.id !== created.id)
+        return created.path ? [...rest, { ...created, archived: false }] : rest
+      })
       setSelectedWorkspaceId(created.id)
+      // The viewer context caches cloud-workspace → local-path for 5s, and a
+      // row created inside that window is missing from it. Session workspace
+      // resolution then finds a binding with no local path and reports none.
+      const { invalidateViewerWorkspaceContext } = await import(
+        '@/lib/session/session-viewer-workspace'
+      )
+      invalidateViewerWorkspaceContext(teamId)
+      void loadWorkspaces()
     } catch (e) {
       const { toast } = await import('sonner')
       toast.error(
@@ -298,8 +319,12 @@ export function NewSessionDialog() {
         agentActorIds,
         messageText: trimmed,
         localWorkspace:
-          localAgentPicked && selectedWorkspace?.path
-            ? { workspaceId: selectedWorkspace.id, path: selectedWorkspace.path }
+          localAgentPicked && localAgentId && selectedWorkspace?.path
+            ? {
+                agentId: localAgentId,
+                workspaceId: selectedWorkspace.id,
+                path: selectedWorkspace.path,
+              }
             : null,
       })
       const agentPicks = pickedActors.filter((p) => p.actor_type === 'agent')

--- a/packages/app/src/components/chat/__tests__/NewSessionDialog.test.tsx
+++ b/packages/app/src/components/chat/__tests__/NewSessionDialog.test.tsx
@@ -132,6 +132,10 @@ vi.mock('@/lib/daemon/daemon-workspaces', () => ({
   setAgentDefaultWorkspace: (...args: unknown[]) => mocks.setAgentDefaultWorkspace(...args),
 }))
 
+vi.mock('@/lib/session/session-viewer-workspace', () => ({
+  invalidateViewerWorkspaceContext: vi.fn(),
+}))
+
 vi.mock('@/lib/backend', () => ({
   getBackend: () => ({
     actors: {
@@ -271,7 +275,11 @@ describe('NewSessionDialog', () => {
       await waitFor(() => {
         expect(mocks.createSessionWithFirstMessage).toHaveBeenCalledWith(
           expect.objectContaining({
-            localWorkspace: { workspaceId: 'ws-other', path: '/tmp/other' },
+            localWorkspace: {
+              agentId: 'agent-1',
+              workspaceId: 'ws-other',
+              path: '/tmp/other',
+            },
           }),
         )
       })

--- a/packages/app/src/components/chat/__tests__/NewSessionDialog.test.tsx
+++ b/packages/app/src/components/chat/__tests__/NewSessionDialog.test.tsx
@@ -12,6 +12,13 @@ const mocks = vi.hoisted(() => ({
   ensureSessionLiveSubscribed: vi.fn(),
   listActorDirectory: vi.fn(),
   requestComposerFocus: vi.fn(),
+  getLocalDaemonActorId: vi.fn(),
+  listDaemonWorkspaces: vi.fn(),
+  setAgentDefaultWorkspace: vi.fn(),
+  createDaemonWorkspace: vi.fn(),
+  rememberDefaultWorkspaceId: vi.fn(),
+  isTauri: vi.fn(() => false),
+  team: { id: 'team-1' } as { id: string } | null,
 }))
 
 vi.mock('react-i18next', () => ({
@@ -74,7 +81,7 @@ vi.mock('@/stores/auth-store', () => ({
 vi.mock('@/stores/current-team', () => ({
   useCurrentTeamStore: (selector: (state: unknown) => unknown) =>
     selector({
-      team: { id: 'team-1' },
+      team: mocks.team,
       currentMember: { id: 'member-1' },
     }),
 }))
@@ -94,6 +101,10 @@ vi.mock('@/stores/session-store', () => ({
   },
 }))
 
+vi.mock('@/stores/agent-default-workspace-store', () => ({
+  rememberDefaultWorkspaceId: (...args: unknown[]) => mocks.rememberDefaultWorkspaceId(...args),
+}))
+
 vi.mock('@/lib/actor/current-actor', () => ({
   resolveCurrentMemberActorId: vi.fn().mockResolvedValue('member-1'),
 }))
@@ -102,10 +113,23 @@ vi.mock('@/lib/cache/local-cache', () => ({
   loadActorsForTeam: vi.fn().mockResolvedValue([
     { id: 'agent-1', actorType: 'agent', displayName: 'MCA2' },
   ]),
+  // Reached only once isTauri() is true — the actor directory writes its
+  // reconcile back to libsql there.
+  upsertActorsBatch: vi.fn().mockResolvedValue(undefined),
 }))
 
 vi.mock('@/lib/sync/actor-sync', () => ({
   syncActorsForTeam: vi.fn().mockResolvedValue(0),
+}))
+
+vi.mock('@/lib/daemon/daemon-agent-admin', () => ({
+  getLocalDaemonActorId: (...args: unknown[]) => mocks.getLocalDaemonActorId(...args),
+}))
+
+vi.mock('@/lib/daemon/daemon-workspaces', () => ({
+  listDaemonWorkspaces: (...args: unknown[]) => mocks.listDaemonWorkspaces(...args),
+  createDaemonWorkspace: (...args: unknown[]) => mocks.createDaemonWorkspace(...args),
+  setAgentDefaultWorkspace: (...args: unknown[]) => mocks.setAgentDefaultWorkspace(...args),
 }))
 
 vi.mock('@/lib/backend', () => ({
@@ -130,7 +154,7 @@ vi.mock('@/lib/session/session-live-subscriptions', () => ({
 
 vi.mock('@/lib/utils', () => ({
   cn: (...parts: Array<string | false | null | undefined>) => parts.filter(Boolean).join(' '),
-  isTauri: () => false,
+  isTauri: () => mocks.isTauri(),
 }))
 
 import { NewSessionDialog } from '../NewSessionDialog'
@@ -138,7 +162,11 @@ import { NewSessionDialog } from '../NewSessionDialog'
 describe('NewSessionDialog', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mocks.team = { id: 'team-1' }
+    mocks.isTauri.mockReturnValue(false)
     mocks.createSessionWithFirstMessage.mockResolvedValue({ sessionId: 'sess-1' })
+    mocks.getLocalDaemonActorId.mockResolvedValue(null)
+    mocks.listDaemonWorkspaces.mockResolvedValue([])
     // Candidates now flow through the shared actor-directory store, which reads
     // the network directory (listActorDirectory) — not the libsql cache — in the
     // jsdom test env (isTauri() === false).
@@ -163,6 +191,108 @@ describe('NewSessionDialog', () => {
         additionalActorIds: ['agent-1'],
         agentActorIds: ['agent-1'],
         messageText: 'hello daemon',
+        localWorkspace: null,
+      })
+    })
+  })
+
+  it('shows an empty state instead of the picker when there is no team', async () => {
+    mocks.team = null
+    render(<NewSessionDialog />)
+
+    expect(screen.getByTestId('new-session-no-team')).toBeTruthy()
+    expect(screen.queryByPlaceholderText('想聊点什么？')).toBeNull()
+    expect(screen.getByRole('button', { name: /创建会话/ })).toBeDisabled()
+  })
+
+  describe('with a local daemon agent', () => {
+    beforeEach(() => {
+      mocks.isTauri.mockReturnValue(true)
+      mocks.getLocalDaemonActorId.mockResolvedValue('agent-1')
+      mocks.listActorDirectory.mockResolvedValue([
+        {
+          id: 'agent-1',
+          actor_type: 'agent',
+          display_name: 'MCA2',
+          default_workspace_id: 'ws-default',
+        },
+        { id: 'agent-2', actor_type: 'agent', display_name: 'MCA2' },
+      ])
+      mocks.listDaemonWorkspaces.mockResolvedValue([
+        { id: 'ws-other', name: 'other', path: '/tmp/other', archived: false },
+        { id: 'ws-default', name: 'teamclu', path: '/tmp/teamclu', archived: false },
+      ])
+    })
+
+    it('badges only the agent on this machine, which display names cannot distinguish', async () => {
+      render(<NewSessionDialog />)
+
+      await screen.findAllByText('MCA2')
+      await waitFor(() => {
+        expect(screen.getAllByTestId('candidate-local-badge')).toHaveLength(1)
+      })
+    })
+
+    it('reveals the workspace picker only while the local agent is a participant', async () => {
+      render(<NewSessionDialog />)
+
+      const rows = await screen.findAllByText('MCA2')
+      expect(screen.queryByTestId('new-session-workspace')).toBeNull()
+
+      fireEvent.click(rows[0])
+      await waitFor(() => {
+        expect(screen.getByTestId('new-session-workspace')).toBeTruthy()
+      })
+
+      fireEvent.click(rows[0])
+      await waitFor(() => {
+        expect(screen.queryByTestId('new-session-workspace')).toBeNull()
+      })
+    })
+
+    it("preselects the agent's default workspace and passes the choice to create", async () => {
+      render(<NewSessionDialog />)
+
+      const rows = await screen.findAllByText('MCA2')
+      fireEvent.click(rows[0])
+      await waitFor(() => {
+        expect(mocks.listDaemonWorkspaces).toHaveBeenCalledWith('team-1', 'agent-1')
+      })
+
+      const select = await screen.findByLabelText('工作目录')
+      await waitFor(() => expect((select as HTMLSelectElement).value).toBe('ws-default'))
+
+      fireEvent.change(select, { target: { value: 'ws-other' } })
+      fireEvent.change(screen.getByPlaceholderText('想聊点什么？'), {
+        target: { value: 'run here' },
+      })
+      fireEvent.click(screen.getByRole('button', { name: /创建会话/ }))
+
+      await waitFor(() => {
+        expect(mocks.createSessionWithFirstMessage).toHaveBeenCalledWith(
+          expect.objectContaining({
+            localWorkspace: { workspaceId: 'ws-other', path: '/tmp/other' },
+          }),
+        )
+      })
+    })
+
+    it('writes the agent default and refreshes the send-path cache', async () => {
+      mocks.setAgentDefaultWorkspace.mockResolvedValue(undefined)
+      render(<NewSessionDialog />)
+
+      const rows = await screen.findAllByText('MCA2')
+      fireEvent.click(rows[0])
+
+      const select = await screen.findByLabelText('工作目录')
+      await waitFor(() => expect((select as HTMLSelectElement).value).toBe('ws-default'))
+      fireEvent.change(select, { target: { value: 'ws-other' } })
+
+      fireEvent.click(await screen.findByRole('button', { name: /设为默认/ }))
+
+      await waitFor(() => {
+        expect(mocks.setAgentDefaultWorkspace).toHaveBeenCalledWith('agent-1', 'ws-other')
+        expect(mocks.rememberDefaultWorkspaceId).toHaveBeenCalledWith(['agent-1'], 'ws-other')
       })
     })
   })

--- a/packages/app/src/components/panel/RightPanel.tsx
+++ b/packages/app/src/components/panel/RightPanel.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next'
 import { SessionActorPanel } from '@/components/chat/SessionActorSheet'
 import { ShortcutsPanel } from './ShortcutsPanel'
 import { FileBrowser } from '@/components/workspace/FileBrowser'
@@ -6,12 +7,59 @@ import { useWorkspaceStore, type RightPanelTab } from '@/stores/workspace'
 import { useSessionSelectionStore } from '@/stores/session-selection-store'
 import { useSessionListStore } from '@/stores/session-list-store'
 import { useCurrentTeamStore } from '@/stores/current-team'
+import { useSessionLocalWorkspace } from '@/hooks/use-session-local-workspace'
+import { shortenWorkspacePath } from '@/lib/workspace/shorten-path'
 
 interface RightPanelProps {
   // Override the active tab from store
   defaultTab?: RightPanelTab
   // Compact mode for file mode layout
   compact?: boolean
+}
+
+/**
+ * The file tree, plus the fixed line naming whose folder it is.
+ *
+ * The tab only opens for a session the local agent is in (App gates the header
+ * entry on the same hook), so the two states here are "bound" and "not bound
+ * yet": a session created a second ago has no workspace binding until its
+ * runtime starts, and rendering the previous session's tree in that gap is the
+ * bug this replaces.
+ */
+function WorkspaceFilesPane() {
+  const { t } = useTranslation()
+  const { agentName, path } = useSessionLocalWorkspace()
+
+  if (!path) {
+    return (
+      <div
+        data-testid="files-agent-not-started"
+        className="flex h-full items-center justify-center px-6 text-center text-[12.5px] text-muted-foreground"
+      >
+        {t('fileExplorer.agentNotStarted', 'Agent 尚未启动')}
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex h-full min-h-0 flex-col">
+      <div className="min-h-0 flex-1">
+        <FileBrowser variant="panel" />
+      </div>
+      <div
+        data-testid="files-workspace-footer"
+        className="flex shrink-0 items-center gap-1.5 border-t border-border px-2 py-1.5 text-[11px] text-muted-foreground"
+        title={path}
+      >
+        {agentName ? (
+          <span className="shrink-0 font-medium text-ink-2">{agentName}</span>
+        ) : null}
+        <span className="min-w-0 flex-1 truncate text-faint">
+          {shortenWorkspacePath(path)}
+        </span>
+      </div>
+    </div>
+  )
 }
 
 export function RightPanel({ defaultTab, compact }: RightPanelProps) {
@@ -40,7 +88,7 @@ export function RightPanel({ defaultTab, compact }: RightPanelProps) {
         <ShortcutsPanel />
       )}
       {activeTab === 'files' && (
-        <FileBrowser variant="panel" />
+        <WorkspaceFilesPane />
       )}
       {activeTab === 'actors' && (
         activeSessionId

--- a/packages/app/src/components/panel/__tests__/RightPanel.test.tsx
+++ b/packages/app/src/components/panel/__tests__/RightPanel.test.tsx
@@ -51,10 +51,22 @@ vi.mock('@/components/chat/SessionActorSheet', () => ({
     React.createElement('div', { 'data-testid': 'session-actor-panel' }, `${sessionId}:${teamId}`),
 }))
 
+const mockLocalWorkspace = {
+  hasLocalAgent: true,
+  agentName: 'Mac-mini-3' as string | null,
+  path: '/Volumes/openbeta/workspace/teamclu' as string | null,
+}
+vi.mock('@/hooks/use-session-local-workspace', () => ({
+  useSessionLocalWorkspace: () => mockLocalWorkspace,
+}))
+
 beforeEach(() => {
   vi.clearAllMocks()
   mockStoreState.activeTab = 'shortcuts'
   mockSelection.activeSessionId = null
+  mockLocalWorkspace.hasLocalAgent = true
+  mockLocalWorkspace.agentName = 'Mac-mini-3'
+  mockLocalWorkspace.path = '/Volumes/openbeta/workspace/teamclu'
 })
 
 describe('RightPanel', () => {
@@ -76,6 +88,25 @@ describe('RightPanel', () => {
     render(React.createElement(RightPanel, { defaultTab: 'files' }))
     expect(screen.getByTestId('file-browser')).toBeDefined()
     expect(screen.queryByTestId('shortcuts-panel')).toBeNull()
+  })
+
+  // A session created a second ago has no workspace binding until its runtime
+  // starts. Rendering the tree anyway showed the PREVIOUS session's folder,
+  // because the workspace store is ambient and lags the session switch.
+  it('files tab says the agent has not started while the session has no bound folder', () => {
+    mockStoreState.activeTab = 'files'
+    mockLocalWorkspace.path = null
+    render(React.createElement(RightPanel))
+    expect(screen.getByTestId('files-agent-not-started')).toBeDefined()
+    expect(screen.queryByTestId('file-browser')).toBeNull()
+  })
+
+  it('files tab names the agent and its folder under the tree', () => {
+    mockStoreState.activeTab = 'files'
+    render(React.createElement(RightPanel))
+    const footer = screen.getByTestId('files-workspace-footer')
+    expect(footer.textContent).toContain('Mac-mini-3')
+    expect(footer.getAttribute('title')).toBe('/Volumes/openbeta/workspace/teamclu')
   })
 
   it('actors tab shows the team actors view without an active session', () => {

--- a/packages/app/src/components/responsive/NarrowChatHeader.tsx
+++ b/packages/app/src/components/responsive/NarrowChatHeader.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { SquarePen, Users, List, MoreHorizontal, Settings, Loader2, LifeBuoy } from 'lucide-react'
+import { SquarePen, SlidersHorizontal, List, MoreHorizontal, Settings, Loader2, LifeBuoy } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { Button } from '@/components/ui/button'
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/components/ui/sheet'
@@ -93,9 +93,9 @@ export function NarrowChatHeader() {
             size="icon"
             className="h-8 w-8"
             onClick={() => useUIStore.getState().openNewSessionDialog()}
-            title={t('chat.newMultiPersonSession', 'Group session')}
+            title={t('chat.advancedSession', 'Advanced session')}
           >
-            <Users className="h-4 w-4" />
+            <SlidersHorizontal className="h-4 w-4" />
           </Button>
         ) : null}
       </div>

--- a/packages/app/src/components/settings/DaemonWorkspacesSection.tsx
+++ b/packages/app/src/components/settings/DaemonWorkspacesSection.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import { useTranslation } from 'react-i18next'
-import { AlertCircle, Archive, CheckCircle2, FolderOpen, Loader2, Plus, RefreshCw, Save } from 'lucide-react'
+import { AlertCircle, Archive, ArrowLeftRight, CheckCircle2, FolderOpen, Loader2, Plus, RefreshCw, Save } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { useCurrentTeamStore } from '@/stores/current-team'
 import { useWorkspaceStore } from '@/stores/workspace'
@@ -14,6 +14,7 @@ import {
   type DaemonWorkspace,
 } from '@/lib/daemon/daemon-workspaces'
 import { cn } from '@/lib/utils'
+import { workspacePathsMatch } from '@/stores/session-utils'
 import { toast } from 'sonner'
 import { SectionHeader, SettingCard } from './shared'
 
@@ -27,20 +28,24 @@ function WorkspaceCard({
   workspace,
   agentDisplayName,
   isDefault,
+  isCurrent,
   showSetDefault,
   settingDefault,
   saving,
   onSetDefault,
+  onOpen,
   onArchive,
   t,
 }: {
   workspace: DaemonWorkspace
   agentDisplayName: string
   isDefault: boolean
+  isCurrent: boolean
   showSetDefault: boolean
   settingDefault: boolean
   saving: boolean
   onSetDefault?: () => void
+  onOpen?: () => void
   onArchive: () => void
   t: (key: string, fallback: string) => string
 }) {
@@ -56,11 +61,26 @@ function WorkspaceCard({
                 {t('settings.daemonWorkspaces.default', 'Default')}
               </span>
             )}
+            {isCurrent && (
+              <span className="inline-flex items-center rounded-full bg-muted px-2 py-0.5 text-[10px] font-medium text-muted-foreground">
+                {t('settings.daemonWorkspaces.current', 'Open')}
+              </span>
+            )}
           </div>
           <p className="mt-1 break-all font-mono text-xs text-foreground">{workspace.path || '-'}</p>
           <p className="mt-1 text-xs text-muted-foreground">{agentDisplayName}</p>
         </div>
         <div className="flex shrink-0 items-center gap-1">
+          {/* The only remaining way to point the file tree and terminal at a
+              folder by hand. The sidebar's workspace list carried it before;
+              without a replacement a session whose binding cannot be resolved
+              left the user with no way to correct the tree. */}
+          {onOpen && !isCurrent && !!workspace.path && (
+            <Button variant="ghost" size="sm" className="h-8 text-xs" onClick={() => void onOpen()} disabled={saving}>
+              <ArrowLeftRight className="mr-1 h-3.5 w-3.5" />
+              {t('settings.daemonWorkspaces.open', 'Open')}
+            </Button>
+          )}
           {showSetDefault && onSetDefault && (
             <Button variant="ghost" size="sm" className="h-8 text-xs" onClick={() => void onSetDefault()} disabled={saving || settingDefault}>
               {settingDefault ? <Loader2 className="mr-1 h-3.5 w-3.5 animate-spin" /> : <Save className="mr-1 h-3.5 w-3.5" />}
@@ -89,6 +109,13 @@ export function DaemonWorkspacesSection() {
   const [settingDefaultWorkspaceId, setSettingDefaultWorkspaceId] = React.useState<string | null>(null)
   const [error, setError] = React.useState<string | null>(null)
 
+
+  const isCurrentWorkspace = React.useCallback(
+    (workspace: DaemonWorkspace) =>
+      !!workspace.path && !!currentWorkspacePath &&
+      workspacePathsMatch(workspace.path, currentWorkspacePath),
+    [currentWorkspacePath],
+  )
 
   const load = React.useCallback(async () => {
     if (!team?.id) return
@@ -224,6 +251,24 @@ export function DaemonWorkspacesSection() {
     }
   }
 
+  // Point the desktop's file tree and terminal at this folder. Everything else
+  // that moves the workspace store does so on its own (startup restore, opening
+  // a session bound elsewhere); this is the manual override.
+  const handleOpenWorkspace = async (workspace: DaemonWorkspace) => {
+    const path = workspace.path?.trim()
+    if (!path) return
+    try {
+      await useWorkspaceStore.getState().setWorkspace(path)
+      toast.success(t('settings.daemonWorkspaces.opened', 'Opened {{name}}', { name: workspace.name }))
+    } catch (err) {
+      toast.error(
+        t('settings.daemonWorkspaces.openFailed', 'Could not open this workspace: {{msg}}', {
+          msg: err instanceof Error ? err.message : String(err),
+        }),
+      )
+    }
+  }
+
   const handleArchive = async (workspace: DaemonWorkspace, archived: boolean) => {
     setSaving(true)
     setError(null)
@@ -345,9 +390,11 @@ export function DaemonWorkspacesSection() {
                     workspace={defaultWorkspace}
                     agentDisplayName={agentDisplayName}
                     isDefault
+                    isCurrent={isCurrentWorkspace(defaultWorkspace)}
                     showSetDefault={false}
                     settingDefault={false}
                     saving={saving}
+                    onOpen={() => handleOpenWorkspace(defaultWorkspace)}
                     onArchive={() => handleArchive(defaultWorkspace, true)}
                     t={t}
                   />
@@ -368,9 +415,11 @@ export function DaemonWorkspacesSection() {
                         workspace={workspace}
                         agentDisplayName={agentDisplayName}
                         isDefault={false}
+                        isCurrent={isCurrentWorkspace(workspace)}
                         showSetDefault={Boolean(workspaceAgentId)}
                         settingDefault={settingDefaultWorkspaceId === workspace.id}
                         saving={saving}
+                        onOpen={() => handleOpenWorkspace(workspace)}
                         onSetDefault={
                           workspaceAgentId
                             ? () => handleSetDefault(workspaceAgentId, workspace.id, workspace.path ?? '')

--- a/packages/app/src/components/settings/__tests__/DaemonWorkspacesSection.test.tsx
+++ b/packages/app/src/components/settings/__tests__/DaemonWorkspacesSection.test.tsx
@@ -68,8 +68,17 @@ vi.mock('@/stores/current-team', () => ({
     sel({ team: { id: 'team-1' }, currentMember: { id: 'member-1' } }),
 }))
 
+const setWorkspace = vi.hoisted(() => vi.fn(async () => {}))
+const workspaceState = vi.hoisted(() => ({ workspacePath: null as string | null }))
 vi.mock('@/stores/workspace', () => ({
-  useWorkspaceStore: (sel: (s: Record<string, unknown>) => unknown) => sel({ workspacePath: null }),
+  useWorkspaceStore: Object.assign(
+    (sel: (s: Record<string, unknown>) => unknown) => sel(workspaceState),
+    { getState: () => ({ setWorkspace }) },
+  ),
+}))
+
+vi.mock('@/stores/session-utils', () => ({
+  workspacePathsMatch: (a: string, b: string) => a === b,
 }))
 
 vi.mock('@/lib/utils', () => ({
@@ -112,6 +121,9 @@ describe('DaemonWorkspacesSection', () => {
     createDaemonWorkspace.mockClear()
     rpcAddWorkspace.mockClear()
     setAgentDefaultWorkspace.mockClear()
+    setWorkspace.mockClear()
+    listDaemonWorkspaces.mockResolvedValue([])
+    workspaceState.workspacePath = null
   })
 
   it('adding a workspace picks a directory, then calls createDaemonWorkspace only', async () => {
@@ -142,5 +154,56 @@ describe('DaemonWorkspacesSection', () => {
 
     await waitFor(() => expect(dialogOpen).toHaveBeenCalled())
     expect(createDaemonWorkspace).not.toHaveBeenCalled()
+  })
+
+  // The sidebar's workspace list used to be the only way to point the desktop
+  // at a folder by hand. It is gone, so this is the replacement — without it a
+  // session whose workspace binding cannot be resolved leaves the file tree
+  // stuck on "agent has not started" with no way to correct it.
+  it('opening a workspace points the desktop workspace store at its path', async () => {
+    listDaemonWorkspaces.mockResolvedValue([
+      {
+        id: 'ws-a',
+        teamId: 'team-1',
+        agentId: 'agent-1',
+        createdByMemberId: null,
+        name: 'other',
+        path: '/Users/me/other',
+        archived: false,
+        createdAt: '',
+        updatedAt: '',
+      },
+    ] as never)
+
+    render(<DaemonWorkspacesSection />)
+
+    const open = await screen.findByRole('button', { name: 'Open' })
+    fireEvent.click(open)
+
+    await waitFor(() => {
+      expect(setWorkspace).toHaveBeenCalledWith('/Users/me/other')
+    })
+  })
+
+  it('offers no open action for the workspace already open', async () => {
+    workspaceState.workspacePath = '/Users/me/other'
+    listDaemonWorkspaces.mockResolvedValue([
+      {
+        id: 'ws-a',
+        teamId: 'team-1',
+        agentId: 'agent-1',
+        createdByMemberId: null,
+        name: 'other',
+        path: '/Users/me/other',
+        archived: false,
+        createdAt: '',
+        updatedAt: '',
+      },
+    ] as never)
+
+    render(<DaemonWorkspacesSection />)
+
+    await screen.findByText('other')
+    expect(screen.queryByRole('button', { name: 'Open' })).toBeNull()
   })
 })

--- a/packages/app/src/components/sidebar/LocalDaemonRow.tsx
+++ b/packages/app/src/components/sidebar/LocalDaemonRow.tsx
@@ -1,16 +1,13 @@
 import * as React from 'react'
 import { useTranslation } from 'react-i18next'
 import {
-  ArrowLeftRight,
   Bot,
   ChevronRight,
   Clock,
   Loader2,
-  Plus,
   RefreshCw,
   Settings,
   Star,
-  Trash2,
   LifeBuoy,
 } from 'lucide-react'
 import {
@@ -19,26 +16,16 @@ import {
   OpencodeMark,
   PiAgentMark,
 } from '@/components/icons/agent-brand-icons'
-import { open } from '@tauri-apps/plugin-dialog'
 import { toast } from 'sonner'
 import type { ActorRow } from '@/stores/actor-directory-store'
-import {
-  listDaemonWorkspaces,
-  createDaemonWorkspace,
-  updateDaemonWorkspace,
-  type DaemonWorkspace,
-} from '@/lib/daemon/daemon-workspaces'
-import { syncSessionWorkspaces } from '@/lib/session/session-workspace-sync'
 import { amuxAgentTypeFromBackend } from '@/lib/agent/amux-agent-type'
 import { useUIStore } from '@/stores/ui'
-import { useWorkspaceStore } from '@/stores/workspace'
 import { useCurrentTeamStore } from '@/stores/current-team'
 import { useDaemonOnboardingStore } from '@/stores/daemon-onboarding'
 import { useMemberPreferencesStore } from '@/stores/member-preferences-store'
 import { recoverMqttConnection } from '@/stores/mqtt-reconnect'
 import { requestDaemonProbe } from '@/lib/daemon/daemon-probe-signal'
 import { type LocalDaemonRuntimeStatus } from '@/hooks/use-local-daemon-http-status'
-import { workspacePathsMatch } from '@/stores/session-utils'
 import { cn } from '@/lib/utils'
 
 interface Props {
@@ -48,11 +35,6 @@ interface Props {
   onViewDetail: (actor: ActorRow) => void
   onCopyName: (actor: ActorRow) => void
   onCopyId: (actor: ActorRow) => void
-}
-
-function workspaceNameFromPath(path: string): string {
-  const trimmed = path.replace(/\/+$/, '')
-  return trimmed.split('/').pop() || trimmed
 }
 
 function shortenActorId(actorId: string): string {
@@ -190,9 +172,6 @@ function SheetHeader({
   displayName,
   actorId,
   agentType,
-  workspaceLabel,
-  workspaceTitle,
-  workspaceUnset,
   runtimeStatus,
   statusLabel,
   expanded,
@@ -202,9 +181,6 @@ function SheetHeader({
   displayName: string
   actorId: string
   agentType?: string | null
-  workspaceLabel: string
-  workspaceTitle?: string
-  workspaceUnset: boolean
   runtimeStatus: LocalDaemonRuntimeStatus
   statusLabel: string
   expanded: boolean
@@ -263,128 +239,15 @@ function SheetHeader({
               <div className="truncate text-[12.5px] font-semibold leading-tight">{displayName}</div>
               <RuntimeStatusDot status={runtimeStatus} label={statusLabel} />
             </div>
-            <div
-              className={cn(
-                'mt-0.5 truncate text-[11px] leading-snug',
-                workspaceUnset ? 'text-faint' : 'text-muted-foreground',
-              )}
-              title={workspaceUnset ? undefined : workspaceTitle}
-            >
-              {workspaceLabel}
+            {/* The current workspace used to be printed here. It now lives in
+                the file tree footer, next to the tree it actually describes —
+                two places showing it disagreed as soon as the tree became
+                session-scoped. */}
+            <div className="mt-0.5 truncate text-[11px] leading-snug text-faint">
+              {shortenActorId(actorId)}
             </div>
           </div>
         </div>
-      </div>
-    </div>
-  )
-}
-
-function SheetGroupWithAction({
-  label,
-  action,
-  children,
-}: {
-  label: string
-  action?: React.ReactNode
-  children: React.ReactNode
-}) {
-  return (
-    <div className="mb-2 last:mb-0">
-      <div className="mb-1 flex items-center justify-between gap-2 pl-0.5 pr-0.5">
-        <span className="text-[10px] font-semibold uppercase tracking-[0.06em] text-faint">
-          {label}
-        </span>
-        {action}
-      </div>
-      {children}
-    </div>
-  )
-}
-
-function WorkspaceRow({
-  ws,
-  active,
-  isCurrent,
-  isDefault,
-  onSelect,
-  onSwitch,
-  onDelete,
-  switchLabel,
-  deleteLabel,
-  currentLabel,
-  defaultLabel,
-}: {
-  ws: DaemonWorkspace
-  active: boolean
-  isCurrent: boolean
-  isDefault: boolean
-  onSelect: () => void
-  onSwitch: () => void
-  onDelete: () => void
-  switchLabel: string
-  deleteLabel: string
-  currentLabel: string
-  defaultLabel: string
-}) {
-  return (
-    <div
-      className={cn(
-        'group/ws-row flex items-center gap-1 rounded-lg pr-1 transition-colors',
-        active ? 'bg-selected' : 'hover:bg-selected/60',
-      )}
-    >
-      <span
-        className={cn(
-          'ml-1.5 h-1.5 w-1.5 shrink-0 rounded-full',
-          isCurrent ? 'bg-emerald-500' : 'bg-transparent',
-        )}
-        title={isCurrent ? currentLabel : undefined}
-        aria-label={isCurrent ? currentLabel : undefined}
-        aria-hidden={!isCurrent}
-      />
-      <button
-        type="button"
-        onClick={onSelect}
-        className={cn(
-          'flex min-w-0 flex-1 cursor-pointer items-center gap-2 rounded-lg py-[6px] pl-1.5 pr-2.5 text-left text-[12.5px] transition-colors',
-          active ? 'font-semibold text-foreground' : 'text-ink-2',
-        )}
-        title={ws.path ?? ws.name}
-      >
-        <span className="min-w-0 flex-1 truncate">{ws.name}</span>
-        {isDefault ? (
-          <Star
-            className="h-3 w-3 shrink-0 fill-coral text-coral"
-            aria-label={defaultLabel}
-          />
-        ) : null}
-      </button>
-      <div className="flex shrink-0 items-center gap-0.5 self-center opacity-40 transition-opacity group-hover/ws-row:opacity-100 group-focus-within/ws-row:opacity-100">
-        <button
-          type="button"
-          onClick={(e) => {
-            e.stopPropagation()
-            onSwitch()
-          }}
-          disabled={!ws.path || isCurrent}
-          className="cursor-pointer rounded-md p-1 text-faint hover:bg-selected hover:text-foreground disabled:cursor-not-allowed disabled:opacity-30"
-          title={switchLabel}
-          aria-label={switchLabel}
-        >
-          <ArrowLeftRight className="h-3.5 w-3.5" />
-        </button>
-        <button
-          type="button"
-          onClick={(e) => {
-            e.stopPropagation()
-            onDelete()
-          }}
-          className="cursor-pointer rounded-md p-1 text-faint hover:bg-destructive/10 hover:text-destructive"
-          title={deleteLabel}
-          aria-label={deleteLabel}
-        >
-          <Trash2 className="h-3.5 w-3.5" />
-        </button>
       </div>
     </div>
   )
@@ -402,119 +265,24 @@ export function LocalDaemonRow({
 }: Props) {
   const { t } = useTranslation()
   const teamId = useCurrentTeamStore((s) => s.team?.id ?? null)
-  const currentMember = useCurrentTeamStore((s) => s.currentMember)
 
   const sheetOpen = useUIStore((s) => s.localDaemonSheetOpen)
   const toggleSheet = useUIStore((s) => s.toggleLocalDaemonSheet)
   const setSheetOpen = useUIStore((s) => s.setLocalDaemonSheetOpen)
 
-  const filter = useUIStore((s) => s.sidebarFilter)
-  const setFilter = useUIStore((s) => s.setSidebarFilter)
   const openSettings = useUIStore((s) => s.openSettings)
   const openAutomationPanel = useUIStore((s) => s.openAutomationPanel)
   const setDefaultAgent = useMemberPreferencesStore((s) => s.setDefaultAgent)
 
-  const currentWorkspacePath = useWorkspaceStore((s) => s.workspacePath)
-  const currentWorkspaceName = useWorkspaceStore((s) => s.workspaceName)
   const refreshDaemon = useDaemonOnboardingStore((s) => s.refresh)
   const checkCloudSession = useDaemonOnboardingStore((s) => s.checkCloudSession)
   const daemonBusy = useDaemonOnboardingStore((s) => s.busy)
-  const workspaceSyncEpoch = useDaemonOnboardingStore((s) => s.workspaceSyncEpoch)
 
   const daemonOffline = runtimeStatus === 'offline'
   const daemonMqttDisconnected = runtimeStatus === 'daemonMqttDisconnected'
   const statusLabel = localDaemonStatusLabel(runtimeStatus, t)
 
-  const agentId = actor?.id ?? null
-  const defaultWorkspaceId = actor?.default_workspace_id ?? null
-  const [workspaces, setWorkspaces] = React.useState<DaemonWorkspace[]>([])
-  const [loading, setLoading] = React.useState(false)
-  const [creating, setCreating] = React.useState(false)
   const [retrying, setRetrying] = React.useState(false)
-  const workspacesRef = React.useRef(workspaces)
-  workspacesRef.current = workspaces
-  const loadGenerationRef = React.useRef(0)
-
-  // Prefetch as soon as the card mounts — don't wait for sheet expand. Opening
-  // the sheet mid-fetch used to mutate content height during the 300ms
-  // grid-rows animation and felt like dropped frames.
-  const loadWorkspaces = React.useCallback(async (opts?: { forceLoading?: boolean }) => {
-    if (!teamId || !agentId) return
-    const generation = loadGenerationRef.current
-    const showLoading = opts?.forceLoading ?? workspacesRef.current.length === 0
-    if (showLoading) setLoading(true)
-    try {
-      const ws = await listDaemonWorkspaces(teamId, agentId)
-      if (generation !== loadGenerationRef.current) return
-      setWorkspaces(ws.filter((w) => !w.archived))
-      void syncSessionWorkspaces(teamId).catch(() => {})
-    } finally {
-      if (showLoading && generation === loadGenerationRef.current) {
-        setLoading(false)
-      }
-    }
-  }, [teamId, agentId])
-
-  React.useEffect(() => {
-    if (daemonOffline) return
-    if (!teamId || !agentId) {
-      setWorkspaces([])
-      return
-    }
-    loadGenerationRef.current += 1
-    setWorkspaces([])
-    void loadWorkspaces({ forceLoading: true })
-  }, [daemonOffline, teamId, agentId, loadWorkspaces, workspaceSyncEpoch])
-
-  const handleNewWorkspace = async () => {
-    if (!teamId || !agentId || creating || daemonOffline) return
-    let selected: string | string[] | null
-    try {
-      selected = await open({ directory: true, multiple: false, title: t('sidebar.newWorkspace', 'New workspace') })
-    } catch (err) {
-      console.error('[LocalDaemonRow] folder dialog failed', err)
-      return
-    }
-    if (typeof selected !== 'string') return
-    const path = selected
-    setCreating(true)
-    try {
-      // createDaemonWorkspace is the sole writer for workspace path/UUID (POST
-      // /v1/workspaces, deduped by (teamId, path) on the server) — no separate
-      // daemon addWorkspace RPC round-trip is needed here.
-      await createDaemonWorkspace({
-        teamId,
-        agentId,
-        createdByMemberId: currentMember?.id ?? null,
-        name: workspaceNameFromPath(path),
-        path,
-      })
-      await useWorkspaceStore.getState().setWorkspace(path)
-      await loadWorkspaces()
-    } catch (err) {
-      toast.error(t('sidebar.workspaceAddFailed', 'Failed to add workspace: {{msg}}', { msg: err instanceof Error ? err.message : String(err) }))
-    } finally {
-      setCreating(false)
-    }
-  }
-
-  const handleSwitchWorkspace = async (ws: DaemonWorkspace) => {
-    if (!ws.path) return
-    try {
-      await useWorkspaceStore.getState().setWorkspace(ws.path)
-    } catch (err) {
-      toast.error(t('sidebar.workspaceSwitchFailed', 'Failed to switch workspace: {{msg}}', { msg: err instanceof Error ? err.message : String(err) }))
-    }
-  }
-
-  const handleDeleteWorkspace = async (ws: DaemonWorkspace) => {
-    try {
-      await updateDaemonWorkspace({ workspaceId: ws.id, name: ws.name, path: ws.path ?? '', archived: true })
-      await loadWorkspaces()
-    } catch (err) {
-      toast.error(t('sidebar.workspaceDeleteFailed', 'Failed to delete workspace: {{msg}}', { msg: err instanceof Error ? err.message : String(err) }))
-    }
-  }
 
   const handleRetryConnection = async () => {
     if (retrying || daemonBusy) return
@@ -567,41 +335,6 @@ export function LocalDaemonRow({
 
   if (!actor) return null
 
-  const workspaceLabel = currentWorkspaceName || t('workspace.selectWorkspace', 'Select Workspace')
-  const workspaceUnset = !currentWorkspaceName
-
-  const workspaceRows = (
-    <div className="max-h-36 overflow-y-auto">
-      {loading && workspaces.length === 0 ? (
-        <div className="px-2.5 py-1.5 text-[12px] text-faint">{t('sidebar.workspacesLoading', 'Loading workspaces…')}</div>
-      ) : null}
-      {!loading && workspaces.length === 0 ? (
-        <div className="px-2.5 py-1.5 text-[12px] text-faint">{t('sidebar.noWorkspaces', 'No workspaces yet')}</div>
-      ) : null}
-      {workspaces.map((ws) => {
-        const active = filter.kind === 'workspace' && (filter.workspaceId === ws.id || filter.path === (ws.path ?? ''))
-        const isCurrent = !!currentWorkspacePath && !!ws.path && workspacePathsMatch(ws.path, currentWorkspacePath)
-        const wsIsDefault = !!defaultWorkspaceId && ws.id === defaultWorkspaceId
-        return (
-          <WorkspaceRow
-            key={ws.id}
-            ws={ws}
-            active={active}
-            isCurrent={isCurrent}
-            isDefault={wsIsDefault}
-            onSelect={() => setFilter({ kind: 'workspace', workspaceId: ws.id, path: ws.path ?? '', name: ws.name })}
-            onSwitch={() => void handleSwitchWorkspace(ws)}
-            onDelete={() => void handleDeleteWorkspace(ws)}
-            switchLabel={t('sidebar.switchToWorkspace', 'Switch to this workspace')}
-            deleteLabel={t('common.delete', 'Delete')}
-            currentLabel={t('sidebar.currentWorkspace', 'Current workspace')}
-            defaultLabel={t('sidebar.defaultWorkspace', 'Default workspace')}
-          />
-        )
-      })}
-    </div>
-  )
-
   return (
     <div className="overflow-hidden">
       <div className={cn(sheetOpen ? 'px-0 pb-2 pt-1' : 'p-0')}>
@@ -609,9 +342,6 @@ export function LocalDaemonRow({
           displayName={actor.display_name}
           actorId={actor.id}
           agentType={resolveActorAgentType(actor)}
-          workspaceLabel={workspaceLabel}
-          workspaceTitle={currentWorkspacePath ?? undefined}
-          workspaceUnset={workspaceUnset}
           runtimeStatus={runtimeStatus}
           statusLabel={statusLabel}
           onHandleClick={toggleSheet}
@@ -707,25 +437,10 @@ export function LocalDaemonRow({
                 </SheetGroup>
               ) : (
                 <>
-                  <SheetGroupWithAction
-                    label={t('sidebar.localDaemonGroupWorkspace', 'Workspace')}
-                    action={(
-                      <button
-                        type="button"
-                        onClick={() => void handleNewWorkspace()}
-                        disabled={creating}
-                        className="cursor-pointer rounded-md p-0.5 text-faint hover:bg-selected hover:text-foreground disabled:cursor-not-allowed disabled:opacity-40"
-                        title={t('sidebar.newWorkspace', 'New workspace')}
-                        aria-label={t('sidebar.newWorkspace', 'New workspace')}
-                      >
-                        {creating
-                          ? <Loader2 className="h-3.5 w-3.5 animate-spin" />
-                          : <Plus className="h-3.5 w-3.5" />}
-                      </button>
-                    )}
-                  >
-                    {workspaceRows}
-                  </SheetGroupWithAction>
+                  {/* Workspaces are listed and managed in Settings ›
+                      Daemon workspaces, and picked per session in the advanced
+                      new-session dialog. This sheet listing them was a third
+                      place to change the same thing. */}
                   <SheetGroup label={t('sidebar.localDaemonGroupDevice', 'Device')}>
                     <SheetMenuItem
                       icon={<Settings className="h-3.5 w-3.5" />}

--- a/packages/app/src/components/sidebar/LocalDaemonRow.tsx
+++ b/packages/app/src/components/sidebar/LocalDaemonRow.tsx
@@ -437,10 +437,10 @@ export function LocalDaemonRow({
                 </SheetGroup>
               ) : (
                 <>
-                  {/* Workspaces are listed and managed in Settings ›
-                      Daemon workspaces, and picked per session in the advanced
-                      new-session dialog. This sheet listing them was a third
-                      place to change the same thing. */}
+                  {/* Workspaces are listed, created, archived, defaulted and
+                      opened in Settings › Daemon workspaces, and picked per
+                      session in the advanced new-session dialog. This sheet
+                      listing them was a third place to change the same thing. */}
                   <SheetGroup label={t('sidebar.localDaemonGroupDevice', 'Device')}>
                     <SheetMenuItem
                       icon={<Settings className="h-3.5 w-3.5" />}

--- a/packages/app/src/components/sidebar/NewChatSplitButton.tsx
+++ b/packages/app/src/components/sidebar/NewChatSplitButton.tsx
@@ -1,9 +1,13 @@
-import * as React from 'react'
 import { useTranslation } from 'react-i18next'
-import { ChevronDown, Loader2, Plus } from 'lucide-react'
+import { Loader2, SlidersHorizontal } from 'lucide-react'
 import type { QuickChatState } from '@/hooks/use-quick-chat-readiness'
 import { useUIStore } from '@/stores/ui'
 import { cn } from '@/lib/utils'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/tooltip'
 
 type NewChatSplitButtonProps = {
   quickChatState: QuickChatState
@@ -20,23 +24,12 @@ function isPrimaryDisabled(state: QuickChatState, creating: boolean): boolean {
   )
 }
 
-function canOpenMore(state: QuickChatState): boolean {
-  return state.kind !== 'no_team'
-}
-
 export function NewChatSplitButton({
   quickChatState,
   creating,
   onPrimaryClick,
 }: NewChatSplitButtonProps) {
   const { t } = useTranslation()
-  const [moreOpen, setMoreOpen] = React.useState(false)
-  const moreEnabled = canOpenMore(quickChatState)
-
-  const openMultiPersonDialog = () => {
-    setMoreOpen(false)
-    useUIStore.getState().openNewSessionDialog()
-  }
 
   const primaryDisabled = isPrimaryDisabled(quickChatState, creating)
   const primaryTitle =
@@ -47,87 +40,53 @@ export function NewChatSplitButton({
         )
       : undefined
 
+  const advancedLabel = t('chat.advancedSession', 'Advanced session')
+
   return (
     <div className="flex w-full flex-col gap-1.5">
-      <div className="flex w-full flex-col overflow-hidden rounded-[10px] shadow-[0_4px_14px_rgba(232,90,74,0.22)]">
-        <div className="flex w-full bg-coral">
-          <button
-            type="button"
-            onClick={onPrimaryClick}
-            disabled={primaryDisabled}
-            title={primaryTitle}
-            className={cn(
-              'flex min-w-0 flex-1 items-center gap-2 rounded-none px-3 py-2.5 text-left text-[13px] font-semibold tracking-tight text-coral-foreground transition-[filter,background-color] duration-150',
-              'hover:brightness-[1.04] disabled:cursor-not-allowed disabled:opacity-40',
-            )}
-          >
-            {creating ? (
-              <Loader2 className="h-[14px] w-[14px] shrink-0 animate-spin" />
-            ) : null}
-            <span className="min-w-0 flex-1 truncate">{t('chat.newChat', 'New Chat')}</span>
-            <span className="ml-auto shrink-0 font-mono text-[10.5px] font-medium tracking-tight text-white/70">
-              ⌘N
-            </span>
-          </button>
-          <button
-            type="button"
-            disabled={!moreEnabled}
-            aria-label={t('chat.newChatMoreOptions', 'More new chat options')}
-            aria-expanded={moreOpen}
-            onClick={() => setMoreOpen((open) => !open)}
-            className={cn(
-              'flex w-8 shrink-0 items-center justify-center rounded-none border-l border-white/15 text-coral-foreground transition-[filter,background-color] duration-150',
-              'hover:brightness-[1.04] disabled:cursor-not-allowed disabled:opacity-40',
-            )}
-          >
-            <ChevronDown
+      <div className="flex w-full overflow-hidden rounded-[10px] bg-coral shadow-[0_4px_14px_rgba(232,90,74,0.22)]">
+        <button
+          type="button"
+          onClick={onPrimaryClick}
+          disabled={primaryDisabled}
+          title={primaryTitle}
+          className={cn(
+            'flex min-w-0 flex-1 items-center gap-2 rounded-none px-3 py-2.5 text-left text-[13px] font-semibold tracking-tight text-coral-foreground transition-[filter,background-color] duration-150',
+            'hover:brightness-[1.04] disabled:cursor-not-allowed disabled:opacity-40',
+          )}
+        >
+          {creating ? (
+            <Loader2 className="h-[14px] w-[14px] shrink-0 animate-spin" />
+          ) : null}
+          <span className="min-w-0 flex-1 truncate">{t('chat.newChat', 'New Chat')}</span>
+          <span className="ml-auto shrink-0 font-mono text-[10.5px] font-medium tracking-tight text-white/70">
+            ⌘N
+          </span>
+        </button>
+        {/*
+          Never disabled, unlike the primary half. This is the escape hatch:
+          with no default agent the quick button is dead, and the advanced
+          dialog — where a participant is picked by hand — is the only way to
+          start a chat at all. `no_team` opens it too and lands on its empty
+          state, which says what to do about it.
+        */}
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              type="button"
+              aria-label={advancedLabel}
+              data-testid="new-chat-advanced"
+              onClick={() => useUIStore.getState().openNewSessionDialog()}
               className={cn(
-                'h-3.5 w-3.5 transition-transform duration-200',
-                moreOpen && 'rotate-180',
+                'flex w-9 shrink-0 items-center justify-center rounded-none border-l border-white/15 text-coral-foreground transition-[filter,background-color] duration-150',
+                'hover:brightness-[1.04]',
               )}
-            />
-          </button>
-        </div>
-        {moreEnabled && (
-          <div
-            data-testid="new-chat-more-panel-wrap"
-            className={cn(
-              'grid transition-[grid-template-rows] duration-200 ease-out motion-reduce:transition-none',
-              moreOpen ? 'grid-rows-[1fr]' : 'grid-rows-[0fr]',
-            )}
-            aria-hidden={!moreOpen}
-          >
-            <div className="overflow-hidden">
-              <div
-                data-testid="new-chat-more-panel"
-                className={cn(
-                  'border-t border-border-soft bg-paper transition-opacity duration-200 ease-out motion-reduce:transition-none',
-                  moreOpen ? 'opacity-100' : 'opacity-0',
-                  !moreOpen && 'pointer-events-none',
-                )}
-              >
-                <button
-                  type="button"
-                  onClick={openMultiPersonDialog}
-                  className={cn(
-                    'flex w-full items-center gap-2 px-2.5 py-2 text-left transition-colors',
-                    'hover:bg-selected',
-                  )}
-                >
-                  <span
-                    className="flex h-[22px] w-[22px] shrink-0 items-center justify-center rounded-full bg-coral/10 text-coral"
-                    aria-hidden
-                  >
-                    <Plus className="h-3 w-3" strokeWidth={2.5} />
-                  </span>
-                  <span className="min-w-0 flex-1 truncate text-[12.5px] font-semibold text-foreground">
-                    {t('chat.newMultiPersonSession', 'Group session')}
-                  </span>
-                </button>
-              </div>
-            </div>
-          </div>
-        )}
+            >
+              <SlidersHorizontal className="h-3.5 w-3.5" />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent side="bottom">{advancedLabel}</TooltipContent>
+        </Tooltip>
       </div>
     </div>
   )

--- a/packages/app/src/components/sidebar/SessionListColumn.tsx
+++ b/packages/app/src/components/sidebar/SessionListColumn.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import { useTranslation } from 'react-i18next'
 import { useVirtualizer } from '@tanstack/react-virtual'
-import { Search, Loader2, MessageSquare, Pin, Archive, Pencil, Ellipsis, Info, SquarePen, Users, X, ListChecks, Check, HelpCircle, Stamp, Clock } from 'lucide-react'
+import { Search, Loader2, MessageSquare, Pin, Archive, Pencil, Ellipsis, Info, SquarePen, SlidersHorizontal, X, ListChecks, Check, HelpCircle, Stamp, Clock } from 'lucide-react'
 import { useSessionStore } from '@/stores/session-store'
 import { useUIStore } from '@/stores/ui'
 import { useWorkspaceStore } from '@/stores/workspace'
@@ -1017,9 +1017,9 @@ export function SessionListColumn({
                   size="icon"
                   className="h-7 w-7 text-muted-foreground hover:text-foreground"
                   onClick={() => useUIStore.getState().openNewSessionDialog()}
-                  title={t('chat.newMultiPersonSession', 'Group session')}
+                  title={t('chat.advancedSession', 'Advanced session')}
                 >
-                  <Users className="h-4 w-4" />
+                  <SlidersHorizontal className="h-4 w-4" />
                 </Button>
               ) : null}
             </>

--- a/packages/app/src/components/sidebar/SessionListColumn.tsx
+++ b/packages/app/src/components/sidebar/SessionListColumn.tsx
@@ -40,7 +40,6 @@ import { useTypeAhead } from '@/hooks/use-type-ahead'
 import type { SessionListActivity } from '@/lib/session/session-list-activity'
 import { useSessionListActivityMap } from '@/hooks/use-session-list-activity-map'
 import { loadSessionIdsForActor } from '@/lib/session/session-by-actor'
-import { loadSessionIdsForWorkspace } from '@/lib/session/session-by-workspace'
 import { actorAvatarColor } from '@/lib/actor/actor-color'
 import { useSessionWorkspaceLabels } from '@/hooks/use-session-workspace-labels'
 import { compareSessionListByRecency } from '@/lib/session/session-list-sort'
@@ -289,20 +288,6 @@ export function SessionListColumn({
     return () => { cancelled = true }
   }, [filter, teamIdFromList])
 
-  // Load workspace-session set when filter switches to workspace mode.
-  // Reads the LOCAL libsql cache only — no cloud round-trip.
-  const [workspaceSessionIds, setWorkspaceSessionIds] = React.useState<Set<string> | null>(null)
-  React.useEffect(() => {
-    if (filter.kind !== 'workspace') {
-      setWorkspaceSessionIds(null)
-      return
-    }
-    let cancelled = false
-    void loadSessionIdsForWorkspace(teamIdFromList, { workspaceId: filter.workspaceId, path: filter.path })
-      .then((ids) => { if (!cancelled) setWorkspaceSessionIds(ids) })
-    return () => { cancelled = true }
-  }, [filter, teamIdFromList])
-
   // ⌘K opens search
   React.useEffect(() => {
     const down = (e: KeyboardEvent) => {
@@ -334,13 +319,10 @@ export function SessionListColumn({
     } else if (filter.kind === 'actor') {
       if (!actorSessionIds) return []
       base = base.filter((r) => actorSessionIds.has(r.id))
-    } else if (filter.kind === 'workspace') {
-      if (!workspaceSessionIds) return []
-      base = base.filter((r) => workspaceSessionIds.has(r.id))
     }
 
     return base.sort(compareSessionListByRecency)
-  }, [listRows, pinnedSessionIds, cronSessionIds, showCronSessions, filter, actorSessionIds, workspaceSessionIds])
+  }, [listRows, pinnedSessionIds, cronSessionIds, showCronSessions, filter, actorSessionIds])
 
   const { pinnedRows, regularRows } = React.useMemo(() => {
     if (filter.kind !== 'all') {
@@ -436,7 +418,6 @@ export function SessionListColumn({
     if (filter.kind === 'pinned') return t('sidebar.pinned', 'Pinned')
     if (filter.kind === 'idea') return filter.title
     if (filter.kind === 'actor') return filter.displayName
-    if (filter.kind === 'workspace') return filter.name
     return ''
   })()
 
@@ -505,7 +486,6 @@ export function SessionListColumn({
     filter.kind,
     filter.kind === 'idea' ? filter.ideaId : '',
     filter.kind === 'actor' ? filter.actorId : '',
-    filter.kind === 'workspace' ? filter.workspaceId : '',
   ])
 
   const exitBatchSelect = React.useCallback(() => {
@@ -622,7 +602,10 @@ export function SessionListColumn({
         (p) => p.actorId === currentMemberId || p.actorId === localAgentId,
       )
     const workspaceLabel = sessionWorkspaceLabels.get(row.id)
-    const showWorkspaceSubline = filter.kind !== 'workspace' && !!workspaceLabel
+    // The subline used to be suppressed while the list was already filtered to
+    // one workspace. That filter has no entry point any more, so the label is
+    // never redundant.
+    const showWorkspaceSubline = !!workspaceLabel
     const actionsId = `v2-session-actions-${row.id}`
     const actionBtnClass =
       'grid h-[34px] place-items-center rounded-lg bg-black/[0.045] text-ink-2 transition-colors hover:bg-black/[0.08] hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50 dark:bg-white/[0.06] dark:hover:bg-white/10'
@@ -1143,9 +1126,7 @@ export function SessionListColumn({
           <div className="flex flex-col items-center justify-center py-8 text-center">
             <MessageSquare className="h-8 w-8 text-muted-foreground mb-2" />
             <p className="text-sm text-muted-foreground">
-              {filter.kind === 'workspace'
-                ? t('sidebar.noWorkspaceSessions', 'No sessions in this workspace yet')
-                : t('sidebar.noConversations', 'No conversations')}
+              {t('sidebar.noConversations', 'No conversations')}
             </p>
           </div>
         ) : (

--- a/packages/app/src/components/sidebar/__tests__/NewChatSplitButton.test.tsx
+++ b/packages/app/src/components/sidebar/__tests__/NewChatSplitButton.test.tsx
@@ -55,7 +55,7 @@ describe('NewChatSplitButton', () => {
     expect(screen.getByRole('button', { name: /新聊天/i })).toBeDisabled()
   })
 
-  it('expands inline panel without workspace when team is available', () => {
+  it('opens the advanced dialog directly, with no intermediate menu', () => {
     render(
       <NewChatSplitButton
         quickChatState={{
@@ -66,24 +66,27 @@ describe('NewChatSplitButton', () => {
         onPrimaryClick={onPrimaryClick}
       />,
     )
-    const wrap = screen.getByTestId('new-chat-more-panel-wrap')
-    expect(wrap).toHaveAttribute('aria-hidden', 'true')
-    fireEvent.click(screen.getByRole('button', { name: /更多新建选项/i }))
-    expect(wrap).toHaveAttribute('aria-hidden', 'false')
-    fireEvent.click(screen.getByRole('button', { name: /多人会话/i }))
-    expect(openDialog).toHaveBeenCalled()
-    expect(wrap).toHaveAttribute('aria-hidden', 'true')
+    fireEvent.click(screen.getByTestId('new-chat-advanced'))
+    expect(openDialog).toHaveBeenCalledTimes(1)
   })
 
-  it('disables more-options chevron when no team', () => {
-    render(
-      <NewChatSplitButton
-        quickChatState={{ kind: 'no_team' }}
-        creating={false}
-        onPrimaryClick={onPrimaryClick}
-      />,
-    )
-    expect(screen.getByRole('button', { name: /更多新建选项/i })).toBeDisabled()
-    expect(screen.queryByTestId('new-chat-more-panel-wrap')).not.toBeInTheDocument()
-  })
+  // The advanced half is the escape hatch: it is the only way to start a chat
+  // when the quick half is dead, so it stays live in every state the quick half
+  // refuses — including `no_team`, which the dialog answers with its empty state.
+  it.each(['no_team', 'no_agent', 'loading'] as const)(
+    'keeps the advanced half enabled when quick chat is %s',
+    (kind) => {
+      render(
+        <NewChatSplitButton
+          quickChatState={{ kind }}
+          creating={true}
+          onPrimaryClick={onPrimaryClick}
+        />,
+      )
+      const advanced = screen.getByTestId('new-chat-advanced')
+      expect(advanced).not.toBeDisabled()
+      fireEvent.click(advanced)
+      expect(openDialog).toHaveBeenCalled()
+    },
+  )
 })

--- a/packages/app/src/components/sidebar/__tests__/SessionListColumn.test.tsx
+++ b/packages/app/src/components/sidebar/__tests__/SessionListColumn.test.tsx
@@ -346,12 +346,13 @@ describe('SessionListColumn', () => {
     }
   })
 
-  it('hides workspace subline when filtering by workspace', () => {
-    useUIStore.setState({
-      sidebarFilter: { kind: 'workspace', workspaceId: 'ws1', path: '/p', name: 'copilot-ws-v3' },
-    })
+  // The subline used to be suppressed while the list was filtered to one
+  // workspace. That filter kind is gone — the sidebar list that set it was its
+  // only producer — so the label is never redundant now.
+  it('shows the workspace subline under sessions that have one', () => {
+    useUIStore.setState({ sidebarFilter: { kind: 'all' } })
     render(<SessionListColumn />)
-    expect(screen.queryByTestId('v2-session-row-workspace')).not.toBeInTheDocument()
+    expect(screen.queryAllByTestId('v2-session-row-workspace').length).toBeGreaterThan(0)
   })
 
   it('renders an inline close button when onDismiss is provided', () => {

--- a/packages/app/src/components/workspace/FileBrowser.tsx
+++ b/packages/app/src/components/workspace/FileBrowser.tsx
@@ -7,7 +7,6 @@ import { toast } from 'sonner'
 import { cn } from '@/lib/utils'
 import { useFileChangeBatchListener } from '@/hooks/use-file-change-batch-listener'
 import { useWorkspaceStore, type FileNode } from '@/stores/workspace'
-import { useOssSyncStore } from '@/stores/oss-sync'
 import { ScrollBar } from '@/components/ui/scroll-area'
 import { Input } from '@/components/ui/input'
 import {
@@ -97,18 +96,12 @@ export function FileBrowser({ className, variant = 'default', rootPath, rootPath
       (singleRootPath === workspacePath || singleRootPath.startsWith(`${workspacePath}/`))
     )
 
-  // Team-share sync state, kept current for the `teamclu-team` node badge that
-  // `FileTree` renders (last-sync time / "Syncing…").
-  //
-  // This toolbar used to carry a "sync now" button too. It was removed: team
-  // sync writes `~/.amuxd/teams/<id>/shared/team-sync/`, so pressing it from the
-  // workspace tree ran an action whose effect was invisible in the tree it sat
-  // on. The trigger belongs to the team-share column (`KnowledgeSyncFooter`),
-  // which owns it. Only the read-only status survives here.
-  const refreshOssSync = useOssSyncStore((s) => s.refresh)
-  React.useEffect(() => {
-    if (workspacePath) void refreshOssSync(workspacePath)
-  }, [workspacePath, refreshOssSync])
+  // Team sync has no surface here any more — neither the "sync now" button nor
+  // the `teamclu-team` node's status badge. Both described
+  // `~/.amuxd/teams/<id>/shared/team-sync/`, which is not this tree, and the
+  // team-share column (`KnowledgeSyncFooter`) owns both the trigger and the
+  // status where they belong. The `oss_sync_status` IPC that ran on every
+  // workspace change fed only that badge, so it went with it.
 
   // When rootPaths is provided, create virtual root folder nodes for each path.
   // When rootPath is provided, extract its subtree from the global fileTree.

--- a/packages/app/src/components/workspace/FileBrowser.tsx
+++ b/packages/app/src/components/workspace/FileBrowser.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import * as ScrollAreaPrimitive from "@radix-ui/react-scroll-area"
-import { Search, ChevronsDownUp, Undo2, LocateFixed, X, RefreshCw } from 'lucide-react'
+import { Search, ChevronsDownUp, Undo2, LocateFixed, X } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { toast } from 'sonner'
 
@@ -83,7 +83,6 @@ export function FileBrowser({ className, variant = 'default', rootPath, rootPath
   const searchExpanded = controlledSearchExpanded ?? internalSearchExpanded
   const setSearchExpanded = onSearchExpandedChange ?? setInternalSearchExpanded
 
-  const isCustomRoot = !!rootPath || !!rootPaths
   // Multi-root trees have no single directory to fall back to, so only the
   // single-root form tells FileTree where untargeted drops and pastes belong.
   const singleRootPath = rootPaths && rootPaths.length > 0 ? undefined : rootPath
@@ -98,19 +97,18 @@ export function FileBrowser({ className, variant = 'default', rootPath, rootPath
       (singleRootPath === workspacePath || singleRootPath.startsWith(`${workspacePath}/`))
     )
 
-  // OSS team-share "sync now" — only surfaced when this workspace actually has
-  // OSS sync state (oss_sync_status reports a teamId). Non-team / git-mode
-  // workspaces report no teamId, so the button stays hidden there.
-  const ossTeamId = useOssSyncStore((s) => s.teamId)
-  const ossSyncing = useOssSyncStore((s) => s.syncing)
+  // Team-share sync state, kept current for the `teamclu-team` node badge that
+  // `FileTree` renders (last-sync time / "Syncing…").
+  //
+  // This toolbar used to carry a "sync now" button too. It was removed: team
+  // sync writes `~/.amuxd/teams/<id>/shared/team-sync/`, so pressing it from the
+  // workspace tree ran an action whose effect was invisible in the tree it sat
+  // on. The trigger belongs to the team-share column (`KnowledgeSyncFooter`),
+  // which owns it. Only the read-only status survives here.
   const refreshOssSync = useOssSyncStore((s) => s.refresh)
-  const ossSyncNow = useOssSyncStore((s) => s.syncNow)
   React.useEffect(() => {
     if (workspacePath) void refreshOssSync(workspacePath)
   }, [workspacePath, refreshOssSync])
-  // Caller-provided actionIcons (KnowledgeBrowser git sync, TeamSharedFilesBrowser
-  // git/oss sync) already own the toolbar sync button — don't duplicate OSS sync.
-  const showOssSync = !isCustomRoot && !!ossTeamId && !actionIcons
 
   // When rootPaths is provided, create virtual root folder nodes for each path.
   // When rootPath is provided, extract its subtree from the global fileTree.
@@ -256,22 +254,6 @@ export function FileBrowser({ className, variant = 'default', rootPath, rootPath
 
   const iconButtonClass = 'flex items-center justify-center h-7 w-7 rounded-md transition-colors shrink-0 text-muted-foreground hover:bg-muted hover:text-foreground'
 
-  const ossSyncButton = showOssSync ? (
-    <Tooltip>
-      <TooltipTrigger asChild>
-        <button
-          onClick={() => workspacePath && void ossSyncNow(workspacePath)}
-          disabled={ossSyncing}
-          className={iconButtonClass}
-          data-testid="filebrowser-oss-sync"
-        >
-          <RefreshCw className={cn('h-3.5 w-3.5', ossSyncing && 'animate-spin')} />
-        </button>
-      </TooltipTrigger>
-      <TooltipContent side="bottom">{t('settings.team.oss.syncNow', 'Sync now')}</TooltipContent>
-    </Tooltip>
-  ) : null
-
   return (
     <div className={cn('flex flex-col h-full', className)} data-file-browser data-testid="file-browser">
 
@@ -312,9 +294,6 @@ export function FileBrowser({ className, variant = 'default', rootPath, rootPath
 
               {/* Caller-provided action icons (e.g. New Note, New Folder, Sync) */}
               {actionIcons}
-
-              {/* OSS team-share sync now — only when this workspace is OSS-synced */}
-              {ossSyncButton}
 
               {/* Collapse all */}
               <Tooltip>
@@ -376,7 +355,6 @@ export function FileBrowser({ className, variant = 'default', rootPath, rootPath
                 className="pl-7 h-7 text-xs"
               />
             </div>
-            {ossSyncButton}
             <Tooltip>
               <TooltipTrigger asChild>
                 <button

--- a/packages/app/src/components/workspace/FileTree.tsx
+++ b/packages/app/src/components/workspace/FileTree.tsx
@@ -6,7 +6,6 @@ import { ChevronRight, File } from "lucide-react";
 import { toast } from 'sonner';
 import { copyToClipboard, isTauri } from '@/lib/utils';
 import { useWorkspaceStore, type FileNode } from "@/stores/workspace";
-import { useOssSyncStore } from "@/stores/oss-sync";
 import { useTeamConflictsStore } from "@/stores/team-conflicts";
 import { withDefaultExtension } from "@/lib/knowledge/knowledge-file-names";
 import { pruneKnowledgeNoise } from "@/lib/knowledge/knowledge-tree-pruning";
@@ -281,8 +280,6 @@ export function FileTree({
   // is keyed by SYNC KEY now (see `badges` above), not by a workspace-relative
   // path — the same document is reachable through two different absolute paths
   // and only the sync key is the same on both.
-  const teamSyncing = useOssSyncStore(s => s.syncing);
-  const teamLastSyncAt = useOssSyncStore(s => s.lastSyncAt);
 
   const collapseCompacted = useCallback((paths: string[]) => {
     const nextExpanded = new Set(useWorkspaceStore.getState().expandedPaths);
@@ -1045,8 +1042,6 @@ export function FileTree({
     isRenaming: renamingPath === node.path,
     isDragOver: dragOverPath === node.path,
     isTeamCluTeam: node.name === TEAM_REPO_DIR && node.type === "directory" && level === 0,
-    teamSyncing: node.name === TEAM_REPO_DIR && node.type === "directory" && level === 0 ? teamSyncing : undefined,
-    teamLastSyncAt: node.name === TEAM_REPO_DIR && node.type === "directory" && level === 0 ? teamLastSyncAt : undefined,
     // Team knowledge only, and on every surface the document appears on: the
     // Knowledge column and the workspace `team-knowledge` link are two
     // spellings of the same file, and `teamSyncKeyForPath` maps both.

--- a/packages/app/src/components/workspace/FileTreeNode.tsx
+++ b/packages/app/src/components/workspace/FileTreeNode.tsx
@@ -35,7 +35,6 @@ import { encodeVersionHistoryTarget } from '@/lib/tabs/teamshare-target';
 import type { SyncBadge } from '@/lib/team/team-sync-badges';
 import { openKnowledgeConflict, openCloudVersion } from '@/lib/tabs/knowledge-tabs';
 import { getFileIcon } from '@/lib/ui/file-icons';
-import { formatDateTime, formatRelativeTime } from '@/lib/ui/date-format';
 import type { FileNode } from "@/stores/workspace";
 import {
   ContextMenu,
@@ -204,10 +203,6 @@ export interface FileTreeItemProps {
   isDragOver: boolean;
   /** Whether this is the root teamclu-team directory (for visual styling) */
   isTeamCluTeam?: boolean;
-  /** Whether the team directory is currently syncing */
-  teamSyncing?: boolean;
-  /** ISO timestamp of last successful team repo sync (for relative-time label) */
-  teamLastSyncAt?: string | null;
   /**
    * What this document's sync state is, for team knowledge. `null` for
    * everything else — a workspace file has no cloud counterpart to differ from.
@@ -327,8 +322,6 @@ export const FileTreeItem = React.memo(function FileTreeItem({
   isRenaming,
   isDragOver,
   isTeamCluTeam,
-  teamSyncing,
-  teamLastSyncAt,
   isTeamKnowledge,
   syncStatus,
   syncIgnored = false,
@@ -506,9 +499,7 @@ export const FileTreeItem = React.memo(function FileTreeItem({
       )}
 
       {isTeamCluTeam && (
-        teamSyncing
-          ? <Loader2 className="h-3.5 w-3.5 shrink-0 animate-spin text-muted-foreground" />
-          : <img src="/logo-64.png" alt="" className="h-3.5 w-3.5 shrink-0" />
+        <img src="/logo-64.png" alt="" className="h-3.5 w-3.5 shrink-0" />
       )}
 
       {isKnowledgeDir && !isTeamCluTeam && (
@@ -566,19 +557,6 @@ export const FileTreeItem = React.memo(function FileTreeItem({
         </span>
       )}
 
-      {isTeamCluTeam && !teamSyncing && teamLastSyncAt && (
-        <span
-          className="ml-auto pl-2 text-[10px] text-muted-foreground/70 font-normal shrink-0"
-          title={t('fileExplorer.teamLastSyncTooltip', 'Last sync: {{time}}', { time: formatDateTime(teamLastSyncAt) })}
-        >
-          {formatRelativeTime(teamLastSyncAt)}
-        </span>
-      )}
-      {isTeamCluTeam && teamSyncing && (
-        <span className="ml-auto pl-2 text-[10px] text-muted-foreground/70 font-normal shrink-0">
-          {t('fileExplorer.teamSyncing', 'Syncing…')}
-        </span>
-      )}
     </button>
   );
 

--- a/packages/app/src/components/workspace/__tests__/FileBrowser.test.tsx
+++ b/packages/app/src/components/workspace/__tests__/FileBrowser.test.tsx
@@ -158,7 +158,7 @@ describe("FileBrowser", () => {
     ossSyncState.teamId = "team-1";
   });
 
-  it("hides built-in OSS sync when the caller already supplies actionIcons", () => {
+  it("still renders caller-supplied action icons", () => {
     render(
       <FileBrowser
         variant="panel"
@@ -167,14 +167,20 @@ describe("FileBrowser", () => {
     );
 
     expect(screen.getByTestId("caller-sync")).toBeTruthy();
-    expect(screen.queryByTestId("filebrowser-oss-sync")).toBeNull();
   });
 
-  it("shows built-in OSS sync for workspace root when no actionIcons are provided", () => {
-    render(<FileBrowser variant="panel" />);
+  // Team sync writes `~/.amuxd/teams/<id>/shared/team-sync/`, not the workspace
+  // tree, so a "sync now" button here fired an action with no visible effect
+  // where it lived. The trigger belongs to the team-share column. Asserted for
+  // both variants because the button used to be rendered in each of them.
+  it.each(["panel", "default"] as const)(
+    "never renders a built-in team-sync button (%s variant)",
+    (variant) => {
+      render(<FileBrowser variant={variant} />);
 
-    expect(screen.getByTestId("filebrowser-oss-sync")).toBeTruthy();
-  });
+      expect(screen.queryByTestId("filebrowser-oss-sync")).toBeNull();
+    },
+  );
 
   it("retries loading custom root ancestors after the global tree becomes available", async () => {
     const rootPath = "/workspace/teamclu-team/knowledge";

--- a/packages/app/src/hooks/__tests__/use-session-local-workspace.test.tsx
+++ b/packages/app/src/hooks/__tests__/use-session-local-workspace.test.tsx
@@ -1,0 +1,111 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+
+const mocks = vi.hoisted(() => ({
+  currentSessionId: 'sess-a' as string | null,
+  teamId: 'team-1' as string | null,
+  workspacePath: '/tmp/a' as string | null,
+  participantsBySession: {} as Record<string, Array<{ actorId: string; displayName: string }>>,
+  ensureParticipants: vi.fn(),
+  knownLocalDaemonActorId: 'agent-local' as string | null,
+  resolveSessionWorkspacePath: vi.fn(),
+}))
+
+vi.mock('@/stores/session-selection-store', () => ({
+  useSessionSelectionStore: (selector: (s: unknown) => unknown) =>
+    selector({ currentSessionId: mocks.currentSessionId }),
+}))
+
+vi.mock('@/stores/current-team', () => ({
+  useCurrentTeamStore: (selector: (s: unknown) => unknown) =>
+    selector({ team: mocks.teamId ? { id: mocks.teamId } : null }),
+}))
+
+vi.mock('@/stores/workspace', () => ({
+  useWorkspaceStore: (selector: (s: unknown) => unknown) =>
+    selector({ workspacePath: mocks.workspacePath }),
+}))
+
+vi.mock('@/stores/session-participant-store', () => ({
+  useSessionParticipantStore: (selector: (s: unknown) => unknown) =>
+    selector({
+      participantsBySession: mocks.participantsBySession,
+      ensureParticipants: mocks.ensureParticipants,
+    }),
+}))
+
+vi.mock('@/lib/daemon/local-daemon-identity', () => ({
+  getKnownLocalDaemonActorId: () => mocks.knownLocalDaemonActorId,
+}))
+
+vi.mock('@/lib/daemon/daemon-agent-admin', () => ({
+  getLocalDaemonActorId: vi.fn().mockResolvedValue(null),
+}))
+
+vi.mock('@/lib/session/session-by-workspace', () => ({
+  resolveSessionWorkspacePath: (...args: unknown[]) => mocks.resolveSessionWorkspacePath(...args),
+}))
+
+import { useSessionLocalWorkspace } from '../use-session-local-workspace'
+
+describe('useSessionLocalWorkspace', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.currentSessionId = 'sess-a'
+    mocks.teamId = 'team-1'
+    mocks.workspacePath = '/tmp/a'
+    mocks.knownLocalDaemonActorId = 'agent-local'
+    mocks.participantsBySession = {
+      'sess-a': [{ actorId: 'agent-local', displayName: 'Mac-mini-3' }],
+      'sess-b': [{ actorId: 'agent-local', displayName: 'Mac-mini-3' }],
+    }
+    mocks.resolveSessionWorkspacePath.mockImplementation(async (_team: string, id: string) =>
+      id === 'sess-a' ? '/tmp/a' : '/tmp/b',
+    )
+  })
+
+  it('reports the session folder once the workspace store agrees', async () => {
+    const { result } = renderHook(() => useSessionLocalWorkspace())
+    await waitFor(() => expect(result.current.path).toBe('/tmp/a'))
+    expect(result.current.hasLocalAgent).toBe(true)
+    expect(result.current.agentName).toBe('Mac-mini-3')
+  })
+
+  // The tree renders from the workspace store while the footer names the
+  // binding. `switchToSessionWorkspaceIfNeeded` moves the store in the
+  // background, so reporting the binding early labels one folder's name over
+  // another folder's tree.
+  it('withholds the path while the workspace store still points elsewhere', async () => {
+    const { result, rerender } = renderHook(() => useSessionLocalWorkspace())
+    await waitFor(() => expect(result.current.path).toBe('/tmp/a'))
+
+    mocks.currentSessionId = 'sess-b'
+    rerender()
+
+    await waitFor(() => expect(mocks.resolveSessionWorkspacePath).toHaveBeenCalledWith('team-1', 'sess-b'))
+    // Store has not followed yet: no path, and crucially never '/tmp/a'.
+    expect(result.current.path).toBeNull()
+    expect(result.current.hasLocalAgent).toBe(true)
+
+    mocks.workspacePath = '/tmp/b'
+    rerender()
+    await waitFor(() => expect(result.current.path).toBe('/tmp/b'))
+  })
+
+  it('reports no local agent when this machine has none in the session', async () => {
+    mocks.participantsBySession = { 'sess-a': [{ actorId: 'agent-remote', displayName: 'Other' }] }
+    const { result } = renderHook(() => useSessionLocalWorkspace())
+    await waitFor(() => expect(mocks.resolveSessionWorkspacePath).toHaveBeenCalled())
+    expect(result.current.hasLocalAgent).toBe(false)
+    expect(result.current.path).toBeNull()
+  })
+
+  // Two instances render this hook (app header, files pane) and each resolve is
+  // an uncached Cloud round trip.
+  it('shares one in-flight resolve across instances', async () => {
+    renderHook(() => useSessionLocalWorkspace())
+    renderHook(() => useSessionLocalWorkspace())
+    await waitFor(() => expect(mocks.resolveSessionWorkspacePath).toHaveBeenCalled())
+    expect(mocks.resolveSessionWorkspacePath).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/app/src/hooks/use-session-local-workspace.ts
+++ b/packages/app/src/hooks/use-session-local-workspace.ts
@@ -1,0 +1,91 @@
+import * as React from 'react'
+import { getKnownLocalDaemonActorId } from '@/lib/daemon/local-daemon-identity'
+import { resolveSessionWorkspacePath } from '@/lib/session/session-by-workspace'
+import { useCurrentTeamStore } from '@/stores/current-team'
+import { useSessionParticipantStore } from '@/stores/session-participant-store'
+import { useSessionSelectionStore } from '@/stores/session-selection-store'
+import { useWorkspaceStore } from '@/stores/workspace'
+
+export type SessionLocalWorkspace = {
+  /** The agent running on this machine is seated in the active session. */
+  hasLocalAgent: boolean
+  /** That agent's display name, for the file-tree footer. */
+  agentName: string | null
+  /**
+   * The folder that agent works in for this session. Null until a runtime has
+   * bound one — a session created a second ago has no binding yet.
+   */
+  path: string | null
+}
+
+const EMPTY: SessionLocalWorkspace = {
+  hasLocalAgent: false,
+  agentName: null,
+  path: null,
+}
+
+/**
+ * The workspace the file tree and terminal describe: the folder the **local**
+ * agent works in for the session currently open.
+ *
+ * Both surfaces reach the filesystem of this machine, so a session with no
+ * local agent has no folder to show — the caller hides them rather than
+ * leaving the previous session's directory on screen, which is what used to
+ * happen because the workspace store is ambient and only changes when a
+ * session that resolves to a local path is opened.
+ *
+ * The path itself still comes from the workspace store. `switchToSession`
+ * already drives that store from the session's own binding
+ * (`switchToSessionWorkspaceIfNeeded`), so this hook reports where the tree is
+ * rather than opening a second, competing source of truth for it — the store
+ * has ~60 readers and they must not disagree with the tree.
+ */
+export function useSessionLocalWorkspace(): SessionLocalWorkspace {
+  const sessionId = useSessionSelectionStore((s) => s.currentSessionId)
+  const teamId = useCurrentTeamStore((s) => s.team?.id ?? null)
+  const participantsBySession = useSessionParticipantStore((s) => s.participantsBySession)
+  const ensureParticipants = useSessionParticipantStore((s) => s.ensureParticipants)
+  const workspacePath = useWorkspaceStore((s) => s.workspacePath)
+
+  const [boundPath, setBoundPath] = React.useState<string | null>(null)
+
+  React.useEffect(() => {
+    if (!sessionId) return
+    void ensureParticipants([sessionId])
+  }, [sessionId, ensureParticipants])
+
+  // `switchToSessionWorkspaceIfNeeded` moves the workspace store in the
+  // background, so the store alone cannot distinguish "this session's folder"
+  // from "the folder left over from the last one". Resolve the binding to tell
+  // them apart; re-run when the store lands on its answer.
+  React.useEffect(() => {
+    if (!sessionId || !teamId) {
+      setBoundPath(null)
+      return
+    }
+    let cancelled = false
+    void resolveSessionWorkspacePath(teamId, sessionId)
+      .then((path) => {
+        if (!cancelled) setBoundPath(path?.trim() || null)
+      })
+      .catch(() => {
+        if (!cancelled) setBoundPath(null)
+      })
+    return () => { cancelled = true }
+  }, [sessionId, teamId, workspacePath])
+
+  return React.useMemo(() => {
+    if (!sessionId) return EMPTY
+    const localAgentId = getKnownLocalDaemonActorId()
+    if (!localAgentId) return EMPTY
+    const participant = (participantsBySession[sessionId] ?? []).find(
+      (p) => p.actorId === localAgentId,
+    )
+    if (!participant) return EMPTY
+    return {
+      hasLocalAgent: true,
+      agentName: participant.displayName || null,
+      path: boundPath,
+    }
+  }, [sessionId, participantsBySession, boundPath])
+}

--- a/packages/app/src/hooks/use-session-local-workspace.ts
+++ b/packages/app/src/hooks/use-session-local-workspace.ts
@@ -1,6 +1,7 @@
 import * as React from 'react'
 import { getKnownLocalDaemonActorId } from '@/lib/daemon/local-daemon-identity'
 import { resolveSessionWorkspacePath } from '@/lib/session/session-by-workspace'
+import { workspacePathsMatch } from '@/stores/session-utils'
 import { useCurrentTeamStore } from '@/stores/current-team'
 import { useSessionParticipantStore } from '@/stores/session-participant-store'
 import { useSessionSelectionStore } from '@/stores/session-selection-store'
@@ -12,8 +13,9 @@ export type SessionLocalWorkspace = {
   /** That agent's display name, for the file-tree footer. */
   agentName: string | null
   /**
-   * The folder that agent works in for this session. Null until a runtime has
-   * bound one — a session created a second ago has no binding yet.
+   * The folder that agent works in for this session, and only once the
+   * workspace store has actually moved there. Null while a switch is in
+   * flight, and for a session whose runtime has never bound a folder.
    */
   path: string | null
 }
@@ -25,67 +27,108 @@ const EMPTY: SessionLocalWorkspace = {
 }
 
 /**
+ * One in-flight resolve per (team, session), shared by every hook instance.
+ *
+ * This hook runs in two places at once (the app header and the files pane) and
+ * each resolve reaches `getSessionParticipants`, which the 5s viewer-context
+ * cache does not cover. Without this, one session click issued four identical
+ * Cloud round trips.
+ */
+const inFlight = new Map<string, Promise<string | null>>()
+
+function resolveOnce(teamId: string, sessionId: string): Promise<string | null> {
+  const key = `${teamId}:${sessionId}`
+  const existing = inFlight.get(key)
+  if (existing) return existing
+  const promise = resolveSessionWorkspacePath(teamId, sessionId)
+    .catch(() => null)
+    .finally(() => { inFlight.delete(key) })
+  inFlight.set(key, promise)
+  return promise
+}
+
+/**
  * The workspace the file tree and terminal describe: the folder the **local**
  * agent works in for the session currently open.
  *
  * Both surfaces reach the filesystem of this machine, so a session with no
  * local agent has no folder to show — the caller hides them rather than
- * leaving the previous session's directory on screen, which is what used to
- * happen because the workspace store is ambient and only changes when a
- * session that resolves to a local path is opened.
+ * leaving the previous session's directory on screen.
  *
- * The path itself still comes from the workspace store. `switchToSession`
- * already drives that store from the session's own binding
- * (`switchToSessionWorkspaceIfNeeded`), so this hook reports where the tree is
- * rather than opening a second, competing source of truth for it — the store
- * has ~60 readers and they must not disagree with the tree.
+ * `path` is deliberately gated on the workspace store agreeing. That store is
+ * what `FileBrowser` renders from, and `switchToSessionWorkspaceIfNeeded` moves
+ * it in the background (fire-and-forget, and it stays put if `setWorkspace`
+ * throws). Reporting the binding before the store has followed would print one
+ * folder's name over another folder's tree — a label that lies is worse than
+ * the unlabelled tree this replaced.
  */
 export function useSessionLocalWorkspace(): SessionLocalWorkspace {
   const sessionId = useSessionSelectionStore((s) => s.currentSessionId)
   const teamId = useCurrentTeamStore((s) => s.team?.id ?? null)
-  const participantsBySession = useSessionParticipantStore((s) => s.participantsBySession)
   const ensureParticipants = useSessionParticipantStore((s) => s.ensureParticipants)
+  // Select this session's roster, not the whole map: every participant load in
+  // the app replaces that object, and this hook is called from the app root.
+  const participants = useSessionParticipantStore((s) =>
+    sessionId ? s.participantsBySession[sessionId] : undefined,
+  )
   const workspacePath = useWorkspaceStore((s) => s.workspacePath)
 
-  const [boundPath, setBoundPath] = React.useState<string | null>(null)
+  // The local actor id arrives from the daemon's `/v1/info` and is cached in a
+  // module + localStorage. A bare read inside a memo can never observe it
+  // landing (nothing in the dep list changes), which on a fresh install left
+  // the tree and terminal hidden with no way back.
+  const [localAgentId, setLocalAgentId] = React.useState<string | null>(() =>
+    getKnownLocalDaemonActorId(),
+  )
+  React.useEffect(() => {
+    if (localAgentId) return
+    let cancelled = false
+    void (async () => {
+      try {
+        const { getLocalDaemonActorId } = await import('@/lib/daemon/daemon-agent-admin')
+        const id = await getLocalDaemonActorId()
+        if (!cancelled && id?.trim()) setLocalAgentId(id.trim())
+      } catch {
+        /* offline — the sidebar's own probe will note it later */
+      }
+    })()
+    return () => { cancelled = true }
+  }, [localAgentId, sessionId])
+
+  // Keyed by session so an in-flight resolve for the session we just left can
+  // never be read as this one's answer.
+  const [bound, setBound] = React.useState<{ sessionId: string; path: string | null } | null>(null)
 
   React.useEffect(() => {
     if (!sessionId) return
     void ensureParticipants([sessionId])
   }, [sessionId, ensureParticipants])
 
-  // `switchToSessionWorkspaceIfNeeded` moves the workspace store in the
-  // background, so the store alone cannot distinguish "this session's folder"
-  // from "the folder left over from the last one". Resolve the binding to tell
-  // them apart; re-run when the store lands on its answer.
   React.useEffect(() => {
     if (!sessionId || !teamId) {
-      setBoundPath(null)
+      setBound(null)
       return
     }
     let cancelled = false
-    void resolveSessionWorkspacePath(teamId, sessionId)
-      .then((path) => {
-        if (!cancelled) setBoundPath(path?.trim() || null)
-      })
-      .catch(() => {
-        if (!cancelled) setBoundPath(null)
-      })
+    void resolveOnce(teamId, sessionId).then((path) => {
+      if (!cancelled) setBound({ sessionId, path: path?.trim() || null })
+    })
     return () => { cancelled = true }
-  }, [sessionId, teamId, workspacePath])
+  }, [sessionId, teamId])
 
   return React.useMemo(() => {
-    if (!sessionId) return EMPTY
-    const localAgentId = getKnownLocalDaemonActorId()
-    if (!localAgentId) return EMPTY
-    const participant = (participantsBySession[sessionId] ?? []).find(
-      (p) => p.actorId === localAgentId,
-    )
+    if (!sessionId || !localAgentId) return EMPTY
+    const participant = (participants ?? []).find((p) => p.actorId === localAgentId)
     if (!participant) return EMPTY
+
+    const boundPath = bound?.sessionId === sessionId ? bound.path : null
+    const settled =
+      !!boundPath && !!workspacePath && workspacePathsMatch(boundPath, workspacePath)
+
     return {
       hasLocalAgent: true,
       agentName: participant.displayName || null,
-      path: boundPath,
+      path: settled ? boundPath : null,
     }
-  }, [sessionId, participantsBySession, boundPath])
+  }, [sessionId, localAgentId, participants, bound, workspacePath])
 }

--- a/packages/app/src/lib/session/session-create.ts
+++ b/packages/app/src/lib/session/session-create.ts
@@ -26,9 +26,11 @@ import {
 import {
   upsertSessionsBatch,
   upsertSessionParticipantsBatch,
+  upsertSessionWorkspacesBatch,
   type SessionRow,
   type SessionParticipantRow,
 } from '@/lib/cache/local-cache'
+import { useCurrentTeamStore } from '@/stores/current-team'
 import { isTauri } from '@/lib/utils'
 import {
   sessionFlowError,
@@ -198,6 +200,72 @@ interface CreateSessionWithFirstMessageArgs {
    * sit there until the user typed something.
    */
   mentionActorIds?: string[]
+  /**
+   * Folder the **local daemon agent** should run this session in, chosen in the
+   * advanced dialog. Ignored unless that agent is among `agentActorIds`:
+   * a cloud workspace row belongs to one agent, so handing its id to a remote
+   * daemon names a row that daemon cannot resolve — it would fall back to its
+   * own onboarded default and run in the wrong directory, silently.
+   */
+  localWorkspace?: { workspaceId: string; path: string } | null
+}
+
+/**
+ * Record the chosen folder as this session's workspace binding, in the local
+ * cache, before anything can start a runtime.
+ *
+ * This is the same row `bindAppWorkspace` writes, and it is read first by
+ * `resolveLiveWorkspaceHint` — ahead of the ambient workspace store, the agent
+ * default and the agent's owned row. Writing it here rather than passing a
+ * hint into a runtime start is what makes the choice durable: this session
+ * does not start its runtimes from the dialog (ChatPanel and the outbox sender
+ * do, later), and a hint that lives only in a function argument would be gone
+ * by the time either of them runs — most visibly when the first send fails and
+ * the outbox retries it.
+ *
+ * Best-effort throughout: a session that cannot be bound falls back to the
+ * agent default, which is the behaviour that existed before the picker.
+ */
+async function bindLocalDaemonSessionWorkspace(
+  sessionId: string,
+  args: CreateSessionWithFirstMessageArgs,
+): Promise<void> {
+  const workspaceId = args.localWorkspace?.workspaceId?.trim()
+  const workspacePath = args.localWorkspace?.path?.trim()
+  if (!workspaceId || !workspacePath || !isTauri()) return
+
+  try {
+    const { getLocalDaemonActorId } = await import('@/lib/daemon/daemon-agent-admin')
+    const localDaemonActorId = (await getLocalDaemonActorId())?.trim()
+    if (!localDaemonActorId) return
+    if (!args.agentActorIds.some((id) => id.trim() === localDaemonActorId)) return
+
+    const viewerMemberId = useCurrentTeamStore.getState().currentMember?.id?.trim()
+    if (!viewerMemberId) return
+
+    await upsertSessionWorkspacesBatch([
+      {
+        sessionId,
+        teamId: args.teamId,
+        viewerMemberId,
+        agentId: localDaemonActorId,
+        workspaceId,
+        workspacePath,
+        updatedAt: new Date().toISOString(),
+      },
+    ])
+    sessionFlowLog('session_with_first_message.bind_workspace.ok', {
+      sessionId,
+      teamId: args.teamId,
+      workspaceId,
+    })
+  } catch (error) {
+    sessionFlowError('session_with_first_message.bind_workspace.failed', error, {
+      sessionId,
+      teamId: args.teamId,
+      workspaceId,
+    })
+  }
 }
 
 interface CreateSessionWithFirstMessageResult {
@@ -239,6 +307,9 @@ export async function createSessionWithFirstMessage(
     ideaId: args.ideaId ?? null,
     ...(args.appId ? { appId: args.appId } : {}),
   })
+
+  // Before the first message exists, so no runtime can start ahead of it.
+  await bindLocalDaemonSessionWorkspace(sessionId, args)
 
   const messageId = crypto.randomUUID()
   const createdAt = BigInt(Math.floor(Date.now() / 1000))

--- a/packages/app/src/lib/session/session-create.ts
+++ b/packages/app/src/lib/session/session-create.ts
@@ -207,7 +207,7 @@ interface CreateSessionWithFirstMessageArgs {
    * daemon names a row that daemon cannot resolve — it would fall back to its
    * own onboarded default and run in the wrong directory, silently.
    */
-  localWorkspace?: { workspaceId: string; path: string } | null
+  localWorkspace?: { agentId: string; workspaceId: string; path: string } | null
 }
 
 /**
@@ -232,12 +232,15 @@ async function bindLocalDaemonSessionWorkspace(
 ): Promise<void> {
   const workspaceId = args.localWorkspace?.workspaceId?.trim()
   const workspacePath = args.localWorkspace?.path?.trim()
-  if (!workspaceId || !workspacePath || !isTauri()) return
+  // The caller resolved this agent id to show the picker at all. Re-deriving it
+  // here would mean a `get_daemon_http_info` IPC plus an uncached HTTP call to
+  // `/v1/info` in the middle of session creation — latency on every create, and
+  // a null on a momentarily unreachable daemon would discard the folder the
+  // user explicitly chose.
+  const localDaemonActorId = args.localWorkspace?.agentId?.trim()
+  if (!workspaceId || !workspacePath || !localDaemonActorId || !isTauri()) return
 
   try {
-    const { getLocalDaemonActorId } = await import('@/lib/daemon/daemon-agent-admin')
-    const localDaemonActorId = (await getLocalDaemonActorId())?.trim()
-    if (!localDaemonActorId) return
     if (!args.agentActorIds.some((id) => id.trim() === localDaemonActorId)) return
 
     const viewerMemberId = useCurrentTeamStore.getState().currentMember?.id?.trim()

--- a/packages/app/src/lib/workspace/__tests__/shorten-path.test.ts
+++ b/packages/app/src/lib/workspace/__tests__/shorten-path.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { shortenWorkspacePath } from '../shorten-path'
+import { shortenWorkspacePath, workspaceNameFromPath } from '../shorten-path'
 
 describe('shortenWorkspacePath', () => {
   it('leaves a path that already fits alone', () => {
@@ -25,5 +25,29 @@ describe('shortenWorkspacePath', () => {
     const out = shortenWorkspacePath('/one/two/three/four/five/six/seven/eight', 20)
     expect(out.length).toBeLessThanOrEqual(20)
     expect(out.endsWith('eight')).toBe(true)
+  })
+
+  // Splitting on '/' alone left Windows paths untouched, so they fell back to
+  // the CSS end-truncation this helper exists to replace.
+  it('shortens Windows paths and keeps their separator', () => {
+    const full = 'C:\\Users\\me\\workspace\\teamclaw-worktrees\\app-website'
+    const out = shortenWorkspacePath(full)
+
+    expect(out).not.toBe(full)
+    expect(out.startsWith('…\\')).toBe(true)
+    expect(out).not.toContain('/')
+    expect(out.endsWith('\\app-website')).toBe(true)
+    expect(out.length).toBeLessThanOrEqual(42)
+  })
+})
+
+describe('workspaceNameFromPath', () => {
+  it('takes the last segment on either separator', () => {
+    expect(workspaceNameFromPath('/tmp/teamclu')).toBe('teamclu')
+    expect(workspaceNameFromPath('C:\\Users\\me\\teamclu')).toBe('teamclu')
+  })
+
+  it('ignores a trailing separator', () => {
+    expect(workspaceNameFromPath('/tmp/teamclu/')).toBe('teamclu')
   })
 })

--- a/packages/app/src/lib/workspace/__tests__/shorten-path.test.ts
+++ b/packages/app/src/lib/workspace/__tests__/shorten-path.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+import { shortenWorkspacePath } from '../shorten-path'
+
+describe('shortenWorkspacePath', () => {
+  it('leaves a path that already fits alone', () => {
+    expect(shortenWorkspacePath('/tmp/teamclu')).toBe('/tmp/teamclu')
+  })
+
+  it('drops leading segments, keeping the tail that identifies the folder', () => {
+    const a = shortenWorkspacePath('/Volumes/openbeta/workspace/teamclaw-worktrees/app-website')
+    const b = shortenWorkspacePath('/Volumes/openbeta/workspace/teamclaw-worktrees/app-project')
+    expect(a.startsWith('…/')).toBe(true)
+    expect(a.endsWith('app-website')).toBe(true)
+    // The whole point: siblings must not collapse to the same string, which is
+    // what end-truncation does to them.
+    expect(a).not.toBe(b)
+  })
+
+  it('never cuts into the last segment, however long it is', () => {
+    const basename = 'a'.repeat(80)
+    expect(shortenWorkspacePath(`/Users/x/${basename}`)).toContain(basename)
+  })
+
+  it('honours the length budget', () => {
+    const out = shortenWorkspacePath('/one/two/three/four/five/six/seven/eight', 20)
+    expect(out.length).toBeLessThanOrEqual(20)
+    expect(out.endsWith('eight')).toBe(true)
+  })
+})

--- a/packages/app/src/lib/workspace/shorten-path.ts
+++ b/packages/app/src/lib/workspace/shorten-path.ts
@@ -1,3 +1,18 @@
+/** Windows paths use `\`, POSIX uses `/`; both appear in this app's data. */
+const SEPARATOR = /[\\/]+/
+
+function splitPath(path: string): { segments: string[]; separator: string } {
+  const segments = path.split(SEPARATOR).filter(Boolean)
+  return { segments, separator: path.includes('\\') ? '\\' : '/' }
+}
+
+/** Last path segment, for naming a workspace after the folder the user picked. */
+export function workspaceNameFromPath(path: string): string {
+  const trimmed = path.replace(/[\\/]+$/, '')
+  const { segments } = splitPath(trimmed)
+  return segments[segments.length - 1] || trimmed
+}
+
 /**
  * Shorten a filesystem path for display by dropping leading segments.
  *
@@ -14,15 +29,17 @@ export function shortenWorkspacePath(path: string, maxLength = 42): string {
   const trimmed = path.trim()
   if (trimmed.length <= maxLength) return trimmed
 
-  const segments = trimmed.split('/').filter(Boolean)
+  const { segments, separator } = splitPath(trimmed)
   // Grow from the tail while it still fits, but never return fewer than the
   // last segment — a basename longer than maxLength is shown in full rather
   // than cut into something that names nothing.
   let kept = segments.slice(-1)
   for (let i = 2; i <= segments.length; i += 1) {
     const candidate = segments.slice(-i)
-    if (`…/${candidate.join('/')}`.length > maxLength) break
+    if (`…${separator}${candidate.join(separator)}`.length > maxLength) break
     kept = candidate
   }
-  return kept.length === segments.length ? trimmed : `…/${kept.join('/')}`
+  return kept.length === segments.length
+    ? trimmed
+    : `…${separator}${kept.join(separator)}`
 }

--- a/packages/app/src/lib/workspace/shorten-path.ts
+++ b/packages/app/src/lib/workspace/shorten-path.ts
@@ -1,0 +1,28 @@
+/**
+ * Shorten a filesystem path for display by dropping leading segments.
+ *
+ * The tail is the half that identifies a path: three sibling checkouts under
+ * the same parent differ only in their last segment, so CSS `truncate` — which
+ * cuts the end — turns them into the same string. The obvious fix,
+ * `dir="rtl"`, is worse than it looks: bidi treats `/` as neutral, so the
+ * leading slash of an absolute path is reordered to the visual end and
+ * `/Volumes/x` renders as `Volumes/x/`.
+ *
+ * Always pair the result with the full path in a `title`.
+ */
+export function shortenWorkspacePath(path: string, maxLength = 42): string {
+  const trimmed = path.trim()
+  if (trimmed.length <= maxLength) return trimmed
+
+  const segments = trimmed.split('/').filter(Boolean)
+  // Grow from the tail while it still fits, but never return fewer than the
+  // last segment — a basename longer than maxLength is shown in full rather
+  // than cut into something that names nothing.
+  let kept = segments.slice(-1)
+  for (let i = 2; i <= segments.length; i += 1) {
+    const candidate = segments.slice(-i)
+    if (`…/${candidate.join('/')}`.length > maxLength) break
+    kept = candidate
+  }
+  return kept.length === segments.length ? trimmed : `…/${kept.join('/')}`
+}

--- a/packages/app/src/locales/en.json
+++ b/packages/app/src/locales/en.json
@@ -2407,9 +2407,6 @@
       "secretStored": "Configured · leave empty to keep"
     },
     "team": {
-      "oss": {
-        "syncNow": "Sync now"
-      },
       "joinedAt": "Joined",
       "disconnectMigrationRequired": "Cloud database is missing the disable_team_share migration. Apply services/supabase/migrations/20260604120000_disable_team_share.sql and redeploy FC.",
       "disconnectSchemaDrift": "Cloud API schema is out of date (disable_team_share). Deploy the latest FC and Supabase migration, then retry.",

--- a/packages/app/src/locales/en.json
+++ b/packages/app/src/locales/en.json
@@ -1060,8 +1060,6 @@
     "confirmDeleteFileDesc": "This will permanently delete this file.",
     "confirmDeleteDirDesc": "This will permanently delete this folder and all its contents.",
     "confirmBatchDeleteDesc": "This will permanently delete all selected items. This action cannot be undone for directories.",
-    "teamLastSyncTooltip": "Last sync: {{time}}",
-    "teamSyncing": "Syncing…",
     "duplicateFailed": "Duplicate failed",
     "undo": "Undo: {{desc}}"
   },

--- a/packages/app/src/locales/en.json
+++ b/packages/app/src/locales/en.json
@@ -1014,10 +1014,10 @@
       "pendingBody": "Running sessions keep their current configuration; the latest configuration loads the next time their runtime starts.",
       "failedGeneric": "Could not read the updated workspace configuration.",
       "dismiss": "Got it"
-    },
-    "selectWorkspace": "Select Workspace"
+    }
   },
   "fileExplorer": {
+    "agentNotStarted": "Agent has not started yet",
     "newFile": "New File",
     "newFolder": "New Folder",
     "copyPath": "Copy Path",
@@ -1108,16 +1108,7 @@
   },
   "sidebar": {
     "apps": "Apps",
-    "newWorkspace": "New workspace",
-    "workspacesLoading": "Loading workspaces…",
-    "noWorkspaces": "No workspaces yet",
     "noWorkspaceSessions": "No sessions in this workspace yet",
-    "workspaceAddFailed": "Failed to add workspace: {{msg}}",
-    "switchToWorkspace": "Switch to this workspace",
-    "workspaceSwitchFailed": "Failed to switch workspace: {{msg}}",
-    "workspaceDeleteFailed": "Failed to delete workspace: {{msg}}",
-    "currentWorkspace": "Current: {{path}}",
-    "defaultWorkspace": "Default workspace",
     "searchSessions": "Search Sessions",
     "searchDescription": "Search and navigate to a session",
     "searchPlaceholder": "Search sessions...",
@@ -1168,7 +1159,6 @@
     "localDaemonExpandSheet": "Expand menu",
     "localDaemonCollapseSheet": "Collapse menu",
     "localDaemonGroupConnection": "Connection",
-    "localDaemonGroupWorkspace": "Workspace",
     "localDaemonGroupDevice": "Device",
     "localDaemonGroupTeam": "Team",
     "localDaemonDaemonSettings": "Daemon settings",

--- a/packages/app/src/locales/en.json
+++ b/packages/app/src/locales/en.json
@@ -1106,7 +1106,6 @@
   },
   "sidebar": {
     "apps": "Apps",
-    "noWorkspaceSessions": "No sessions in this workspace yet",
     "searchSessions": "Search Sessions",
     "searchDescription": "Search and navigate to a session",
     "searchPlaceholder": "Search sessions...",
@@ -1887,6 +1886,10 @@
       "resetIncomplete": "Reset did not take effect: this machine is still bound to team {{teamId}}. Check ~/.amuxd/logs/amuxd.managed.log."
     },
     "daemonWorkspaces": {
+      "current": "Open",
+      "open": "Open",
+      "opened": "Opened {{name}}",
+      "openFailed": "Could not open this workspace: {{msg}}",
       "title": "Workspace",
       "description": "Manage workspaces that daemon agents can use",
       "noTeam": "Join or create a team before configuring daemon workspaces.",

--- a/packages/app/src/locales/en.json
+++ b/packages/app/src/locales/en.json
@@ -531,8 +531,7 @@
       "failedClickToRetry": "Failed — click to retry"
     },
     "newChat": "New Chat",
-    "newChatMoreOptions": "More new chat options",
-    "newMultiPersonSession": "Group Session",
+    "advancedSession": "Advanced session",
     "quickSessionCreateError": "Could not start a session",
     "quickSessionNoAgentHint": "Set a personal default agent, or ask admin for a team default.",
     "quickSessionNoAgentTitle": "No default agent set",
@@ -834,7 +833,21 @@
       "create": "Create session",
       "noActorError": "No member identity found for this team",
       "createError": "Failed to create session",
-      "removeParticipantAria": "Remove participant"
+      "removeParticipantAria": "Remove participant",
+      "localAgentBadge": "This machine",
+      "noTeamTitle": "No team yet",
+      "noTeamHint": "Create or join a team before starting a session.",
+      "workspaceLabel": "Workspace",
+      "workspaceScope": "Applies to the agent on this machine",
+      "workspaceNone": "No workspace on this machine yet",
+      "workspaceDefaultTag": "default",
+      "workspaceBrowse": "Choose a workspace folder",
+      "workspaceBrowseAction": "Browse…",
+      "workspaceAddFailed": "Failed to add workspace: {{msg}}",
+      "workspaceSetDefault": "Set as default",
+      "workspaceDefaultWarning": "Changes this agent's default folder for every future session and scheduled task",
+      "workspaceDefaultSet": "Default workspace updated",
+      "workspaceDefaultFailed": "Failed to set default workspace: {{msg}}"
     },
     "commandPopover": {
       "prompt": "Select role, skill, or command",

--- a/packages/app/src/locales/zh-CN.json
+++ b/packages/app/src/locales/zh-CN.json
@@ -1060,8 +1060,6 @@
     "confirmDeleteFileDesc": "此操作将永久删除该文件。",
     "confirmDeleteDirDesc": "此操作将永久删除该文件夹及其所有内容。",
     "confirmBatchDeleteDesc": "此操作将永久删除所有选中项。文件夹删除后无法撤销。",
-    "teamLastSyncTooltip": "最后同步：{{time}}",
-    "teamSyncing": "同步中…",
     "duplicateFailed": "创建副本失败",
     "undo": "撤销：{{desc}}"
   },

--- a/packages/app/src/locales/zh-CN.json
+++ b/packages/app/src/locales/zh-CN.json
@@ -2407,9 +2407,6 @@
       "secretStored": "已配置 · 留空即保持不变"
     },
     "team": {
-      "oss": {
-        "syncNow": "立即同步"
-      },
       "joinedAt": "加入时间",
       "disconnectMigrationRequired": "云端数据库缺少 disable_team_share 迁移。请应用 services/supabase/migrations/20260604120000_disable_team_share.sql 并重新部署 FC。",
       "disconnectSchemaDrift": "Cloud API 架构过旧（缺少 disable_team_share）。请部署最新 FC 与 Supabase 迁移后重试。",

--- a/packages/app/src/locales/zh-CN.json
+++ b/packages/app/src/locales/zh-CN.json
@@ -1106,7 +1106,6 @@
   },
   "sidebar": {
     "apps": "应用",
-    "noWorkspaceSessions": "该工作区下暂无会话",
     "searchSessions": "搜索会话",
     "searchDescription": "搜索并导航到会话",
     "searchPlaceholder": "搜索会话...",
@@ -1887,6 +1886,10 @@
       "resetIncomplete": "重置未生效：本机仍绑定在团队 {{teamId}} 上。请查看 ~/.amuxd/logs/amuxd.managed.log。"
     },
     "daemonWorkspaces": {
+      "current": "当前",
+      "open": "打开",
+      "opened": "已切换到 {{name}}",
+      "openFailed": "打开工作目录失败：{{msg}}",
       "title": "工作区",
       "description": "管理 Daemon Agent 可使用的 workspace",
       "noTeam": "加入或创建团队后再配置 Daemon workspace。",

--- a/packages/app/src/locales/zh-CN.json
+++ b/packages/app/src/locales/zh-CN.json
@@ -531,8 +531,7 @@
       "failedClickToRetry": "发送失败 — 点击重试"
     },
     "newChat": "新聊天",
-    "newChatMoreOptions": "更多新建选项",
-    "newMultiPersonSession": "多人会话",
+    "advancedSession": "高级会话",
     "quickSessionCreateError": "无法创建会话",
     "quickSessionNoAgentHint": "请设置个人默认 Agent，或联系管理员设置团队默认 Agent。",
     "quickSessionNoAgentTitle": "尚未设置默认 Agent",
@@ -834,7 +833,21 @@
       "create": "创建会话",
       "noActorError": "当前团队没有找到成员身份",
       "createError": "创建会话失败",
-      "removeParticipantAria": "移除成员"
+      "removeParticipantAria": "移除成员",
+      "localAgentBadge": "本机",
+      "noTeamTitle": "还没有团队",
+      "noTeamHint": "先创建或加入一个团队，才能发起会话。",
+      "workspaceLabel": "工作目录",
+      "workspaceScope": "仅对本机 Agent 生效",
+      "workspaceNone": "本机还没有工作目录",
+      "workspaceDefaultTag": "默认",
+      "workspaceBrowse": "选择工作目录",
+      "workspaceBrowseAction": "浏览…",
+      "workspaceAddFailed": "添加工作目录失败：{{msg}}",
+      "workspaceSetDefault": "设为默认",
+      "workspaceDefaultWarning": "将改变该 Agent 今后所有会话与定时任务的默认目录",
+      "workspaceDefaultSet": "已设为默认工作目录",
+      "workspaceDefaultFailed": "设置默认工作目录失败：{{msg}}"
     },
     "commandPopover": {
       "prompt": "选择角色、技能或命令",

--- a/packages/app/src/locales/zh-CN.json
+++ b/packages/app/src/locales/zh-CN.json
@@ -1014,10 +1014,10 @@
       "pendingBody": "运行中的会话保持当前配置，运行环境下次启动时自动加载最新配置。",
       "failedGeneric": "无法读取更新后的工作区配置。",
       "dismiss": "知道了"
-    },
-    "selectWorkspace": "选择工作区"
+    }
   },
   "fileExplorer": {
+    "agentNotStarted": "Agent 尚未启动",
     "newFile": "新建文件",
     "newFolder": "新建文件夹",
     "copyPath": "复制路径",
@@ -1108,16 +1108,7 @@
   },
   "sidebar": {
     "apps": "应用",
-    "newWorkspace": "新建工作区",
-    "workspacesLoading": "正在加载工作区…",
-    "noWorkspaces": "暂无工作区",
     "noWorkspaceSessions": "该工作区下暂无会话",
-    "workspaceAddFailed": "添加工作区失败：{{msg}}",
-    "switchToWorkspace": "切换到此工作区",
-    "workspaceSwitchFailed": "切换工作区失败：{{msg}}",
-    "workspaceDeleteFailed": "删除工作区失败：{{msg}}",
-    "currentWorkspace": "当前：{{path}}",
-    "defaultWorkspace": "默认工作区",
     "searchSessions": "搜索会话",
     "searchDescription": "搜索并导航到会话",
     "searchPlaceholder": "搜索会话...",
@@ -1168,7 +1159,6 @@
     "localDaemonExpandSheet": "展开菜单",
     "localDaemonCollapseSheet": "收起菜单",
     "localDaemonGroupConnection": "连接",
-    "localDaemonGroupWorkspace": "Workspace",
     "localDaemonGroupDevice": "设备",
     "localDaemonGroupTeam": "团队",
     "localDaemonDaemonSettings": "Daemon 设置",

--- a/packages/app/src/stores/__tests__/daemon-onboarding-refresh.test.ts
+++ b/packages/app/src/stores/__tests__/daemon-onboarding-refresh.test.ts
@@ -152,7 +152,6 @@ const reset = () =>
     cloudAuthExpired: false,
     healing: false,
     healError: null,
-    workspaceSyncEpoch: 0,
   })
 
 beforeEach(() => {
@@ -445,7 +444,6 @@ describe('daemon-onboarding refresh() orchestration', () => {
     expect(setAgentDefaultWorkspace).toHaveBeenCalledWith('actor-1', 'ws-cloud-1')
     expect(h.invokeCalls).toContain('register_daemon_workspace')
     expect(h.registerArgs?.workspacePath).toBe('/home/u/projects/app')
-    expect(useDaemonOnboardingStore.getState().workspaceSyncEpoch).toBe(1)
   })
 
   it('skips local daemon mirror while cloud auth is expired but still registers cloud workspace', async () => {
@@ -457,9 +455,9 @@ describe('daemon-onboarding refresh() orchestration', () => {
     h.probeQueue = [{ ok: true, baseUrl: 'http://127.0.0.1:1' }]
     await useDaemonOnboardingStore.getState().refresh()
     expect(useDaemonOnboardingStore.getState().status).toBe('ready')
-    // Cloud row is written with the app JWT so the sidebar can populate.
+    // Cloud row is written with the app JWT, so Settings and the advanced
+    // new-session dialog can list it.
     expect(createDaemonWorkspace).toHaveBeenCalled()
-    expect(useDaemonOnboardingStore.getState().workspaceSyncEpoch).toBe(1)
     // Local amuxd mirror needs daemon cloud auth — skipped while expired.
     expect(h.invokeCalls).not.toContain('register_daemon_workspace')
   })

--- a/packages/app/src/stores/__tests__/daemon-onboarding-steps.test.ts
+++ b/packages/app/src/stores/__tests__/daemon-onboarding-steps.test.ts
@@ -131,7 +131,6 @@ beforeEach(() => {
     runStartedAt: null,
     completedAgent: null,
     pendingName: null,
-    workspaceSyncEpoch: 0,
   })
 })
 

--- a/packages/app/src/stores/daemon-onboarding.ts
+++ b/packages/app/src/stores/daemon-onboarding.ts
@@ -444,7 +444,13 @@ async function ensureHealthy(): Promise<boolean> {
  * side effect after status flipped to ready. That raced the agent bind and
  * never told the sidebar to reload, so WORKSPACE stayed empty until a later
  * incidental refresh. Fix: after bind, POST /v1/workspaces with this machine's
- * agentId (user JWT), bump workspaceSyncEpoch so LocalDaemonRow reloads.
+ * agentId (user JWT).
+ *
+ * `workspaceSyncEpoch` was the reload signal for the sidebar's workspace list.
+ * That list is gone — workspaces are managed in Settings and picked per session
+ * in the advanced new-session dialog — so the counter currently has no reader.
+ * Kept as the signal for whoever needs to react to a newly registered
+ * workspace next.
  *
  * The local daemon mirror is best-effort and needs daemon cloud auth.
  */

--- a/packages/app/src/stores/daemon-onboarding.ts
+++ b/packages/app/src/stores/daemon-onboarding.ts
@@ -178,7 +178,6 @@ type DaemonOnboardingState = {
    * LocalDaemonRow listens and reloads so the panel does not stay empty until
    * a later incidental refresh.
    */
-  workspaceSyncEpoch: number
   /** Create this machine's agent under `name` and finish binding. */
   nameDeviceAgent: (name: string) => Promise<void>
   /** `forceIdentityRebind` re-binds even when the daemon already points at the
@@ -446,12 +445,6 @@ async function ensureHealthy(): Promise<boolean> {
  * incidental refresh. Fix: after bind, POST /v1/workspaces with this machine's
  * agentId (user JWT).
  *
- * `workspaceSyncEpoch` was the reload signal for the sidebar's workspace list.
- * That list is gone — workspaces are managed in Settings and picked per session
- * in the advanced new-session dialog — so the counter currently has no reader.
- * Kept as the signal for whoever needs to react to a newly registered
- * workspace next.
- *
  * The local daemon mirror is best-effort and needs daemon cloud auth.
  */
 async function ensureDefaultWorkspaceRegistered(teamId: string): Promise<void> {
@@ -499,11 +492,6 @@ async function ensureDefaultWorkspaceRegistered(teamId: string): Promise<void> {
       console.warn('[daemon-onboarding] set default workspace failed', e)
     }
   }
-
-  // Sidebar can reload as soon as the cloud row exists.
-  useDaemonOnboardingStore.setState((s) => ({
-    workspaceSyncEpoch: s.workspaceSyncEpoch + 1,
-  }))
 
   // Local daemon registry (cron / model catalog). Needs daemon cloud auth.
   // checkCloudSession already ran before us — if it left cloudAuthExpired,
@@ -578,7 +566,6 @@ export const useDaemonOnboardingStore = create<DaemonOnboardingState>((set, get)
   runStartedAt: null,
   completedAgent: null,
   pendingName: null,
-  workspaceSyncEpoch: 0,
 
   nameDeviceAgent: async (name) => {
     const pending = get().pendingName

--- a/packages/app/src/stores/ui.ts
+++ b/packages/app/src/stores/ui.ts
@@ -47,7 +47,6 @@ export type SidebarFilter =
    *  It spans every actor kind, external gateway contacts included. */
   | { kind: 'actor'; actorId: string; displayName: string; actorType: 'member' | 'agent' | 'external' }
   | { kind: 'idea'; ideaId: string; title: string }
-  | { kind: 'workspace'; workspaceId: string | null; path: string; name: string }
   | { kind: 'teamShare'; section: TeamShareSection }
 
 export type SettingsSection = 'llm' | 'general' | 'prompt' | 'channels' | 'automation' | 'daemonGeneral' | 'daemonWorkspaces' | 'daemonRuntimes' | 'envVars' | 'skills' | 'roles' | 'rolesSkills' | 'deps' | 'billing'


### PR DESCRIPTION
新会话入口改成分体按钮，右半直接开「高级会话」；工作目录在那里按会话选，只对本机 Agent 生效；左下角浮层不再列 workspace，文件树改为跟着会话走；文件树上两处团队同步的入口一并删掉。

## 1. 分体按钮（`NewChatSplitButton`）

右半原来是个 chevron，展开一个只有一项的内联菜单。现在直接打开对话框，图标换成 sliders，并且**永不禁用** —— 没有默认 Agent 时左半是死的，手动挑参与者是唯一还能开聊的路径。`no_team` 也能点开，落在一个空态上，这是原来那个禁用的 chevron 说不出来的话。

`chat.newMultiPersonSession` 在三个入口（分体按钮、会话列表头、窄屏头）统一改名 `chat.advancedSession` —— 同一个对话框，一个名字。

## 2. 高级会话里选工作目录

**只对本机 Agent 生效。** 一条 cloud workspace 行属于某一个 Agent，把它的 id 交给远端 daemon，那台机器解析不出来，会回退到自己 onboarding 时的默认目录并**静默**跑错地方（`resolve-runtime-start-workspace.ts` 里已有记录）。所以选择器只在本机 Agent 被选中时出现，取消勾选就丢弃选择。

哪一行是本机**不能靠显示名判断** —— 一个团队里三个 Agent 都叫 `liziliudeMacBook-Air` 是常态 —— 徽标和选择器都以本机 daemon `/v1/info` 的 actor id 为准。

选择落库为该会话在**本地缓存**里的 workspace 绑定，和 `bindAppWorkspace` 写的是同一行，而 `resolveLiveWorkspaceHint` 读它的优先级高于 workspace store、Agent 默认值和 Agent 自有行。写在第一条消息之前，所以没有任何 runtime 能抢在它前面启动。这里不能用「传一个 hint 参数」：对话框本身不启动 runtime（ChatPanel 和 outbox sender 稍后才启动），首次发送失败后 outbox 重试时那个参数早就不在了。

「设为默认」写 `agents.default_workspace_id` 并同步刷新发送路径的缓存（缓存陈旧正是首条消息付两次冷启动的成因）。tooltip 写明代价：这一列也是 cron 和网关会话解析目录用的，那些场景没有客户端在场。

## 3. 左下角浮层 + 文件树

浮层里的 workspace 列表（新增 / 切换 / 删除）和头部的当前 workspace 名删除 —— 它是第三个改同一件事的地方。

**没有东西接替它当切换器，也不需要**：`switchToSessionWorkspaceIfNeeded` 早就在打开会话时用会话自己的绑定驱动 workspace store，而那个 store 有约 60 个读点，必须继续互相一致。文件树是**报告** store 在哪，而不是另开一个真相源。

树换来的是「它显示的到底是谁的目录」这件事说得清楚：

- 文件树和终端都够得到本机文件系统，所以**会话里没有本机 Agent 时两者都隐藏** —— 以前它们会挂在那儿显示上一个会话的目录
- 本机 Agent 在场但还没有 runtime 绑定过目录（刚建的会话）时，显示「Agent 尚未启动」而不是渲染一棵过期的树
- 底部固定一行标出 Agent 名和路径

`shortenWorkspacePath` 给这一行和对话框那行做左截断。`truncate` 砍的是尾巴，而尾巴恰恰是区分三个同级 checkout 的那一半；`dir="rtl"` 能修这个但会坏另一件事 —— bidi 把 `/` 当中性字符，绝对路径开头的斜杠会被重排到视觉末尾。

## 4. 文件树上的团队同步入口

工具栏的「立即同步」按钮，以及 `teamclu-team` 节点上的「同步中… / 上次同步」角标，都在描述 `~/.amuxd/teams/<id>/shared/team-sync/` —— **不是**它们所在的这棵树。触发和状态都归团队共享那一列（`KnowledgeSyncFooter`）所有。角标没了之后，`FileBrowser` 里那个每次切 workspace 都发一次的 `oss_sync_status` IPC 也没有读者了，一并删除。`oss-sync` store 本身保留。

## 5. Review 修掉的（`/code-review` 15 条，逐条核实）

12 条是真 bug，其中几条打脸：

- **切会话时报旧路径** —— `boundPath` 从不清空，A→B 的整个解析往返里都在报 A 的目录，正是这个功能要修的 bug
- **标签盖在错的树上** —— 页脚报绑定路径而树从 store 渲染，两者会不一致；现在 store 没跟上就不给路径
- **终端开在上个会话的目录** —— 拿的还是 ambient path；树能自愈，shell 不能
- **本机身份可能永远到不了** —— `getKnownLocalDaemonActorId()` 塞在 `useMemo` 里观察不到它落地，全新安装会永久隐藏文件树和终端
- **一次点击 4 个云请求** —— 无关的 dep + 两个 hook 实例；去掉 dep 并共享 in-flight
- **App 根订阅整张参与者表** —— 选择器收窄到当前会话
- **浏览选的目录被静默丢弃** —— 重新拉列表吞异常后 id 指向空气，会话建在默认目录且无提示
- **新建 workspace 5 秒内解析不出来** —— viewer context 缓存窗口内的新行拿到 null path，反而压过本地缓存回退
- **建会话路径上多一次 IPC+HTTP** —— daemon 一时不可达就把用户选的目录扔了
- **Windows 路径根本没被截断** —— 只按 `/` split
- 列表加载补回 generation guard；`workspaceNameFromPath` 第四份拷贝合并

剩下三条按 review 一并处理：

- 删掉 `{kind:'workspace'}` 侧栏筛选（唯一生产者已随列表删除，四处消费分支不可达）
- Settings › Daemon workspaces 加「打开」动作 —— 否则绑定解析不出来的会话会**永久**卡在「Agent 尚未启动」，用户无法纠正
- 删掉 `workspaceSyncEpoch`（零读者的死状态，每次 refresh 白唤醒所有订阅者）

## 验证

`pnpm typecheck` 通过，`pnpm lint` 0 errors，`pnpm test:unit` **504 files / 3378 tests 通过**。

唯一红的 `SidebarSecondColumn.test.tsx` **不是本分支引入的**：把 `packages/app/src` 整个还原到 `origin/main` 后单独跑，报的是同一个错（lazy 的 `ShortcutsListColumn` chunk 卡在 Suspense）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011tGJPYDAWzbouakfxeZAyZ
