### PR TITLE
fix(fc): restore the eight credit repository methods the routes call

### DIFF
--- a/services/fc/src/lib/routes/team-credits.ts
+++ b/services/fc/src/lib/routes/team-credits.ts
@@ -1,5 +1,3 @@
-import { aiGateway } from "../ai-gateway.js";
-
 /**
  * Team credits: balance, usage, top-up history, member limits.
  *

--- a/services/fc/src/lib/supabase-repo.ts
+++ b/services/fc/src/lib/supabase-repo.ts
@@ -954,6 +954,85 @@ export function createSupabaseBusinessRepository(options) {
       };
     },
 
+    // ── team credits ────────────────────────────────────────────────────────
+    // Every read and write goes through the AI gateway rather than these tables
+    // directly: it is the ledger's only writer (design §4.9.1), and routing reads
+    // the same way keeps period boundaries and shapes identical on both sides of
+    // the billing screen.
+    //
+    // Permission split per §12.6: balance and usage are visible to every member
+    // — an exhausted wallet stops their work, so they must be able to see why —
+    // while the ledger and every mutation are owner-only.
+    //
+    // These are restored, not new. They were adjacent to the LiteLLM block that
+    // `feat(fc)!: remove LiteLLM token-usage reporting` deleted, and went with
+    // it, leaving `routes/team-credits.ts` calling eight methods no repository
+    // implemented: every credits and quota endpoint answered
+    // `ctx.repository.<method> is not a function`. Both that file and this one
+    // kept importing `aiGateway` without using it, which is what the deletion
+    // left behind.
+    async getTeamCredits(teamId: string) {
+      await requireCallerTeamMember(teamId);
+      const [summary, usage] = await Promise.all([
+        aiGateway.creditsSummary(teamId),
+        aiGateway.usage(teamId, { range: "month" }),
+      ]);
+      return {
+        teamId,
+        balanceCredits: summary.balanceCredits ?? 0,
+        period: { range: usage.range, startUtc: usage.startUtc, endUtc: usage.endUtc },
+        usedCredits: usage.summary?.credits ?? 0,
+      };
+    },
+    async getCreditUsage(teamId: string, opts: { range?: string; date?: string } = {}) {
+      await requireCallerTeamMember(teamId);
+      return aiGateway.usage(teamId, opts);
+    },
+    async getCreditLedger(teamId: string, opts: { limit?: number } = {}) {
+      await requireCallerTeamOwner(teamId);
+      return aiGateway.ledger(teamId, opts.limit);
+    },
+    async topUpCredits(teamId: string, input: any) {
+      await requireCallerTeamOwner(teamId);
+      const amount = Number(input?.amountCredits);
+      if (!Number.isSafeInteger(amount) || amount <= 0) {
+        throw new ApiError(400, "invalid_request", "amountCredits must be a positive integer");
+      }
+      // Required rather than generated here: an idempotency key the server
+      // invents is a new key on every retry, which defeats the point.
+      if (!input?.idempotencyKey) {
+        throw new ApiError(400, "invalid_request", "idempotencyKey is required");
+      }
+      return aiGateway.topUp(teamId, {
+        amountCredits: amount,
+        kind: input.kind ?? "top_up",
+        idempotencyKey: input.idempotencyKey,
+        note: input.note ?? null,
+      });
+    },
+    async listCreditPackages(teamId: string) {
+      await requireCallerTeamMember(teamId);
+      // Resolves to the `./stripe.js` import, not to this method: a property of
+      // an object literal is not in scope inside its own body.
+      return { items: await listCreditPackages() };
+    },
+    async createCreditCheckoutSession(teamId: string, input: any) {
+      await requireCallerTeamOwner(teamId);
+      const priceId = String(input?.priceId ?? "").trim();
+      if (!priceId) {
+        throw new ApiError(400, "invalid_request", "priceId is required");
+      }
+      return createCheckoutSession({ teamId, priceId });
+    },
+    async getMemberQuotas(teamId: string) {
+      await requireCallerTeamMember(teamId);
+      return aiGateway.quotas(teamId);
+    },
+    async setMemberQuotas(teamId: string, input: any) {
+      await requireCallerTeamOwner(teamId);
+      return aiGateway.setQuotas(teamId, input ?? {});
+    },
+
     async listTeamActors(teamId, { kind = null, limit = 500 } = {}) {
       let query = supabase
         .from("actor_directory")

--- a/services/fc/test/team-credits.test.ts
+++ b/services/fc/test/team-credits.test.ts
@@ -1,0 +1,176 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { handleBusinessApiRequest } from "../src/lib/business-api.js";
+import { createSupabaseBusinessRepository } from "../src/lib/supabase-repo.js";
+
+/**
+ * Every credits and quota endpoint answered `ctx.repository.<method> is not a
+ * function` in production: `routes/team-credits.ts` called eight repository
+ * methods that no repository implemented. They had been written next to the
+ * LiteLLM block and were deleted along with it, and nothing noticed — this
+ * directory had no test that touched credits at all.
+ *
+ * The first test here is the general guard, not a list of the eight: it reads
+ * the route file and requires the repository to implement whatever that file
+ * calls. A method deleted out from under a route fails here rather than in
+ * someone's billing screen.
+ */
+
+const ROUTE_SRC = new URL("../src/lib/routes/team-credits.ts", import.meta.url);
+
+function repositoryMethodsCalledByRoutes(): string[] {
+  const src = readFileSync(ROUTE_SRC, "utf8");
+  const names = new Set<string>();
+  for (const m of src.matchAll(/ctx\.repository\.([A-Za-z0-9_]+)\s*\(/g)) {
+    names.add(m[1]);
+  }
+  return [...names].sort();
+}
+
+/** The real repository, wired to a client that is never actually reached —
+ *  method identity is the contract under test, not query behaviour. */
+function realRepository() {
+  return createSupabaseBusinessRepository({
+    supabaseUrl: "https://example.supabase.co",
+    publishableKey: "publishable-key",
+    accessToken: "caller-token",
+    createClient: () => ({
+      auth: { getUser: async () => ({ data: { user: { id: "u1" } }, error: null }) },
+      from: () => { throw new Error("not reached"); },
+      rpc: () => { throw new Error("not reached"); },
+    }),
+  } as any);
+}
+
+test("every repository method the credits routes call actually exists", () => {
+  const called = repositoryMethodsCalledByRoutes();
+  const repo = realRepository() as Record<string, unknown>;
+
+  assert.ok(called.length >= 8, `expected the route file to call methods, found ${called.length}`);
+
+  const missing = called.filter((name) => typeof repo[name] !== "function");
+  assert.deepEqual(
+    missing,
+    [],
+    `routes/team-credits.ts calls ${missing.join(", ")}, which the repository does not implement`,
+  );
+});
+
+test("the eight credits and quota methods are on the repository by name", () => {
+  const repo = realRepository() as Record<string, unknown>;
+  for (const name of [
+    "getTeamCredits",
+    "getCreditUsage",
+    "getCreditLedger",
+    "topUpCredits",
+    "listCreditPackages",
+    "createCreditCheckoutSession",
+    "getMemberQuotas",
+    "setMemberQuotas",
+  ]) {
+    assert.equal(typeof repo[name], "function", `${name} must be implemented`);
+  }
+});
+
+// ── route wiring ────────────────────────────────────────────────────────────
+
+function makeRepo(overrides: Record<string, any> = {}) {
+  const calls: Array<{ method: string; args: unknown[] }> = [];
+  const record = (method: string) => async (...args: unknown[]) => {
+    calls.push({ method, args });
+    const fn = overrides[method];
+    return typeof fn === "function" ? fn(...args) : {};
+  };
+  return {
+    calls,
+    getTeamCredits: record("getTeamCredits"),
+    getCreditUsage: record("getCreditUsage"),
+    getCreditLedger: record("getCreditLedger"),
+    topUpCredits: record("topUpCredits"),
+    listCreditPackages: record("listCreditPackages"),
+    createCreditCheckoutSession: record("createCreditCheckoutSession"),
+    getMemberQuotas: record("getMemberQuotas"),
+    setMemberQuotas: record("setMemberQuotas"),
+  };
+}
+
+async function request(
+  repo: any,
+  { method, path, body, query = {} }: { method: string; path: string; body?: any; query?: any },
+) {
+  return handleBusinessApiRequest(
+    {
+      httpMethod: method,
+      path,
+      headers: { Authorization: "Bearer caller-token" },
+      body: body !== undefined ? JSON.stringify(body) : undefined,
+      queryStringParameters: query,
+    } as any,
+    { createRepository: () => repo, createAuthRepository: () => repo } as any,
+  );
+}
+
+test("GET /v1/teams/:id/credits/usage forwards range and date", async () => {
+  const repo = makeRepo({ getCreditUsage: () => ({ range: "month", byActor: [] }) });
+  const res = await request(repo, {
+    method: "GET",
+    path: "/v1/teams/team-1/credits/usage",
+    query: { range: "week", date: "2026-09-01" },
+  });
+
+  assert.equal(res.statusCode, 200);
+  assert.equal(JSON.parse(res.body).range, "month");
+  assert.deepEqual(repo.calls[0], {
+    method: "getCreditUsage",
+    args: ["team-1", { range: "week", date: "2026-09-01" }],
+  });
+});
+
+test("GET /v1/teams/:id/credits/usage defaults to the month, with no date", async () => {
+  const repo = makeRepo();
+  await request(repo, { method: "GET", path: "/v1/teams/team-1/credits/usage" });
+
+  assert.deepEqual(repo.calls[0].args, ["team-1", { range: "month", date: undefined }]);
+});
+
+test("the remaining credits and quota routes reach their repository method", async () => {
+  const cases: Array<{ method: string; path: string; body?: any; expect: string }> = [
+    { method: "GET", path: "/v1/teams/team-1/credits", expect: "getTeamCredits" },
+    { method: "GET", path: "/v1/teams/team-1/credits/ledger", expect: "getCreditLedger" },
+    { method: "GET", path: "/v1/teams/team-1/credits/packages", expect: "listCreditPackages" },
+    {
+      method: "POST",
+      path: "/v1/teams/team-1/credits/top-up",
+      body: { amountCredits: 10, idempotencyKey: "k1" },
+      expect: "topUpCredits",
+    },
+    {
+      method: "POST",
+      path: "/v1/teams/team-1/credits/checkout-session",
+      body: { priceId: "price_1" },
+      expect: "createCreditCheckoutSession",
+    },
+    { method: "GET", path: "/v1/teams/team-1/quotas", expect: "getMemberQuotas" },
+    { method: "PUT", path: "/v1/teams/team-1/quotas", body: {}, expect: "setMemberQuotas" },
+  ];
+
+  for (const c of cases) {
+    const repo = makeRepo();
+    const res = await request(repo, c);
+    assert.equal(res.statusCode, 200, `${c.method} ${c.path} -> ${res.statusCode}: ${res.body}`);
+    assert.equal(repo.calls[0]?.method, c.expect, `${c.method} ${c.path}`);
+    assert.equal(repo.calls[0]?.args[0], "team-1");
+  }
+});
+
+test("GET /v1/teams/:id/credits/ledger forwards an explicit limit", async () => {
+  const repo = makeRepo();
+  await request(repo, {
+    method: "GET",
+    path: "/v1/teams/team-1/credits/ledger",
+    query: { limit: "5" },
+  });
+
+  assert.deepEqual(repo.calls[0].args, ["team-1", { limit: 5 }]);
+});


### PR DESCRIPTION
## Description

Every credits and quota endpoint answered `ctx.repository.<method> is not a function`. The Token Usage screen showed it as `ctx.repository.getCreditUsage is not a function`; the Billing screen was equally dead, because it is the same eight methods.

`services/fc/src/lib/routes/team-credits.ts` calls eight repository methods. `supabase-repo.ts` implemented **none** of them:

| Endpoint | Method | Implementations before this PR |
|---|---|---|
| `GET /v1/teams/:id/credits` | `getTeamCredits` | 0 |
| `GET /v1/teams/:id/credits/usage` | `getCreditUsage` | 0 |
| `GET /v1/teams/:id/credits/ledger` | `getCreditLedger` | 0 |
| `POST /v1/teams/:id/credits/top-up` | `topUpCredits` | 0 |
| `GET /v1/teams/:id/credits/packages` | `listCreditPackages` | 0 |
| `POST /v1/teams/:id/credits/checkout-session` | `createCreditCheckoutSession` | 0 |
| `GET /v1/teams/:id/quotas` | `getMemberQuotas` | 0 |
| `PUT /v1/teams/:id/quotas` | `setMemberQuotas` | 0 |

### How they went missing

They were not absent by design. `a5b658c7b` added them in two places — the postgres repo and this one — written directly above the LiteLLM block. `eb3f89730` deleted the postgres backend, and `ca11bd0c7` took 125 lines out of `supabase-repo.ts` to remove LiteLLM usage reporting; the credits block went with it.

What survived is the tell: **both** `routes/team-credits.ts` and `supabase-repo.ts` kept importing `aiGateway` and never using it — an import of exactly the thing the deleted methods delegated to.

### What this restores

The eight methods, taken verbatim from `a5b658c7b` and `1a98c680e` (Stripe phase 4), so the authz split is the one the design specifies rather than one I invented: balance, usage, packages and quota reads are member-visible — an exhausted wallet stops a member's work, so they must be able to see why — while the ledger and every mutation are owner-only. Reads and writes both go through the gateway, which is the ledger's only writer, so the usage report and the quota check cannot disagree about where the period starts.

The now-genuinely-unused `aiGateway` import is dropped from the route file.

## Related Issue

None — reported from the app as `ctx.repository.getCreditUsage is not a function`.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

**Why nothing caught this.** `services/fc/test/` had no test that touched credits — 54 test files, `credits` appearing only in `stripe.test.ts` — and `ci.yml` has no job that runs FC's tests at all, so the whole 938-test suite is local-only. Worth considering separately whether that job should exist.

**The new test is a general guard, not a list of eight.** It reads the route file, extracts every `ctx.repository.X` it calls, and requires the real repository to implement each one — so a method deleted out from under a route fails there instead of in someone's billing screen. Verified red before the fix (it names all eight) and green after. The route-forwarding tests beside it pass either way, since they drive a fake repo; that is precisely why the structural one is the important half, and precisely the gap that let this reach production.

**Deployment.** This only takes effect once merged: `services/fc/**` on `main` triggers `self-host-deploy.yml`. Until then both screens stay broken.

**Unrelated pre-existing issue found while verifying:** the checked-in `stripe` dependency is not present in a stale local `services/fc/node_modules`, so `npm run build` fails with three `Cannot find module 'stripe'` errors on `main` too. `npm ci` fixes it locally; the lockfile was not modified by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017LGh88cvMMZeMForNo45i1
