### PR TITLE
fix(daemon): do not block session attach on a pending skills refresh

### DIFF
--- a/apps/daemon/src/http/runtime_adapter.rs
+++ b/apps/daemon/src/http/runtime_adapter.rs
@@ -1655,7 +1655,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn spawn_runtime_refuses_when_skills_refresh_is_blocked_by_active_turn() {
+    async fn spawn_runtime_attaches_when_skills_refresh_is_deferred_by_active_turn() {
         let workspace = tempfile::tempdir().unwrap();
         let workspace_id =
             crate::runtime::refresh::refresh_watch::workspace_runtime_id(workspace.path());
@@ -1687,24 +1687,31 @@ mod tests {
                 captured: Arc::new(std::sync::Mutex::new(Vec::new())),
             })),
         );
-        adapter.set_runtime_supervisor(supervisor);
+        adapter.set_runtime_supervisor(supervisor.clone());
 
-        let err = adapter
+        adapter
             .spawn_runtime_in_worktree(
                 Uuid::new_v4(),
                 amux::AgentType::Opencode,
-                Some(workspace_id),
+                Some(workspace_id.clone()),
                 None,
                 None,
                 workspace.path().to_string_lossy().as_ref(),
             )
             .await
-            .expect_err("busy pending skills must refuse spawn");
-        assert_eq!(err.code, ErrorCode::SessionBusy);
-        assert!(
-            attach_captures.lock().unwrap().is_empty(),
-            "fail-closed attach must not start a runtime"
+            .expect("busy workspace must still attach; skills refresh is deferred");
+        assert_eq!(
+            attach_captures.lock().unwrap().len(),
+            1,
+            "deferred skills must not block runtime start"
         );
+        let dto = supervisor
+            .refresh_coordinator()
+            .runtime_refresh_dto(&workspace_id)
+            .await;
+        assert_eq!(dto.status, "pending");
+        assert!(dto.change_kinds.iter().any(|k| k == "skills"));
+        assert!(dto.auto_apply_blocked_by_active_runtime);
     }
 
     #[tokio::test]

--- a/apps/daemon/src/runtime/supervisor.rs
+++ b/apps/daemon/src/runtime/supervisor.rs
@@ -2209,10 +2209,11 @@ impl RuntimeSupervisor {
         }
     }
 
-    /// Session attach barrier: only an applied Skills refresh may proceed.
+    /// Session attach barrier: apply a pending Skills refresh when idle.
     ///
-    /// `PendingActiveTurn` and dispose/apply errors both refuse the spawn so
-    /// a new session cannot attach to a stale OpenCode instance.
+    /// An active turn must not block a new session: the refresh stays pending
+    /// for the auto-applier (or the next idle attach). Dispose/apply errors
+    /// still refuse the spawn so we never attach to a half-applied instance.
     pub async fn require_skills_refresh_for_attach(
         &self,
         workspace_id: &str,
@@ -2223,9 +2224,7 @@ impl RuntimeSupervisor {
             .await?
         {
             SkillsRefreshApplyStatus::Applied(outcome) => Ok(outcome),
-            SkillsRefreshApplyStatus::PendingActiveTurn => {
-                Err(WorkspaceControlError::ActiveTurn(workspace_id.to_owned()))
-            }
+            SkillsRefreshApplyStatus::PendingActiveTurn => Ok(ApplyOutcome::ReloadRequired),
         }
     }
 }
@@ -3185,7 +3184,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn require_skills_refresh_for_attach_fails_closed_when_busy() {
+    async fn require_skills_refresh_for_attach_defers_when_busy() {
         let dir = tempfile::tempdir().unwrap();
         let workspace_id = refresh_watch::workspace_runtime_id(dir.path());
         let supervisor = RuntimeSupervisor::new(Arc::new(AsyncMutex::new(RuntimeManager::new(
@@ -3212,20 +3211,21 @@ mod tests {
             .await
             .unwrap();
 
-        let err = supervisor
+        let outcome = supervisor
             .require_skills_refresh_for_attach(&workspace_id, dir.path())
             .await
-            .expect_err("busy workspace must refuse attach");
-        assert!(matches!(
-            err,
-            WorkspaceControlError::ActiveTurn(ref id) if id == &workspace_id
-        ));
+            .expect("busy workspace must still attach; skills refresh is deferred");
+        assert!(
+            matches!(outcome, ApplyOutcome::ReloadRequired),
+            "deferred skills stay pending for the next idle apply, got {outcome:?}"
+        );
         let dto = supervisor
             .refresh_coordinator()
             .runtime_refresh_dto(&workspace_id)
             .await;
         assert_eq!(dto.status, "pending");
         assert!(dto.change_kinds.iter().any(|k| k == "skills"));
+        assert!(dto.auto_apply_blocked_by_active_runtime);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- `runtimeStart` no longer fails with `workspace has active turn` when a skills refresh is pending during another turn in the same workspace.
- The pending skills refresh stays queued for the auto-applier (or the next idle attach). Dispose/IO errors still refuse spawn.
- New sessions may briefly run on a stale OpenCode skills cache until the busy turn ends.

## Test plan
- [ ] `cargo test -p amuxd --locked --bin amuxd require_skills_refresh_for_attach`
- [ ] `cargo test -p amuxd --locked --bin amuxd apply_pending_skills_refresh`
- [ ] Manual: with one session generating in a workspace, send a message in a second session of the same workspace — no "Agent runtime 未启动" toast; new skills apply after the first turn ends


Made with [Cursor](https://cursor.com)