### PR TITLE
feat(daemon): generate session titles from the first user prompt via pi

### DIFF
--- a/apps/daemon/assets/pi-extension/session-context.test.mjs
+++ b/apps/daemon/assets/pi-extension/session-context.test.mjs
@@ -283,6 +283,12 @@ function shouldSkipTitlePrompt(prompt) {
   return body.startsWith("/") || body.startsWith("!") || body.startsWith("$");
 }
 
+const CRON_REPLY_TOKEN_MARKER = "[SYSTEM] Reply token for this run:";
+
+function isCronJobPrompt(raw) {
+  return raw.includes(CRON_REPLY_TOKEN_MARKER);
+}
+
 const TITLE_FOLLOW_MARKER = "Reply only to the user prompt that follows.]";
 const TITLE_END_CONTEXT_MARKER = "[End context]";
 
@@ -389,7 +395,9 @@ async function maybeGenerateSessionTitle(pi, event, ctx, deps = {}) {
   if (attempted.has(sessionId)) return;
   if (String(pi.getSessionName?.() ?? "").trim()) return;
 
-  const prompt = userPromptForTitle(String(event.prompt ?? ""));
+  const raw = String(event.prompt ?? "");
+  if (isCronJobPrompt(raw)) return;
+  const prompt = userPromptForTitle(raw);
   if (shouldSkipTitlePrompt(prompt)) return;
 
   attempted.add(sessionId);
@@ -433,6 +441,43 @@ test("session title skips slash commands and empty prompts", () => {
   assert.equal(shouldSkipTitlePrompt("!ls"), true);
   assert.equal(shouldSkipTitlePrompt("$ echo hi"), true);
   assert.equal(shouldSkipTitlePrompt("帮我查一下深圳美食"), false);
+});
+
+test("session title treats cron run tokens as cron, not chat tokens", () => {
+  assert.equal(
+    isCronJobPrompt(
+      "[SYSTEM] Reply token for this run: tok\nPass it as `reply_token`\n\nnightly sync",
+    ),
+    true,
+  );
+  assert.equal(
+    isCronJobPrompt("[SYSTEM] Reply token for this chat: tok\nhello"),
+    false,
+  );
+});
+
+test("session title does not run for cron job prompts", async () => {
+  let llmCalled = false;
+  const attempted = new Set();
+  const pi = { getSessionName: () => "", setSessionName() {} };
+  const ctx = { ui: { sessionId: "pi:/tmp/cron.json", setTitle() {} } };
+  await maybeGenerateSessionTitle(
+    pi,
+    {
+      prompt:
+        "[SYSTEM] Reply token for this run: tok\nPass it as `reply_token`\n\nnightly sync",
+    },
+    ctx,
+    {
+      attempted,
+      llmTitle: async () => {
+        llmCalled = true;
+        return "Nope";
+      },
+    },
+  );
+  assert.equal(llmCalled, false);
+  assert.equal(attempted.size, 0);
 });
 
 test("session title strips TeamClu instruction wrappers to the user text", () => {

--- a/apps/daemon/assets/pi-extension/session-context.test.mjs
+++ b/apps/daemon/assets/pi-extension/session-context.test.mjs
@@ -254,3 +254,463 @@ test("before_agent_start skips when ctx.ui.sessionId is missing", async () => {
   assert.equal(result, undefined);
   assert.equal(called, false);
 });
+
+/** Mirrors session-title helpers in teamclu.ts */
+const SESSION_TITLE_MAX_LEN = 80;
+const AGENT_MENTION_LINE_RE = /^\[Mentioned agents:[^\]]*\]$/i;
+const HUMAN_MENTION_ONLY_LINE_RE =
+  /^\[Mentioned:[^\]]*\|instruction:[^\]]*\]$/i;
+const INLINE_HUMAN_MENTION_RE =
+  /\[Mentioned:[^\]]*\|instruction:[^\]]*\]/gi;
+
+function stripMentionsForSessionTitle(content) {
+  return content
+    .split(/\n+/)
+    .map((line) => {
+      const trimmed = line.trim();
+      if (!trimmed) return "";
+      if (AGENT_MENTION_LINE_RE.test(trimmed)) return "";
+      if (HUMAN_MENTION_ONLY_LINE_RE.test(trimmed)) return "";
+      return trimmed.replace(INLINE_HUMAN_MENTION_RE, "").replace(/\s+/g, " ").trim();
+    })
+    .filter(Boolean)
+    .join("\n");
+}
+
+function shouldSkipTitlePrompt(prompt) {
+  const body = stripMentionsForSessionTitle(prompt).trim();
+  if (!body) return true;
+  return body.startsWith("/") || body.startsWith("!") || body.startsWith("$");
+}
+
+const TITLE_FOLLOW_MARKER = "Reply only to the user prompt that follows.]";
+const TITLE_END_CONTEXT_MARKER = "[End context]";
+
+function userPromptForTitle(raw) {
+  let text = raw;
+  const endCtx = text.lastIndexOf(TITLE_END_CONTEXT_MARKER);
+  if (endCtx >= 0) {
+    text = text.slice(endCtx + TITLE_END_CONTEXT_MARKER.length);
+  }
+  const follow = text.lastIndexOf(TITLE_FOLLOW_MARKER);
+  if (follow >= 0) {
+    text = text.slice(follow + TITLE_FOLLOW_MARKER.length);
+  }
+  const lines = text.split("\n");
+  let i = 0;
+  while (i < lines.length && !lines[i].trim()) i += 1;
+  while (i < lines.length && /^\[[^\]]+\] /.test(lines[i])) i += 1;
+  while (i < lines.length && !lines[i].trim()) i += 1;
+  return lines.slice(i).join("\n").trim();
+}
+
+function looksLikeMachineTitle(title) {
+  const t = title.trim();
+  if (!t) return true;
+  return (
+    t.includes("TeamClu Instructions") ||
+    t.startsWith("[Context —") ||
+    t.startsWith("[End context]")
+  );
+}
+
+function sanitizeGeneratedTitle(raw) {
+  let title = raw.trim().replace(/^["'“”‘’`]+|["'“”‘’`]+$/g, "");
+  title = (title.split("\n")[0] || title).trim();
+  title = title.replace(/[。.\s]+$/g, "").trim();
+  title = title.slice(0, SESSION_TITLE_MAX_LEN);
+  return looksLikeMachineTitle(title) ? "" : title;
+}
+
+function assistantMessageText(message) {
+  if (!message) return "";
+  if (message.stopReason === "error" || message.stopReason === "aborted") return "";
+  const parts = Array.isArray(message.content) ? message.content : [];
+  return parts
+    .filter((b) => b && b.type === "text" && typeof b.text === "string")
+    .map((b) => b.text)
+    .join("")
+    .trim();
+}
+
+function describeTitleResponse(message) {
+  const types = Array.isArray(message?.content)
+    ? message.content.map((b) => b?.type ?? "?").join(",")
+    : "";
+  return `stopReason=${message?.stopReason ?? "missing"} error=${message?.errorMessage ?? ""} types=${types}`;
+}
+
+function titleCompleteOptions(model) {
+  const options = {
+    maxTokens: 256,
+    timeoutMs: 15_000,
+  };
+  if (!model || typeof model !== "object" || model.reasoning !== true) return options;
+  const map = model.thinkingLevelMap && typeof model.thinkingLevelMap === "object"
+    ? model.thinkingLevelMap
+    : undefined;
+  if (map?.off === null) return options;
+  options.reasoning = "off";
+  if (map) {
+    options.reasoningEffort = typeof map.off === "string" && map.off ? map.off : "none";
+  }
+  return options;
+}
+
+/** Mirrors teamclu.ts llmSessionTitle — uses ctx.modelRegistry.complete, not pi-ai. */
+async function llmSessionTitle(ctx, prompt) {
+  const model = ctx.model;
+  const registry = ctx.modelRegistry;
+  const complete = registry?.complete;
+  if (!model || typeof complete !== "function") return "";
+  const user = [
+    "Write a short session title for this user request.",
+    "Maximum 8 words or 40 characters. Match the user's language.",
+    "Reply with ONLY the title, no quotes.",
+    "",
+    "User request:",
+    prompt.slice(0, 2000),
+  ].join("\n");
+  const response = await complete.call(
+    registry,
+    model,
+    { messages: [{ role: "user", content: user }] },
+    titleCompleteOptions(model),
+  );
+  const text = assistantMessageText(response);
+  if (!text) describeTitleResponse(response);
+  return text;
+}
+
+async function maybeGenerateSessionTitle(pi, event, ctx, deps = {}) {
+  const sessionId = backendSessionIdFromContext(ctx);
+  if (!sessionId) return;
+  const attempted = deps.attempted ?? new Set();
+  if (attempted.has(sessionId)) return;
+  if (String(pi.getSessionName?.() ?? "").trim()) return;
+
+  const prompt = userPromptForTitle(String(event.prompt ?? ""));
+  if (shouldSkipTitlePrompt(prompt)) return;
+
+  attempted.add(sessionId);
+  const ui = ctx.ui;
+  const job = {
+    prompt,
+    model: ctx.model,
+    registry: ctx.modelRegistry,
+    setTitle: ui.setTitle?.bind(ui),
+    setSessionName: pi.setSessionName?.bind(pi),
+    getSessionName: () => pi.getSessionName?.(),
+    llmTitle: deps.llmTitle,
+  };
+
+  const apply = async () => {
+    let title = "";
+    try {
+      title = sanitizeGeneratedTitle(
+        await (job.llmTitle?.({ model: job.model, modelRegistry: job.registry }, job.prompt) ?? ""),
+      );
+    } catch {
+      title = "";
+    }
+    if (!title) return;
+    if (String(job.getSessionName?.() ?? "").trim()) return;
+    job.setSessionName?.(title);
+    job.setTitle?.(title);
+  };
+
+  if (deps.fireAndForget) {
+    deps.pending?.push(apply());
+    return;
+  }
+  await apply();
+}
+
+test("session title skips slash commands and empty prompts", () => {
+  assert.equal(shouldSkipTitlePrompt(""), true);
+  assert.equal(shouldSkipTitlePrompt("   "), true);
+  assert.equal(shouldSkipTitlePrompt("/compact"), true);
+  assert.equal(shouldSkipTitlePrompt("!ls"), true);
+  assert.equal(shouldSkipTitlePrompt("$ echo hi"), true);
+  assert.equal(shouldSkipTitlePrompt("帮我查一下深圳美食"), false);
+});
+
+test("session title strips TeamClu instruction wrappers to the user text", () => {
+  const wrapped = [
+    "[TeamClu Instructions — follow for all replies in this session. Do not acknowledge separately. Reply only to the user prompt that follows.]",
+    "[system] 请使用中文回答",
+    "",
+    "帮我查一下深圳美食",
+  ].join("\n");
+  assert.equal(userPromptForTitle(wrapped), "帮我查一下深圳美食");
+});
+
+test("session title strips silent context wrappers", () => {
+  const wrapped = [
+    "[Context — messages received in this session while you were not mentioned. Read for context but do not reply to them. Reply only to the user prompt that follows.]",
+    "Ann: earlier note",
+    "[End context]",
+    "",
+    "real question",
+  ].join("\n");
+  assert.equal(userPromptForTitle(wrapped), "real question");
+});
+
+test("session title sends unwrapped user text to the LLM", async () => {
+  const seen = [];
+  const named = [];
+  const pi = { getSessionName: () => "", setSessionName: (name) => named.push(name) };
+  const ctx = { ui: { sessionId: "pi:/tmp/wrap.json", setTitle() {} } };
+  const wrapped = [
+    "[TeamClu Instructions — follow for all replies in this session. Do not acknowledge separately. Reply only to the user prompt that follows.]",
+    "[system] 请使用中文回答",
+    "",
+    "帮我查一下深圳美食",
+  ].join("\n");
+  await maybeGenerateSessionTitle(pi, { prompt: wrapped }, ctx, {
+    llmTitle: async (_ctx, prompt) => {
+      seen.push(prompt);
+      return "深圳美食推荐";
+    },
+  });
+  assert.deepEqual(seen, ["帮我查一下深圳美食"]);
+  assert.deepEqual(named, ["深圳美食推荐"]);
+});
+
+test("session title sanitizes model output", () => {
+  assert.equal(sanitizeGeneratedTitle('"深圳美食推荐"'), "深圳美食推荐");
+  assert.equal(sanitizeGeneratedTitle("Launch Plan.\nextra"), "Launch Plan");
+  assert.equal(sanitizeGeneratedTitle(""), "");
+  assert.equal(
+    sanitizeGeneratedTitle(
+      "[TeamClu Instructions — follow for all replies in this session. Do not acknowled",
+    ),
+    "",
+  );
+});
+
+test("session title LLM uses modelRegistry.complete with the session model", async () => {
+  const calls = [];
+  const ctx = {
+    model: {
+      id: "gpt-5.6-luna",
+      provider: "openai-codex",
+      reasoning: true,
+      thinkingLevelMap: { xhigh: "xhigh", minimal: "low" },
+    },
+    modelRegistry: {
+      complete: async function complete(model, context, options) {
+        calls.push({ thisArg: this, model, context, options });
+        return {
+          stopReason: "stop",
+          content: [{ type: "text", text: "深圳美食" }],
+        };
+      },
+    },
+  };
+  const text = await llmSessionTitle(ctx, "帮我查一下深圳美食");
+  assert.equal(text, "深圳美食");
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].thisArg, ctx.modelRegistry);
+  assert.equal(calls[0].model.provider, "openai-codex");
+  assert.match(calls[0].context.messages[0].content, /帮我查一下深圳美食/);
+  assert.equal(calls[0].options.reasoning, "off");
+  assert.equal(calls[0].options.reasoningEffort, "none");
+  assert.equal(calls[0].options.reasoningSummary, undefined);
+  assert.equal(calls[0].options.maxTokens, 256);
+});
+
+test("session title LLM omits thinking options for non-reasoning models", async () => {
+  const calls = [];
+  await llmSessionTitle(
+    {
+      model: { id: "gpt-4.1", provider: "openai", reasoning: false },
+      modelRegistry: {
+        complete: async function complete(_model, _context, options) {
+          calls.push(options);
+          return { stopReason: "stop", content: [{ type: "text", text: "ok" }] };
+        },
+      },
+    },
+    "hello",
+  );
+  assert.equal(calls[0].maxTokens, 256);
+  assert.equal(calls[0].reasoning, undefined);
+  assert.equal(calls[0].reasoningEffort, undefined);
+});
+
+test("session title LLM skips disable when the model forbids off", async () => {
+  const calls = [];
+  await llmSessionTitle(
+    {
+      model: {
+        id: "claude-sonnet",
+        provider: "anthropic",
+        reasoning: true,
+        thinkingLevelMap: { off: null, high: "high" },
+      },
+      modelRegistry: {
+        complete: async function complete(_model, _context, options) {
+          calls.push(options);
+          return { stopReason: "stop", content: [{ type: "text", text: "ok" }] };
+        },
+      },
+    },
+    "hello",
+  );
+  assert.equal(calls[0].reasoning, undefined);
+  assert.equal(calls[0].reasoningEffort, undefined);
+});
+
+test("session title LLM uses the model's mapped off effort", async () => {
+  const calls = [];
+  await llmSessionTitle(
+    {
+      model: {
+        id: "gpt-5.4",
+        provider: "openai-codex",
+        reasoning: true,
+        thinkingLevelMap: { off: "none", minimal: "low" },
+      },
+      modelRegistry: {
+        complete: async function complete(_model, _context, options) {
+          calls.push(options);
+          return { stopReason: "stop", content: [{ type: "text", text: "ok" }] };
+        },
+      },
+    },
+    "hello",
+  );
+  assert.equal(calls[0].reasoning, "off");
+  assert.equal(calls[0].reasoningEffort, "none");
+});
+
+test("session title LLM returns empty for thinking-only responses", async () => {
+  const text = await llmSessionTitle(
+    {
+      model: { id: "gpt-5.6-luna", provider: "openai-codex" },
+      modelRegistry: {
+        complete: async () => ({
+          stopReason: "length",
+          errorMessage: "",
+          content: [{ type: "thinking" }],
+        }),
+      },
+    },
+    "你有哪些能力？",
+  );
+  assert.equal(text, "");
+});
+
+test("session title LLM returns empty without modelRegistry.complete", async () => {
+  assert.equal(await llmSessionTitle({ model: { provider: "openai-codex" } }, "hello"), "");
+  assert.equal(await llmSessionTitle({ modelRegistry: { complete: async () => "x" } }, "hello"), "");
+});
+
+test("session title ignores errored assistant messages", () => {
+  assert.equal(
+    assistantMessageText({
+      stopReason: "error",
+      content: [{ type: "text", text: "nope" }],
+    }),
+    "",
+  );
+  assert.equal(
+    assistantMessageText({
+      stopReason: "stop",
+      content: [{ type: "thinking", thinking: "..." }],
+    }),
+    "",
+  );
+  assert.equal(
+    assistantMessageText({
+      stopReason: "stop",
+      content: [{ type: "text", text: "深圳美食推荐" }],
+    }),
+    "深圳美食推荐",
+  );
+});
+
+test("session title fire-and-forget does not wait for the LLM", async () => {
+  const named = [];
+  let release;
+  const llmTitle = () =>
+    new Promise((resolve) => {
+      release = resolve;
+    });
+  const pending = [];
+  const pi = {
+    getSessionName: () => "",
+    setSessionName: (name) => named.push(name),
+  };
+  const ctx = { ui: { sessionId: "pi:/tmp/defer.json", setTitle() {} } };
+  await maybeGenerateSessionTitle(pi, { prompt: "帮我查一下深圳美食" }, ctx, {
+    fireAndForget: true,
+    pending,
+    llmTitle,
+  });
+  assert.deepEqual(named, []);
+  release("Deferred Title");
+  await Promise.all(pending);
+  assert.deepEqual(named, ["Deferred Title"]);
+});
+
+test("session title uses LLM result and setTitle", async () => {
+  const named = [];
+  const titles = [];
+  const pi = {
+    getSessionName: () => "",
+    setSessionName: (name) => named.push(name),
+  };
+  const ctx = {
+    ui: {
+      sessionId: "pi:/tmp/a.json",
+      setTitle: (title) => titles.push(title),
+    },
+  };
+  await maybeGenerateSessionTitle(pi, { prompt: "帮我写一份发布计划" }, ctx, {
+    llmTitle: async () => '"Launch Plan"',
+  });
+  assert.deepEqual(named, ["Launch Plan"]);
+  assert.deepEqual(titles, ["Launch Plan"]);
+});
+
+test("session title does not set a title when LLM returns nothing", async () => {
+  const named = [];
+  const pi = { getSessionName: () => "", setSessionName: (name) => named.push(name) };
+  const ctx = { ui: { sessionId: "pi:/tmp/b.json", setTitle() {} } };
+  await maybeGenerateSessionTitle(pi, { prompt: "帮我查一下深圳美食" }, ctx, {
+    llmTitle: async () => "",
+  });
+  assert.deepEqual(named, []);
+});
+
+test("session title does not run twice for the same session", async () => {
+  let calls = 0;
+  const attempted = new Set();
+  const pi = { getSessionName: () => "", setSessionName() {} };
+  const ctx = { ui: { sessionId: "pi:/tmp/c.json", setTitle() {} } };
+  const deps = {
+    attempted,
+    llmTitle: async () => {
+      calls += 1;
+      return "Once";
+    },
+  };
+  await maybeGenerateSessionTitle(pi, { prompt: "hello" }, ctx, deps);
+  await maybeGenerateSessionTitle(pi, { prompt: "hello again" }, ctx, deps);
+  assert.equal(calls, 1);
+});
+
+test("session title skips when pi already has a session name", async () => {
+  let llmCalled = false;
+  const pi = { getSessionName: () => "Already Named", setSessionName() {} };
+  const ctx = { ui: { sessionId: "pi:/tmp/d.json", setTitle() {} } };
+  await maybeGenerateSessionTitle(pi, { prompt: "hello" }, ctx, {
+    llmTitle: async () => {
+      llmCalled = true;
+      return "Nope";
+    },
+  });
+  assert.equal(llmCalled, false);
+});

--- a/apps/daemon/assets/pi-extension/teamclu.ts
+++ b/apps/daemon/assets/pi-extension/teamclu.ts
@@ -1265,6 +1265,13 @@ function shouldSkipTitlePrompt(prompt: string): boolean {
   return body.startsWith("/") || body.startsWith("!") || body.startsWith("$");
 }
 
+/** Cron job prompts — they already have a daemon-minted `Cron:` title. */
+const CRON_REPLY_TOKEN_MARKER = "[SYSTEM] Reply token for this run:";
+
+function isCronJobPrompt(raw: string): boolean {
+  return raw.includes(CRON_REPLY_TOKEN_MARKER);
+}
+
 /**
  * amuxd prefixes the user text with `[TeamClu Instructions …]` / silent
  * `[Context — …][End context]` wrappers. `event.prompt` is that whole blob;
@@ -1408,7 +1415,9 @@ function startSessionTitle(
   if (titleAttemptedSessionIds.has(sessionId)) return;
   if (String(pi.getSessionName?.() ?? "").trim()) return;
 
-  const prompt = userPromptForTitle(String(event.prompt ?? ""));
+  const raw = String(event.prompt ?? "");
+  if (isCronJobPrompt(raw)) return;
+  const prompt = userPromptForTitle(raw);
   if (shouldSkipTitlePrompt(prompt)) return;
 
   let ui: TeamcluExtensionUIContext;

--- a/apps/daemon/assets/pi-extension/teamclu.ts
+++ b/apps/daemon/assets/pi-extension/teamclu.ts
@@ -75,11 +75,22 @@ type TeamcluExtensionUIContext = {
     options: string[],
     opts?: { timeout?: number; signal?: AbortSignal },
   ): Promise<string | undefined>;
+  setTitle?(title: string): void;
 };
 type ExtensionContext = {
   ui: TeamcluExtensionUIContext;
+  model?: unknown;
+  modelRegistry?: {
+    complete?(
+      model: unknown,
+      context: { messages: Array<{ role: string; content: string }> },
+      options?: Record<string, unknown>,
+    ): Promise<unknown>;
+  };
 };
 type ExtensionAPI = {
+  getSessionName?(): string | undefined;
+  setSessionName?(name: string, source?: string): void;
   on(
     event: "tool_call",
     handler: (
@@ -90,7 +101,7 @@ type ExtensionAPI = {
   on(
     event: "before_agent_start",
     handler: (
-      event: { systemPrompt?: string },
+      event: { systemPrompt?: string; prompt?: string },
       ctx: ExtensionContext,
     ) => Promise<{ systemPrompt?: string } | undefined>,
   ): void;
@@ -1201,6 +1212,253 @@ function registerQuestionTool(pi: ExtensionAPI, ownTools: Set<string>): void {
 }
 
 // ---------------------------------------------------------------------------
+// Auto session title (LLM from the first real prompt)
+// ---------------------------------------------------------------------------
+// Fire-and-forget on `before_agent_start`: capture model / setTitle while
+// ctx is active, then `complete()` without awaiting so the first turn is
+// not blocked. Title `complete()` does not pass `sessionId`, so it does
+// not share the agent Codex websocket. Uses the session's current model
+// + auth. Thinking is disabled from that model's `reasoning` /
+// `thinkingLevelMap`. amuxd turns `setTitle` into `session_title` and
+// adopts it over the frontend first-message title.
+
+const SESSION_TITLE_MAX_LEN = 80;
+const SESSION_TITLE_MAX_INPUT = 2000;
+const SESSION_TITLE_MAX_TOKENS = 256;
+const SESSION_TITLE_TIMEOUT_MS = 15_000;
+
+/** Prefix line from TeamClu `buildStructuredMentionLines`. */
+const AGENT_MENTION_LINE_RE = /^\[Mentioned agents:[^\]]*\]$/i;
+const HUMAN_MENTION_ONLY_LINE_RE =
+  /^\[Mentioned:[^\]]*\|instruction:[^\]]*\]$/i;
+const INLINE_HUMAN_MENTION_RE =
+  /\[Mentioned:[^\]]*\|instruction:[^\]]*\]/gi;
+
+const titleAttemptedSessionIds = new Set<string>();
+
+type SessionTitleJob = {
+  prompt: string;
+  model: unknown;
+  registry: ExtensionContext["modelRegistry"];
+  setTitle?: (title: string) => void;
+  setSessionName?: (name: string, source?: string) => void;
+  getSessionName?: () => string | undefined;
+};
+
+function stripMentionsForSessionTitle(content: string): string {
+  return content
+    .split(/\n+/)
+    .map((line) => {
+      const trimmed = line.trim();
+      if (!trimmed) return "";
+      if (AGENT_MENTION_LINE_RE.test(trimmed)) return "";
+      if (HUMAN_MENTION_ONLY_LINE_RE.test(trimmed)) return "";
+      return trimmed.replace(INLINE_HUMAN_MENTION_RE, "").replace(/\s+/g, " ").trim();
+    })
+    .filter(Boolean)
+    .join("\n");
+}
+
+function shouldSkipTitlePrompt(prompt: string): boolean {
+  const body = stripMentionsForSessionTitle(prompt).trim();
+  if (!body) return true;
+  return body.startsWith("/") || body.startsWith("!") || body.startsWith("$");
+}
+
+/**
+ * amuxd prefixes the user text with `[TeamClu Instructions …]` / silent
+ * `[Context — …][End context]` wrappers. `event.prompt` is that whole blob;
+ * the LLM must see only the user tail.
+ */
+const TITLE_FOLLOW_MARKER = "Reply only to the user prompt that follows.]";
+const TITLE_END_CONTEXT_MARKER = "[End context]";
+
+function userPromptForTitle(raw: string): string {
+  let text = raw;
+  const endCtx = text.lastIndexOf(TITLE_END_CONTEXT_MARKER);
+  if (endCtx >= 0) {
+    text = text.slice(endCtx + TITLE_END_CONTEXT_MARKER.length);
+  }
+  const follow = text.lastIndexOf(TITLE_FOLLOW_MARKER);
+  if (follow >= 0) {
+    text = text.slice(follow + TITLE_FOLLOW_MARKER.length);
+  }
+  const lines = text.split("\n");
+  let i = 0;
+  while (i < lines.length && !lines[i].trim()) i += 1;
+  while (i < lines.length && /^\[[^\]]+\] /.test(lines[i])) i += 1;
+  while (i < lines.length && !lines[i].trim()) i += 1;
+  return lines.slice(i).join("\n").trim();
+}
+
+function looksLikeMachineTitle(title: string): boolean {
+  const t = title.trim();
+  if (!t) return true;
+  return (
+    t.includes("TeamClu Instructions") ||
+    t.startsWith("[Context —") ||
+    t.startsWith("[End context]")
+  );
+}
+
+function sanitizeGeneratedTitle(raw: string): string {
+  let title = raw.trim().replace(/^["'“”‘’`]+|["'“”‘’`]+$/g, "");
+  title = (title.split("\n")[0] || title).trim();
+  title = title.replace(/[。.\s]+$/g, "").trim();
+  title = title.slice(0, SESSION_TITLE_MAX_LEN);
+  return looksLikeMachineTitle(title) ? "" : title;
+}
+
+function assistantMessageText(message: {
+  stopReason?: string;
+  errorMessage?: string;
+  content?: Array<{ type?: string; text?: string }>;
+} | null | undefined): string {
+  if (!message) return "";
+  if (message.stopReason === "error" || message.stopReason === "aborted") return "";
+  const parts = Array.isArray(message.content) ? message.content : [];
+  return parts
+    .filter((b) => b && b.type === "text" && typeof b.text === "string")
+    .map((b) => b.text as string)
+    .join("")
+    .trim();
+}
+
+function describeTitleResponse(message: {
+  stopReason?: string;
+  errorMessage?: string;
+  content?: Array<{ type?: string }>;
+} | null | undefined): string {
+  const types = Array.isArray(message?.content)
+    ? message.content.map((b) => b?.type ?? "?").join(",")
+    : "";
+  return `stopReason=${message?.stopReason ?? "missing"} error=${message?.errorMessage ?? ""} types=${types}`;
+}
+
+type TitleLlmCtx = {
+  model?: unknown;
+  modelRegistry?: ExtensionContext["modelRegistry"];
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+/** Options for `modelRegistry.complete` — derived from the session model. */
+function titleCompleteOptions(model: unknown): Record<string, unknown> {
+  const options: Record<string, unknown> = {
+    maxTokens: SESSION_TITLE_MAX_TOKENS,
+    timeoutMs: SESSION_TITLE_TIMEOUT_MS,
+  };
+  if (!isRecord(model) || model.reasoning !== true) return options;
+  const map = isRecord(model.thinkingLevelMap) ? model.thinkingLevelMap : undefined;
+  // `off: null` means this model cannot disable thinking.
+  if (map?.off === null) return options;
+  options.reasoning = "off";
+  // `complete()` uses provider.stream(), which often reads reasoningEffort
+  // instead of `reasoning`. Use the model's mapped off value when present.
+  if (map) {
+    options.reasoningEffort = typeof map.off === "string" && map.off ? map.off : "none";
+  }
+  return options;
+}
+
+async function llmSessionTitle(ctx: TitleLlmCtx, prompt: string): Promise<string> {
+  const model = ctx.model;
+  const registry = ctx.modelRegistry;
+  const complete = registry?.complete;
+  if (!model || typeof complete !== "function") {
+    console.error("[teamclu] session title LLM skipped: no model or modelRegistry.complete");
+    return "";
+  }
+
+  const user = [
+    "Write a short session title for this user request.",
+    "Maximum 8 words or 40 characters. Match the user's language.",
+    "Reply with ONLY the title, no quotes.",
+    "",
+    "User request:",
+    prompt.slice(0, SESSION_TITLE_MAX_INPUT),
+  ].join("\n");
+
+  const response = (await complete.call(
+    registry,
+    model,
+    { messages: [{ role: "user", content: user }] },
+    titleCompleteOptions(model),
+  )) as {
+    stopReason?: string;
+    errorMessage?: string;
+    content?: Array<{ type?: string; text?: string }>;
+  };
+  const text = assistantMessageText(response);
+  if (!text) {
+    console.error(`[teamclu] session title LLM empty: ${describeTitleResponse(response)}`);
+  }
+  return text;
+}
+
+function startSessionTitle(
+  pi: ExtensionAPI,
+  event: { prompt?: string },
+  ctx: ExtensionContext,
+): void {
+  const sessionId = backendSessionIdFromContext(ctx);
+  if (!sessionId) return;
+  if (titleAttemptedSessionIds.has(sessionId)) return;
+  if (String(pi.getSessionName?.() ?? "").trim()) return;
+
+  const prompt = userPromptForTitle(String(event.prompt ?? ""));
+  if (shouldSkipTitlePrompt(prompt)) return;
+
+  let ui: TeamcluExtensionUIContext;
+  let model: unknown;
+  let registry: ExtensionContext["modelRegistry"];
+  try {
+    ui = ctx.ui;
+    model = ctx.model;
+    registry = ctx.modelRegistry;
+  } catch (e) {
+    console.error(`[teamclu] session title capture failed: ${e}`);
+    return;
+  }
+
+  titleAttemptedSessionIds.add(sessionId);
+  void applySessionTitle({
+    prompt,
+    model,
+    registry,
+    setTitle: ui.setTitle?.bind(ui),
+    setSessionName: pi.setSessionName?.bind(pi),
+    getSessionName: () => pi.getSessionName?.(),
+  });
+}
+
+async function applySessionTitle(job: SessionTitleJob): Promise<void> {
+  let title = "";
+  try {
+    title = sanitizeGeneratedTitle(
+      await llmSessionTitle({ model: job.model, modelRegistry: job.registry }, job.prompt),
+    );
+  } catch (e) {
+    console.error(`[teamclu] session title LLM failed: ${e}`);
+  }
+  if (!title) return;
+  if (String(job.getSessionName?.() ?? "").trim()) return;
+
+  try {
+    job.setSessionName?.(title);
+  } catch (e) {
+    console.error(`[teamclu] setSessionName failed: ${e}`);
+  }
+  try {
+    job.setTitle?.(title);
+  } catch (e) {
+    console.error(`[teamclu] setTitle failed: ${e}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Extension entry point
 // ---------------------------------------------------------------------------
 
@@ -1225,6 +1483,7 @@ export default async function (pi: ExtensionAPI) {
 
   // -- Permission gate -------------------------------------------------------
   pi.on("before_agent_start", async (event, ctx) => {
+    startSessionTitle(pi, event, ctx);
     const backendSessionId = backendSessionIdFromContext(ctx);
     if (!backendSessionId) return undefined;
     const append = await fetchSessionPromptAppend(backendSessionId);

--- a/apps/daemon/src/daemon/server/messaging.rs
+++ b/apps/daemon/src/daemon/server/messaging.rs
@@ -173,8 +173,8 @@ impl DaemonServer {
 
     /// Adopt an agent-generated session title. Daemon LLM titles win over
     /// placeholders and the frontend first-message auto-title. Cron-minted
-    /// titles (`Cron: …`) are the one exception — those are daemon-authored
-    /// already and must not be rewritten by the first job prompt.
+    /// titles (`Cron: …` / `Cron job`) must not be rewritten. A missing local
+    /// cache row is treated as unknown — do not adopt.
     async fn maybe_adopt_generated_session_title(&mut self, session_id: &str, title: &str) {
         let title = title.trim();
         if session_id.is_empty() || title.is_empty() {
@@ -1243,17 +1243,21 @@ impl DaemonServer {
 }
 
 /// Daemon LLM titles overwrite placeholders *and* the frontend first-message
-/// auto-title. The only title we refuse to clobber is a Cron-minted one.
+/// auto-title. Refuse Cron-minted titles and an empty/unknown current title
+/// (cache miss — cron sessions often never land in the local store).
 pub(crate) fn should_adopt_generated_session_title(current: &str, new_title: &str) -> bool {
     let current = current.trim();
     let new_title = new_title.trim();
-    if new_title.is_empty() || current == new_title {
+    if current.is_empty() || new_title.is_empty() || current == new_title {
         return false;
     }
     if new_title.contains("TeamClu Instructions") || new_title.starts_with("[Context —") {
         return false;
     }
-    !current.starts_with("Cron:")
+    if current.starts_with("Cron:") || current.eq_ignore_ascii_case("Cron job") {
+        return false;
+    }
+    true
 }
 
 /// Whether `title` looks like a client-minted default rather than something a
@@ -1325,7 +1329,7 @@ mod default_title_tests {
             "深圳美食推荐"
         ));
         assert!(should_adopt_generated_session_title("New chat", "Standup"));
-        assert!(should_adopt_generated_session_title("", "Standup"));
+        assert!(!should_adopt_generated_session_title("", "Standup"));
         assert!(!should_adopt_generated_session_title(
             "深圳美食推荐",
             "深圳美食推荐"
@@ -1335,6 +1339,7 @@ mod default_title_tests {
             "Cron: nightly-sync",
             "Launch Plan"
         ));
+        assert!(!should_adopt_generated_session_title("Cron job", "Launch Plan"));
         assert!(!should_adopt_generated_session_title(
             "帮我查一下深圳美食",
             "[TeamClu Instructions — follow for all replies in this session. Do not acknowled"

--- a/apps/daemon/src/daemon/server/messaging.rs
+++ b/apps/daemon/src/daemon/server/messaging.rs
@@ -171,8 +171,10 @@ impl DaemonServer {
         }
     }
 
-    /// Adopt an agent-generated session title, but only over a default one.
-    /// A user-set title ("人工自己设定") must never be overwritten.
+    /// Adopt an agent-generated session title. Daemon LLM titles win over
+    /// placeholders and the frontend first-message auto-title. Cron-minted
+    /// titles (`Cron: …`) are the one exception — those are daemon-authored
+    /// already and must not be rewritten by the first job prompt.
     async fn maybe_adopt_generated_session_title(&mut self, session_id: &str, title: &str) {
         let title = title.trim();
         if session_id.is_empty() || title.is_empty() {
@@ -184,14 +186,14 @@ impl DaemonServer {
             .and_then(|tc| tc.sessions.find_by_id(session_id))
             .map(|s| s.title.trim().to_string())
             .unwrap_or_default();
-        if current == title || !is_default_session_title(&current) {
+        if !should_adopt_generated_session_title(&current, title) {
             return;
         }
         tracing::info!(
             session_id,
             old_title = %current,
             new_title = %title,
-            "adopting opencode-generated session title"
+            "adopting agent-generated session title"
         );
         if let Err(e) = self.backend.update_session_title(session_id, title).await {
             tracing::warn!(session_id, error = %e, "session title update failed");
@@ -471,8 +473,7 @@ impl DaemonServer {
                             let backend_handle = agents.agent_backend_handle();
                             let mut backend = backend_handle.lock().await;
                             if handle.acp_session_id.starts_with("pi:") {
-                                let leaf = backend
-                                    .completed_turn_leaf_id(&handle.acp_session_id);
+                                let leaf = backend.completed_turn_leaf_id(&handle.acp_session_id);
                                 metadata_json =
                                     crate::runtime::backend_session_metadata::stamp_pi_backend_session_metadata(
                                         &metadata_json,
@@ -1241,10 +1242,25 @@ impl DaemonServer {
     }
 }
 
+/// Daemon LLM titles overwrite placeholders *and* the frontend first-message
+/// auto-title. The only title we refuse to clobber is a Cron-minted one.
+pub(crate) fn should_adopt_generated_session_title(current: &str, new_title: &str) -> bool {
+    let current = current.trim();
+    let new_title = new_title.trim();
+    if new_title.is_empty() || current == new_title {
+        return false;
+    }
+    if new_title.contains("TeamClu Instructions") || new_title.starts_with("[Context —") {
+        return false;
+    }
+    !current.starts_with("Cron:")
+}
+
 /// Whether `title` looks like a client-minted default rather than something a
 /// person typed. Defaults are `<agent name> (HH:MM)` (desktop new-chat),
 /// `Session <id>` and `New session…` placeholders. An unknown/empty title is
 /// NOT treated as default — when in doubt, never overwrite.
+#[cfg(test)]
 pub(crate) fn is_default_session_title(title: &str) -> bool {
     let title = title.trim();
     if title.is_empty() {
@@ -1295,6 +1311,34 @@ mod default_title_tests {
         assert!(!is_default_session_title("Cron: Test"));
         assert!(!is_default_session_title("发布计划 (v2)"));
         assert!(!is_default_session_title("standup (today)"));
+    }
+
+    #[test]
+    fn llm_title_overwrites_first_message_and_placeholders() {
+        use super::should_adopt_generated_session_title;
+        assert!(should_adopt_generated_session_title(
+            "Mac-mini-8 (10:50)",
+            "Launch Plan"
+        ));
+        assert!(should_adopt_generated_session_title(
+            "帮我查一下深圳美食",
+            "深圳美食推荐"
+        ));
+        assert!(should_adopt_generated_session_title("New chat", "Standup"));
+        assert!(should_adopt_generated_session_title("", "Standup"));
+        assert!(!should_adopt_generated_session_title(
+            "深圳美食推荐",
+            "深圳美食推荐"
+        ));
+        assert!(!should_adopt_generated_session_title("Launch Plan", ""));
+        assert!(!should_adopt_generated_session_title(
+            "Cron: nightly-sync",
+            "Launch Plan"
+        ));
+        assert!(!should_adopt_generated_session_title(
+            "帮我查一下深圳美食",
+            "[TeamClu Instructions — follow for all replies in this session. Do not acknowled"
+        ));
     }
 }
 

--- a/apps/daemon/src/runtime/pi_rpc/events.rs
+++ b/apps/daemon/src/runtime/pi_rpc/events.rs
@@ -534,6 +534,32 @@ async fn handle_ui_request(
                 .send(AcpEventFrame::new(session_id, ev).with_reply_to(reply_to))
                 .await;
         }
+        "setTitle" => {
+            let title = event
+                .get("title")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .trim();
+            if title.is_empty() {
+                return;
+            }
+            let Some(session_id) = event_session(shared, key, event) else {
+                debug!(worktree = %key.worktree, "pi setTitle with no session dropped");
+                return;
+            };
+            let (event_tx, reply_to) = {
+                let routes = shared.routes.lock();
+                let Some(route) = routes.get(&session_id) else {
+                    return;
+                };
+                (route.event_tx.clone(), route.turn_reply_to.clone())
+            };
+            let ev = translate::session_title_event(title);
+            crate::runtime::agent_trace::log_acp_event(&session_id, &ev);
+            let _ = event_tx
+                .send(AcpEventFrame::new(session_id, ev).with_reply_to(reply_to))
+                .await;
+        }
         // Other dialog methods block until answered — cancel them.
         "input" | "editor" => {
             warn!(worktree = %key.worktree, method, "unsupported pi dialog method; cancelling");
@@ -712,6 +738,32 @@ mod tests {
             }
             other => panic!("unexpected: {other:?}"),
         }
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn set_title_becomes_session_title_event() {
+        let shared = test_shared();
+        let key = super::super::process::test_pool_key("/w");
+        let (route, mut rx) = test_route(key.clone(), "/s/a.jsonl");
+        shared.routes.lock().insert("pi:/s/a.jsonl".into(), route);
+        let client = test_client();
+
+        let ev = serde_json::json!({
+            "type": "extension_ui_request", "id": "ui_title", "sessionId": "pi:/s/a.jsonl",
+            "method": "setTitle", "title": "深圳美食推荐"
+        });
+        handle_event(&shared, &key, &client, &ev).await;
+
+        let frame = rx.try_recv().expect("session_title forwarded");
+        match frame.event.event.as_ref().unwrap() {
+            amux::acp_event::Event::Raw(raw) => {
+                assert_eq!(raw.method, "session_title");
+                assert_eq!(String::from_utf8_lossy(&raw.json_payload), "深圳美食推荐");
+            }
+            other => panic!("unexpected: {other:?}"),
+        }
+        assert!(rx.try_recv().is_err(), "setTitle is fire-and-forget");
     }
 
     /// Drive a failed `message_end` into a live turn and hand back the route's

--- a/apps/daemon/src/runtime/pi_rpc/translate.rs
+++ b/apps/daemon/src/runtime/pi_rpc/translate.rs
@@ -455,6 +455,19 @@ pub fn parse_question_payload(title: &str) -> Option<serde_json::Value> {
         .filter(|v| v.is_object())
 }
 
+/// Internal `session_title` raw event the daemon already adopts
+/// (`maybe_adopt_generated_session_title`). Payload is UTF-8 title bytes,
+/// matching the opencode-era wire shape.
+pub fn session_title_event(title: &str) -> amux::AcpEvent {
+    amux::AcpEvent {
+        event: Some(amux::acp_event::Event::Raw(amux::AcpRawJson {
+            method: "session_title".to_string(),
+            json_payload: title.as_bytes().to_vec(),
+        })),
+        model: String::new(),
+    }
+}
+
 /// Build the `question_asked` raw event clients already render for opencode's
 /// question tool: `{id, questions, tool: {callID}}`. `request_id` is the
 /// extension_ui_request id — the same id `AnswerQuestion` sends back, which is
@@ -1012,6 +1025,18 @@ mod tests {
                 assert_eq!(body["id"], "ui_1");
                 assert_eq!(body["tool"]["callID"], "call_3");
                 assert_eq!(body["questions"][0]["question"], "Q?");
+            }
+            other => panic!("unexpected: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn session_title_event_is_raw_utf8_payload() {
+        let ev = session_title_event("深圳美食推荐");
+        match ev.event.as_ref().unwrap() {
+            amux::acp_event::Event::Raw(raw) => {
+                assert_eq!(raw.method, "session_title");
+                assert_eq!(String::from_utf8_lossy(&raw.json_payload), "深圳美食推荐");
             }
             other => panic!("unexpected: {other:?}"),
         }


### PR DESCRIPTION
## Summary
- Pi extension generates an LLM session title from the first real user prompt on `before_agent_start`, fire-and-forget so the main turn is not blocked.
- Daemon adopts the title via `setTitle` → `session_title`, overwriting frontend placeholders / first-message auto-titles, but never `Cron: …` titles.
- LLM failure keeps the existing title (no truncation fallback). Each pi session is attempted once; slash/`!`/`$` prompts wait for a real question.

## Test plan
- [ ] New session: send a real question, confirm placeholder like `HGBOT (HH:mm)` is replaced by an LLM title, and the agent reply still streams.
- [ ] Same session, second message (and after daemon restart): title must not generate again.
- [ ] Cron-minted session: first job prompt must not rewrite a `Cron: …` title.
- [ ] LLM / empty response: existing title stays; no instruction-header or truncated fallback.
- [ ] `node --test apps/daemon/assets/pi-extension/session-context.test.mjs`
- [ ] `pnpm rust:check` (or the daemon unit tests covering adopt / `setTitle`)


Made with [Cursor](https://cursor.com)