### PR TITLE
fix(runtime): stop reporting expected runtime states, and a false "未启动" toast

### DIFF
--- a/packages/app/src/lib/teamclu/__tests__/ensure-agent-runtime-cancelled-notify.test.ts
+++ b/packages/app/src/lib/teamclu/__tests__/ensure-agent-runtime-cancelled-notify.test.ts
@@ -43,7 +43,10 @@ describe("notifyRuntimeStartFailures", () => {
     );
     await flush();
 
-    // Still reported — the startup race stays measurable, just as a warning.
+    // The reporter is still *called*: this layer hands every failure to it and
+    // the reporter decides what reaches Sentry (since 2026-09-04 a cancellation
+    // reaches nothing). Asserting the call keeps the two decisions separable —
+    // "should the user be told" here, "is it worth an event" there.
     expect(mocks.reportRuntimeStartFailure).toHaveBeenCalledTimes(1);
     expect(mocks.toastError).not.toHaveBeenCalled();
   });
@@ -57,9 +60,31 @@ describe("notifyRuntimeStartFailures", () => {
     );
     await flush();
 
-    // The persistent agent status already shows offline. Keep the failure in
-    // telemetry for diagnosis without duplicating it as a transient toast.
+    // The persistent agent status already shows offline, so no toast. The
+    // reporter is handed it and drops it internally — see the note above.
     expect(mocks.reportRuntimeStartFailure).toHaveBeenCalledTimes(1);
+    expect(mocks.toastError).not.toHaveBeenCalled();
+  });
+
+  it("does not toast a refusal to interrupt a running turn", async () => {
+    const { notifyRuntimeStartFailures } = await import("@/lib/teamclu/ensure-agent-runtime");
+
+    notifyRuntimeStartFailures(
+      [
+        {
+          agentActorId: "agent-1",
+          code: "runtime_rpc_failed",
+          reason: "workspace has active turn: e3b1cae9-7db8-4c20-a8d6-0c806a531bde",
+        },
+      ],
+      { trigger: "session_runtime_wake" },
+    );
+    await flush();
+
+    // The runtime is up and working; the daemon declined a reload rather than
+    // interrupt it. Before this filter, `failureDescription` fell through to the
+    // raw reason, so the user got "未启动" over an English daemon string with a
+    // UUID in it — for a session that was running normally.
     expect(mocks.toastError).not.toHaveBeenCalled();
   });
 

--- a/packages/app/src/lib/teamclu/ensure-agent-runtime.ts
+++ b/packages/app/src/lib/teamclu/ensure-agent-runtime.ts
@@ -37,6 +37,7 @@ import {
 } from "@/lib/teamclu/runtime-rpc-timeouts";
 import { sessionFlowError, sessionFlowLog } from "@/lib/session/session-flow-log";
 import {
+  isActiveTurnRefusal,
   isCancelledRuntimeFailure,
   isTransientRuntimeNetworkFailure,
   reportRuntimeEnsureCrash,
@@ -128,12 +129,16 @@ export function notifyRuntimeStartFailures(
   }
   // Offline presence is already persistent in the selected-agent status.
   // Client-cancelled requests and daemon → Cloud API network failures are
-  // retried by the recoverable-runtime tick. Keep these in telemetry/debug,
-  // but do not duplicate expected transient states as error toasts.
+  // retried by the recoverable-runtime tick. An active-turn refusal is not a
+  // failure at all — the runtime is up and mid-turn, and `failureDescription`
+  // would put the raw daemon string ("workspace has active turn: <uuid>") under
+  // a "未启动" title for a session that is working normally. Keep these in
+  // debug logs, but do not surface expected states as error toasts.
   const toastable = failures.filter(
     (f) =>
       f.code !== "device_offline" &&
       !isCancelledRuntimeFailure(f.reason) &&
+      !isActiveTurnRefusal(f.reason) &&
       !isTransientRuntimeNetworkFailure(f.reason),
   );
   if (toastable.length === 0) return;

--- a/packages/app/src/lib/telemetry/__tests__/runtime-error-report.test.ts
+++ b/packages/app/src/lib/telemetry/__tests__/runtime-error-report.test.ts
@@ -14,6 +14,7 @@ import {
   __resetRuntimeErrorReportThrottleForTest,
   __resetSentryModuleForTest,
   classifyRuntimeFailureReason,
+  isActiveTurnRefusal,
   isCancelledRuntimeFailure,
   isTransientRuntimeNetworkFailure,
   reportRuntimeEnsureCrash,
@@ -57,6 +58,11 @@ describe('classifyRuntimeFailureReason', () => {
     expect(classifyRuntimeFailureReason('mqtt disconnected')).toBe('mqtt_disconnected')
     expect(classifyRuntimeFailureReason('device offline')).toBe('device_offline')
     expect(classifyRuntimeFailureReason('runtimeStart rejected')).toBe('daemon_rejected')
+    expect(
+      classifyRuntimeFailureReason(
+        'workspace has active turn: e3b1cae9-7db8-4c20-a8d6-0c806a531bde',
+      ),
+    ).toBe('active_turn')
     expect(classifyRuntimeFailureReason('')).toBe('unknown')
     expect(classifyRuntimeFailureReason(undefined)).toBe('unknown')
   })
@@ -127,7 +133,13 @@ describe('reportRuntimeStartFailure', () => {
     })
   })
 
-  it('downgrades expected offline states to warning', async () => {
+  // These four were reported as warnings until 2026-09-04. Level is irrelevant
+  // to Sentry's quota, and together they were 893 of the 1,147 events this
+  // family produced in one billing period — on a plan with 5,000 errors/month
+  // and no on-demand budget, that crowds out the crashes the budget exists for.
+  // They stay in the Diagnostics ring buffer via `logDebug`; what is given up is
+  // the aggregate count.
+  it('does not report an offline device or transport at all', async () => {
     reportRuntimeStartFailure({
       agentActorId: 'agent-1',
       code: 'device_offline',
@@ -140,13 +152,10 @@ describe('reportRuntimeStartFailure', () => {
     })
     await flush()
 
-    expect(mocks.captureMessage).toHaveBeenCalledTimes(2)
-    for (const call of mocks.captureMessage.mock.calls) {
-      expect((call[1] as { level: string }).level).toBe('warning')
-    }
+    expect(mocks.captureMessage).not.toHaveBeenCalled()
   })
 
-  it('downgrades a cancellation that arrives as a plain runtime_rpc_failed', async () => {
+  it('does not report a cancellation that arrives as a plain runtime_rpc_failed', async () => {
     reportRuntimeStartFailure({
       agentActorId: 'agent-1',
       code: 'runtime_rpc_failed',
@@ -154,13 +163,22 @@ describe('reportRuntimeStartFailure', () => {
     })
     await flush()
 
-    expect(mocks.captureMessage).toHaveBeenCalledTimes(1)
-    const [, options] = mocks.captureMessage.mock.calls[0] as [string, Record<string, never>]
-    expect(options).toMatchObject({
-      level: 'warning',
-      fingerprint: ['runtime', 'runtime_start_failure', 'runtime_rpc_failed', 'rpc_disposed'],
-      tags: { runtime_failure_reason_kind: 'rpc_disposed' },
+    expect(mocks.captureMessage).not.toHaveBeenCalled()
+  })
+
+  it('does not report a refusal to interrupt a running turn', async () => {
+    // Not a failure: the daemon declined to reload *because* the runtime is up
+    // and mid-turn. It arrives as a plain `runtime_rpc_failed`, so before
+    // `active_turn` existed it classified as `unknown`, took the default error
+    // level, and was the second largest group in this family.
+    reportRuntimeStartFailure({
+      agentActorId: 'agent-1',
+      code: 'runtime_rpc_failed',
+      reason: 'workspace has active turn: e3b1cae9-7db8-4c20-a8d6-0c806a531bde',
     })
+    await flush()
+
+    expect(mocks.captureMessage).not.toHaveBeenCalled()
   })
 
   it('downgrades a transient Cloud API network failure to warning', async () => {
@@ -186,6 +204,29 @@ describe('reportRuntimeStartFailure', () => {
     })
   })
 
+  it('recognises an active-turn refusal through the exported predicate', () => {
+    expect(
+      isActiveTurnRefusal('workspace has active turn: e3b1cae9-7db8-4c20-a8d6-0c806a531bde'),
+    ).toBe(true)
+    expect(isActiveTurnRefusal('rpc timeout after 20000ms')).toBe(false)
+    expect(isActiveTurnRefusal(undefined)).toBe(false)
+  })
+
+  it('keeps an active-turn batch crash off the error feed', async () => {
+    // `reportRuntimeStartFailure` drops these before capture, but the
+    // ensure-crash path shares `capture` and passes no code — so the level
+    // policy has to hold on the reason alone.
+    reportRuntimeEnsureCrash(
+      new Error('workspace has active turn: e3b1cae9-7db8-4c20-a8d6-0c806a531bde'),
+      { sessionId: 'sess-1', trigger: 'session_runtime_wake' },
+    )
+    await flush()
+
+    expect(mocks.captureException).toHaveBeenCalledTimes(1)
+    const [, options] = mocks.captureException.mock.calls[0] as [unknown, { level: string }]
+    expect(options.level).toBe('warning')
+  })
+
   it('keeps a real rpc failure at error level', async () => {
     reportRuntimeStartFailure({
       agentActorId: 'agent-1',
@@ -196,11 +237,13 @@ describe('reportRuntimeStartFailure', () => {
     expect((mocks.captureMessage.mock.calls[0]?.[1] as { level: string }).level).toBe('error')
   })
 
+  // Uses a genuine failure: the expected states this throttle was written for
+  // no longer reach Sentry at all, so throttling them is no longer observable.
   it('throttles the same (code, agent) within the window but not after it', async () => {
     const failure = {
       agentActorId: 'agent-1',
-      code: 'device_offline' as const,
-      reason: 'device offline',
+      code: 'runtime_rpc_failed' as const,
+      reason: 'rpc timeout after 20000ms',
     }
     reportRuntimeStartFailure(failure)
     reportRuntimeStartFailure(failure)
@@ -214,16 +257,19 @@ describe('reportRuntimeStartFailure', () => {
     expect(mocks.captureMessage).toHaveBeenCalledTimes(2)
   })
 
+  // Per-agent granularity is deliberate: with the expected states filtered out,
+  // what is left are real faults, and "three agents are failing" is different
+  // information from "one is".
   it('does not throttle a different agent with the same code', async () => {
     reportRuntimeStartFailure({
       agentActorId: 'agent-1',
-      code: 'device_offline',
-      reason: 'device offline',
+      code: 'runtime_rpc_failed',
+      reason: 'rpc timeout after 20000ms',
     })
     reportRuntimeStartFailure({
       agentActorId: 'agent-2',
-      code: 'device_offline',
-      reason: 'device offline',
+      code: 'runtime_rpc_failed',
+      reason: 'rpc timeout after 20000ms',
     })
     await flush()
     expect(mocks.captureMessage).toHaveBeenCalledTimes(2)

--- a/packages/app/src/lib/telemetry/runtime-error-report.ts
+++ b/packages/app/src/lib/telemetry/runtime-error-report.ts
@@ -39,6 +39,8 @@ type RuntimeFailureReasonKind =
   | 'rpc_not_initialized'
   /** We cancelled the request ourselves. See {@link isCancelledRuntimeFailure}. */
   | 'rpc_disposed'
+  /** The daemon declined because the runtime is busy. See {@link isActiveTurnRefusal}. */
+  | 'active_turn'
   | 'mqtt_publish_failed'
   | 'mqtt_disconnected'
   | 'device_offline'
@@ -62,6 +64,7 @@ export function classifyRuntimeFailureReason(reason: string | undefined): Runtim
   if (lower.includes('local rpc timeout')) return 'local_rpc_timeout'
   if (lower.includes('rpc timeout')) return 'rpc_timeout'
   if (lower.includes('rpc disposed')) return 'rpc_disposed'
+  if (lower.includes('workspace has active turn')) return 'active_turn'
   if (lower.includes('not initialized') || lower.includes('actorid required')) {
     return 'rpc_not_initialized'
   }
@@ -90,7 +93,12 @@ export function classifyRuntimeFailureReason(reason: string | undefined): Runtim
  * runtimeStart in flight at that moment lands here, and the next tick just
  * re-attempts it. Before this was classified, the only lasting effects were an
  * error-level Sentry event and an error toast for something that was never
- * broken — most of TEAMCLU-REACT-7W.
+ * broken.
+ *
+ * This group is TEAMCLU-REACT-94, not 7W as an earlier revision of this comment
+ * said — 7W is the active-turn refusal below, which classified as `unknown` and
+ * so kept the default error level. The two were conflated because both arrive
+ * as a bare `runtime_rpc_failed`.
  */
 export function isCancelledRuntimeFailure(reason: string | undefined): boolean {
   return classifyRuntimeFailureReason(reason) === 'rpc_disposed'
@@ -99,6 +107,51 @@ export function isCancelledRuntimeFailure(reason: string | undefined): boolean {
 /** A daemon → Cloud API transport failure that the runtime retry loop can recover. */
 export function isTransientRuntimeNetworkFailure(reason: string | undefined): boolean {
   return classifyRuntimeFailureReason(reason) === 'cloud_network_error'
+}
+
+/**
+ * Not a failure at all: the daemon refused to reload a workspace *because the
+ * runtime is up and mid-turn*.
+ *
+ * `supervisor.rs::reload_workspace` returns `WorkspaceControlError::ActiveTurn`
+ * to avoid interrupting a running turn — deliberately, per the comment on
+ * `auto_applicable_refresh`. It reaches the client as a plain
+ * `runtime_rpc_failed`, so nothing downstream could tell it apart from a real
+ * one: it classified as `unknown`, took the default `error` level, and passed
+ * the toast filter. Users got "agent 未启动" over the raw daemon string —
+ * UUID and all — while their agent was working normally. 279 events across 21
+ * users in one billing period, the second largest group in this family.
+ */
+export function isActiveTurnRefusal(reason: string | undefined): boolean {
+  return classifyRuntimeFailureReason(reason) === 'active_turn'
+}
+
+/**
+ * Expected operating states that do not belong in Sentry.
+ *
+ * These were reported deliberately — `notifyRuntimeStartFailures` already keeps
+ * them out of toasts and its comment says to "keep these in telemetry/debug".
+ * That was the right call while telemetry was free. It is not: the org has
+ * 5,000 errors per month with no on-demand budget, level is irrelevant to the
+ * quota, and these four were 893 of the 1,147 events this family produced in
+ * one period — crowding out the crashes the budget exists for.
+ *
+ * They stay observable. `notifyRuntimeStartFailures` logs every failure through
+ * `logDebug` before this runs, which the console capture keeps in the
+ * Diagnostics ring buffer and attaches to any later event as a breadcrumb. What
+ * is given up is the aggregate count — how often users hit an offline device is
+ * no longer a number we can read off Sentry.
+ *
+ * `cloud_network_error` is deliberately absent: it is equally recoverable, but
+ * its volume is negligible (it did not reach the top 15), so leaving it
+ * reporting costs nothing and keeps one transport fault visible.
+ */
+function isExpectedRuntimeState(
+  code: RuntimeStartFailureCode | undefined,
+  reasonKind: RuntimeFailureReasonKind,
+): boolean {
+  if (code === 'device_offline' || code === 'transport_offline') return true
+  return reasonKind === 'rpc_disposed' || reasonKind === 'active_turn'
 }
 
 /**
@@ -113,6 +166,10 @@ function levelFor(
 ): TelemetryLevel {
   if (code === 'device_offline' || code === 'transport_offline') return 'warning'
   if (reasonKind === 'rpc_disposed' || reasonKind === 'cloud_network_error') return 'warning'
+  // `reportRuntimeStartFailure` already drops active_turn, but `capture` is
+  // shared with the ensure-crash path — a batch that fails this way must not
+  // come back as an error either.
+  if (reasonKind === 'active_turn') return 'warning'
   return 'error'
 }
 
@@ -147,7 +204,8 @@ function capture({ kind, code, reason, error, context }: CaptureArgs): void {
 }
 
 /**
- * Report one per-agent runtimeStart failure. Throttled per
+ * Report one per-agent runtimeStart failure. Expected states are dropped
+ * outright (see {@link isExpectedRuntimeState}); the rest are throttled per
  * (kind, code, agent) so the wake/focus/reconnect ensure loop cannot flood
  * Sentry with the same offline daemon.
  */
@@ -155,6 +213,9 @@ export function reportRuntimeStartFailure(
   failure: RuntimeStartFailure,
   context: RuntimeErrorContext = {},
 ): void {
+  if (isExpectedRuntimeState(failure.code, classifyRuntimeFailureReason(failure.reason))) {
+    return
+  }
   const key = `runtime_start_failure|${failure.code}|${failure.agentActorId}`
   if (!shouldReportThrottled(key, THROTTLE_WINDOW_MS)) return
   capture({


### PR DESCRIPTION
## Description

`runtime_start_failure` produced **1,147 events in one billing period, 893 of which were not defect signal**. On a plan with 5,000 errors/month and no on-demand budget, that crowds out the crashes the budget exists for.

### An active-turn refusal is not a failure

`supervisor.rs::reload_workspace` returns `WorkspaceControlError::ActiveTurn` when a workspace is mid-turn — deliberately, so a reload never interrupts a running turn. It reached the client as a bare `runtime_rpc_failed` with the reason `workspace has active turn: <uuid>`, which nothing downstream could tell apart from a real failure: it classified as `unknown`, took the default `error` level, and passed the toast filter. `failureDescription` then fell through to the raw reason, so users got **"agent 未启动" over an English daemon string with a UUID in it — while their agent was working normally**. 279 events across 21 users, the second largest group in the family.

Now classified as `active_turn`, dropped before capture, and filtered out of toasts.

### Expected states no longer reach Sentry

`device_offline`, `transport_offline` and `rpc_disposed` were reported on purpose — `notifyRuntimeStartFailures` already keeps them out of toasts and its comment says to "keep these in telemetry/debug". That was right while telemetry was free. Level does not matter to the quota, and these three plus `active_turn` were the 893.

They stay observable: every failure still goes through `logDebug` before this runs, which the console capture keeps in the Diagnostics ring buffer and attaches to later events as a breadcrumb. What is given up is the aggregate count — how often users hit an offline device is no longer readable off Sentry. `cloud_network_error` is deliberately left reporting: equally recoverable, but its volume is negligible, so it costs nothing and keeps one transport fault visible.

### What still reports

`rpc_timeout` (144), `rpc_not_ready` (101), `rpc_not_initialized` (9) and the rest — 254 events, which is what the budget is for. The per-agent throttle key is kept: with the expected states gone, "three agents are failing" is different information from "one is".

Also corrects a comment that attributed `TEAMCLU-REACT-7W` to `rpc_disposed`. 7W is the active-turn group; `rpc_disposed` is 94. The two were conflated because both arrive as a bare `runtime_rpc_failed`.

## Related Issue

Sentry: `TEAMCLU-REACT-7W` (active-turn group). No GitHub issue.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

Tests: two existing tests encoded the old policy (assert warning-level events for offline/cancelled) and now assert suppression; two throttle tests moved to a fixture that still reports. Verified red before the fix — 7 failures, each for its own reason — and green after. Full app suite: **3,360 passed**.

Trade-off worth flagging for review: suppressing `device_offline` / `transport_offline` / `rpc_disposed` means their aggregate frequency is no longer visible in Sentry. If that trend turns out to matter, the right home for it is a counter/metric, not an error event.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017LGh88cvMMZeMForNo45i1
