### PR TITLE
fix(desktop): kill amuxd sidecars on Windows NSIS uninstall/upgrade

### DIFF
--- a/apps/desktop/tauri.conf.json
+++ b/apps/desktop/tauri.conf.json
@@ -71,6 +71,11 @@
     "macOS": {
       "entitlements": "./Entitlements.plist"
     },
+    "windows": {
+      "nsis": {
+        "installerHooks": "./windows/installer-hooks.nsh"
+      }
+    },
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",

--- a/apps/desktop/windows/installer-hooks.nsh
+++ b/apps/desktop/windows/installer-hooks.nsh
@@ -1,0 +1,41 @@
+; Kill sidecars that NSIS does not know about before it copies or deletes
+; install-dir files. Tauri's CheckIfAppIsRunning only closes ${MAINBINARYNAME}.exe;
+; amuxd / teamclu-introspect are externalBin children with kill_on_drop(false), so
+; a force-closed (or crashed) desktop leaves them holding amuxd.exe /
+; teamclu-introspect.exe open — Windows then refuses Delete / File overwrite and
+; uninstall leaves the binaries behind (or the upgrade keeps a stale sidecar).
+;
+; Also drop the legacy ONLOGON scheduled task named "amuxd" (pre desktop-managed
+; era). Best-effort: errors are ignored so a clean machine is not blocked.
+;
+; Deliberately no `"$INSTDIR\amuxd.exe" stop` here: a hung daemon would stall the
+; installer; taskkill /T is enough to release the PE image lock.
+
+!macro TEAMCLU_STOP_SIDECARS
+  ; /T kills the process tree (opencode serve children, etc.). Image names match
+  ; both the packaged plain names and any leftover target-triple copies.
+  nsExec::ExecToLog 'taskkill /F /T /IM amuxd.exe'
+  Pop $R9
+  nsExec::ExecToLog 'taskkill /F /T /IM amuxd-x86_64-pc-windows-msvc.exe'
+  Pop $R9
+  nsExec::ExecToLog 'taskkill /F /T /IM teamclu-introspect.exe'
+  Pop $R9
+  nsExec::ExecToLog 'taskkill /F /T /IM teamclu-introspect-x86_64-pc-windows-msvc.exe'
+  Pop $R9
+
+  ; Give the kernel a beat to release the PE image mappings before Delete/File.
+  Sleep 800
+
+  ; Legacy: amuxd install-service registered an ONLOGON task. Desktop-managed
+  ; mode no longer creates it, but old installs still have it.
+  nsExec::ExecToLog 'schtasks /Delete /F /TN amuxd'
+  Pop $R9
+!macroend
+
+!macro NSIS_HOOK_PREINSTALL
+  !insertmacro TEAMCLU_STOP_SIDECARS
+!macroend
+
+!macro NSIS_HOOK_PREUNINSTALL
+  !insertmacro TEAMCLU_STOP_SIDECARS
+!macroend


### PR DESCRIPTION
## Summary
- NSIS only closes the main `teamclu.exe`; leftover `amuxd` / `teamclu-introspect` (externalBin, `kill_on_drop(false)`) keep the install-dir binaries locked, so uninstall cannot delete them and upgrades can leave a stale sidecar.
- Add `NSIS_HOOK_PREINSTALL` / `PREUNINSTALL` hooks that `taskkill` those processes (and drop the legacy `amuxd` scheduled task), wired via `bundle.windows.nsis.installerHooks`.

## Test plan
- [ ] Build a Windows NSIS installer that includes this hook
- [ ] Start the app so `amuxd.exe` / `teamclu-introspect.exe` are running under the install dir
- [ ] Run uninstall (or install over the existing copy) while those processes are still alive
- [ ] Confirm the installer no longer fails on locked files and the install dir / scheduled task `amuxd` are cleaned up
