### PR TITLE
fix(llm): the team model tier is an identifier, not prose

### DIFF
--- a/crates/teamclu-runtime-env/src/team_provider.rs
+++ b/crates/teamclu-runtime-env/src/team_provider.rs
@@ -17,8 +17,13 @@ use crate::DEFAULT_TEAM_REPO_DIR;
 /// Sourcing this list from the cloud instead (which is what it used to do) made
 /// every member's model menu depend on a network round-trip that could return
 /// stale or empty, for a list that has not changed in the product's lifetime.
-pub const TEAM_MODEL_TIERS: [(&str, &str); 3] =
-    [("default", "标准"), ("pro", "高级"), ("max", "旗舰")];
+///
+/// The id is also the display name. These used to carry Chinese labels
+/// (标准 / 高级 / 旗舰) that were shown instead of the id, which made the tier a
+/// user picks in the model menu unrecognizable as the tier named in billing,
+/// usage reports and support threads — all of which speak `default` / `pro` /
+/// `max`. A tier is an identifier, not prose, so it is not translated.
+pub const TEAM_MODEL_TIERS: [&str; 3] = ["default", "pro", "max"];
 
 /// The base URL a RUNTIME should call, which is not the one the daemon calls.
 ///
@@ -132,11 +137,11 @@ pub fn mutate_team_provider(
         ManagedLlmState::Enabled(provider) => {
             // Pinned, not read from `provider.models` (see TEAM_MODEL_TIERS).
             let mut models_out = serde_json::Map::new();
-            for (id, label) in TEAM_MODEL_TIERS {
+            for id in TEAM_MODEL_TIERS {
                 models_out.insert(
                     id.to_string(),
                     serde_json::json!({
-                        "name": label,
+                        "name": id,
                         "limit": { "context": 256000, "output": 16000 }
                     }),
                 );
@@ -423,8 +428,8 @@ mod tests {
 
         let models = config["provider"]["team"]["models"].as_object().unwrap();
         assert_eq!(models.len(), 3);
-        for (id, label) in TEAM_MODEL_TIERS {
-            assert_eq!(models[id]["name"].as_str(), Some(label), "tier {id}");
+        for id in TEAM_MODEL_TIERS {
+            assert_eq!(models[id]["name"].as_str(), Some(id), "tier {id}");
         }
         assert!(
             !models.contains_key("some-cloud-model"),

--- a/crates/teamclu-runtime-env/src/team_provider_sync.rs
+++ b/crates/teamclu-runtime-env/src/team_provider_sync.rs
@@ -291,8 +291,8 @@ mod tests {
         let parsed: serde_json::Value = serde_json::from_str(&global).unwrap();
         let models = parsed["provider"]["team"]["models"].as_object().unwrap();
         assert_eq!(models.len(), 3, "exactly the three tiers");
-        for (id, label) in crate::team_provider::TEAM_MODEL_TIERS {
-            assert_eq!(models[id]["name"].as_str(), Some(label), "tier {id}");
+        for id in crate::team_provider::TEAM_MODEL_TIERS {
+            assert_eq!(models[id]["name"].as_str(), Some(id), "tier {id}");
         }
         assert!(
             !models.contains_key("model-a"),

--- a/packages/app/src/components/settings/llm/TeamProviderCard.tsx
+++ b/packages/app/src/components/settings/llm/TeamProviderCard.tsx
@@ -80,12 +80,11 @@ export function TeamProviderCard({ className }: { className?: string }) {
           </p>
           {TEAM_MODEL_TIERS.map((tier) => (
             <div
-              key={tier.id}
+              key={tier}
               className="flex items-center gap-2 rounded-md px-2 py-1.5 text-[13px] hover:bg-muted/50"
             >
               <Zap className="h-3.5 w-3.5 text-muted-foreground" />
-              <span>{t(tier.labelKey, tier.label)}</span>
-              <span className="ml-auto font-mono text-xs text-muted-foreground">{tier.id}</span>
+              <span className="font-mono">{tier}</span>
             </div>
           ))}
         </div>

--- a/packages/app/src/components/settings/llm/__tests__/TeamProviderCard.test.tsx
+++ b/packages/app/src/components/settings/llm/__tests__/TeamProviderCard.test.tsx
@@ -31,9 +31,11 @@ describe('TeamProviderCard', () => {
     for (const id of ['default', 'pro', 'max']) {
       expect(screen.getByText(id)).toBeTruthy()
     }
-    expect(screen.getByText('标准')).toBeTruthy()
-    expect(screen.getByText('高级')).toBeTruthy()
-    expect(screen.getByText('旗舰')).toBeTruthy()
+    // The tier id is the display name — never a translated label, so that the
+    // tier picked here is the tier named in billing and usage reports.
+    for (const label of ['标准', '高级', '旗舰']) {
+      expect(screen.queryByText(label)).toBeNull()
+    }
 
     // The whole point of the card: the team's plan is the credential, so there
     // is no control here that could take it away.

--- a/packages/app/src/lib/agent/team-provider.ts
+++ b/packages/app/src/lib/agent/team-provider.ts
@@ -33,9 +33,11 @@ export const TEAM_SHARED_PROVIDER_ID = 'team'
  * Deliberately NOT sourced from the cloud team config: that made every member's
  * model menu depend on a round-trip that could come back stale or empty, for a
  * list that has not changed in the product's lifetime.
+ *
+ * The id is also the display name. These used to carry translated labels
+ * (标准 / 高级 / 旗舰) shown in place of the id, which made the tier a user picks
+ * unrecognizable as the tier named in billing, usage reports and support
+ * threads — all of which speak `default` / `pro` / `max`. A tier is an
+ * identifier, not prose, so it is not translated.
  */
-export const TEAM_MODEL_TIERS: ReadonlyArray<{ id: string; labelKey: string; label: string }> = [
-  { id: 'default', labelKey: 'settings.llm.teamTier.default', label: '标准' },
-  { id: 'pro', labelKey: 'settings.llm.teamTier.pro', label: '高级' },
-  { id: 'max', labelKey: 'settings.llm.teamTier.max', label: '旗舰' },
-]
+export const TEAM_MODEL_TIERS: ReadonlyArray<string> = ['default', 'pro', 'max']

--- a/packages/app/src/locales/en.json
+++ b/packages/app/src/locales/en.json
@@ -1567,11 +1567,6 @@
       "teamProviderName": "Team Model",
       "teamProviderPinned": "Built-in",
       "teamProviderDesc": "Provided and billed by your team — nothing to configure",
-      "teamTier": {
-        "default": "Standard",
-        "pro": "Advanced",
-        "max": "Flagship"
-      },
       "availableModels": "Available Models"
     },
     "piLlm": {

--- a/packages/app/src/locales/zh-CN.json
+++ b/packages/app/src/locales/zh-CN.json
@@ -1567,11 +1567,6 @@
       "teamProviderName": "团队模型",
       "teamProviderPinned": "内置",
       "teamProviderDesc": "由团队统一提供并计费，无需配置",
-      "teamTier": {
-        "default": "标准",
-        "pro": "高级",
-        "max": "旗舰"
-      },
       "availableModels": "可用模型"
     },
     "piLlm": {


### PR DESCRIPTION
## Description

The three gateway tiers carried translated display names — 标准 / 高级 / 旗舰, and Standard / Advanced / Flagship in English — shown in place of the id. So the tier a user picks in the model menu was not recognizable as the tier named everywhere else: billing, the usage report's `byModel` rows, `s.yaml`, the gateway catalog and support threads all speak `default` / `pro` / `max`.

A member on a Chinese client picking 旗舰 and a member on an English one picking Flagship had no way to tell they had picked the same thing, or to say which one they meant.

The id is now the display name, on both sides of the contract:

| Where | Before | After |
|---|---|---|
| `crates/teamclu-runtime-env/src/team_provider.rs` | `[("default","标准"),("pro","高级"),("max","旗舰")]` | `["default","pro","max"]` — writes `"name": id` into the runtime's pinned model catalog |
| `packages/app/src/lib/agent/team-provider.ts` | `{ id, labelKey, label: '标准' }` | plain id list |
| `TeamProviderCard.tsx` | translated label on the left, id in mono on the right | the id alone, in mono |
| `settings.llm.teamTier.*` (en + zh-CN) | Standard/Advanced/Flagship, 标准/高级/旗舰 | deleted |

The Rust constant is the one that matters: it writes the pinned model catalog the model menu actually reads. The settings card is just a display surface.

## Related Issue

None — reported directly: tier names should not be translated.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

The two Rust tests that pinned this iterate the constant, so they assert the new rule without being rewritten: `models[id]["name"] == id`. The card test now asserts the translated labels are *absent*, since "shows nothing translated" is the thing that regresses quietly.

**`cargo fmt` was deliberately not run.** `teamclu-runtime-env` is not fmt-clean on `main` (8 files carry diffs, same situation as `apps/daemon`), so running it would reformat unrelated files. Verified instead that the fmt diff set is identical before and after these edits, modulo one line-number shift caused by the new doc comment.

Verification: `cargo test -p teamclu-runtime-env` 127 passed; `cargo clippy -p teamclu-runtime-env --all-targets -- -D warnings` clean; app suite **3,326 passed / 10 skipped**; `pnpm lint` 0 errors; `pnpm typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017LGh88cvMMZeMForNo45i1
