### PR TITLE
fix(apps): 让 daemon 自己的文件不要被提交进应用仓库

### DIFF
--- a/apps/daemon/src/sync/app_build.rs
+++ b/apps/daemon/src/sync/app_build.rs
@@ -245,6 +245,13 @@ pub fn prepare_git_build(
     app_git::set_remote_origin(workdir, git.remote_url, Some(&ssh))?;
     app_git::fetch_origin(workdir, Some(&ssh))?;
 
+    // Before anything is staged: the deploy commits the workdir now, and the
+    // daemon's own runtime files sit in it untracked. Best-effort — a checkout
+    // we cannot write an exclude file into should still deploy.
+    if let Err(e) = app_git::ensure_runtime_excludes(workdir) {
+        tracing::warn!(app_id = git.app_id, error = %e, "could not write .git/info/exclude");
+    }
+
     // Whatever the agent left behind gets committed and pushed rather than
     // refused. When that happens HEAD is already the commit to build, and
     // checking out the caller's older sha would ship without it.

--- a/apps/daemon/src/sync/app_git.rs
+++ b/apps/daemon/src/sync/app_git.rs
@@ -516,6 +516,95 @@ pub fn has_unpushed_commits(dir: &Path) -> anyhow::Result<bool> {
 }
 
 /// Refuse deploy when the checkout is dirty or has unpushed work.
+/// What the daemon and the agents it runs leave inside an app checkout that is
+/// not the app's source: per-machine runtime config and agent state.
+///
+/// Surveyed on a real machine rather than guessed — across the app checkouts
+/// there, the untracked entries are the brand meta directory, `.claude/`,
+/// `.opencode/` and `opencode.json`. Everything else that turns up untracked is
+/// the app's own files, which a deploy *should* commit.
+///
+/// Brand-aware, so a white-label build excludes its own meta directory; the
+/// legacy one is listed too because a checkout seeded before the rename still
+/// has it.
+///
+/// The brand is a parameter rather than read from the environment so the
+/// template drift test can ask for the official one without racing whatever
+/// else has the brand env set.
+pub(crate) fn runtime_exclude_entries(brand: &str) -> Vec<String> {
+    let mut entries = vec![
+        format!("{}/", teamclu_runtime_env::workspace_meta_dir_name(brand)),
+        format!("{}/", teamclu_runtime_env::LEGACY_BRAND_WORKSPACE_META_DIR),
+        teamclu_runtime_env::workspace_config_file_name(brand),
+    ];
+    // Agent-local state, not brand-scoped: whichever agent ran in this checkout
+    // wrote it, and none of it describes the app.
+    entries.extend([
+        ".claude/".to_string(),
+        ".opencode/".to_string(),
+        "opencode.json".to_string(),
+    ]);
+    entries.dedup();
+    entries
+}
+
+/// Keep `.git/info/exclude` covering the daemon's own runtime files.
+///
+/// Not `.gitignore`: that file belongs to the app, is committed, and for an
+/// imported repo is none of our business. `info/exclude` is per-checkout and
+/// untracked — exactly the right home for machine-local state, and it reaches
+/// the checkouts that already exist, which editing a template never can.
+///
+/// Best-effort by contract: a deploy that cannot write this should still
+/// deploy. Callers log and continue.
+pub fn ensure_runtime_excludes(dir: &Path) -> std::io::Result<()> {
+    const HEADER: &str = "# managed by amuxd — app runtime files, never app source";
+    let path = dir.join(".git").join("info").join("exclude");
+    let existing = std::fs::read_to_string(&path).unwrap_or_default();
+
+    // Replace the whole managed block rather than appending: the entries are
+    // brand-derived, so a rebrand must be able to drop the old ones.
+    let mut kept: Vec<&str> = Vec::new();
+    let mut in_block = false;
+    for line in existing.lines() {
+        if line.trim() == HEADER {
+            in_block = true;
+            continue;
+        }
+        if in_block {
+            if line.trim().is_empty() {
+                in_block = false;
+            }
+            continue;
+        }
+        kept.push(line);
+    }
+
+    let mut out = String::new();
+    for line in kept {
+        out.push_str(line);
+        out.push('\n');
+    }
+    if !out.is_empty() && !out.ends_with("\n\n") {
+        out.push('\n');
+    }
+    out.push_str(HEADER);
+    out.push('\n');
+    for entry in runtime_exclude_entries(&teamclu_runtime_env::brand_short_name_from_env()) {
+        out.push_str(&entry);
+        out.push('\n');
+    }
+    out.push('\n');
+
+    if out == existing {
+        return Ok(());
+    }
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    std::fs::write(&path, out)
+}
+
 /// Whether `git commit` would find an author here (repo-local or global).
 fn has_commit_identity(dir: &Path) -> bool {
     ["user.name", "user.email"].iter().all(|key| {
@@ -647,6 +736,11 @@ pub fn init_commit_push(
     }
     set_remote_origin(dir, remote_url, Some(&ssh))?;
     ensure_on_branch(dir)?;
+    // Same reason as the deploy path: the seed commit is an `add -A`, and a
+    // reseed runs over a checkout the daemon has already been living in.
+    if let Err(e) = ensure_runtime_excludes(dir) {
+        tracing::warn!(app_id, error = %e, "could not write .git/info/exclude");
+    }
     add_all(dir)?;
     commit_if_needed(dir, commit_message)?;
     push_origin_head(dir, Some(&ssh))?;
@@ -805,7 +899,12 @@ mod tests {
         let out = run_git(&work, None, &["config", "--get", "ssh.variant"]).unwrap();
         assert_eq!(String::from_utf8_lossy(&out.stdout).trim(), "ssh");
         // Repo-local only: it must not leak into any other repo on the machine.
-        let out = run_git(&work, None, &["config", "--local", "--get", "core.sshCommand"]).unwrap();
+        let out = run_git(
+            &work,
+            None,
+            &["config", "--local", "--get", "core.sshCommand"],
+        )
+        .unwrap();
         assert!(out.status.success(), "core.sshCommand must be repo-local");
     }
 
@@ -814,7 +913,10 @@ mod tests {
         // amuxd ships inside an .app bundle, so its path routinely has spaces.
         // Unquoted, git splits it and reports a missing command instead.
         let quoted = shell_quote("/Applications/My App.app/Contents/MacOS/amuxd");
-        assert!(quoted.starts_with('"') && quoted.ends_with('"'), "got {quoted}");
+        assert!(
+            quoted.starts_with('"') && quoted.ends_with('"'),
+            "got {quoted}"
+        );
     }
 
     #[test]
@@ -974,6 +1076,71 @@ mod tests {
         add_all(&work).unwrap();
         commit_if_needed(&work, "local only").unwrap();
         ensure_clean_and_pushed(&work).unwrap_err();
+    }
+
+    #[test]
+    fn runtime_excludes_are_written_without_touching_what_was_there() {
+        let tmp = tempfile::tempdir().unwrap();
+        let work = tmp.path().join("app");
+        std::fs::create_dir_all(work.join(".git").join("info")).unwrap();
+        std::fs::write(work.join(".git/info/exclude"), "# mine\nscratch/\n").unwrap();
+
+        ensure_runtime_excludes(&work).unwrap();
+        let first = std::fs::read_to_string(work.join(".git/info/exclude")).unwrap();
+        assert!(
+            first.contains("scratch/"),
+            "user lines must survive: {first}"
+        );
+        for entry in runtime_exclude_entries(&teamclu_runtime_env::brand_short_name_from_env()) {
+            assert!(first.contains(&entry), "missing {entry} in {first}");
+        }
+
+        // Idempotent: a second deploy must not stack another block.
+        ensure_runtime_excludes(&work).unwrap();
+        let second = std::fs::read_to_string(work.join(".git/info/exclude")).unwrap();
+        assert_eq!(first, second);
+    }
+
+    #[test]
+    fn runtime_excludes_keep_an_agents_own_files_out_of_the_app_repo() {
+        // The point of the whole thing: deploy commits the workdir, so anything
+        // the daemon left in it that git can see ends up in the app's history.
+        let tmp = tempfile::tempdir().unwrap();
+        let work = tmp.path().join("app");
+        std::fs::create_dir_all(&work).unwrap();
+        init_if_needed(&work).unwrap();
+        ensure_test_identity(&work);
+        ensure_runtime_excludes(&work).unwrap();
+
+        // Built from the helper, not spelled out: `storage_lint` scans test
+        // code too, and a quoted brand-directory literal is what it forbids.
+        let meta = teamclu_runtime_env::workspace_meta_dir_name(
+            &teamclu_runtime_env::brand_short_name_from_env(),
+        );
+        std::fs::write(work.join("index.html"), b"app source").unwrap();
+        std::fs::create_dir_all(work.join(".claude")).unwrap();
+        std::fs::write(work.join(".claude/settings.json"), b"{}").unwrap();
+        std::fs::create_dir_all(work.join(&meta)).unwrap();
+        std::fs::write(work.join(&meta).join("state.json"), b"{}").unwrap();
+        std::fs::write(work.join("opencode.json"), b"{}").unwrap();
+
+        add_all(&work).unwrap();
+        let out = run_git(&work, None, &["diff", "--cached", "--name-only"]).unwrap();
+        let staged = String::from_utf8_lossy(&out.stdout);
+        assert!(
+            staged.contains("index.html"),
+            "app source must be staged: {staged}"
+        );
+        for runtime in [
+            ".claude/".to_string(),
+            format!("{meta}/"),
+            "opencode.json".to_string(),
+        ] {
+            assert!(
+                !staged.contains(&runtime),
+                "{runtime} must not be staged: {staged}"
+            );
+        }
     }
 
     #[test]

--- a/apps/daemon/src/sync/app_templates.rs
+++ b/apps/daemon/src/sync/app_templates.rs
@@ -116,6 +116,27 @@ fn write_dir(dir: &Dir<'_>, dest: &Path, vars: &TemplateVars<'_>) -> anyhow::Res
 
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn every_template_ignores_the_daemon_runtime_files() {
+        // The deploy commits the workdir, so a template that does not ignore
+        // these seeds an app whose first deploy pushes machine-local state into
+        // its own repo. The list lives in `app_git`; this is the drift guard.
+        for app_type in [AppType::StaticWeb, AppType::Slides, AppType::DataApp] {
+            let gitignore = app_type
+                .dir()
+                .get_file(".gitignore")
+                .unwrap_or_else(|| panic!("{app_type:?} template has no .gitignore"))
+                .contents_utf8()
+                .expect("utf-8 .gitignore");
+            for entry in crate::sync::app_git::runtime_exclude_entries("teamclu") {
+                assert!(
+                    gitignore.lines().any(|line| line.trim() == entry),
+                    "{app_type:?} template does not ignore {entry}"
+                );
+            }
+        }
+    }
+
     use super::*;
 
     #[test]

--- a/templates/slides/.gitignore
+++ b/templates/slides/.gitignore
@@ -2,3 +2,13 @@
 dist/
 node_modules/
 .DS_Store
+
+# TeamClu runtime files — written per machine by the daemon and the agents it
+# runs, never part of the app. A deploy commits the workdir, so anything here
+# that is not ignored ends up in the app's repo.
+.teamclu/
+.teamclaw/
+teamclu.json
+.claude/
+.opencode/
+opencode.json

--- a/templates/static-web/.gitignore
+++ b/templates/static-web/.gitignore
@@ -2,3 +2,13 @@
 dist/
 node_modules/
 .DS_Store
+
+# TeamClu runtime files — written per machine by the daemon and the agents it
+# runs, never part of the app. A deploy commits the workdir, so anything here
+# that is not ignored ends up in the app's repo.
+.teamclu/
+.teamclaw/
+teamclu.json
+.claude/
+.opencode/
+opencode.json

--- a/templates/tanstack-postgres/.gitignore
+++ b/templates/tanstack-postgres/.gitignore
@@ -6,3 +6,13 @@ dist/
 .tanstack/
 src/routeTree.gen.ts
 .env
+
+# TeamClu runtime files — written per machine by the daemon and the agents it
+# runs, never part of the app. A deploy commits the workdir, so anything here
+# that is not ignored ends up in the app's repo.
+.teamclu/
+.teamclaw/
+teamclu.json
+.claude/
+.opencode/
+opencode.json


### PR DESCRIPTION
#1273 让部署自动提交工作区，而 daemon 会在工作区里留下一堆不属于应用的东西。**不改这个，每个存量应用的第一次部署都会把本机状态推进它自己的仓库，历史很难撤。**

列表是**实测得来的**，不是猜的：在本机所有应用 checkout 上跑 `git status --porcelain`，未跟踪的就是这四类 —— 品牌 meta 目录、`.claude/`、`.opencode/`、`opencode.json`；其余未跟踪的都是应用自己的文件（比如 agent 新写的 `public/*.html`），那些恰恰是部署该提交的。

## 两半，缺一不可

- **`.git/info/exclude`**，在每次部署和每次播种时写入。**不是**应用的 `.gitignore` —— 那个文件是提交进去的、属于仓库主人，对导入的应用更是轮不到我们改。`info/exclude` 是 per-checkout 且不被跟踪的，正好是本机状态该待的地方，也是**唯一能够到存量 checkout 的那一半**（改模板对已经存在的应用毫无作用）。按品牌解析，白标构建排除它自己的 meta 目录；写成可替换的托管块，改名后旧条目会被丢掉。
- **三个启动模板**，让新播种的应用把同样的规则带在仓库里，别人 clone 下来也看得见。

两边不会漂移：`every_template_ignores_the_daemon_runtime_files` 遍历嵌入的模板，断言每一个都覆盖了 daemon 会排除的全部条目。

## 两个 lint 上的坑

`storage_lint` **连测试代码一起扫**，所以测试里的 meta 目录名是用 `workspace_meta_dir_name` 拼出来的，没有写死字面量——同一次运行也顺带证明生产路径走的是品牌 helper（`workspace_meta_gate` 那条也过）。

`app_git.rs` 里有两处断言被 rustfmt 重排了，那是本次改动没碰到的既有行；现在整个文件在 `rustfmt --check` 下是干净的。

## 验证

`cargo test -p amuxd --bin amuxd` **1567 条全过**，`cargo clippy -p amuxd --all-targets` exit 0，`cargo test -p teamclu-runtime-env` 全过（含 `storage_lint` 那条棘轮）。新增三条测试：exclude 块幂等且保留用户原有行、staged 内容里应用源码在而运行时文件不在、模板与 daemon 列表一致。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FrF3nNFmobpFqzA6zFSkUN