### PR TITLE
fix(sidebar): 会话列表自己加载它需要的应用列表

### DIFF
--- a/packages/app/src/components/sidebar/SessionListColumn.tsx
+++ b/packages/app/src/components/sidebar/SessionListColumn.tsx
@@ -634,10 +634,12 @@ export function SessionListColumn({
     /**
      * The app this session belongs to, if any.
      *
-     * This slot used to hold a workspace label, which for an app session was a
-     * raw cloud workspace uuid: the app's checkout is daemon-owned, so it is
-     * never a workspace registered on this machine, and the label fell through
-     * to printing the id. Nothing about a session is better said by a uuid.
+     * This slot used to hold a workspace label, and for an app session that was
+     * always a uuid. The label is the workspace directory's basename, and an
+     * app's checkout is `<amuxd home>/teams/<team>/apps/<appId>` — so the
+     * basename is the app's own id. (The label's other branch, for a workspace
+     * this machine has not registered, returns the cloud workspace id: also a
+     * uuid.) Nothing about a session is better said by one.
      */
     const rowApp = row.appId ? appsById.get(row.appId) ?? null : null
     const actionsId = `v2-session-actions-${row.id}`

--- a/packages/app/src/components/sidebar/SessionListColumn.tsx
+++ b/packages/app/src/components/sidebar/SessionListColumn.tsx
@@ -42,6 +42,7 @@ import { useSessionListActivityMap } from '@/hooks/use-session-list-activity-map
 import { loadSessionIdsForActor } from '@/lib/session/session-by-actor'
 import { actorAvatarColor } from '@/lib/actor/actor-color'
 import { useAppsStore } from '@/stores/apps-store'
+import { useFeatures } from '@/lib/config/remote-features'
 import { appTypeIcon } from '@/lib/apps/app-type-icon'
 import { compareSessionListByRecency } from '@/lib/session/session-list-sort'
 import { buildSessionListGlassLayoutKey } from '@/lib/ui/session-list-glass-layout-key'
@@ -274,15 +275,30 @@ export function SessionListColumn({
   /**
    * Apps by id, for the subline on a session that belongs to one.
    *
-   * The rail's Apps entry is what loads this list, so it is already here by the
-   * time the sidebar paints; when Apps is off for the build it stays empty and
-   * no session gets a subline, which is right.
+   * Loaded here rather than relied on from elsewhere. The rail's Apps entry
+   * loads the same list, but it lives inside the 更多 group, which starts
+   * collapsed — so on a fresh launch nothing had mounted it and every app
+   * session rendered with no subline until the user happened to open that
+   * group. Verified against the running app: 0 sublines collapsed, 9 the
+   * moment it was expanded.
    */
+  const appsEnabled = useFeatures().apps
   const appItems = useAppsStore((s) => s.items)
+  const loadApps = useAppsStore((s) => s.load)
   const appsById = React.useMemo(
     () => new Map(appItems.map((app) => [app.id, app])),
     [appItems],
   )
+  // Only when a row actually claims an app: a team with no app sessions makes
+  // no request, and the store no-ops once the team's list is in.
+  const hasAppSessions = React.useMemo(
+    () => listRows.some((row) => !!row.app_id),
+    [listRows],
+  )
+  React.useEffect(() => {
+    if (!appsEnabled || !hasAppSessions || !teamIdFromList) return
+    void loadApps(teamIdFromList)
+  }, [appsEnabled, hasAppSessions, teamIdFromList, loadApps])
   React.useEffect(() => {
     initPinnedSessionIds(teamIdFromList || null)
   }, [initPinnedSessionIds, teamIdFromList])

--- a/packages/app/src/components/sidebar/__tests__/SessionListColumn.test.tsx
+++ b/packages/app/src/components/sidebar/__tests__/SessionListColumn.test.tsx
@@ -327,9 +327,9 @@ describe('SessionListColumn', () => {
   })
 
   it('names the app under a session that belongs to one', () => {
-    // What this slot held before was a workspace label, which for an app
-    // session resolved to a raw cloud workspace uuid — the app's checkout is
-    // daemon-owned, so it is never a workspace registered on this machine.
+    // What this slot held before was a workspace label — the workspace
+    // directory's basename — and an app's checkout is `…/apps/<appId>`, so for
+    // an app session it rendered the app's own uuid.
     useAppsStore.setState({ items: [mkAppRow('app-1', 'teamclu 官网')] })
     useSessionListStore.setState({
       rows: [mkSessionRow({ id: 's1', title: 'Alpha', app_id: 'app-1' })],

--- a/packages/app/src/components/sidebar/__tests__/SessionListColumn.test.tsx
+++ b/packages/app/src/components/sidebar/__tests__/SessionListColumn.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import { describe, it, expect, beforeEach, vi } from 'vitest'
-import { render, screen, fireEvent, within } from '@testing-library/react'
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react'
 import { SessionListColumn } from '../SessionListColumn'
 import { useUIStore } from '@/stores/ui'
 import { useSessionListStore } from '@/stores/session-list-store'
@@ -62,6 +62,13 @@ vi.mock('@/stores/current-team', () => ({
     (selector: (s: typeof currentTeamState) => unknown) => selector(currentTeamState),
     { getState: () => currentTeamState, subscribe: () => () => {} },
   ),
+}))
+
+// Apps is a remote flag, off by default. The session list only names an app
+// when the build actually has the Apps surface to reach.
+const features = { apps: true }
+vi.mock('@/lib/config/remote-features', () => ({
+  useFeatures: () => features,
 }))
 
 const PINNED_STORAGE_KEY = `${appShortName}-pinned-sessions`
@@ -132,7 +139,7 @@ describe('SessionListColumn', () => {
       cronSessionIds: new Set<string>(),
       showCronSessions: false,
     })
-    useAppsStore.setState({ items: [] })
+    useAppsStore.setState({ items: [], load: vi.fn().mockResolvedValue(undefined) })
     useSessionListStore.setState({
       rows: [
         mkSessionRow({ id: 's1', title: 'Alpha', idea_id: null, has_unread: true }),
@@ -335,6 +342,38 @@ describe('SessionListColumn', () => {
     useAppsStore.setState({ items: [mkAppRow('app-1', 'teamclu 官网')] })
     render(<SessionListColumn />)
     expect(screen.queryByTestId('v2-session-row-app')).not.toBeInTheDocument()
+  })
+
+  it('asks for the app list itself when a row claims an app', async () => {
+    // Regression: this used to lean on the rail's Apps entry to have loaded it,
+    // and that entry lives inside the 更多 group, which starts collapsed. On a
+    // fresh launch nothing mounted it, so every app session rendered with no
+    // subline until the user happened to open that group.
+    useSessionListStore.setState({
+      rows: [mkSessionRow({ id: 's1', title: 'Alpha', app_id: 'app-1' })],
+    })
+    render(<SessionListColumn />)
+    await waitFor(() =>
+      expect(useAppsStore.getState().load).toHaveBeenCalledWith('team-1'),
+    )
+  })
+
+  it('asks for nothing when no session belongs to an app', () => {
+    render(<SessionListColumn />)
+    expect(useAppsStore.getState().load).not.toHaveBeenCalled()
+  })
+
+  it('asks for nothing when the build has no Apps surface', () => {
+    features.apps = false
+    useSessionListStore.setState({
+      rows: [mkSessionRow({ id: 's1', title: 'Alpha', app_id: 'app-1' })],
+    })
+    try {
+      render(<SessionListColumn />)
+      expect(useAppsStore.getState().load).not.toHaveBeenCalled()
+    } finally {
+      features.apps = true
+    }
   })
 
   it('draws nothing when the app list has not arrived', () => {

--- a/services/fc/test/supabase-repo.test.ts
+++ b/services/fc/test/supabase-repo.test.ts
@@ -109,8 +109,8 @@ test("listSessions maps current actor session rpc rows", async () => {
 test("listSessions carries the app a session belongs to", async () => {
   // `amux.sessions.app_id` reached the list RPC in 20260907000000. It is what
   // lets a client tell an app's session from any other; before it, the sidebar
-  // had only the workspace label, which for an app's daemon-owned checkout was
-  // a raw workspace uuid.
+  // had only the workspace label — that directory's basename, which for an
+  // app's checkout is the app's own uuid.
   const repo = createRepo(fakeSupabase({
     rpcData: {
       list_current_actor_sessions: [{

--- a/services/supabase/migrations/20260907000000_session_list_app_id.sql
+++ b/services/supabase/migrations/20260907000000_session_list_app_id.sql
@@ -2,9 +2,9 @@
 --
 -- `amux.sessions.app_id` has existed since the apps module landed, but nothing
 -- read it back: the sidebar could not tell an app's session from any other, and
--- the only signal it had — the workspace label — printed a raw cloud workspace
--- uuid whenever the app's daemon-owned checkout was not a workspace registered
--- on this machine, which for an app is always.
+-- the only signal it had — the workspace label — is that directory's basename,
+-- which for an app's checkout (`teams/<team>/apps/<appId>`) is the app's own
+-- uuid.
 --
 -- Appended to RETURNS TABLE, so the argument signature (and therefore the
 -- REVOKE/GRANT below and pgTAP's has_function assertion in 016) is unchanged.


### PR DESCRIPTION
#1271 里的应用副标题在真机上**冷启动时一行都不显示**。

根因：它读 `useAppsStore.items`，指望导航栏的「应用」入口已经把这个列表拉回来了——但那个入口在「更多」分组里，而分组默认是**收起**的，于是没有任何组件挂载过它，每个 app 会话都是空的，直到用户碰巧展开了那个分组。

在跑着的桌面端上验证过（服务端这时已经部署完毕）：**更多收起时 0 条副标题，展开的那一刻变成 9 条**。

改法：列表自己去要它需要的数据，而且只在需要的时候要——effect 的触发条件是「确实有某一行带着 `app_id`」，所以没有 app 会话的团队一个请求都不会发，`load` 在该团队列表到位后也会自己 no-op。用 `features.apps` 挡了一层：在一个根本打不开应用的构建里说出应用名，比什么都不说更糟。

两条回归测试钉住这件事：带 `app_id` 的行必须触发 `load('team-1')`；没有 app 会话、以及构建没有 Apps 时都不发请求。

`pnpm test:unit` 505 文件 / 3339 用例全绿，`tsc` 干净，`eslint` 0 error。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FrF3nNFmobpFqzA6zFSkUN