### PR TITLE
fix(daemon): prefer local worktree when cloud path is foreign

### DIFF
--- a/apps/daemon/src/daemon/server/runtime_lifecycle.rs
+++ b/apps/daemon/src/daemon/server/runtime_lifecycle.rs
@@ -3,6 +3,23 @@
 
 use super::*;
 
+/// True when the workspace's stored path cannot be used on this machine while
+/// the client sent one that can.
+///
+/// A workspace row stores an absolute path on whichever machine created it, so
+/// a teammate's app points at *their* home directory. Feeding that to
+/// `Command::current_dir` fails the spawn with `NotFound`, which the pi runtime
+/// then reports as a missing Node.js. Both sides must be checked: an empty or
+/// non-existent client path is no better than the cloud's, and a cloud path
+/// that does exist here stays authoritative.
+fn prefer_client_worktree(cloud_path: &str, client_worktree: &str) -> bool {
+    let cloud = cloud_path.trim();
+    !cloud.is_empty()
+        && !std::path::Path::new(cloud).is_dir()
+        && !client_worktree.is_empty()
+        && std::path::Path::new(client_worktree).is_dir()
+}
+
 /// The local fast-path starts before cloud workspace resolution and therefore
 /// legitimately has no workspace id. A concurrent focus/ensure request for
 /// the same directory has the canonical id; it must reuse that runtime rather
@@ -172,6 +189,22 @@ impl DaemonServer {
                 // local path. Falling through to the client's worktree beats
                 // handing env setup an empty directory.
                 Ok(ws) if ws.path.trim().is_empty() && !worktree.is_empty() => {
+                    (worktree.to_string(), workspace_id.to_string())
+                }
+                // The stored path is an absolute path on whichever machine
+                // created the workspace. A teammate's app row therefore points
+                // at *their* home directory, which does not exist here — and
+                // handing that to `Command::current_dir` fails the spawn with
+                // `NotFound`, reported as a missing binary. The client sends
+                // the path it actually has, so prefer it when the cloud's is
+                // not a directory on this machine.
+                Ok(ws) if prefer_client_worktree(&ws.path, worktree) => {
+                    warn!(
+                        workspace_id,
+                        cloud_path = %ws.path,
+                        local_path = worktree,
+                        "workspace path does not exist here (likely another member's machine); using the client's path"
+                    );
                     (worktree.to_string(), workspace_id.to_string())
                 }
                 Ok(ws) => (ws.path, workspace_id.to_string()),
@@ -1045,7 +1078,7 @@ impl DaemonServer {
 
 #[cfg(test)]
 mod workspace_binding_tests {
-    use super::same_runtime_workspace;
+    use super::{prefer_client_worktree, same_runtime_workspace};
 
     #[test]
     fn local_fast_path_and_canonical_workspace_id_share_one_runtime() {
@@ -1070,6 +1103,51 @@ mod workspace_binding_tests {
             "workspace-1",
             "/Users/test/project",
             "workspace-2",
+        ));
+    }
+
+    /// The bug this guards: a teammate created the app, so the workspace row
+    /// holds *their* absolute path. Running it here used to hand that path to
+    /// `Command::current_dir`, and the resulting spawn `NotFound` surfaced as
+    /// "managed Node.js not found; run `amuxd install-pi`" — against a Node.js
+    /// that was present the whole time.
+    #[test]
+    fn another_machines_workspace_path_yields_to_the_local_one() {
+        let local = tempfile::tempdir().expect("tempdir");
+        let local_path = local.path().to_string_lossy().into_owned();
+        assert!(prefer_client_worktree(
+            "/Users/someone-else/.amuxd/teams/t/apps/a",
+            &local_path
+        ));
+    }
+
+    #[test]
+    fn a_usable_cloud_path_stays_authoritative() {
+        let cloud = tempfile::tempdir().expect("tempdir");
+        let local = tempfile::tempdir().expect("tempdir");
+        // The cloud path exists here: it is the source of truth, not a guess.
+        assert!(!prefer_client_worktree(
+            &cloud.path().to_string_lossy(),
+            &local.path().to_string_lossy()
+        ));
+    }
+
+    #[test]
+    fn a_client_path_that_is_no_better_is_not_preferred() {
+        let local = tempfile::tempdir().expect("tempdir");
+        // Nothing to fall back to.
+        assert!(!prefer_client_worktree("/Users/someone-else/app", ""));
+        // The client's path does not exist here either — swapping one broken
+        // path for another only moves the error.
+        assert!(!prefer_client_worktree(
+            "/Users/someone-else/app",
+            "/also/missing"
+        ));
+        // An empty cloud path is handled by its own arm before this one.
+        assert!(!prefer_client_worktree("", &local.path().to_string_lossy()));
+        assert!(!prefer_client_worktree(
+            "   ",
+            &local.path().to_string_lossy()
         ));
     }
 }

--- a/apps/daemon/src/runtime/pi_rpc/process.rs
+++ b/apps/daemon/src/runtime/pi_rpc/process.rs
@@ -500,19 +500,9 @@ impl PiProcessPool {
             session_dir = %session_dir.display(),
             "spawning pi child"
         );
-        let mut child = cmd.spawn().map_err(|e| {
-            if e.kind() == std::io::ErrorKind::NotFound {
-                crate::error::agent_binary_missing(
-                    "pi",
-                    format_args!(
-                        "managed Node.js ({}) not found; run `amuxd install-pi`",
-                        launch.node.display()
-                    ),
-                )
-            } else {
-                crate::error::AmuxError::Agent(format!("spawn pi ({}): {e}", launch.node.display()))
-            }
-        })?;
+        let mut child = cmd
+            .spawn()
+            .map_err(|e| spawn_failure(&e, worktree, &launch.node))?;
 
         let stdin = child
             .stdin
@@ -744,6 +734,36 @@ pub(crate) fn test_pool_key(worktree: &str) -> PoolKey {
         env_revision: ProcessEnvRevision::from_bindings(&HashMap::new()),
         worktree: worktree.to_string(),
     }
+}
+
+/// Name what is actually missing when spawning pi fails.
+///
+/// `Command::spawn` reports a missing program *and* a missing `current_dir` as
+/// the same `NotFound`. The worktree is the one that goes missing in practice:
+/// a workspace row stores an absolute path from whichever machine created it,
+/// so a teammate's app points somewhere that does not exist here. Blaming the
+/// binary sent people to `amuxd install-pi` for a Node.js that was present the
+/// whole time, which is a dead end — so check the cwd before the binary.
+fn spawn_failure(
+    err: &std::io::Error,
+    worktree: &str,
+    node: &std::path::Path,
+) -> crate::error::AmuxError {
+    if err.kind() != std::io::ErrorKind::NotFound {
+        return crate::error::AmuxError::Agent(format!("spawn pi ({}): {err}", node.display()));
+    }
+    if !std::path::Path::new(worktree).is_dir() {
+        return crate::error::AmuxError::Agent(format!(
+            "pi worktree does not exist on this machine: {worktree}"
+        ));
+    }
+    crate::error::agent_binary_missing(
+        "pi",
+        format_args!(
+            "managed Node.js ({}) not found; run `amuxd install-pi`",
+            node.display()
+        ),
+    )
 }
 
 #[cfg(test)]
@@ -1000,5 +1020,53 @@ mod tests {
 
         in_flight.abort();
         shared.pool.kill_all();
+    }
+
+    /// The misdiagnosis this guards: a teammate's workspace path does not
+    /// exist here, `spawn` reports `NotFound` for the *cwd*, and the daemon
+    /// used to blame the binary — sending people to `amuxd install-pi` for a
+    /// Node.js that was sitting right there.
+    #[test]
+    fn a_missing_worktree_is_not_blamed_on_node() {
+        let err = std::io::Error::from(std::io::ErrorKind::NotFound);
+        let msg = spawn_failure(
+            &err,
+            "/Users/someone-else/.amuxd/teams/t/apps/a",
+            std::path::Path::new("/usr/local/bin/node"),
+        )
+        .to_string();
+        assert!(msg.contains("worktree does not exist"), "{msg}");
+        // The whole point: do not send anyone to reinstall a working runtime.
+        assert!(!msg.contains("install-pi"), "{msg}");
+        assert!(!msg.contains("Node.js"), "{msg}");
+    }
+
+    #[test]
+    fn a_genuinely_missing_binary_still_names_the_binary() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let err = std::io::Error::from(std::io::ErrorKind::NotFound);
+        let msg = spawn_failure(
+            &err,
+            &dir.path().to_string_lossy(),
+            std::path::Path::new("/nope/node"),
+        )
+        .to_string();
+        // `agent_binary_missing(pi)` is a wire contract the desktop matches on.
+        assert!(msg.contains("agent_binary_missing(pi)"), "{msg}");
+        assert!(msg.contains("install-pi"), "{msg}");
+    }
+
+    #[test]
+    fn other_spawn_errors_pass_through_unchanged() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let err = std::io::Error::from(std::io::ErrorKind::PermissionDenied);
+        let msg = spawn_failure(
+            &err,
+            &dir.path().to_string_lossy(),
+            std::path::Path::new("/x/node"),
+        )
+        .to_string();
+        assert!(msg.contains("spawn pi"), "{msg}");
+        assert!(!msg.contains("worktree does not exist"), "{msg}");
     }
 }


### PR DESCRIPTION
## Summary
- When a workspace row stores another machine's absolute path, prefer the client's local worktree if it exists, instead of feeding a missing `current_dir` into pi spawn.
- Distinguish spawn `NotFound` for a missing worktree vs a missing Node.js binary, so teammates are not sent to `amuxd install-pi` for a working runtime.

## Test plan
- [ ] Unit: `prefer_client_worktree` / `spawn_failure` cases in `runtime_lifecycle` and `pi_rpc/process`
- [ ] Open a teammate-created app whose cloud workspace path points at their home dir; runtime should start on the local path
- [ ] With a genuinely missing Node binary and a valid worktree, still surface `agent_binary_missing(pi)` / `install-pi`
- [ ] When the cloud path exists locally, it remains authoritative


Made with [Cursor](https://cursor.com)