### PR TITLE
release(desktop): v0.4.1-beta.43

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -268,7 +268,7 @@ dependencies = [
 
 [[package]]
 name = "amuxd"
-version = "0.4.1-beta.42"
+version = "0.4.1-beta.43"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -9461,7 +9461,7 @@ dependencies = [
 
 [[package]]
 name = "teamclu"
-version = "0.4.1-beta.42"
+version = "0.4.1-beta.43"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/apps/daemon/Cargo.toml
+++ b/apps/daemon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "amuxd"
-version = "0.4.1-beta.42"
+version = "0.4.1-beta.43"
 edition = "2021"
 
 [dependencies]

--- a/apps/desktop/Cargo.toml
+++ b/apps/desktop/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "teamclu"
-version = "0.4.1-beta.42"
+version = "0.4.1-beta.43"
 description = "TeamClu - AI Agent Desktop Platform"
 authors = ["TeamClu Team"]
 edition = "2021"

--- a/apps/desktop/tauri.conf.json
+++ b/apps/desktop/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "TeamClu Dev",
-  "version": "0.4.1-beta.42",
+  "version": "0.4.1-beta.43",
   "identifier": "com.teamclu.app",
   "build": {
     "beforeDevCommand": "pnpm --filter @teamclu/app dev",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "teamclu",
-  "version": "0.4.1-beta.42",
+  "version": "0.4.1-beta.43",
   "private": true,
   "description": "TeamClu - AI Agent Desktop Platform",
   "scripts": {


### PR DESCRIPTION
## Summary

Automated desktop release bump **→ v0.4.1-beta.43** via `scripts/release-desktop.sh`.

- Version sources + `Cargo.lock` (teamclu/amuxd) aligned
- Local frontend build + preflight passed

## Test plan

- [ ] CI green on PR
- [ ] Tag `v0.4.1-beta.43` triggers Release workflow
- [ ] GitHub Release assets published (macOS DMG + Windows NSIS)