### PR TITLE
feat(sidebar): show the local agent's gateway token usage, or nothing

### DIFF
--- a/packages/app/src/components/sidebar/LocalDaemonCard.tsx
+++ b/packages/app/src/components/sidebar/LocalDaemonCard.tsx
@@ -6,6 +6,7 @@ import { LocalDaemonRow } from '@/components/sidebar/LocalDaemonRow'
 import { getLocalDaemonAgent } from '@/lib/daemon/daemon-agent-admin'
 import { getKnownLocalDaemonActorId, noteLocalDaemonActorId } from '@/lib/daemon/local-daemon-identity'
 import { useLocalDaemonRuntimeStatus } from '@/hooks/use-local-daemon-http-status'
+import { useLocalDaemonTokenUsage } from '@/hooks/use-local-daemon-token-usage'
 import { cn } from '@/lib/utils'
 import { ActorDetailDialog } from '@/components/sidebar/ActorDetailDialog'
 import { useMemberPreferencesStore } from '@/stores/member-preferences-store'
@@ -56,6 +57,7 @@ export function LocalDaemonCard() {
     !!localDaemonActor,
   )
   const daemonMqttDisconnected = runtimeStatus === 'daemonMqttDisconnected'
+  const tokenUsage = useLocalDaemonTokenUsage(teamId, localDaemonActor?.id ?? null)
 
   const handleCopyName = async (actor: ActorRow) => {
     try {
@@ -93,6 +95,7 @@ export function LocalDaemonCard() {
           actor={localDaemonActor}
           runtimeStatus={runtimeStatus}
           isDefault={localDaemonActor.id === defaultAgentId}
+          tokenUsage={tokenUsage}
           onViewDetail={setDetailFor}
           onCopyName={handleCopyName}
           onCopyId={handleCopyId}

--- a/packages/app/src/components/sidebar/LocalDaemonRow.tsx
+++ b/packages/app/src/components/sidebar/LocalDaemonRow.tsx
@@ -20,12 +20,16 @@ import { useMemberPreferencesStore } from '@/stores/member-preferences-store'
 import { recoverMqttConnection } from '@/stores/mqtt-reconnect'
 import { requestDaemonProbe } from '@/lib/daemon/daemon-probe-signal'
 import { type LocalDaemonRuntimeStatus } from '@/hooks/use-local-daemon-http-status'
+import { type LocalDaemonTokenUsage } from '@/hooks/use-local-daemon-token-usage'
+import { formatTokenCount } from '@/lib/ui/format-tokens'
 import { cn } from '@/lib/utils'
 
 interface Props {
   actor: ActorRow | null
   runtimeStatus: LocalDaemonRuntimeStatus
   isDefault?: boolean
+  /** Null whenever there is no real number to show — see the hook. */
+  tokenUsage?: LocalDaemonTokenUsage | null
   onViewDetail: (actor: ActorRow) => void
   onCopyName: (actor: ActorRow) => void
   onCopyId: (actor: ActorRow) => void
@@ -155,6 +159,7 @@ function SheetHeader({
   agentType,
   runtimeStatus,
   statusLabel,
+  tokenUsage,
   expanded,
   onHandleClick,
   onAvatarClick,
@@ -164,12 +169,22 @@ function SheetHeader({
   agentType?: string | null
   runtimeStatus: LocalDaemonRuntimeStatus
   statusLabel: string
+  tokenUsage?: LocalDaemonTokenUsage | null
   expanded: boolean
   onHandleClick: () => void
   onAvatarClick: () => void
 }) {
   const { t } = useTranslation()
-  const headTitle = `${displayName} · ${shortenActorId(actorId)}`
+  const usageLine = tokenUsage
+    ? t('sidebar.localDaemonTokensThisMonth', '{{tokens}} tokens this month', {
+        tokens: formatTokenCount(tokenUsage.inputTokens + tokenUsage.outputTokens),
+      })
+    : null
+  // The id stays in the tooltip and in "Copy ID" — the subtitle line is the
+  // only thing usage takes over, and only when there is usage to show.
+  const headTitle = [`${displayName} · ${shortenActorId(actorId)}`, usageLine]
+    .filter(Boolean)
+    .join(' · ')
 
   return (
     <div>
@@ -223,10 +238,14 @@ function SheetHeader({
             {/* The current workspace used to be printed here. It now lives in
                 the file tree footer, next to the tree it actually describes —
                 two places showing it disagreed as soon as the tree became
-                session-scoped. */}
-            <div className="mt-0.5 truncate text-[11px] leading-snug text-faint">
-              {shortenActorId(actorId)}
-            </div>
+                session-scoped. The actor id that replaced it is now in the
+                tooltip instead: this line shows gateway token usage when the
+                team has any, and collapses when it does not. */}
+            {usageLine && (
+              <div className="mt-0.5 truncate text-[11px] leading-snug text-faint">
+                {usageLine}
+              </div>
+            )}
           </div>
         </div>
       </div>
@@ -242,6 +261,7 @@ export function LocalDaemonRow({
   actor,
   runtimeStatus,
   isDefault = false,
+  tokenUsage = null,
   onViewDetail,
 }: Props) {
   const { t } = useTranslation()
@@ -325,6 +345,7 @@ export function LocalDaemonRow({
           agentType={resolveActorAgentType(actor)}
           runtimeStatus={runtimeStatus}
           statusLabel={statusLabel}
+          tokenUsage={tokenUsage}
           onHandleClick={toggleSheet}
           onAvatarClick={() => onViewDetail(actor)}
           expanded={sheetOpen}

--- a/packages/app/src/hooks/__tests__/use-local-daemon-token-usage.test.ts
+++ b/packages/app/src/hooks/__tests__/use-local-daemon-token-usage.test.ts
@@ -1,0 +1,86 @@
+import { renderHook, waitFor } from '@testing-library/react'
+import { beforeEach, describe, it, expect, vi } from 'vitest'
+import { useLocalDaemonTokenUsage } from '../use-local-daemon-token-usage'
+
+const mocks = vi.hoisted(() => ({
+  getCreditUsage: vi.fn(),
+}))
+
+vi.mock('@/lib/backend', () => ({
+  getBackend: () => ({ teams: { getCreditUsage: mocks.getCreditUsage } }),
+}))
+
+const ACTOR = 'b0f2c15f-0000-4000-8000-000000000001'
+
+function report(byActor: Array<Record<string, unknown>>) {
+  return {
+    range: 'month',
+    startUtc: '2026-09-01T00:00:00Z',
+    endUtc: '2026-10-01T00:00:00Z',
+    summary: { credits: 0, inputTokens: 0, cachedInputTokens: 0, outputTokens: 0, requests: 0 },
+    byModel: [],
+    byActor,
+  }
+}
+
+describe('useLocalDaemonTokenUsage', () => {
+  beforeEach(() => {
+    mocks.getCreditUsage.mockReset()
+  })
+
+  it('returns the actor row when it has usage', async () => {
+    mocks.getCreditUsage.mockResolvedValue(
+      report([
+        { actorId: 'someone-else', displayName: 'Other', inputTokens: 999, cachedInputTokens: 0, outputTokens: 999, requests: 9, credits: 1 },
+        { actorId: ACTOR, displayName: 'Mac-mini-3', inputTokens: 12_000, cachedInputTokens: 400, outputTokens: 3_400, requests: 42, credits: 5 },
+      ]),
+    )
+
+    const { result } = renderHook(() => useLocalDaemonTokenUsage('team-1', ACTOR))
+
+    await waitFor(() => {
+      expect(result.current).toEqual({ inputTokens: 12_000, outputTokens: 3_400, requests: 42 })
+    })
+    expect(mocks.getCreditUsage).toHaveBeenCalledWith('team-1', { range: 'month' })
+  })
+
+  it('returns null when the gateway is unavailable — the majority of teams', async () => {
+    mocks.getCreditUsage.mockRejectedValue(
+      Object.assign(new Error('no gateway'), { code: 'ai_gateway_unavailable' }),
+    )
+
+    const { result } = renderHook(() => useLocalDaemonTokenUsage('team-1', ACTOR))
+
+    await waitFor(() => expect(mocks.getCreditUsage).toHaveBeenCalled())
+    expect(result.current).toBeNull()
+  })
+
+  it('returns null when the actor has no row in the period', async () => {
+    mocks.getCreditUsage.mockResolvedValue(
+      report([{ actorId: 'someone-else', displayName: 'Other', inputTokens: 5, cachedInputTokens: 0, outputTokens: 5, requests: 1, credits: 0 }]),
+    )
+
+    const { result } = renderHook(() => useLocalDaemonTokenUsage('team-1', ACTOR))
+
+    await waitFor(() => expect(mocks.getCreditUsage).toHaveBeenCalled())
+    expect(result.current).toBeNull()
+  })
+
+  it('returns null for a zero row rather than reporting 0 under a working agent', async () => {
+    mocks.getCreditUsage.mockResolvedValue(
+      report([{ actorId: ACTOR, displayName: 'Mac-mini-3', inputTokens: 0, cachedInputTokens: 0, outputTokens: 0, requests: 0, credits: 0 }]),
+    )
+
+    const { result } = renderHook(() => useLocalDaemonTokenUsage('team-1', ACTOR))
+
+    await waitFor(() => expect(mocks.getCreditUsage).toHaveBeenCalled())
+    expect(result.current).toBeNull()
+  })
+
+  it('does not query without a team or an actor', () => {
+    const { result } = renderHook(() => useLocalDaemonTokenUsage(null, ACTOR))
+    expect(result.current).toBeNull()
+    renderHook(() => useLocalDaemonTokenUsage('team-1', null))
+    expect(mocks.getCreditUsage).not.toHaveBeenCalled()
+  })
+})

--- a/packages/app/src/hooks/use-local-daemon-token-usage.ts
+++ b/packages/app/src/hooks/use-local-daemon-token-usage.ts
@@ -1,0 +1,85 @@
+import * as React from 'react'
+import { getBackend } from '@/lib/backend'
+
+/** Input + output tokens this actor burned in the current billing month. */
+export interface LocalDaemonTokenUsage {
+  inputTokens: number
+  outputTokens: number
+  requests: number
+}
+
+/** Slow on purpose: this is a sidebar footnote, not a live meter, and the
+ *  report is an aggregate query on the gateway's ledger. */
+const POLL_INTERVAL_MS = 5 * 60_000
+
+/**
+ * The local daemon agent's token consumption for the current month, or `null`
+ * when there is nothing honest to show.
+ *
+ * `null` covers four different situations on purpose, because the card has one
+ * line and they all render the same way — nothing:
+ *
+ * - the team has no AI gateway (`ai_gateway_unavailable`), which is the common
+ *   case: `managed_llm.rs` only reports `Enabled` for a team with both
+ *   `llm_enabled` and a `baseUrl`, and everyone else runs pi on their own
+ *   provider keys, which the gateway never sees;
+ * - the gateway is there but this actor has no row in the period;
+ * - the row exists and is zero;
+ * - the request failed.
+ *
+ * The distinction that matters is "we have a real number" vs "we do not". A
+ * literal `0` under an agent that is visibly working reads as "this agent did
+ * nothing", which is a claim about the agent rather than about our telemetry,
+ * so it is deliberately not rendered. Settings › Token Usage is where the
+ * team-wide breakdown, including genuine zeroes, belongs.
+ */
+export function useLocalDaemonTokenUsage(
+  teamId: string | null,
+  actorId: string | null,
+): LocalDaemonTokenUsage | null {
+  const [usage, setUsage] = React.useState<LocalDaemonTokenUsage | null>(null)
+
+  React.useEffect(() => {
+    if (!teamId || !actorId) {
+      setUsage(null)
+      return
+    }
+
+    let cancelled = false
+
+    const load = async () => {
+      try {
+        const report = await getBackend().teams.getCreditUsage(teamId, { range: 'month' })
+        if (cancelled) return
+        const row = report.byActor.find((a) => a.actorId === actorId)
+        const total = (row?.inputTokens ?? 0) + (row?.outputTokens ?? 0)
+        setUsage(
+          row && total > 0
+            ? {
+                inputTokens: row.inputTokens,
+                outputTokens: row.outputTokens,
+                requests: row.requests,
+              }
+            : null,
+        )
+      } catch {
+        // Includes `ai_gateway_unavailable`, which is not an error condition
+        // here — it is the majority of teams. Nothing to show either way.
+        if (!cancelled) setUsage(null)
+      }
+    }
+
+    void load()
+    const timer = setInterval(() => void load(), POLL_INTERVAL_MS)
+    const onFocus = () => void load()
+    window.addEventListener('focus', onFocus)
+
+    return () => {
+      cancelled = true
+      clearInterval(timer)
+      window.removeEventListener('focus', onFocus)
+    }
+  }, [teamId, actorId])
+
+  return usage
+}

--- a/packages/app/src/locales/en.json
+++ b/packages/app/src/locales/en.json
@@ -1123,6 +1123,7 @@
     "localDaemonAutomation": "Automation",
     "localDaemonAutomationAria": "Open automation tasks",
     "localDaemonRetrying": "Retrying…",
+    "localDaemonTokensThisMonth": "{{tokens}} tokens this month",
     "ideas": "Ideas"
   },
   "errors": {

--- a/packages/app/src/locales/zh-CN.json
+++ b/packages/app/src/locales/zh-CN.json
@@ -1123,6 +1123,7 @@
     "localDaemonAutomation": "自动化",
     "localDaemonAutomationAria": "打开自动化任务",
     "localDaemonRetrying": "正在重试…",
+    "localDaemonTokensThisMonth": "本月消耗 {{tokens}} tokens",
     "ideas": "想法"
   },
   "errors": {


### PR DESCRIPTION
## Description

The line under the local agent's name in the sidebar printed the first 8 characters of its actor id — `b0f2c15f…` — which is not information anyone reads off a sidebar. It now shows what that agent burned through the team AI gateway this month.

**Before:** `Mac-mini-3` / `b0f2c15f…`
**After:** `Mac-mini-3` / `15.4k tokens this month` — or, for most teams, nothing at all.

### Only real numbers get rendered

The only per-actor token data that exists is the gateway's credit ledger (`GET /v1/teams/:id/credits/usage` → `byActor[]`), and it only records traffic that went through the team AI gateway. `apps/daemon/src/runtime/managed_llm.rs::resolve` returns `Enabled` for a team with both `llm_enabled` and a `baseUrl`, and `Disabled` otherwise — a disabled team's pi runs on the user's own provider keys, which the gateway never sees. So for most teams there is no number at all.

`useLocalDaemonTokenUsage` returns `null` for all four ways that happens — no gateway (`ai_gateway_unavailable`), no row for this actor, a zero row, or a failed request — and the line is not rendered.

A literal `0` under an agent that is visibly working reads as "this agent did nothing", which is a claim about the agent rather than about our telemetry. Settings › Token Usage remains where the team-wide breakdown, genuine zeroes included, belongs.

### The actor id is not lost

It stays in the header tooltip (now carrying both id and usage) and in the existing "Copy ID" action, which is where anyone who actually wanted it was already going.

### Polling

5 minutes, plus a refetch on window focus. This is a footnote, not a meter, and the report is an aggregate query on the ledger.

## Related Issue

None — follows from a question about what that subtitle line was for.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

**Visible side effect worth calling out in review:** for teams without a gateway — the majority — this line disappears and the card gets one line shorter. That is the intended consequence of choosing "render nothing" over "render 0", but it is a layout change every one of those users will see.

Verification: `pnpm typecheck` clean; `pnpm lint` 0 errors (the 48 warnings are all pre-existing, none in the changed files); i18n parity passes with the two new keys (`en` + `zh-CN`, edited textually, not parse-and-dumped); five new cases pin the null rule, because "shows nothing" is the behaviour that is easy to regress into "shows 0". Full app suite: **3,327 passed / 10 skipped**.

Not attempted here: pi's own per-turn usage, which would be the honest number for BYOK users, is not plumbed anywhere — `grep input_tokens|output_tokens` over `apps/daemon/src` returns nothing, and `Message.tokens` in `session-types.ts` is dead opencode-era shape. That is a separate, much larger change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017LGh88cvMMZeMForNo45i1
