### PR TITLE
fix(apps): 中文应用名的 vanity 域名改用 punycode，让它能部署

### DIFF
--- a/services/fc/src/lib/apps-public-host.ts
+++ b/services/fc/src/lib/apps-public-host.ts
@@ -11,6 +11,8 @@
  * `*.<domain>`, so a label containing a dot is rejected rather than served
  * with a certificate that cannot exist.
  */
+import { domainToASCII, domainToUnicode } from "node:url";
+
 type Env = NodeJS.ProcessEnv;
 
 /** Blank disables vanity hostnames entirely — the app keeps its FC trigger URL. */
@@ -18,8 +20,35 @@ export const appsPublicDomain = (env: Env = process.env) => env.APPS_PUBLIC_DOMA
 
 export const ID_PREFIX_LEN = 8;
 
-export function appPublicLabel(slug: string, appId: string): string {
-  return `${slug}-${appId.slice(0, ID_PREFIX_LEN)}`;
+/** RFC 1035: one DNS label is at most 63 bytes, punycode included. */
+const MAX_LABEL_BYTES = 63;
+
+/**
+ * The label, in the ASCII form DNS actually accepts.
+ *
+ * `slugify` keeps CJK on purpose — it is what stops every Chinese-named app in
+ * a team collapsing to the same `app` slug and colliding on
+ * `apps_team_slug_uniq` — so the slug is routinely not ASCII, and the label
+ * built from it is not a legal hostname. Alibaba FC rejects the custom domain
+ * outright, which is how a Chinese app name turned into a failed deploy.
+ *
+ * Punycode rather than stripping the non-ASCII: stripping would collapse those
+ * slugs the same way, and could not fix an app that already has one. The stored
+ * slug is untouched; only the name derived from it changes, so an existing app
+ * starts working on its next deploy with no migration. An ASCII slug encodes to
+ * itself, so nothing changes for the apps that already deploy.
+ *
+ * `null` when the label cannot be expressed — unencodable, or past the 63-byte
+ * limit. Callers then fall back to the app's FC trigger URL, which is the same
+ * thing that happens on a deployment with no apps domain at all. Fail closed:
+ * a hostname no certificate can cover is worse than no vanity hostname.
+ */
+export function appPublicLabel(slug: string, appId: string): string | null {
+  const ascii = domainToASCII(`${slug}-${appId.slice(0, ID_PREFIX_LEN)}`);
+  // WHATWG's answer for "this is not encodable" is the empty string.
+  if (!ascii) return null;
+  if (Buffer.byteLength(ascii) > MAX_LABEL_BYTES) return null;
+  return ascii;
 }
 
 /**
@@ -51,7 +80,8 @@ export function appFcRouteHost(
 ): string | null {
   const domain = appsFcRouteDomain(env);
   if (!domain || !slug || !appId) return null;
-  return `${appPublicLabel(slug, appId)}.${domain}`;
+  const label = appPublicLabel(slug, appId);
+  return label && `${label}.${domain}`;
 }
 
 /** Public URL for an app, or null when this deployment has no apps domain. */
@@ -62,7 +92,8 @@ export function appPublicUrl(
 ): string | null {
   const domain = appsPublicDomain(env);
   if (!domain || !slug || !appId) return null;
-  return `https://${appPublicLabel(slug, appId)}.${domain}`;
+  const label = appPublicLabel(slug, appId);
+  return label && `https://${label}.${domain}`;
 }
 
 /**
@@ -80,9 +111,16 @@ export function parseAppPublicHost(
   const name = host.split(":")[0].trim().toLowerCase();
   const suffix = `.${domain.toLowerCase()}`;
   if (!name.endsWith(suffix)) return null;
-  const label = name.slice(0, -suffix.length);
+  const asciiLabel = name.slice(0, -suffix.length);
   // Exactly one level: `*.<domain>` matches `x.<domain>`, never `x.y.<domain>`.
-  if (!label || label.includes(".")) return null;
+  if (!asciiLabel || asciiLabel.includes(".")) return null;
+  // DNS and the Host header carry the punycode form, and the id prefix is
+  // encoded *inside* it — `xn--teamclu--cb4f314d-nx65apz36b` has no readable
+  // `-cb4f314d` to split on. Decode first, then split, or every non-ASCII app
+  // fails to route no matter how correctly its hostname was created.
+  const label = asciiLabel.startsWith("xn--")
+    ? domainToUnicode(asciiLabel) || asciiLabel
+    : asciiLabel;
   const cut = label.lastIndexOf("-");
   if (cut <= 0) return null;
   const slug = label.slice(0, cut);

--- a/services/fc/test/apps-vanity.test.ts
+++ b/services/fc/test/apps-vanity.test.ts
@@ -48,6 +48,45 @@ test("the label carries an id suffix because slugs are only unique per team", ()
   assert.equal(appPublicUrl("website", APP_ID, env), `https://website-18e4ecad.${DOMAIN}`);
 });
 
+test("a non-ascii slug becomes a legal hostname instead of a failed deploy", () => {
+  // `slugify` keeps CJK on purpose (it is what stops every Chinese-named app
+  // in a team collapsing to `app`), so the slug routinely is not ASCII. The
+  // label built from it went to Alibaba FC as a custom domain name and was
+  // rejected — three of seventeen apps on the live deployment have such a
+  // slug, two of them stuck in deploy_error.
+  const label = appPublicLabel("teamclu-官网", APP_ID);
+  assert.equal(label, "xn--teamclu--18e4ecad-nx65apz36b");
+  assert.match(label!, /^[a-z0-9-]+$/, "a DNS label is ASCII letters, digits and hyphens");
+  assert.equal(
+    appPublicUrl("teamclu-官网", APP_ID, env),
+    `https://xn--teamclu--18e4ecad-nx65apz36b.${DOMAIN}`,
+  );
+});
+
+test("the id prefix survives the encoding, so the host still routes", () => {
+  // The prefix ends up INSIDE the punycode, with no readable `-18e4ecad` to
+  // split on. Parsing has to decode before it splits, or every app this fixes
+  // would deploy to a hostname that then resolves to nothing.
+  const label = appPublicLabel("teamclu-官网", APP_ID);
+  assert.deepEqual(parseAppPublicHost(`${label}.${DOMAIN}`, env), {
+    slug: "teamclu-官网",
+    idPrefix: "18e4ecad",
+  });
+});
+
+test("a label too long for DNS gets no vanity host at all", () => {
+  // Fail closed: 63 bytes is the hard limit, and a hostname no certificate can
+  // cover is worse than falling back to the app's FC trigger URL.
+  //
+  // 60 characters, not 40: punycode compresses a repeated character hard
+  // (40 of them still encode to 58 bytes), and `domainToASCII` enforces no
+  // length limit of its own — the check here is the only thing standing
+  // between a very long name and an illegal hostname.
+  const long = "验".repeat(60);
+  assert.equal(appPublicLabel(long, APP_ID), null);
+  assert.equal(appPublicUrl(long, APP_ID, env), null);
+});
+
 test("no apps domain means no public URL at all", () => {
   assert.equal(appPublicUrl("website", APP_ID, {} as NodeJS.ProcessEnv), null);
   assert.equal(parseAppPublicHost(`website-18e4ecad.${DOMAIN}`, {} as NodeJS.ProcessEnv), null);


### PR DESCRIPTION
## 根因

`slugify`（`supabase-repo/shared.ts:109`）的字符类里**明确保留了 CJK**：

```js
.replace(/[^a-z0-9一-龥]+/g, "-")
```

这是有意的——不保留的话，同一个团队里所有中文名应用都会退化成同一个 `app`，撞 `apps_team_slug_uniq`。代价是 slug 经常不是 ASCII，于是 `<slug>-<id8>` 不是合法 DNS 标签。`finalizeDeploy` 把它当自定义域名交给阿里云 FC（`app-deploy.ts:290-292`），FC 直接拒，部署失败。

**线上 17 个应用里有 3 个是这种 slug，其中两个此刻正卡在 `deploy_error`：**

```
抖音生活数据助手   deploy_error
douyin数据分析     deploy_error
teamclu-官网       （还没部署过）
```

## 改法

`appPublicLabel` 改成输出 punycode。**不选「剥掉非 ASCII」**：那会把 slug 按字符类特意避免的方式重新压平，而且修不了已经存在的应用。

本次改动**不碰任何存量数据**——`publicUrl` 是 `mapApp` 在读取时算出来的，不是存的列，所以那三个应用一上线就会拿到合法域名，下一次部署即可通过。纯 ASCII 的 slug 编码后**等于自身**，另外 14 个应用一个字节都不变。

**容易漏的另一半是解析。** id 前缀会被编进 punycode 里——`xn--teamclu--cb4f314d-nx65apz36b` 里根本没有可供 `lastIndexOf` 找的 `-cb4f314d`。不在 `parseAppPublicHost` 里先 `domainToUnicode` 解码，这次修好的每一个域名都会**建得出来但解析不到**，请求落地即 404。

超过 63 字节直接没有 vanity 域名，应用退回用 FC 触发器 URL（跟「部署没有配 apps 域名」是同一条回退路径）。一个签不出证书的域名比没有域名更糟。顺带一提 `domainToASCII` **自己不做长度限制**（40 个重复汉字才 58 字节，punycode 对重复字符压缩很狠），所以那个检查是真在干活的。

用 Node 内置的 `domainToASCII` / `domainToUnicode`，没有新依赖。

## 验证

`npm test` **942 条 / 929 通过 / 0 失败**（13 条 skip 是需要本地 Supabase 的那些）；`npm run build`（镜像用的 tsconfig）通过。新增 3 条测试：中文 slug 产出合法 ASCII 标签、**编码后 id 前缀仍能解析回来**、超长时 fail closed。

⚠️ 动了 `services/fc/**`，合并会触发 self-host 自动部署。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FrF3nNFmobpFqzA6zFSkUN