### PR TITLE
feat(skills): add an opt-in header button to force-refresh skills

### DIFF
--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -11,6 +11,7 @@ import { buildSessionDeeplink, parseSessionDeeplink } from "@/lib/session/sessio
 import { markStartup } from "@/lib/telemetry/startup-perf";
 import { BookOpen, ChevronLeft, X, PanelRightClose, Link2, Loader2, RotateCw, MessageSquarePlus, AppWindow, Users, SlidersHorizontal } from "lucide-react";
 import { DiagnoseSessionButton } from "@/components/chat/DiagnoseSessionButton";
+import { RefreshSkillsHeaderButton } from "@/components/chat/RefreshSkillsHeaderButton";
 import { useWorkspaceInit } from "@/hooks/use-workspace-init";
 import { useChannelGatewayInit } from "@/hooks/use-channel-gateway-init";
 import { useGitReposInit } from "@/hooks/use-git-repos-init";
@@ -183,6 +184,7 @@ function AppContent() {
   // conditions below. Defaults hidden; users enable per-icon in Settings →
   // General → "会话头部图标". See stores/header-preferences-store.ts.
   const showTerminalToggle = useHeaderPreferencesStore((s) => s.showTerminalToggle);
+  const showSkillsRefresh = useHeaderPreferencesStore((s) => s.showSkillsRefresh);
   const { open: sidebarOpen, setOpen: setSidebarOpen } = useSidebar();
   const hasActiveFileTab = !!useTabsStore(selectActiveTab);
   const hasHiddenTabs = useTabsStore(selectHasHiddenTabs);
@@ -675,6 +677,9 @@ function AppContent() {
                   folder — which a terminal, unlike a tree, then keeps. */}
               {capabilities.workspace && sessionWorkspacePath && showTerminalToggle && (
                 <TerminalToggleButton workspacePath={sessionWorkspacePath} />
+              )}
+              {capabilities.workspace && sessionWorkspacePath && showSkillsRefresh && (
+                <RefreshSkillsHeaderButton workspacePath={sessionWorkspacePath} />
               )}
               {activeSession && hasCurrentSession && (
                 <SessionThreadsHeaderButton sessionId={activeSession.id} />

--- a/packages/app/src/components/chat/RefreshSkillsHeaderButton.tsx
+++ b/packages/app/src/components/chat/RefreshSkillsHeaderButton.tsx
@@ -1,0 +1,52 @@
+import * as React from 'react'
+import { RefreshCw } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+import { toast } from 'sonner'
+import { cn } from '@/lib/utils'
+import { SKILLS_CHANGED_EVENT } from '@/lib/skills/changed-event'
+import {
+  encodeWorkspaceId,
+  notifyDaemonSkillsChanged,
+} from '@/lib/daemon/daemon-local-client'
+import { useWorkspaceRuntimeRefreshStore } from '@/stores/workspace-runtime-refresh'
+
+export function RefreshSkillsHeaderButton({ workspacePath }: { workspacePath: string }) {
+  const { t } = useTranslation()
+  const [busy, setBusy] = React.useState(false)
+
+  const onClick = async () => {
+    if (busy) return
+    setBusy(true)
+    try {
+      const result = await notifyDaemonSkillsChanged(encodeWorkspaceId(workspacePath))
+      window.dispatchEvent(new CustomEvent(SKILLS_CHANGED_EVENT))
+      void useWorkspaceRuntimeRefreshStore.getState().refreshNow(workspacePath)
+      if (result.status === 'pending_active_turn') {
+        toast.message(t('chat.refreshSkillsPending', '当前会话正在运行，Skills 将在结束后生效'))
+      } else {
+        toast.success(t('chat.refreshSkillsApplied', 'Skills 已刷新'))
+      }
+    } catch (error) {
+      toast.error(
+        error instanceof Error
+          ? error.message
+          : t('chat.refreshSkillsFailed', 'Skills 刷新失败'),
+      )
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <button
+      type="button"
+      data-testid="refresh-skills-header-button"
+      disabled={busy}
+      onClick={() => void onClick()}
+      className="rounded p-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground disabled:opacity-50"
+      title={t('chat.refreshSkills', '强制刷新 Skills')}
+    >
+      <RefreshCw className={cn('h-4 w-4', busy && 'animate-spin')} />
+    </button>
+  )
+}

--- a/packages/app/src/components/chat/__tests__/RefreshSkillsHeaderButton.test.tsx
+++ b/packages/app/src/components/chat/__tests__/RefreshSkillsHeaderButton.test.tsx
@@ -1,0 +1,88 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { RefreshSkillsHeaderButton } from '../RefreshSkillsHeaderButton'
+import { SKILLS_CHANGED_EVENT } from '@/lib/skills/changed-event'
+
+const notifyDaemonSkillsChanged = vi.fn()
+const refreshNow = vi.fn(async () => {})
+const toastSuccess = vi.fn()
+const toastMessage = vi.fn()
+const toastError = vi.fn()
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (_key: string, fallback?: string) => fallback ?? _key }),
+}))
+
+vi.mock('sonner', () => ({
+  toast: {
+    success: (...args: unknown[]) => toastSuccess(...args),
+    message: (...args: unknown[]) => toastMessage(...args),
+    error: (...args: unknown[]) => toastError(...args),
+  },
+}))
+
+vi.mock('@/lib/daemon/daemon-local-client', () => ({
+  encodeWorkspaceId: (path: string) => `ws:${path}`,
+  notifyDaemonSkillsChanged: (...args: unknown[]) => notifyDaemonSkillsChanged(...args),
+}))
+
+vi.mock('@/stores/workspace-runtime-refresh', () => ({
+  useWorkspaceRuntimeRefreshStore: {
+    getState: () => ({ refreshNow }),
+  },
+}))
+
+describe('RefreshSkillsHeaderButton', () => {
+  beforeEach(() => {
+    notifyDaemonSkillsChanged.mockReset()
+    refreshNow.mockReset()
+    toastSuccess.mockReset()
+    toastMessage.mockReset()
+    toastError.mockReset()
+  })
+
+  it('refreshes skills and toasts applied', async () => {
+    notifyDaemonSkillsChanged.mockResolvedValue({ ok: true, status: 'applied' })
+    const changed = vi.fn()
+    window.addEventListener(SKILLS_CHANGED_EVENT, changed)
+
+    render(<RefreshSkillsHeaderButton workspacePath="/tmp/ws" />)
+    fireEvent.click(screen.getByRole('button', { name: '强制刷新 Skills' }))
+
+    await waitFor(() => {
+      expect(notifyDaemonSkillsChanged).toHaveBeenCalledWith('ws:/tmp/ws')
+    })
+    expect(changed).toHaveBeenCalled()
+    expect(refreshNow).toHaveBeenCalledWith('/tmp/ws')
+    expect(toastSuccess).toHaveBeenCalledWith('Skills 已刷新')
+    window.removeEventListener(SKILLS_CHANGED_EVENT, changed)
+  })
+
+  it('toasts pending when an active turn blocks apply', async () => {
+    notifyDaemonSkillsChanged.mockResolvedValue({
+      ok: true,
+      status: 'pending_active_turn',
+    })
+
+    render(<RefreshSkillsHeaderButton workspacePath="/tmp/ws" />)
+    fireEvent.click(screen.getByRole('button', { name: '强制刷新 Skills' }))
+
+    await waitFor(() => {
+      expect(toastMessage).toHaveBeenCalledWith(
+        '当前会话正在运行，Skills 将在结束后生效',
+      )
+    })
+    expect(toastSuccess).not.toHaveBeenCalled()
+  })
+
+  it('toasts the daemon error when refresh fails', async () => {
+    notifyDaemonSkillsChanged.mockRejectedValue(new Error('daemon down'))
+
+    render(<RefreshSkillsHeaderButton workspacePath="/tmp/ws" />)
+    fireEvent.click(screen.getByRole('button', { name: '强制刷新 Skills' }))
+
+    await waitFor(() => {
+      expect(toastError).toHaveBeenCalledWith('daemon down')
+    })
+  })
+})

--- a/packages/app/src/components/settings/GeneralSection.tsx
+++ b/packages/app/src/components/settings/GeneralSection.tsx
@@ -15,6 +15,7 @@ import {
   PanelBottom,
   TerminalSquare,
   FolderGit,
+  Sparkles,
 } from 'lucide-react'
 import { toast } from 'sonner'
 import { cn, isTauri } from '@/lib/utils'
@@ -160,6 +161,8 @@ export const GeneralSection = React.memo(function GeneralSection() {
   const setShowTerminalToggle = useHeaderPreferencesStore((s) => s.setShowTerminalToggle)
   const showChangesTab = useHeaderPreferencesStore((s) => s.showChangesTab)
   const setShowChangesTab = useHeaderPreferencesStore((s) => s.setShowChangesTab)
+  const showSkillsRefresh = useHeaderPreferencesStore((s) => s.showSkillsRefresh)
+  const setShowSkillsRefresh = useHeaderPreferencesStore((s) => s.setShowSkillsRefresh)
   const [closePref, setClosePref] = React.useState<'ask' | 'tray' | 'quit'>('ask')
   React.useEffect(() => {
     if (!isTauri()) return
@@ -477,6 +480,24 @@ export const GeneralSection = React.memo(function GeneralSection() {
               <ToggleSwitch
                 enabled={showChangesTab}
                 onChange={setShowChangesTab}
+              />
+            </div>
+          </div>
+
+          <div className="border-t pt-4">
+            <div className="flex items-center justify-between gap-4">
+              <div className="space-y-1">
+                <label className="text-[13px] font-medium flex items-center gap-2">
+                  <Sparkles className="h-4 w-4 text-muted-foreground" />
+                  {t('settings.general.showSkillsRefresh', '强制刷新 Skills')}
+                </label>
+                <p className="text-xs text-muted-foreground">
+                  {t('settings.general.showSkillsRefreshDesc', '在会话右上角显示强制刷新 Skills 的按钮。热更新异常时用来立刻重载当前工作区的 skill 目录。')}
+                </p>
+              </div>
+              <ToggleSwitch
+                enabled={showSkillsRefresh}
+                onChange={setShowSkillsRefresh}
               />
             </div>
           </div>

--- a/packages/app/src/lib/daemon/daemon-local-client.ts
+++ b/packages/app/src/lib/daemon/daemon-local-client.ts
@@ -980,9 +980,16 @@ export async function putDaemonSkill(
   return result.ok ? result.data : null
 }
 
-/** Register a Skills refresh without rewriting files. Next idle apply disposes the OpenCode instance. */
-export async function notifyDaemonSkillsChanged(workspaceId: string): Promise<void> {
-  await daemonFetchData<{ ok: boolean }>(
+export interface DaemonSkillsRefreshResult {
+  ok: boolean
+  status: 'applied' | 'pending_active_turn' | string
+}
+
+/** Register a Skills refresh without rewriting files. Idle apply disposes the OpenCode instance. */
+export async function notifyDaemonSkillsChanged(
+  workspaceId: string,
+): Promise<DaemonSkillsRefreshResult> {
+  return daemonFetchData<DaemonSkillsRefreshResult>(
     `/v1/workspaces/${workspaceId}/skills/refresh`,
     { method: 'POST' },
   )

--- a/packages/app/src/locales/en.json
+++ b/packages/app/src/locales/en.json
@@ -525,6 +525,10 @@
   },
   "chat": {
     "diagnoseSession": "Diagnose this session",
+    "refreshSkills": "Force refresh skills",
+    "refreshSkillsApplied": "Skills refreshed",
+    "refreshSkillsPending": "A turn is running; skills will apply when it ends",
+    "refreshSkillsFailed": "Could not refresh skills",
     "sendStatus": {
       "sending": "Sending…",
       "delivered": "Delivered",
@@ -1599,7 +1603,9 @@
       "showTerminalToggle": "Terminal toggle",
       "showTerminalToggleDesc": "Show the terminal panel toggle in the conversation's top-right. The Ctrl+` shortcut always works regardless of this setting.",
       "showChangesTab": "File changes",
-      "showChangesTabDesc": "Show this session's file-changes entry in the conversation's top-right. Only appears when there is an active session."
+      "showChangesTabDesc": "Show this session's file-changes entry in the conversation's top-right. Only appears when there is an active session.",
+      "showSkillsRefresh": "Force refresh skills",
+      "showSkillsRefreshDesc": "Show a button in the conversation's top-right that reloads this workspace's skill directories. Use it when hot-reload misses a change."
     },
     "llm": {
       "cursorTitle": "Cursor models",

--- a/packages/app/src/locales/zh-CN.json
+++ b/packages/app/src/locales/zh-CN.json
@@ -525,6 +525,10 @@
   },
   "chat": {
     "diagnoseSession": "诊断此会话",
+    "refreshSkills": "强制刷新 Skills",
+    "refreshSkillsApplied": "Skills 已刷新",
+    "refreshSkillsPending": "当前会话正在运行，Skills 将在结束后生效",
+    "refreshSkillsFailed": "Skills 刷新失败",
     "sendStatus": {
       "sending": "发送中…",
       "delivered": "已送达",
@@ -1599,7 +1603,9 @@
       "showTerminalToggle": "终端开关",
       "showTerminalToggleDesc": "在会话右上角显示终端面板开关。快捷键 Ctrl+` 始终可用，不受此设置影响。",
       "showChangesTab": "文件更改",
-      "showChangesTabDesc": "在会话右上角显示本会话的文件更改入口。仅在有活跃会话时显示。"
+      "showChangesTabDesc": "在会话右上角显示本会话的文件更改入口。仅在有活跃会话时显示。",
+      "showSkillsRefresh": "强制刷新 Skills",
+      "showSkillsRefreshDesc": "在会话右上角显示强制刷新 Skills 的按钮。热更新异常时用来立刻重载当前工作区的 skill 目录。"
     },
     "llm": {
       "cursorTitle": "Cursor 模型",

--- a/packages/app/src/stores/__tests__/header-preferences-store.test.ts
+++ b/packages/app/src/stores/__tests__/header-preferences-store.test.ts
@@ -25,6 +25,7 @@ describe("header-preferences-store", () => {
     useHeaderPreferencesStore.setState({
       showTerminalToggle: false,
       showChangesTab: false,
+      showSkillsRefresh: false,
     });
   });
 
@@ -32,6 +33,7 @@ describe("header-preferences-store", () => {
     const s = useHeaderPreferencesStore.getState();
     expect(s.showTerminalToggle).toBe(false);
     expect(s.showChangesTab).toBe(false);
+    expect(s.showSkillsRefresh).toBe(false);
   });
 
   test("setShowTerminalToggle flips state and persists to localStorage", () => {
@@ -41,6 +43,7 @@ describe("header-preferences-store", () => {
     expect(loaded).toEqual({
       showTerminalToggle: true,
       showChangesTab: false,
+      showSkillsRefresh: false,
     });
   });
 
@@ -51,6 +54,7 @@ describe("header-preferences-store", () => {
     expect(loaded).toEqual({
       showTerminalToggle: false,
       showChangesTab: true,
+      showSkillsRefresh: false,
     });
   });
 
@@ -61,16 +65,30 @@ describe("header-preferences-store", () => {
     const s = useHeaderPreferencesStore.getState();
     expect(s.showTerminalToggle).toBe(false);
     expect(s.showChangesTab).toBe(true);
+    expect(s.showSkillsRefresh).toBe(false);
+  });
+
+  test("setShowSkillsRefresh flips state and persists to localStorage", () => {
+    useHeaderPreferencesStore.getState().setShowSkillsRefresh(true);
+    expect(useHeaderPreferencesStore.getState().showSkillsRefresh).toBe(true);
+    const loaded = loadFromStorage(STORAGE_KEY, null);
+    expect(loaded).toEqual({
+      showTerminalToggle: false,
+      showChangesTab: false,
+      showSkillsRefresh: true,
+    });
   });
 
   test("storage helpers round-trip the persisted shape the store writes", () => {
     saveToStorage(STORAGE_KEY, {
       showTerminalToggle: true,
       showChangesTab: true,
+      showSkillsRefresh: true,
     });
     expect(loadFromStorage(STORAGE_KEY, null)).toEqual({
       showTerminalToggle: true,
       showChangesTab: true,
+      showSkillsRefresh: true,
     });
   });
 
@@ -81,8 +99,10 @@ describe("header-preferences-store", () => {
     const loaded = loadFromStorage<Partial<{
       showTerminalToggle: boolean;
       showChangesTab: boolean;
+      showSkillsRefresh: boolean;
     }>>(STORAGE_KEY, {});
     expect(loaded.showTerminalToggle ?? false).toBe(true);
     expect(loaded.showChangesTab ?? false).toBe(false);
+    expect(loaded.showSkillsRefresh ?? false).toBe(false);
   });
 });

--- a/packages/app/src/stores/header-preferences-store.ts
+++ b/packages/app/src/stores/header-preferences-store.ts
@@ -24,8 +24,11 @@ interface HeaderPreferencesState {
   showTerminalToggle: boolean
   /** Show the "Changes" (file diff) panel entry in the conversation header. Default false. */
   showChangesTab: boolean
+  /** Show the force-refresh-skills icon in the conversation header. Default false. */
+  showSkillsRefresh: boolean
   setShowTerminalToggle: (show: boolean) => void
   setShowChangesTab: (show: boolean) => void
+  setShowSkillsRefresh: (show: boolean) => void
 }
 
 const STORAGE_KEY = `${appStoragePrefix}-header-prefs`
@@ -36,6 +39,7 @@ function persist(state: HeaderPreferencesState) {
   saveToStorage(STORAGE_KEY, {
     showTerminalToggle: state.showTerminalToggle,
     showChangesTab: state.showChangesTab,
+    showSkillsRefresh: state.showSkillsRefresh,
   })
 }
 
@@ -44,6 +48,7 @@ export const useHeaderPreferencesStore = create<HeaderPreferencesState>((set, ge
   // fallback is already `{}`, so missing keys read as `undefined` → false.
   showTerminalToggle: persisted.showTerminalToggle ?? false,
   showChangesTab: persisted.showChangesTab ?? false,
+  showSkillsRefresh: persisted.showSkillsRefresh ?? false,
 
   setShowTerminalToggle: (show) => {
     set({ showTerminalToggle: show })
@@ -51,6 +56,10 @@ export const useHeaderPreferencesStore = create<HeaderPreferencesState>((set, ge
   },
   setShowChangesTab: (show) => {
     set({ showChangesTab: show })
+    persist(get())
+  },
+  setShowSkillsRefresh: (show) => {
+    set({ showSkillsRefresh: show })
     persist(get())
   },
 }))


### PR DESCRIPTION
## Description

Skills hot-reload still misses updates. This adds a manual force-refresh button in the conversation header's top-right, gated by the existing **Settings → General → 会话头部图标** prefs and **hidden by default**.

Clicking it calls `POST /v1/workspaces/:id/skills/refresh`, then:
- toasts "applied" when idle
- toasts that it will apply after the current turn if the workspace is busy
- fires `skills-files-changed` so the command picker reloads

## Related Issue

N/A

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Test plan

- [ ] Confirm the header has no new icon with default prefs
- [ ] Enable **强制刷新 Skills** in Settings → General → 会话头部图标
- [ ] Open a session with a local workspace and confirm the refresh icon appears top-right
- [ ] Click it while idle: toast "Skills 已刷新", picker sees updated skills
- [ ] Click it during an active turn: toast that it will apply when the turn ends; the running turn is not interrupted
- [ ] Click it with the daemon down: error toast, no crash


Made with [Cursor](https://cursor.com)