### PR TITLE
fix(deploy): 部署的 fetch 只用它自己的 deploy key，并自动发布工作区改动

### DIFF
--- a/apps/daemon/src/http/apps.rs
+++ b/apps/daemon/src/http/apps.rs
@@ -494,6 +494,11 @@ pub struct BuildAppBody {
 #[serde(rename_all = "camelCase")]
 pub struct BuildAppResponse {
     pub status: &'static str,
+    /// The commit that was actually built, when the daemon published work the
+    /// caller did not know about. Absent when it built the sha it was given —
+    /// the caller then finalizes with its own.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub git_commit_sha: Option<String>,
 }
 
 /// `POST /v1/apps/build` — build the app (`pnpm build` + zip `.output`) and
@@ -548,7 +553,7 @@ pub async fn build_app(
         )));
     }
 
-    let bytes = tokio::task::spawn_blocking(move || {
+    let built = tokio::task::spawn_blocking(move || {
         let git_ctx = use_git.then(|| crate::sync::app_build::BuildGitContext {
             app_id: &app_id,
             commit_sha: &git_commit_sha,
@@ -563,7 +568,7 @@ pub async fn build_app(
 
     let resp = reqwest::Client::new()
         .put(&presigned_put)
-        .body(bytes)
+        .body(built.bytes)
         .send()
         .await
         .map_err(|e| HttpError::internal(format!("upload PUT failed: {e}")))?;
@@ -579,7 +584,10 @@ pub async fn build_app(
         )));
     }
 
-    Ok(Json(BuildAppResponse { status: "built" }))
+    Ok(Json(BuildAppResponse {
+        status: "built",
+        git_commit_sha: built.git_commit_sha,
+    }))
 }
 
 #[derive(Debug, Deserialize)]
@@ -908,6 +916,7 @@ fn map_build_error(err: anyhow::Error) -> HttpError {
     let msg = format!("{err}");
     let validation_markers = [
         crate::sync::app_git::ERR_DIRTY,
+        crate::sync::app_git::ERR_PUSH_REJECTED,
         crate::sync::app_git::ERR_SHA_NOT_ON_REMOTE,
         crate::sync::app_git::ERR_INVALID_SHA,
         crate::sync::app_build::ERR_OUTPUT_MISSING,
@@ -1194,7 +1203,7 @@ mod tests {
 
     #[test]
     fn map_build_error_marks_known_validation_failures() {
-        let err = map_build_error(anyhow::anyhow!(crate::sync::app_git::ERR_DIRTY));
+        let err = map_build_error(anyhow::anyhow!(crate::sync::app_git::ERR_PUSH_REJECTED));
         assert!(matches!(err.code, ErrorCode::ValidationFailed));
         let err = map_build_error(anyhow::anyhow!("mystery failure"));
         assert!(matches!(err.code, ErrorCode::Internal));

--- a/apps/daemon/src/sync/app_build.rs
+++ b/apps/daemon/src/sync/app_build.rs
@@ -217,13 +217,23 @@ fn kill_process_tree(child: &mut std::process::Child) {
     let _ = child.wait();
 }
 
-/// Prepare the workdir for a deploy build: fetch, clean tree, checkout `sha`.
+/// Message on the commit a deploy makes for work the agent left uncommitted.
+const DEPLOY_COMMIT_MESSAGE: &str = "chore(app): publish workdir for deploy";
+
+/// Prepare the workdir for a deploy build: fetch, publish pending work,
+/// checkout what is to be built.
 ///
-/// The fetch runs **before** the clean/pushed gate on purpose. That gate
-/// compares HEAD against remote-tracking refs, and refs left over from the
-/// previous deploy report a commit that was pushed minutes ago as unpushed
+/// The fetch runs **before** anything reads ahead/behind state on purpose. That
+/// state compares HEAD against remote-tracking refs, and refs left over from
+/// the previous deploy report a commit that was pushed minutes ago as unpushed
 /// local work — every deploy after the first one was refused as dirty.
-pub fn prepare_git_build(workdir: &Path, git: &BuildGitContext<'_>) -> anyhow::Result<()> {
+///
+/// Returns the sha to build when publishing moved HEAD past the one the caller
+/// asked for, and `None` when the caller's sha is what got checked out.
+pub fn prepare_git_build(
+    workdir: &Path,
+    git: &BuildGitContext<'_>,
+) -> anyhow::Result<Option<String>> {
     app_git::init_if_needed(workdir)?;
     // Re-stamped on every deploy so the shim path survives an amuxd upgrade
     // that moves the binary. Cheap, idempotent, and the only self-healing this
@@ -234,20 +244,41 @@ pub fn prepare_git_build(workdir: &Path, git: &BuildGitContext<'_>) -> anyhow::R
     let ssh = SshEnv::from_deploy_key_pem(git.deploy_key_pem)?;
     app_git::set_remote_origin(workdir, git.remote_url, Some(&ssh))?;
     app_git::fetch_origin(workdir, Some(&ssh))?;
-    app_git::ensure_clean_and_pushed(workdir)?;
-    app_git::checkout_fetched_sha(workdir, git.commit_sha)
+
+    // Whatever the agent left behind gets committed and pushed rather than
+    // refused. When that happens HEAD is already the commit to build, and
+    // checking out the caller's older sha would ship without it.
+    if let Some(published) =
+        app_git::publish_pending_work(workdir, Some(&ssh), DEPLOY_COMMIT_MESSAGE)?
+    {
+        return Ok(Some(published));
+    }
+
+    app_git::checkout_fetched_sha(workdir, git.commit_sha)?;
+    Ok(None)
+}
+
+/// A finished build: the artifact, and the commit it was made from.
+pub struct BuildOutput {
+    pub bytes: Vec<u8>,
+    /// Set only when the deploy published pending work and so built a commit
+    /// the caller did not know about. The caller must finalize with this one:
+    /// recording the sha it started with would name a commit that is not what
+    /// is now running.
+    pub git_commit_sha: Option<String>,
 }
 
 /// Run `pnpm install` then `pnpm build` in `workdir`, then zip the `.output` dir.
 ///
-/// When `git` is present the workdir must be clean, fetched, and checked out
-/// at `git.commit_sha` before building (see [`prepare_git_build`]).
+/// When `git` is present the workdir is fetched, published and checked out
+/// first (see [`prepare_git_build`]).
 pub fn build_artifact(
     workdir: &Path,
     git: Option<&BuildGitContext<'_>>,
-) -> anyhow::Result<Vec<u8>> {
+) -> anyhow::Result<BuildOutput> {
+    let mut git_commit_sha = None;
     if let Some(ctx) = git {
-        prepare_git_build(workdir, ctx)?;
+        git_commit_sha = prepare_git_build(workdir, ctx)?;
     }
     run_with_timeout(
         "pnpm",
@@ -276,7 +307,10 @@ pub fn build_artifact(
     if bytes.len() > MAX_ARTIFACT_BYTES {
         anyhow::bail!("{ERR_ARTIFACT_TOO_LARGE}");
     }
-    Ok(bytes)
+    Ok(BuildOutput {
+        bytes,
+        git_commit_sha,
+    })
 }
 
 #[cfg(test)]

--- a/apps/daemon/src/sync/app_git.rs
+++ b/apps/daemon/src/sync/app_git.rs
@@ -10,7 +10,16 @@ use std::path::{Path, PathBuf};
 use std::process::{Command, Output, Stdio};
 
 /// English messages the HTTP layer maps to user-facing copy.
+/// No longer raised by a deploy — [`publish_pending_work`] publishes that state
+/// instead of refusing it. Kept because the desktop still maps this text: a
+/// current client talking to an older daemon gets it, and the mapping is the
+/// only thing that turns it into something a user can act on.
 pub const ERR_DIRTY: &str = "uncommitted or unpushed changes; commit and push first";
+/// Deploy committed the workdir but could not publish it: `origin` has commits
+/// this checkout does not. Resolving that is a merge, and a deploy must not
+/// guess at one.
+pub const ERR_PUSH_REJECTED: &str =
+    "origin has commits this checkout does not; pull and resolve them, then deploy again";
 pub const ERR_SHA_NOT_ON_REMOTE: &str = "git commit not found on remote";
 pub const ERR_INVALID_SHA: &str = "gitCommitSha must be a 7–40 character hex object id";
 
@@ -154,9 +163,17 @@ impl SshEnv {
         })
     }
 
+    /// `IdentitiesOnly=yes` is load-bearing, not belt-and-braces.
+    ///
+    /// `-i` only *adds* a key to the candidates: OpenSSH still offers every
+    /// identity in the agent and the default `~/.ssh/id_*` files, and Gitea
+    /// closes the connection after `MaxAuthTries` (6). On a developer machine
+    /// with a few keys loaded, the JIT deploy key was never reached — the fetch
+    /// failed with "Too many authentication failures" and read as a bad
+    /// credential. `cli/git_ssh.rs` has always passed it; this path had not.
     pub fn git_ssh_command(&self) -> String {
         format!(
-            "ssh -i {} -o StrictHostKeyChecking=accept-new -o BatchMode=yes",
+            "ssh -i {} -o IdentitiesOnly=yes -o StrictHostKeyChecking=accept-new -o BatchMode=yes",
             shell_quote(&self.key_path.to_string_lossy())
         )
     }
@@ -499,6 +516,80 @@ pub fn has_unpushed_commits(dir: &Path) -> anyhow::Result<bool> {
 }
 
 /// Refuse deploy when the checkout is dirty or has unpushed work.
+/// Whether `git commit` would find an author here (repo-local or global).
+fn has_commit_identity(dir: &Path) -> bool {
+    ["user.name", "user.email"].iter().all(|key| {
+        run_git(dir, None, &["config", "--get", key])
+            .map(|out| out.status.success())
+            .unwrap_or(false)
+    })
+}
+
+/// Commit and push whatever the workdir has pending; report the new HEAD.
+///
+/// Deploy used to refuse a workdir with uncommitted or unpushed work
+/// ([`ensure_clean_and_pushed`]), which is the state an agent leaves behind
+/// every time it edits an app and stops — so the common case was a deploy that
+/// could not run until someone went to a terminal. Publishing it is what the
+/// user would have done by hand.
+///
+/// `Ok(None)` means there was nothing to publish and the caller should build
+/// the commit it was given. `Ok(Some(sha))` means HEAD moved and *that* is the
+/// commit to build — building the caller's older sha would silently ship
+/// without the work this just committed.
+///
+/// A rejected push is [`ERR_PUSH_REJECTED`], never a merge and never a force:
+/// diverged history is the one thing here a deploy cannot decide on its own.
+pub fn publish_pending_work(
+    dir: &Path,
+    ssh: Option<&SshEnv>,
+    message: &str,
+) -> anyhow::Result<Option<String>> {
+    let dirty = has_uncommitted_changes(dir)?;
+    let ahead = has_unpushed_commits(dir)?;
+    if !dirty && !ahead {
+        return Ok(None);
+    }
+
+    // A detached HEAD cannot be pushed at all, and a previous deploy is the
+    // usual way a checkout ends up on one.
+    ensure_on_branch(dir)?;
+    if dirty {
+        // A commit needs an author. The seed path sets one, but a checkout that
+        // predates it — or was re-inited by hand — may have neither a repo-local
+        // identity nor a global fallback, and `git commit` fails on that rather
+        // than on anything to do with the deploy. Filled in only when missing:
+        // a repo where someone set their own name keeps it.
+        if !has_commit_identity(dir) {
+            set_repo_user_identity(dir, None, None)?;
+        }
+        add_all(dir)?;
+        commit_if_needed(dir, message)?;
+    }
+
+    let out = run_git(dir, ssh, &["push", "-u", "origin", "HEAD"])?;
+    if !out.status.success() {
+        let text = format!(
+            "{}{}",
+            String::from_utf8_lossy(&out.stdout),
+            String::from_utf8_lossy(&out.stderr)
+        );
+        let lower = text.to_ascii_lowercase();
+        if lower.contains("non-fast-forward")
+            || lower.contains("fetch first")
+            || lower.contains("rejected")
+            || lower.contains("behind its remote")
+        {
+            anyhow::bail!("{ERR_PUSH_REJECTED}");
+        }
+        ensure_success(&out, "git push")?;
+    }
+    Ok(Some(head_sha(dir)?))
+}
+
+/// Test-only since deploy stopped gating on it: the assertion that
+/// [`publish_pending_work`] left the checkout in the state it claims to.
+#[cfg(test)]
 pub fn ensure_clean_and_pushed(dir: &Path) -> anyhow::Result<()> {
     if has_uncommitted_changes(dir)? || has_unpushed_commits(dir)? {
         anyhow::bail!("{ERR_DIRTY}");
@@ -883,6 +974,137 @@ mod tests {
         add_all(&work).unwrap();
         commit_if_needed(&work, "local only").unwrap();
         ensure_clean_and_pushed(&work).unwrap_err();
+    }
+
+    #[test]
+    fn git_ssh_command_uses_only_the_deploy_key() {
+        // `-i` alone only adds a candidate: ssh still offers every agent key
+        // and default identity first, and Gitea hangs up after MaxAuthTries.
+        let ssh = SshEnv::from_deploy_key_pem("-----BEGIN KEY-----\nx\n-----END KEY-----")
+            .expect("temp key");
+        let cmd = ssh.git_ssh_command();
+        assert!(cmd.contains("IdentitiesOnly=yes"), "{cmd}");
+        assert!(cmd.contains("-i "), "{cmd}");
+        assert!(cmd.contains("BatchMode=yes"), "{cmd}");
+    }
+
+    #[test]
+    fn publish_pending_work_commits_and_pushes_what_the_agent_left() {
+        // The state an agent leaves behind whenever it edits an app and stops.
+        // Deploy used to refuse it outright.
+        let tmp = tempfile::tempdir().unwrap();
+        let Some(bare) = local_origin(tmp.path()) else {
+            eprintln!("git not usable; skipping");
+            return;
+        };
+        let url = bare.to_string_lossy().to_string();
+        let work = tmp.path().join("app");
+        std::fs::create_dir_all(&work).unwrap();
+        std::fs::write(work.join("README.md"), b"seed").unwrap();
+        init_if_needed(&work).unwrap();
+        ensure_test_identity(&work);
+        set_remote_test(&work, &url).unwrap();
+        add_all(&work).unwrap();
+        commit_if_needed(&work, "seed").unwrap();
+        push_origin_head(&work, None).unwrap();
+        let seeded = head_sha(&work).unwrap();
+
+        // Clean and pushed: nothing to do, and the caller's sha still rules.
+        fetch_origin(&work, None).unwrap();
+        assert_eq!(publish_pending_work(&work, None, "deploy").unwrap(), None);
+
+        // Uncommitted work — including a file git has never seen, which is what
+        // `.teamclu/` and friends are.
+        std::fs::write(work.join("README.md"), b"edited by the agent").unwrap();
+        std::fs::write(work.join("new-file.txt"), b"untracked").unwrap();
+        let published = publish_pending_work(&work, None, "deploy")
+            .unwrap()
+            .expect("a dirty tree must publish");
+        assert_ne!(published, seeded, "HEAD must have moved");
+        assert_eq!(published, head_sha(&work).unwrap());
+        ensure_clean_and_pushed(&work).expect("published work is clean and pushed");
+    }
+
+    #[test]
+    fn publish_pending_work_publishes_a_commit_that_was_never_pushed() {
+        let tmp = tempfile::tempdir().unwrap();
+        let Some(bare) = local_origin(tmp.path()) else {
+            eprintln!("git not usable; skipping");
+            return;
+        };
+        let url = bare.to_string_lossy().to_string();
+        let work = tmp.path().join("app");
+        std::fs::create_dir_all(&work).unwrap();
+        std::fs::write(work.join("README.md"), b"seed").unwrap();
+        init_if_needed(&work).unwrap();
+        ensure_test_identity(&work);
+        set_remote_test(&work, &url).unwrap();
+        add_all(&work).unwrap();
+        commit_if_needed(&work, "seed").unwrap();
+        push_origin_head(&work, None).unwrap();
+
+        // Committed but never pushed: clean tree, still not publishable.
+        std::fs::write(work.join("README.md"), b"local only").unwrap();
+        add_all(&work).unwrap();
+        assert!(commit_if_needed(&work, "local only").unwrap());
+        let local = head_sha(&work).unwrap();
+
+        let published = publish_pending_work(&work, None, "deploy")
+            .unwrap()
+            .expect("an unpushed commit must publish");
+        assert_eq!(
+            published, local,
+            "an existing commit is pushed, not re-made"
+        );
+        ensure_clean_and_pushed(&work).unwrap();
+    }
+
+    #[test]
+    fn publish_pending_work_refuses_a_diverged_remote() {
+        // The one case a deploy must not decide on its own: origin moved. No
+        // merge, no force — an error the user can act on.
+        let tmp = tempfile::tempdir().unwrap();
+        let Some(bare) = local_origin(tmp.path()) else {
+            eprintln!("git not usable; skipping");
+            return;
+        };
+        let url = bare.to_string_lossy().to_string();
+
+        let seed = |dir: &Path, body: &[u8], msg: &str| {
+            std::fs::create_dir_all(dir).unwrap();
+            std::fs::write(dir.join("README.md"), body).unwrap();
+            init_if_needed(dir).unwrap();
+            ensure_test_identity(dir);
+            set_remote_test(dir, &url).unwrap();
+            add_all(dir).unwrap();
+            commit_if_needed(dir, msg).unwrap();
+        };
+
+        let work = tmp.path().join("app");
+        seed(&work, b"seed", "seed");
+        push_origin_head(&work, None).unwrap();
+
+        // Someone else pushes on top of the same branch.
+        let other = tmp.path().join("other");
+        let git = git_bin();
+        assert!(Command::new(&git)
+            .args(["clone", "-q", &url, other.to_string_lossy().as_ref()])
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false));
+        ensure_test_identity(&other);
+        std::fs::write(other.join("README.md"), b"theirs").unwrap();
+        add_all(&other).unwrap();
+        commit_if_needed(&other, "theirs").unwrap();
+        push_origin_head(&other, None).unwrap();
+
+        // Our checkout still has local work and no idea the remote moved.
+        std::fs::write(work.join("README.md"), b"ours").unwrap();
+        let err = publish_pending_work(&work, None, "deploy").unwrap_err();
+        assert!(
+            format!("{err}").contains(ERR_PUSH_REJECTED),
+            "expected a rejection, got: {err}"
+        );
     }
 
     #[test]

--- a/packages/app/src/lib/daemon/daemon-local-client.ts
+++ b/packages/app/src/lib/daemon/daemon-local-client.ts
@@ -1008,6 +1008,15 @@ export interface BuildAppResult {
   outcome: BuildAppOutcome
   /** Why it failed, for the toast. Null unless the outcome is `failed`. */
   error: string | null
+  /**
+   * The commit the daemon actually built, when it differs from the one we
+   * asked for.
+   *
+   * A deploy publishes whatever the agent left uncommitted, which moves HEAD
+   * past the sha we read off Gitea before starting. Finalizing with the old
+   * one would record a commit that is not what is now running.
+   */
+  gitCommitSha: string | null
 }
 
 /**
@@ -1203,7 +1212,7 @@ export async function buildDaemonApp(
   input: BuildDaemonAppInput,
 ): Promise<BuildAppResult> {
   try {
-    const result = await daemonFetch<{ status: string }>('/v1/apps/build', {
+    const result = await daemonFetch<{ status: string; gitCommitSha?: string }>('/v1/apps/build', {
       method: 'POST',
       body: JSON.stringify({
         appId,
@@ -1214,16 +1223,22 @@ export async function buildDaemonApp(
         presignedPut: input.presignedPut.trim(),
       }),
     })
-    if (result.ok) return { outcome: "built", error: null }
+    if (result.ok) {
+      return {
+        outcome: "built",
+        error: null,
+        gitCommitSha: result.data?.gitCommitSha?.trim() || null,
+      }
+    }
     if (result.status === 0) {
       console.warn('[daemon-local-client] app build unreachable (non-fatal):', result.error)
-      return { outcome: "unreachable", error: null }
+      return { outcome: "unreachable", error: null, gitCommitSha: null }
     }
     console.warn('[daemon-local-client] app build failed:', result.error)
-    return { outcome: "failed", error: result.error ?? null }
+    return { outcome: "failed", error: result.error ?? null, gitCommitSha: null }
   } catch (err) {
     console.warn('[daemon-local-client] app build unavailable:', err)
-    return { outcome: "unreachable", error: null }
+    return { outcome: "unreachable", error: null, gitCommitSha: null }
   }
 }
 

--- a/packages/app/src/locales/en.json
+++ b/packages/app/src/locales/en.json
@@ -1364,6 +1364,7 @@
     "deleted": "App deleted",
     "deployErrorReason": {
       "uncommitted": "The workspace has uncommitted or unpushed changes. Commit and push, then deploy.",
+      "pushRejected": "The repo has commits this machine does not. Pull and resolve them, then deploy again.",
       "installTimeout": "Dependency install timed out after 10 minutes. Check the network or the lockfile, then retry.",
       "buildTimeout": "Build timed out after 10 minutes. Check the build script, then retry.",
       "artifactTooLarge": "Build output is over the 50 MiB limit. Trim it, then retry.",

--- a/packages/app/src/locales/zh-CN.json
+++ b/packages/app/src/locales/zh-CN.json
@@ -1364,6 +1364,7 @@
     "deleted": "应用已删除",
     "deployErrorReason": {
       "uncommitted": "工作区有未提交或未推送的改动，请先 commit 并 push 后再部署。",
+      "pushRejected": "仓库里有本机没有的提交。请先拉取并解决冲突，然后重新部署。",
       "installTimeout": "依赖安装超时（10 分钟），请检查网络或 lockfile 后重试。",
       "buildTimeout": "构建超时（10 分钟），请检查构建脚本后重试。",
       "artifactTooLarge": "构建产物超过 50 MiB 上限，请精简输出后重试。",

--- a/packages/app/src/stores/apps-store.test.ts
+++ b/packages/app/src/stores/apps-store.test.ts
@@ -85,7 +85,8 @@ const seedResult = (
 const buildResult = (
   outcome: "built" | "failed" | "unreachable",
   error: string | null = null,
-) => ({ outcome, error });
+  gitCommitSha: string | null = null,
+) => ({ outcome, error, gitCommitSha });
 
 const gitCred = {
   remoteUrl: "git@gitea:team/app-1.git",
@@ -629,6 +630,37 @@ describe("apps-store deploy", () => {
       fcEndpoint: "https://x.fcapp.run",
     });
     expect(useAppsStore.getState().deployingIds).toEqual([]);
+  });
+
+  it("finalizes with the commit the daemon built, not the one we asked for", async () => {
+    // A deploy publishes whatever the agent left uncommitted, so HEAD moves
+    // past the sha read off Gitea before any of this started. Recording that
+    // one would name a commit the running function was not built from.
+    mocks.deployApp.mockResolvedValueOnce({
+      ...readyApp(),
+      fcStatus: "awaiting_build",
+      presignedPut: "https://oss/put?sig=x",
+      deployToken: "tok-1",
+      gitCommitSha: "abc1234567890",
+    });
+    mocks.buildDaemonApp.mockResolvedValueOnce(
+      buildResult("built", null, "def4567890123"),
+    );
+    mocks.finalizeDeploy.mockResolvedValueOnce({ ...readyApp(), fcStatus: "live" });
+    const { useAppsStore } = await import("./apps-store");
+    await useAppsStore.getState().deploy("app-1");
+
+    // The build still ASKED for the sha we resolved — publishing is the
+    // daemon's decision, made once it sees the workdir.
+    expect(mocks.buildDaemonApp).toHaveBeenCalledWith(
+      "app-1",
+      "team-1",
+      expect.objectContaining({ gitCommitSha: "abc1234567890" }),
+    );
+    expect(mocks.finalizeDeploy).toHaveBeenCalledWith("app-1", {
+      gitCommitSha: "def4567890123",
+      deployToken: "tok-1",
+    });
   });
 
   it("authMode=none prompts for public deploy confirmation", async () => {

--- a/packages/app/src/stores/apps-store.ts
+++ b/packages/app/src/stores/apps-store.ts
@@ -150,10 +150,18 @@ async function reportDeployError(set: SetState, appId: string, reason: string): 
  */
 export function mapDeployErrorReason(raw: string): string {
   const lower = raw.toLowerCase();
+  // Deploy publishes uncommitted work now, so this only fires for a daemon
+  // older than that change. Kept for exactly that reason.
   if (raw.includes("uncommitted or unpushed")) {
     return i18n.t(
       "apps.deployErrorReason.uncommitted",
       "The workspace has uncommitted or unpushed changes. Commit and push, then deploy.",
+    );
+  }
+  if (raw.includes("origin has commits this checkout does not")) {
+    return i18n.t(
+      "apps.deployErrorReason.pushRejected",
+      "The repo has commits this machine does not. Pull and resolve them, then deploy again.",
     );
   }
   if (lower.includes("pnpm install timed out")) {
@@ -610,8 +618,13 @@ export const useAppsStore = create<AppsState>((set, get) => ({
       // naming the wrong host on every deploy is worse than no popup: the
       // merged row flips the row to live on its own.
       setDeployProgress(set, appId, "finalize");
+      // What the daemon built, not what we asked for. A deploy publishes work
+      // the agent left uncommitted, and HEAD then sits past the sha read off
+      // Gitea before any of this started; recording that one would name a
+      // commit the running function was not built from.
+      const builtSha = build.gitCommitSha ?? gitCommitSha;
       const finalized = await getBackend().apps.finalizeDeploy(appId, {
-        ...(gitCommitSha ? { gitCommitSha } : {}),
+        ...(builtSha ? { gitCommitSha: builtSha } : {}),
         deployToken: started.deployToken,
       });
       // The merged row carries `authModePendingRedeploy` straight from the


### PR DESCRIPTION
两件卡在同一步（构建前那次 fetch）的问题。

## 1. deploy key 根本没被试到

\`git_ssh_command\` 只给了 \`-i <key>\`，没有 \`IdentitiesOnly=yes\`。\`-i\` 单独使用**只是往候选里加一把**——OpenSSH 仍然会先把 ssh-agent 里的全部身份和默认的 \`~/.ssh/id_*\` 递出去，Gitea 在 \`MaxAuthTries\`（默认 6）之后直接断开。于是在一台加载了几把 key 的开发机上，那把 JIT deploy key 永远轮不到，报出来的样子像是"凭证不对"。

同一个仓库里 \`cli/git_ssh.rs\` 一直传着这个参数，只有这条路径漏了；\`app_clone.rs\` 用的是同一个方法，所以**克隆路径有同样的缺口**，一并修好。

## 2. agent 没提交的改动是一堵墙

\`ensure_clean_and_pushed\` 会拒绝构建一个有未提交/未推送改动的工作区——而这正是 agent 每次改完应用停下来时留下的状态，所以常见情况是"部署跑不了，得先开个终端"。

改成 \`publish_pending_work\`：提交并推送。**push 被拒（origin 上有本机没有的提交）就报错** —— \`ERR_PUSH_REJECTED\`，不 merge 也不 force。历史分叉是这里唯一一件部署不该替用户拿主意的事。

顺带一处必须跟着改的：发布会把 HEAD 推到桌面端开始前从 Gitea 读到的那个 sha **之后**。所以 \`prepare_git_build\` 现在返回它真正构建的 commit，\`POST /v1/apps/build\` 把它带出来，桌面端用这个 sha 去 finalize——否则记录下来的 commit 并不是线上函数构建自的那个。

\`ensure_clean_and_pushed\` 变成 \`#[cfg(test)]\`（没有生产调用点了，但它正好是新测试需要的断言）；\`ERR_DIRTY\` 保留，因为新客户端连旧 daemon 时仍会收到那段文本，桌面端的映射得留着。

## ⚠️ 上线顺序：这个 PR 应该在忽略规则之后合

自动提交是 \`git add -A\`，会把工作区里的**一切**收进去。我在本机一个 data_app 的 checkout 上实测：

```
?? .claude/
?? .opencode/
?? .teamclu/
?? opencode.json
```

三个模板（\`templates/{static-web,slides,tanstack-postgres}/.gitignore\`）**一个都没忽略**这些运行时目录。所以如果本 PR 先上，第一次部署就会把它们提交进各个应用的 Gitea 仓库，而历史很难撤。

同事正在做忽略规则那一半（模板 + 现有 checkout）。**建议那个先合，或者两个一起合。**

## 验证

- \`cargo test -p amuxd --bin amuxd\` 全量 **1571 条通过**；\`sync::app*\` 51 条、\`http::apps\` 20 条单独复跑也绿。新增 4 条测试：\`IdentitiesOnly\` 在命令里、脏工作区（含未跟踪文件）会被提交并推送、只是没推过的 commit 会被推送而不是重新提交、**远端分叉时报 ERR_PUSH_REJECTED**。
- \`cargo clippy -p amuxd --all-targets\` exit 0；\`rustfmt --check\` 对我改的文件干净（\`app_git.rs\` 剩两处 diff 在 781/790 行，是本来就有的，没跑全 crate 的 fmt）。
- 前端 \`tsc\` 干净、\`pnpm test:unit\` **505 文件 / 3344 用例全绿**，新增一条：finalize 用的是 daemon 构建的那个 sha，不是我们要的那个。

**没有在真机上跑过一次成功的部署** —— 那需要重建 amuxd sidecar 并重启正在跑的 daemon。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FrF3nNFmobpFqzA6zFSkUN