### PR TITLE
fix(wecom): record streamed replies even if file delivery fails

### DIFF
--- a/apps/daemon/src/channels/core/mod.rs
+++ b/apps/daemon/src/channels/core/mod.rs
@@ -506,10 +506,21 @@ impl Core {
             .update(&handle, &outbound.text, Some(end))
             .await
             .map_err(|e| CoreError::Render(e.to_string()))?;
+
+        // Record before the file send. WeCom media goes out on a separate
+        // API that can fail after the text already landed in the chat
+        // (a reload clearing the process-global gateway holder); skipping
+        // write_reply then left the desktop session with no answer.
+        if !produced_nothing {
+            self.writer
+                .write_reply(&session.session_id, &reply, attachments)
+                .await?;
+        }
+
         let file_deliveries = if outbound.attachments.is_empty() {
             0
         } else {
-            driver
+            match driver
                 .deliver(
                     &msg.conversation,
                     msg.reply_context.as_deref(),
@@ -520,18 +531,18 @@ impl Core {
                     },
                 )
                 .await
-                .map_err(|e| CoreError::Render(e.to_string()))?;
-            1
+            {
+                Ok(_) => 1,
+                Err(e) => {
+                    tracing::warn!(
+                        session_id = %session.session_id,
+                        error = %e,
+                        "gateway: file delivery failed after the reply was recorded"
+                    );
+                    0
+                }
+            }
         };
-
-        // Nothing to record: the store rejects an empty message outright
-        // ("content is required"), so a cancelled turn used to end on an error
-        // log for a turn that did exactly what was asked of it.
-        if !produced_nothing {
-            self.writer
-                .write_reply(&session.session_id, &reply, attachments)
-                .await?;
-        }
         // The opening delivery, every intermediate edit, the final one, and
         // any file delivery.
         Ok(1 + updates + 1 + file_deliveries)

--- a/apps/daemon/src/channels/core/tests.rs
+++ b/apps/daemon/src/channels/core/tests.rs
@@ -187,6 +187,8 @@ struct FakeDriver {
     updates: Mutex<Vec<(String, bool)>>,
     /// How each update reported the turn's state — `None` while streaming.
     ends: Mutex<Vec<Option<TurnEnd>>>,
+    /// When set, `deliver` fails if the outbound message carries files.
+    fail_attachment_deliver: bool,
 }
 
 #[async_trait]
@@ -220,6 +222,12 @@ impl ChannelDriver for FakeDriver {
         reply_context: Option<&str>,
         msg: &OutboundMessage,
     ) -> Result<DeliveryId, DriverError> {
+        if self.fail_attachment_deliver && !msg.attachments.is_empty() {
+            return Err(DriverError::Transport(
+                "WeCom gateway is not running. Start the WeCom gateway before sending media."
+                    .into(),
+            ));
+        }
         self.delivered
             .lock()
             .unwrap()
@@ -564,6 +572,31 @@ fn attaching_fixture(
         },
         writer,
     )
+}
+
+#[tokio::test]
+async fn a_streamed_reply_is_written_even_when_the_file_delivery_fails() {
+    // WeCom: the stream finish already sent the text; uploading the attached
+    // file then looked up a process-global gateway holder that a reload had
+    // cleared. Failing that send used to skip write_reply, so the desktop
+    // session never got the answer the chat already showed.
+    let (core, writer) = attaching_fixture("u-att-fail", "hello.txt", "created /tmp/hello.txt");
+    let d = FakeDriver {
+        caps: Some(IM),
+        fail_attachment_deliver: true,
+        ..Default::default()
+    };
+
+    let outcome = core
+        .handle(&d, inbound_from("u-att-fail", "create hello.txt"))
+        .await
+        .expect("the session reply must not depend on the file send");
+
+    assert!(matches!(outcome, Outcome::Handled { .. }));
+    assert_eq!(
+        writer.replies.lock().unwrap().as_slice(),
+        ["created /tmp/hello.txt"]
+    );
 }
 
 #[tokio::test]

--- a/crates/teamclu-gateway/src/wecom.rs
+++ b/crates/teamclu-gateway/src/wecom.rs
@@ -930,18 +930,18 @@ pub(crate) fn normalize_callback(
 
 /// WeCom as a transport driver.
 ///
-/// Holds only what rendering needs: the shared websocket sink (set on connect),
-/// the config (for `bot_id`, which is part of the binding), and the pacers for
-/// in-flight streaming replies.
+/// Holds a clone of the gateway this driver was built from (shared sink,
+/// upload, pending-response map) plus the pacers for in-flight streaming
+/// replies. Media and proactive sends go through that clone — not the
+/// process-global `ACTIVE_GATEWAY` holder, which a channel-reload can
+/// clear while this driver is still connected.
 ///
 /// The pacer map is why `update` cannot be stateless: WeCom throttles card
 /// updates, and the gap is measured from the previous frame of *that* reply.
 /// Rebuilding a pacer per update would reset the clock and burst straight
 /// through the limit.
 pub struct WeComDriver {
-    #[allow(dead_code)]
-    config: Arc<RwLock<WeComConfig>>,
-    shared_ws_sink: Arc<RwLock<Option<WsSink>>>,
+    gateway: WeComGateway,
     pacers: tokio::sync::Mutex<std::collections::HashMap<String, InFlightReply>>,
 }
 
@@ -959,23 +959,40 @@ struct InFlightReply {
 }
 
 impl WeComDriver {
-    pub fn new(
-        config: Arc<RwLock<WeComConfig>>,
-        shared_ws_sink: Arc<RwLock<Option<WsSink>>>,
-    ) -> Self {
+    pub fn new(gateway: WeComGateway) -> Self {
         Self {
-            config,
-            shared_ws_sink,
+            gateway,
             pacers: tokio::sync::Mutex::new(std::collections::HashMap::new()),
         }
     }
 
     async fn sink(&self) -> Result<WsSink, driver::DriverError> {
-        self.shared_ws_sink
+        self.gateway
+            .shared_ws_sink
             .read()
             .await
             .clone()
             .ok_or_else(|| driver::DriverError::Transport("WeCom is not connected".into()))
+    }
+
+    async fn send_media(
+        &self,
+        chatid: &str,
+        chat_type: u32,
+        data: &[u8],
+        filename: &str,
+        media_type: &str,
+    ) -> Result<(), driver::DriverError> {
+        let sink = self.sink().await?;
+        let media_id = self
+            .gateway
+            .upload_media(data, filename, media_type, &sink)
+            .await
+            .map_err(driver::DriverError::Transport)?;
+        self.gateway
+            .send_media_to_chat(chatid, chat_type, &media_id, media_type)
+            .await
+            .map_err(driver::DriverError::Transport)
     }
 
     /// `(chatid, chat_type)` for the media APIs, which address chats by number
@@ -1048,15 +1065,14 @@ impl driver::ChannelDriver for WeComDriver {
             let path = att.local_path.as_deref().unwrap_or_default();
             let bytes = std::fs::read(path)
                 .map_err(|e| driver::DriverError::Transport(format!("read {path}: {e}")))?;
-            upload_and_send_media(
+            self.send_media(
                 chatid,
                 chat_type,
                 &bytes,
                 &att.filename,
                 media_type_for(&att.mime),
             )
-            .await
-            .map_err(driver::DriverError::Transport)?;
+            .await?;
         }
 
         // Files with no text of their own: the caption already went out with
@@ -1071,7 +1087,8 @@ impl driver::ChannelDriver for WeComDriver {
             // Nothing to answer: this is proactive, which WeCom does through a
             // different command entirely.
             let (chatid, chat_type) = Self::chat_target(to);
-            send_proactive_message(chatid, chat_type, &msg.text)
+            self.gateway
+                .send_chat_message(chatid, chat_type, &msg.text)
                 .await
                 .map_err(driver::DriverError::Transport)?;
             return Ok(driver::DeliveryId(format!("proactive:{chatid}")));
@@ -1082,7 +1099,8 @@ impl driver::ChannelDriver for WeComDriver {
         // A finished one-shot reply (a command answer, an error). Sent as
         // markdown so a reply containing a list or a code block renders as one.
         if !msg.text.trim().is_empty() {
-            send_proactive_message(chatid, chat_type, &msg.text)
+            self.gateway
+                .send_chat_message(chatid, chat_type, &msg.text)
                 .await
                 .map_err(driver::DriverError::Transport)?;
             return Ok(driver::DeliveryId(format!("markdown:{chatid}")));
@@ -1162,7 +1180,8 @@ impl driver::ChannelDriver for WeComDriver {
         if text.trim().is_empty() {
             return Ok(());
         }
-        send_proactive_message(&chatid, chat_type, text)
+        self.gateway
+            .send_chat_message(&chatid, chat_type, text)
             .await
             .map_err(driver::DriverError::Transport)
     }
@@ -1330,7 +1349,7 @@ impl WeComGateway {
     /// replies through. Shares the config and websocket sink rather than
     /// copying them, so a reconnect is visible to both.
     pub fn as_driver(&self) -> WeComDriver {
-        WeComDriver::new(self.config.clone(), self.shared_ws_sink.clone())
+        WeComDriver::new(self.clone())
     }
 
     pub fn workspace_path(&self) -> &str {


### PR DESCRIPTION
## Description

A WeCom streamed turn that attaches a file could deliver the text to the chat and then fail uploading the file (`WeCom gateway is not running`). That error skipped `write_reply`, so the desktop session never got an agent reply the channel already showed.

Two changes:

1. **Pipeline:** `run_streamed` records the session reply after the stream finish, *before* the file send. A file-delivery error is a warning, not a failed turn.
2. **WeCom driver:** media and proactive sends go through the driver's own `WeComGateway` clone (the live websocket), not the process-global `ACTIVE_GATEWAY` holder. Channel reloads can clear that holder while the driver is still connected; introspect/MCP still use the holder functions.

## Related Issue

Live session `d8239e9f-4eb6-4bb1-9184-624a5ac8e742` — WeCom got “created hello.txt”, desktop did not.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

- `cargo test -p amuxd --bin amuxd channels::core::tests` — 22 passed (includes the new streamed-reply-on-file-failure case).
- `cargo test -p teamclu-gateway --lib wecom::` — 44 passed.
- Related: stream-finish content is #1275. This PR is the persist / media-holder fix; they can land independently.
- The running desktop sidecar will not pick this up until `amuxd` is rebuilt and restarted.


Made with [Cursor](https://cursor.com)