### PR TITLE
fix(deploy): 应用没有代码时说人话，别把 pnpm 的原文甩给用户

### DIFF
--- a/apps/daemon/src/http/apps.rs
+++ b/apps/daemon/src/http/apps.rs
@@ -922,6 +922,7 @@ fn map_build_error(err: anyhow::Error) -> HttpError {
         crate::sync::app_build::ERR_OUTPUT_MISSING,
         crate::sync::app_build::ERR_ARTIFACT_TOO_LARGE,
         crate::sync::app_build::ERR_LOCKFILE_MISMATCH,
+        crate::sync::app_build::ERR_NO_PACKAGE_JSON,
         crate::sync::app_build::ERR_INSTALL_TIMEOUT,
         crate::sync::app_build::ERR_BUILD_TIMEOUT,
         "git repo URL",

--- a/apps/daemon/src/sync/app_build.rs
+++ b/apps/daemon/src/sync/app_build.rs
@@ -18,6 +18,10 @@ pub fn oss_object_key(app_id: &str) -> String {
 /// English messages the HTTP layer maps to user-facing copy.
 pub const ERR_OUTPUT_MISSING: &str = "build output missing in .output/";
 pub const ERR_ARTIFACT_TOO_LARGE: &str = "artifact exceeds 50 MiB limit";
+/// The app has no code to build. `pnpm install` reports it as
+/// `ERR_PNPM_NO_PKG_MANIFEST`, which is accurate and says nothing a user can
+/// act on; the desktop turns this marker into the two things they can do.
+pub const ERR_NO_PACKAGE_JSON: &str = "the app's folder has no package.json to build";
 pub const ERR_LOCKFILE_MISMATCH: &str =
     "lockfile out of sync with package.json; commit updated pnpm-lock.yaml";
 pub const ERR_INSTALL_TIMEOUT: &str = "pnpm install timed out after 10 minutes";
@@ -110,6 +114,12 @@ fn map_pnpm_failure(cmd: &str, args: &[&str], stdout: &str, stderr: &str) -> Str
         && (lower.contains("err_pnpm_outdated_lockfile") || lower.contains("cannot install with"))
     {
         return ERR_LOCKFILE_MISMATCH.to_string();
+    }
+    // An empty workdir is the failure a user is most likely to hit and least
+    // likely to diagnose: nothing about "no package.json found in
+    // /Users/…/apps/<uuid>" says the app was never given any code.
+    if lower.contains("err_pnpm_no_pkg_manifest") {
+        return ERR_NO_PACKAGE_JSON.to_string();
     }
     format!(
         "{cmd} {:?} failed: {}",
@@ -382,18 +392,30 @@ mod tests {
     }
 
     #[test]
-    fn map_pnpm_failure_reports_what_pnpm_wrote_on_stdout() {
-        // The failure this was written for: a deploy of an app whose workdir
-        // has no package.json reported the `.npmrc` warning as the reason,
-        // because the reason itself was on the stream nobody read.
+    fn map_pnpm_failure_names_an_app_with_no_code() {
         let msg = map_pnpm_failure(
             "pnpm",
             &["install", "--frozen-lockfile"],
             " ERR_PNPM_NO_PKG_MANIFEST  No package.json found in /apps/app-1",
+            "",
+        );
+        assert_eq!(msg, ERR_NO_PACKAGE_JSON);
+    }
+
+    #[test]
+    fn map_pnpm_failure_reports_what_pnpm_wrote_on_stdout() {
+        // The shape of the failure this was written for: the reason is on
+        // stdout and stderr holds an unrelated warning, so reading stderr alone
+        // reported the warning as the cause. A code with no friendly mapping of
+        // its own, so what is being checked is that the raw cause survives.
+        let msg = map_pnpm_failure(
+            "pnpm",
+            &["install", "--frozen-lockfile"],
+            " ERR_PNPM_FETCH_404  GET https://registry/x: Not Found",
             " WARN  Issue while reading \"/home/me/.npmrc\". Failed to replace env in config: ${NODE_AUTH_TOKEN}",
         );
         assert!(
-            msg.contains("ERR_PNPM_NO_PKG_MANIFEST"),
+            msg.contains("ERR_PNPM_FETCH_404"),
             "the actual cause must survive: {msg}"
         );
         assert_ne!(msg, ERR_LOCKFILE_MISMATCH);

--- a/packages/app/src/locales/en.json
+++ b/packages/app/src/locales/en.json
@@ -1365,6 +1365,7 @@
     "deployErrorReason": {
       "uncommitted": "The workspace has uncommitted or unpushed changes. Commit and push, then deploy.",
       "pushRejected": "The repo has commits this machine does not. Pull and resolve them, then deploy again.",
+      "noPackageJson": "This app has no code yet — its folder has no package.json. Ask the agent to build it, or reseed the app.",
       "installTimeout": "Dependency install timed out after 10 minutes. Check the network or the lockfile, then retry.",
       "buildTimeout": "Build timed out after 10 minutes. Check the build script, then retry.",
       "artifactTooLarge": "Build output is over the 50 MiB limit. Trim it, then retry.",

--- a/packages/app/src/locales/zh-CN.json
+++ b/packages/app/src/locales/zh-CN.json
@@ -1365,6 +1365,7 @@
     "deployErrorReason": {
       "uncommitted": "工作区有未提交或未推送的改动，请先 commit 并 push 后再部署。",
       "pushRejected": "仓库里有本机没有的提交。请先拉取并解决冲突，然后重新部署。",
+      "noPackageJson": "这个应用还没有代码——目录里没有 package.json。让 agent 先把应用做出来，或者重新播种。",
       "installTimeout": "依赖安装超时（10 分钟），请检查网络或 lockfile 后重试。",
       "buildTimeout": "构建超时（10 分钟），请检查构建脚本后重试。",
       "artifactTooLarge": "构建产物超过 50 MiB 上限，请精简输出后重试。",

--- a/packages/app/src/stores/apps-store.test.ts
+++ b/packages/app/src/stores/apps-store.test.ts
@@ -869,6 +869,15 @@ describe("mapDeployErrorReason", () => {
       .toContain("上传链接");
   });
 
+  it("says an app has no code, not what pnpm called it", async () => {
+    // The daemon maps ERR_PNPM_NO_PKG_MANIFEST to this marker. What reached the
+    // user before was the raw pnpm line — accurate, and no help at all.
+    const { mapDeployErrorReason } = await import("./apps-store");
+    const raw = "app build failed: the app's folder has no package.json to build";
+    expect(mapDeployErrorReason(raw)).toContain("还没有代码");
+    expect(mapDeployErrorReason(raw)).not.toContain("package.json to build");
+  });
+
   it("does not read the workdir path as a dead daemon", async () => {
     // Daemon errors quote `~/.amuxd/teams/<team>/apps/<app>`. Matching the bare
     // substring "amuxd" reported every one of them as "the daemon is not

--- a/packages/app/src/stores/apps-store.ts
+++ b/packages/app/src/stores/apps-store.ts
@@ -158,6 +158,12 @@ export function mapDeployErrorReason(raw: string): string {
       "The workspace has uncommitted or unpushed changes. Commit and push, then deploy.",
     );
   }
+  if (raw.includes("no package.json to build")) {
+    return i18n.t(
+      "apps.deployErrorReason.noPackageJson",
+      "This app has no code yet — its folder has no package.json. Ask the agent to build it, or reseed the app.",
+    );
+  }
   if (raw.includes("origin has commits this checkout does not")) {
     return i18n.t(
       "apps.deployErrorReason.pushRejected",


### PR DESCRIPTION
#1273 之后 pnpm 的真实报错终于能透出来了，但透出来的是这个：

```
ERR_PNPM_NO_PKG_MANIFEST  No package.json found in
/Users/…/.amuxd/teams/<uuid>/apps/<uuid>
```

准确，且对用户毫无用处——尤其是它完全没说出真正的意思：**这个应用根本还没有代码**。而这恰恰是最容易撞上的一种失败：agent 什么都没写过的应用，一点部署就是它。

daemon 把这一个错误码映射成 `ERR_NO_PACKAGE_JSON`，形状跟 `ERR_LOCKFILE_MISMATCH` 一样——一个稳定的英文标记，由桌面端翻成本地化文案，并指出两条出路：

> 这个应用还没有代码——目录里没有 package.json。让 agent 先把应用做出来，或者重新播种。

`map_pnpm_failure_reports_what_pnpm_wrote_on_stdout` 的 fixture 换成了 `ERR_PNPM_FETCH_404`：那条测试的主题是「原因在 stdout、stderr 上只有无关警告时，原因要能活下来」，所以它需要一个**没有**友好映射的错误码才测得住这件事。

## 验证

`cargo test -p amuxd --bin amuxd` **1568 条全过**、`cargo clippy --all-targets` exit 0、`rustfmt --check` 干净；前端 `tsc` 干净、`eslint` 0 error、`pnpm test:unit` **3345 条全过**，新增一条断言映射后的文案里不再出现 pnpm 原文。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FrF3nNFmobpFqzA6zFSkUN