### PR TITLE
docs(agents): move seahelm pane when changing worktrees

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -473,3 +473,18 @@ Give 2-5 short imperative phrases separated by ` | `. seahelm turns that line in
 clickable buttons for the user. Make it the LAST line of your message; do NOT run
 a tool or shell command to produce it.
 <!-- seahelm:suggest:end -->
+
+<!-- seahelm:worktree:start -->
+## Moving into another worktree (seahelm)
+
+seahelm draws one card per git worktree, and your pane is filed under the one it
+started in. If you move into a different worktree and start working there, say so:
+
+    seahelm pane move "$SEAHELM_PANE_ID" <absolute-worktree-path>
+
+Your pane — and everything running in it — moves to that worktree's card, instead
+of a stray empty pane appearing there while you keep reporting under the old one.
+
+Only when you actually work in it. Creating a worktree you do not move into needs
+nothing. seahelm often notices on its own; saying it means it is never missed.
+<!-- seahelm:worktree:end -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -318,3 +318,18 @@ Give 2-5 short imperative phrases separated by ` | `. seahelm turns that line in
 clickable buttons for the user. Make it the LAST line of your message; do NOT run
 a tool or shell command to produce it.
 <!-- seahelm:suggest:end -->
+
+<!-- seahelm:worktree:start -->
+## Moving into another worktree (seahelm)
+
+seahelm draws one card per git worktree, and your pane is filed under the one it
+started in. If you move into a different worktree and start working there, say so:
+
+    seahelm pane move "$SEAHELM_PANE_ID" <absolute-worktree-path>
+
+Your pane — and everything running in it — moves to that worktree's card, instead
+of a stray empty pane appearing there while you keep reporting under the old one.
+
+Only when you actually work in it. Creating a worktree you do not move into needs
+nothing. seahelm often notices on its own; saying it means it is never missed.
+<!-- seahelm:worktree:end -->


### PR DESCRIPTION
## Summary
- Document the `seahelm pane move` convention in `AGENTS.md` and `CLAUDE.md` so agents relocate their pane when they start working in a different worktree
- Prevents seahelm from leaving a stray empty pane on the new worktree while status keeps reporting under the old card

## Test plan
- [ ] Confirm the new section renders correctly in both agent instruction files
- [ ] In a multi-worktree seahelm session, have an agent move into another worktree and verify it issues `seahelm pane move "$SEAHELM_PANE_ID" <path>`


Made with [Cursor](https://cursor.com)