### PR TITLE
fix(daemon): fan out auth_refresh after models.json writes so new sessions see a just-added LLM

### DIFF
--- a/apps/daemon/src/runtime/pi_rpc/events.rs
+++ b/apps/daemon/src/runtime/pi_rpc/events.rs
@@ -364,7 +364,7 @@ async fn try_backfill(
     Ok(())
 }
 
-/// Tell every *other* live child to reload the provider a login just unlocked.
+/// Tell every *other* live child to reload the providers that just changed.
 ///
 /// Logins run on their own child (see `pi_auth_request`), and each child holds
 /// its own `ModelRuntime`. Without this, a provider signed in from the settings
@@ -372,12 +372,22 @@ async fn try_backfill(
 /// respawned — which is exactly the property reusing a session's child used to
 /// buy, and the reason it is safe to stop doing that.
 ///
+/// Also used after a `models.json` write (custom provider added/edited/
+/// deleted) and after an explicit `auth_refresh`: those change the same
+/// device-wide catalog every child serves, and pi reports them as a plain
+/// command response rather than a host event, so `auth_login_end` cannot
+/// cover them.
+///
 /// Detached rather than awaited: this reader task is the only thing draining
 /// that child's stdout, and `auth_refresh` waits on a network catalog fetch.
 /// Awaiting it here would stall every event from the child that just answered.
 /// Best-effort by design — a child that fails to refresh still picks the
 /// credential up from `auth.json` the next time it starts.
-fn broadcast_auth_refresh(shared: &Arc<Shared>, origin: &PiClient, event: &serde_json::Value) {
+pub(crate) fn broadcast_auth_refresh(
+    shared: &Arc<Shared>,
+    origin: &PiClient,
+    event: &serde_json::Value,
+) {
     let provider_id = event
         .get("providerId")
         .and_then(|v| v.as_str())

--- a/apps/daemon/src/runtime/pi_rpc/mod.rs
+++ b/apps/daemon/src/runtime/pi_rpc/mod.rs
@@ -455,6 +455,42 @@ struct EstablishedSession {
     leaf_id: Option<String>,
 }
 
+/// Which `auth_*` command responses should fan an `auth_refresh` out to every
+/// *other* live child, and with which provider scope.
+///
+/// `Some(None)` — fan out a **full** refresh. `Some(Some(id))` — scoped to one
+/// provider. `None` — no fan-out.
+///
+/// A successful login already fans out from its `auth_login_end` host event
+/// ([`events::broadcast_auth_refresh`]), so it is deliberately absent here.
+/// What it cannot cover: a `models.json` write (custom provider added, edited
+/// or deleted) and an explicit `auth_refresh` both change the catalog every
+/// live child serves, and pi reports them as a plain command response, never
+/// as a host event. Without this, a provider added from the settings pane is
+/// invisible to new sessions too — `attach` reuses a pooled (often prewarmed)
+/// child, so its `get_available_models` still answers from the pre-add
+/// `ModelRuntime`.
+fn auth_command_refresh_fanout(request: &serde_json::Value) -> Option<Option<String>> {
+    match request.get("type").and_then(|v| v.as_str()) {
+        // Full rebuild, never a provider scope: a brand-new provider id has
+        // nothing to recompose yet, and a deleted one must disappear from
+        // every child — the request carries a `providerId`, but scoping the
+        // fan-out to it would reproduce exactly the staleness being fixed.
+        Some("auth_models_put") | Some("auth_models_delete") => Some(None),
+        // The manual refresh re-reads `models.json` on the auth child; the
+        // rest of the device learns about it the same way a login teaches
+        // them, scoped to the provider when the caller named one.
+        Some("auth_refresh") => Some(
+            request
+                .get("providerId")
+                .and_then(|v| v.as_str())
+                .filter(|p| !p.trim().is_empty())
+                .map(str::to_string),
+        ),
+        _ => None,
+    }
+}
+
 async fn attach(shared: &Arc<Shared>, args: AttachArgs) -> Result<AcpStartupMetadata, String> {
     let worktree = canonical_dir(&args.worktree);
     let key = PoolKey {
@@ -1651,6 +1687,10 @@ impl AgentBackend for PiRpcBackend {
             .filter(|t| *t == "auth_login_start")
             .and_then(|_| request.get("loginId").and_then(|v| v.as_str()))
             .map(str::to_string);
+        // A successful command that changes the device-wide catalog must also
+        // reach the children already serving sessions — read *before* the
+        // request is moved into `client.request`.
+        let fanout = auth_command_refresh_fanout(&request);
         // The slot was reserved by the HTTP layer (`auth::begin`); this binds
         // the child that will run it, and must happen before the command goes
         // out so an answer can be routed the moment a prompt appears.
@@ -1664,10 +1704,18 @@ impl AgentBackend for PiRpcBackend {
                 auth::unregister(login_id);
             }
         }
-        Ok(result?
+        let data = result?
             .get("data")
             .cloned()
-            .unwrap_or(serde_json::Value::Null))
+            .unwrap_or(serde_json::Value::Null);
+        if let Some(provider_scope) = fanout {
+            let mut event = serde_json::json!({});
+            if let Some(provider_id) = provider_scope {
+                event["providerId"] = serde_json::json!(provider_id);
+            }
+            events::broadcast_auth_refresh(&self.shared, &proc.client, &event);
+        }
+        Ok(data)
     }
 
     async fn model_catalog_for_context(
@@ -1755,6 +1803,53 @@ mod tests {
         let busy = pi_mid_turn_prompt_plan(true);
         assert!(!busy.emit_turn_open);
         assert!(busy.use_steer);
+    }
+
+    #[test]
+    fn models_json_writes_fan_out_a_full_refresh_despite_carrying_a_provider_id() {
+        // The put request names the provider, but the fan-out must NOT scope to
+        // it: a brand-new id has nothing to recompose on a child that has never
+        // seen it, and a deleted one must vanish everywhere.
+        let put = serde_json::json!({
+            "type": "auth_models_put",
+            "providerId": "ollama",
+            "provider": {"baseUrl": "http://localhost:11434/v1"},
+        });
+        assert_eq!(auth_command_refresh_fanout(&put), Some(None));
+
+        let delete = serde_json::json!({"type": "auth_models_delete", "providerId": "ollama"});
+        assert_eq!(auth_command_refresh_fanout(&delete), Some(None));
+    }
+
+    #[test]
+    fn an_explicit_refresh_fans_out_scoped_to_its_provider() {
+        let scoped = serde_json::json!({"type": "auth_refresh", "providerId": "anthropic"});
+        assert_eq!(
+            auth_command_refresh_fanout(&scoped),
+            Some(Some("anthropic".to_string()))
+        );
+
+        // No provider named — a full refresh of every provider the child serves.
+        let bare = serde_json::json!({"type": "auth_refresh"});
+        assert_eq!(auth_command_refresh_fanout(&bare), Some(None));
+        // Whitespace-only is the same as absent.
+        let blank = serde_json::json!({"type": "auth_refresh", "providerId": "  "});
+        assert_eq!(auth_command_refresh_fanout(&blank), Some(None));
+    }
+
+    #[test]
+    fn commands_that_do_not_change_the_catalog_do_not_fan_out() {
+        // A login fans out from its `auth_login_end` host event instead.
+        for ty in [
+            "auth_login_start",
+            "auth_login_cancel",
+            "auth_models_get",
+            "auth_list",
+            "auth_logout",
+        ] {
+            let req = serde_json::json!({"type": ty});
+            assert_eq!(auth_command_refresh_fanout(&req), None, "{ty} must not fan out");
+        }
     }
 
     #[test]

--- a/packages/app/src/components/settings/PiLLMSection.tsx
+++ b/packages/app/src/components/settings/PiLLMSection.tsx
@@ -30,6 +30,7 @@ import {
   type PiProviderList,
 } from '@/lib/daemon/daemon-pi-auth'
 import { encodeWorkspaceId } from '@/lib/daemon/daemon-local-client'
+import { ensureLocalDaemonCatalog } from '@/stores/local-daemon-catalog-store'
 import { SectionHeader, SettingCard } from './shared'
 import { TeamProviderCard } from './llm/TeamProviderCard'
 import { PiLoginDialog } from './llm/PiLoginDialog'
@@ -115,6 +116,16 @@ export function PiLLMSection() {
     void load()
   }, [load])
 
+  // Every action below changes the catalog this device can run, and the
+  // new-session pill reads it from `useLocalDaemonCatalogStore`, whose 'ready'
+  // entries sit for five minutes before a natural re-probe. Without forcing it
+  // here, an LLM added on this pane stays invisible to new chats until that
+  // window expires (the daemon-side fan-out fixes the live children; this
+  // fixes the client cache).
+  const invalidateLocalCatalog = React.useCallback(() => {
+    if (workspacePath) ensureLocalDaemonCatalog(workspacePath, undefined, { force: true })
+  }, [workspacePath])
+
   const handleRefresh = React.useCallback(async () => {
     setRefreshing(true)
     try {
@@ -124,8 +135,9 @@ export function PiLLMSection() {
       // that fails still leaves the cached models usable.
     }
     await load()
+    invalidateLocalCatalog()
     setRefreshing(false)
-  }, [load, workspaceId])
+  }, [load, workspaceId, invalidateLocalCatalog])
 
   const handleLogout = React.useCallback(
     async (provider: PiProvider) => {
@@ -134,13 +146,14 @@ export function PiLLMSection() {
       try {
         await logoutPiProvider(provider.id, workspaceId)
         await load()
+        invalidateLocalCatalog()
       } catch (e) {
         setError(e instanceof Error ? e.message : String(e))
       } finally {
         setBusyProvider(null)
       }
     },
-    [load, workspaceId],
+    [load, workspaceId, invalidateLocalCatalog],
   )
 
   const handleDeleteCustom = React.useCallback(
@@ -150,13 +163,14 @@ export function PiLLMSection() {
       try {
         await deletePiCustomProvider(providerId, workspaceId)
         await load()
+        invalidateLocalCatalog()
       } catch (e) {
         setError(e instanceof Error ? e.message : String(e))
       } finally {
         setBusyProvider(null)
       }
     },
-    [load, workspaceId],
+    [load, workspaceId, invalidateLocalCatalog],
   )
 
   const providers = data?.providers ?? []
@@ -412,7 +426,10 @@ export function PiLLMSection() {
           authType={login.authType}
           workspaceId={workspaceId}
           onClose={() => setLogin(null)}
-          onFinished={() => void load()}
+          onFinished={() => {
+            void load()
+            invalidateLocalCatalog()
+          }}
         />
       )}
 
@@ -426,6 +443,7 @@ export function PiLLMSection() {
           onSave={async (id, provider) => {
             await putPiCustomProvider(id, provider, workspaceId)
             await load()
+            invalidateLocalCatalog()
           }}
         />
       )}


### PR DESCRIPTION
## 问题

在「设置 → Pi 模型」添加 LLM(自定义 provider / 登录)后,**新会话里看不到新模型**。

## 根因

添加自定义 provider 通过一个**专用的 pi-auth 子进程**写入 `~/.pi/agent/models.json`,该子进程只刷新自己的 `ModelRuntime`。而新会话 attach 时会从进程池**复用已有的(通常是 prewarm 的)子进程**(`pi_rpc::attach` → `pool.ensure_with_env`),它的 `ModelRuntime` 仍是写入前构建的 —— `get_available_models` 因此返回旧目录,新会话 retain 的 `available_models` 里没有新 LLM。

此前只有**登录成功**(`auth_login_end` host 事件)才会向其余存活子进程 fan-out `auth_refresh`;`models.json` 写入与手动刷新只产生普通命令响应,不产生 host 事件,无人通知。

客户端还有第二层:新会话(草稿态)的模型列表读 `useLocalDaemonCatalogStore`,`ready` 条目 5 分钟内不会自然重新探测,设置页保存后也没有任何失效动作。

## 修复

**Daemon**(`apps/daemon/src/runtime/pi_rpc/`):
- `pi_auth_request` 在 `auth_models_put` / `auth_models_delete` 成功后(全量重建,不按 providerId 局部刷新 —— 新 provider 在未见过它的子进程里无从重组,被删除的必须处处消失),以及转发的 `auth_refresh`(按 providerId 局部)之后,通过 `events::broadcast_auth_refresh` 通知其余存活子进程。
- `broadcast_auth_refresh` 改为 `pub(crate)`,doc 补充 models.json 写入场景。
- 新增 3 个单元测试覆盖 fan-out 决策(put/delete 全量、refresh 局部/全量、登录等不触发)。

**App**(`packages/app/src/components/settings/PiLLMSection.tsx`):
- 保存/删除自定义 provider、登录完成、退出登录、手动刷新后,`ensureLocalDaemonCatalog(..., { force: true })` 强制失效本地目录缓存。

## 验证

- `cargo test --bin amuxd pi_rpc`:68 passed(含新增 3 个)
- `cargo test --test pi_host custom_provider`:passed
- `tsc --noEmit`:clean;catalog store + llm 组件测试 14 passed

## 注意

需要重新构建/重启 amuxd 才会生效;临时办法是重启应用(子进程全部重生,重新读 models.json)。
