### PR TITLE
fix(release): Windows 官方包 updater 缺 token/endpoints

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -497,6 +497,10 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+          # Bake into the custom Rust updater (option_env!). Without this,
+          # Windows falls into GitHub API mode with an empty token and fails
+          # check_update with "Updater token not configured".
+          UPDATER_GITHUB_TOKEN: ${{ secrets.UPDATER_GITHUB_TOKEN }}
           DEVICE_JWT_SECRET: ${{ secrets.DEVICE_JWT_SECRET }}
         with:
           tagName: ${{ github.ref_name }}

--- a/build.config.production.json
+++ b/build.config.production.json
@@ -7,7 +7,6 @@
     "shortName": "teamclu",
     "updater": {
       "endpoints": [
-        "__OSS_BASE_URL__/releases/latest.json",
         "https://github.com/different-ai-studio/teamclu/releases/latest/download/latest.json"
       ],
       "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDFEMDg3REY5MEI2RDAyMzMKUldRekFtMEwrWDBJSFhTdHYvbStkclEvTEVRNFlpZExxSHNTSTA2V2ZHS0xPUEZ4WnF5d2RxQ0gK"

--- a/build.config.production.json
+++ b/build.config.production.json
@@ -4,7 +4,14 @@
   "app": {
     "name": "TeamClu",
     "displayName": "TeamClu",
-    "shortName": "teamclu"
+    "shortName": "teamclu",
+    "updater": {
+      "endpoints": [
+        "__OSS_BASE_URL__/releases/latest.json",
+        "https://github.com/different-ai-studio/teamclu/releases/latest/download/latest.json"
+      ],
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDFEMDg3REY5MEI2RDAyMzMKUldRekFtMEwrWDBJSFhTdHYvbStkclEvTEVRNFlpZExxSHNTSTA2V2ZHS0xPUEZ4WnF5d2RxQ0gK"
+    }
   },
   "features": {
     "updater": true

--- a/docs/release/desktop.md
+++ b/docs/release/desktop.md
@@ -1,6 +1,13 @@
 # Desktop Release（Tauri）
 
-TeamClu 桌面端通过 **Git tag 触发 GitHub Actions**，自动构建 macOS / Windows 安装包并发布到 GitHub Releases，同时镜像到国内 OSS CDN。
+TeamClu 桌面端有两条独立发布渠道，不要混用：
+
+| 渠道 | 触发 | Workflow | 产物去向 |
+|------|------|----------|----------|
+| 官方 GitHub Release | `v*` tag push | `release.yml` | GitHub Releases（含 `latest.json`） |
+| 每日 Beta（OSS） | nightly / 手动 `workflow_dispatch` | `release-oss.yml`（brand=`teamclu`） | CDN `https://teamclaw.ucar.cc/beta/` |
+
+`release.yml` **不会**把官方包镜像到 OSS；国内 Beta 清单由 `release-oss.yml` 单独发布。
 
 ## 版本号来源
 
@@ -89,33 +96,38 @@ Workflow：`.github/workflows/release.yml`
 |-----|------|------|
 | `release-macos` ×2 | ARM64 + Intel | `.dmg` |
 | `release-windows` | x64 | NSIS `.exe` |
-| `update-release-notes` | — | OSS `latest.json` 镜像 + Release 说明补充 |
 
 Sidecar 随 Desktop 一起编译打包：`teamclu-introspect`、`amuxd`。
 
+国内 Beta 的 OSS 发布是另一条流水线（`release-oss.yml` → `publish-manifest`），把安装包与 `latest.json` 写到 `https://teamclaw.ucar.cc/beta/`（兼容旧 TeamClaw CDN 域名；前缀是 `beta`，不是 `releases`）。
+
 ### 5. 发布后验收
 
-**GitHub Release 资产：**
+**GitHub Release 资产（`release.yml`）：**
 
 - `TeamClu_<version>_aarch64.dmg`
 - `TeamClu_<version>_x64.dmg`
 - `TeamClu_<version>_x64-setup.exe`
-- `latest.json`（Tauri 自动更新清单）
+- `latest.json`（官方包自动更新清单）
 
 **安装验证：**
 
 ```bash
-# 海外（GitHub latest release）
+# 官方 GitHub Release
 curl -fsSL https://raw.githubusercontent.com/different-ai-studio/teamclu/main/scripts/install-mac.sh | bash
 
-# 国内（OSS 镜像，需 OSS secrets 已配置）
-curl -fsSL https://teamclu.ucar.cc/install-mac-cn.sh | bash
+# 每日 Beta（OSS CDN）
+curl -fsSL https://teamclaw.ucar.cc/beta/install.sh | bash
 ```
 
-**自动更新端点（`tauri.conf.json`）：**
+**自动更新端点（按渠道）：**
 
-- `https://teamclu.ucar.cc/releases/latest.json`
-- `https://github.com/different-ai-studio/teamclu/releases/latest/download/latest.json`
+| 渠道 | 清单 URL |
+|------|----------|
+| 官方 GitHub 包（`build.config.production.json` bake） | `https://github.com/different-ai-studio/teamclu/releases/latest/download/latest.json` |
+| 每日 Beta OSS 包（`release-oss.yml` 写入） | `https://teamclaw.ucar.cc/beta/latest.json` |
+
+自定义 Rust updater 读的是编译期 bake 的 `UPDATER_ENDPOINTS`（来自 `build.config`），不是 `tauri.conf.json` 的 `plugins.updater.endpoints`。
 
 **通知：** Release published 后 `wecom-notify.yml` 会推送企业微信（需 `WECOM_WEBHOOK_KEY`）。
 
@@ -128,11 +140,10 @@ curl -fsSL https://teamclu.ucar.cc/install-mac-cn.sh | bash
 | Secret | 用途 |
 |--------|------|
 | `TAURI_SIGNING_PRIVATE_KEY` + `PASSWORD` | Updater 签名（缺失则构建失败） |
-| `BUILD_CONFIG_PRODUCTION` | 生产 `build.config.json` |
 | `DEVICE_JWT_SECRET` | 设备 JWT |
 | `APPLE_CERTIFICATE` + 相关 | macOS 代码签名（缺失则 ad-hoc，用户需 `xattr`） |
-| `OSS_*` | 国内 CDN 镜像（**teamclu 仓库必须配置**，否则 OSS 端点不会更新） |
-| `UPDATER_GITHUB_TOKEN` | macOS / Windows job bake 进自定义 updater（GitHub 兜底模式） |
+| `OSS_*` | 给 `release-oss.yml` / brand-setup 用（每日 Beta 与白标）；**不是** `release.yml` 写官方 GitHub 包清单所需） |
+| `UPDATER_GITHUB_TOKEN` | macOS / Windows `release.yml` job bake 进自定义 updater（GitHub API 兜底） |
 
 生产配置结构参考 `build.config.example.json`。
 

--- a/docs/release/desktop.md
+++ b/docs/release/desktop.md
@@ -132,7 +132,7 @@ curl -fsSL https://teamclu.ucar.cc/install-mac-cn.sh | bash
 | `DEVICE_JWT_SECRET` | 设备 JWT |
 | `APPLE_CERTIFICATE` + 相关 | macOS 代码签名（缺失则 ad-hoc，用户需 `xattr`） |
 | `OSS_*` | 国内 CDN 镜像（**teamclu 仓库必须配置**，否则 OSS 端点不会更新） |
-| `UPDATER_GITHUB_TOKEN` | macOS job 写 GitHub Release |
+| `UPDATER_GITHUB_TOKEN` | macOS / Windows job bake 进自定义 updater（GitHub 兜底模式） |
 
 生产配置结构参考 `build.config.example.json`。
 


### PR DESCRIPTION
## Summary
- Bake the GitHub `latest.json` endpoint (+ pubkey) into `build.config.production.json` so the custom Rust updater uses endpoint mode instead of falling into empty GitHub API mode
- Pass `UPDATER_GITHUB_TOKEN` on the Windows release job (macOS already had it) as the GitHub-mode fallback
- Align `docs/release/desktop.md` secret description with the dual-platform bake
- Do **not** include `__OSS_BASE_URL__/releases/latest.json` — official `release.yml` never publishes there; TeamClu Beta OSS is `https://teamclaw.ucar.cc/beta/latest.json` via `release-oss.yml`

Fixes Windows in-app update failing with `Updater token not configured (GitHub mode requires UPDATER_GITHUB_TOKEN)` on official builds (repro on `v0.4.1-beta.42`).

## Test plan
- [ ] Confirm next `release.yml` Windows job env lists `UPDATER_GITHUB_TOKEN`
- [ ] Confirm Windows build log includes `Using UPDATER_ENDPOINTS=https://github.com/different-ai-studio/teamclu/releases/latest/download/latest.json`
- [ ] Install the new Windows NSIS build and run in-app check update — should not show the token error
- [ ] macOS release still succeeds with the same production config