### PR TITLE
fix(daemon): stop sibling session dispose from poisoning shared pi runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,7 @@ jobs:
           apps/daemon/shared/session-context-client.test.mjs
           apps/daemon/shared/session-context-plugin-install.test.mjs
           apps/daemon/assets/pi-extension/session-context.test.mjs
+          apps/daemon/assets/pi-host/shared-runtime-guard.test.mjs
 
       # The scripts above are scoped to @teamclu/app, so the Expo app was
       # outside every gate until now. See apps/expo/CI.md for what is and is

--- a/apps/daemon/assets/pi-extension/session-context.test.mjs
+++ b/apps/daemon/assets/pi-extension/session-context.test.mjs
@@ -2,8 +2,18 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 /** Mirrors `backendSessionIdFromContext` in teamclu.ts */
+function isStaleExtensionCtxError(error) {
+  const message = error instanceof Error ? error.message : String(error ?? "");
+  return message.includes("extension ctx is stale after session replacement or reload");
+}
+
 function backendSessionIdFromContext(ctx) {
-  return ctx?.ui?.sessionId?.trim() || undefined;
+  try {
+    return ctx?.ui?.sessionId?.trim() || undefined;
+  } catch (error) {
+    if (isStaleExtensionCtxError(error)) return undefined;
+    throw error;
+  }
 }
 
 /** Mirrors PI MCP proxy injection gate in teamclu.ts */
@@ -248,6 +258,41 @@ test("before_agent_start skips when ctx.ui.sessionId is missing", async () => {
       fetchPrompt: async () => {
         called = true;
         return "x";
+      },
+    },
+  );
+  assert.equal(result, undefined);
+  assert.equal(called, false);
+});
+
+test("stale ctx.ui after sibling session dispose fails open without throwing", () => {
+  const stale = {
+    get ui() {
+      throw new Error(
+        "This extension ctx is stale after session replacement or reload. Do not use a captured pi or command ctx after ctx.newSession(), ctx.fork(), ctx.switchSession(), or ctx.reload().",
+      );
+    },
+  };
+  assert.equal(backendSessionIdFromContext(stale), undefined);
+  assert.equal(isStaleExtensionCtxError(new Error("session_context_unavailable")), false);
+});
+
+test("before_agent_start swallows stale ctx instead of surfacing pi extension error", async () => {
+  const stale = {
+    get ui() {
+      throw new Error(
+        "This extension ctx is stale after session replacement or reload. Do not use a captured pi or command ctx after ctx.newSession().",
+      );
+    },
+  };
+  let called = false;
+  const result = await appendSystemPromptForTurn(
+    { systemPrompt: "base" },
+    stale,
+    {
+      fetchPrompt: async () => {
+        called = true;
+        return { append: "should not inject", rosterResolved: true };
       },
     },
   );

--- a/apps/daemon/assets/pi-extension/teamclu.ts
+++ b/apps/daemon/assets/pi-extension/teamclu.ts
@@ -137,8 +137,20 @@ function isSessionScopedTool(name: string): boolean {
   return SESSION_SCOPED_TOOLS.has(normalizeSessionScopedToolName(name));
 }
 
+function isStaleExtensionCtxError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error ?? "");
+  return message.includes("extension ctx is stale after session replacement or reload");
+}
+
 function backendSessionIdFromContext(ctx?: ExtensionContext): string | undefined {
-  return ctx?.ui?.sessionId?.trim() || undefined;
+  try {
+    return ctx?.ui?.sessionId?.trim() || undefined;
+  } catch (error) {
+    // Shared-runtime poison from a sibling session's dispose (pi 0.84+).
+    // Fail open: skip session-id injection rather than toast every turn.
+    if (isStaleExtensionCtxError(error)) return undefined;
+    throw error;
+  }
 }
 
 async function resolveTeamcluSessionId(backendSessionId: string): Promise<string> {
@@ -1028,40 +1040,48 @@ function registerBridgeTools(
   for (const tool of entry.tools) {
     const name = registeredName(label, tool.name);
     ownTools.add(name);
-    pi.registerTool({
-      name,
-      label: name,
-      description: tool.description ?? `TeamClu MCP tool ${tool.name} (${label})`,
-      // MCP inputSchema is plain JSON Schema; pi's TypeBox parameters are
-      // JSON Schema objects at runtime, so pass it through directly.
-      parameters: tool.inputSchema ?? { type: "object", properties: {} },
-      async execute(_toolCallId, params, signal, _onUpdate, ctx) {
-        // A server can drop a tool at runtime (`tools/list_changed`). pi has no
-        // unregister, so the registration outlives the tool: answer honestly
-        // instead of calling a name the server no longer knows.
-        if (!entry.tools.some((t) => t.name === tool.name)) {
-          return {
-            content: [{ type: "text" as const, text: `MCP tool ${tool.name} is no longer offered by ${label}.` }],
-            isError: true,
-          };
-        }
-        let callParams = params ?? {};
-        try {
-          callParams = await injectSessionIdForTool(
-            tool.name,
-            callParams,
-            backendSessionIdFromContext(ctx),
-          );
-        } catch {
-          return sessionContextUnavailableResult();
-        }
-        // On a cached start the connection may still be opening; this is the
-        // only place that waits for it, and only when a tool is actually used.
-        const bridge = await entry.ready;
-        const result = await bridge.callTool(tool.name, callParams, signal);
-        return { content: toPiContent(result), isError: result?.isError === true };
-      },
-    });
+    try {
+      pi.registerTool({
+        name,
+        label: name,
+        description: tool.description ?? `TeamClu MCP tool ${tool.name} (${label})`,
+        // MCP inputSchema is plain JSON Schema; pi's TypeBox parameters are
+        // JSON Schema objects at runtime, so pass it through directly.
+        parameters: tool.inputSchema ?? { type: "object", properties: {} },
+        async execute(_toolCallId, params, signal, _onUpdate, ctx) {
+          // A server can drop a tool at runtime (`tools/list_changed`). pi has no
+          // unregister, so the registration outlives the tool: answer honestly
+          // instead of calling a name the server no longer knows.
+          if (!entry.tools.some((t) => t.name === tool.name)) {
+            return {
+              content: [{ type: "text" as const, text: `MCP tool ${tool.name} is no longer offered by ${label}.` }],
+              isError: true,
+            };
+          }
+          let callParams = params ?? {};
+          try {
+            callParams = await injectSessionIdForTool(
+              tool.name,
+              callParams,
+              backendSessionIdFromContext(ctx),
+            );
+          } catch {
+            return sessionContextUnavailableResult();
+          }
+          // On a cached start the connection may still be opening; this is the
+          // only place that waits for it, and only when a tool is actually used.
+          const bridge = await entry.ready;
+          const result = await bridge.callTool(tool.name, callParams, signal);
+          return { content: toPiContent(result), isError: result?.isError === true };
+        },
+      });
+    } catch (error) {
+      if (isStaleExtensionCtxError(error)) {
+        console.error(`[teamclu] MCP ${label}: skip registerTool on stale extension ctx (${name})`);
+        continue;
+      }
+      throw error;
+    }
   }
 }
 
@@ -1106,7 +1126,8 @@ function questionOptionLabels(q: QuestionSpec): string[] {
 
 function registerQuestionTool(pi: ExtensionAPI, ownTools: Set<string>): void {
   ownTools.add("question");
-  pi.registerTool({
+  try {
+    pi.registerTool({
     name: "question",
     label: "Question",
     description:
@@ -1170,7 +1191,18 @@ function registerQuestionTool(pi: ExtensionAPI, ownTools: Set<string>): void {
       // Flattened labels keep the dialog renderable by a plain select UI; the
       // TeamClu host reads the marker payload instead.
       const flatLabels = questionOptionLabels(questions[0] ?? {});
-      const value = await ctx.ui.select(`${QUESTION_MARKER}${payload}`, flatLabels, { signal });
+      let value: string | undefined;
+      try {
+        value = await ctx.ui.select(`${QUESTION_MARKER}${payload}`, flatLabels, { signal });
+      } catch (error) {
+        if (isStaleExtensionCtxError(error)) {
+          return {
+            content: [{ type: "text", text: "Question UI unavailable in this run mode." }],
+            isError: true,
+          };
+        }
+        throw error;
+      }
       if (value === undefined) {
         return {
           content: [{ type: "text", text: "The user dismissed the question without answering." }],
@@ -1198,6 +1230,13 @@ function registerQuestionTool(pi: ExtensionAPI, ownTools: Set<string>): void {
       return { content: [{ type: "text", text: lines.join("\n") }] };
     },
   });
+  } catch (error) {
+    if (isStaleExtensionCtxError(error)) {
+      console.error("[teamclu] skip question tool on stale extension ctx");
+      return;
+    }
+    throw error;
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -1250,7 +1289,15 @@ export default async function (pi: ExtensionAPI) {
     const argsJson = (JSON.stringify(event.input ?? {}, null, 2) ?? "{}").slice(0, 2000);
     const message = `${argsJson}\n\nteamclu.always-pattern=${pattern}`;
 
-    const confirmed = await ctx.ui.confirm(title, message);
+    let confirmed: boolean;
+    try {
+      confirmed = await ctx.ui.confirm(title, message);
+    } catch (error) {
+      if (isStaleExtensionCtxError(error)) {
+        return { block: true, reason: "Denied by TeamClu permission gate" };
+      }
+      throw error;
+    }
     if (!confirmed) {
       return { block: true, reason: "Denied by TeamClu permission gate" };
     }

--- a/apps/daemon/assets/pi-host/host.mjs
+++ b/apps/daemon/assets/pi-host/host.mjs
@@ -41,6 +41,12 @@
  * TeamClu extension uses them, and stock `pi --mode rpc` has the same
  * last-bind-wins behaviour across `switch_session`, so this is not a regression.
  *
+ * Pi 0.84+ also invalidates that *shared* runtime from `AgentSession.dispose()`.
+ * Closing one session (LRU `close_session` included) would otherwise make
+ * `pi.registerTool` throw "extension ctx is stale" on every remaining session.
+ * `shieldSharedRuntimeFromSessionDispose` keeps the poison on the closed
+ * runner only while siblings are still live.
+ *
  * ## Protocol
  *
  * Commands (stdin, one JSON object per line):
@@ -96,6 +102,7 @@ import * as crypto from "node:crypto";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { pathToFileURL } from "node:url";
+import { shieldSharedRuntimeFromSessionDispose } from "./shared-runtime-guard.mjs";
 
 const PROTOCOL_VERSION = 1;
 
@@ -379,6 +386,14 @@ function makeUiContext(sessionId) {
 async function adoptSession(sessionManager) {
   const { session } = await pi.createAgentSessionFromServices({ services, sessionManager });
   const sessionId = sessionIdFor(session);
+
+  // Pi dispose() invalidates the ExtensionRuntime the runner was built with.
+  // Every session in this process shares one ResourceLoader / runtime, so a
+  // close_session (LRU eviction included) would otherwise mark `pi` stale for
+  // every remaining session — the "extension ctx is stale after session
+  // replacement or reload" toast on the next turn. Read `sessions.size` at
+  // invalidate-time: closeSession deletes the victim before dispose().
+  shieldSharedRuntimeFromSessionDispose(session.extensionRunner, () => sessions.size);
 
   await session.bindExtensions({
     uiContext: makeUiContext(sessionId),

--- a/apps/daemon/assets/pi-host/shared-runtime-guard.mjs
+++ b/apps/daemon/assets/pi-host/shared-runtime-guard.mjs
@@ -1,0 +1,44 @@
+/**
+ * Isolate per-session ExtensionRunner invalidation from the process-wide
+ * ExtensionRuntime that TeamClu's multi-session pi host shares.
+ *
+ * Pi 0.84+ `AgentSession.dispose()` calls `extensionRunner.invalidate()`, which
+ * marks that runner stale *and* the ExtensionRuntime it was constructed with.
+ * The host reuses one ResourceLoader (hence one runtime) for every session in
+ * the process, so disposing session A would make `pi.registerTool` / `pi.on`
+ * throw "extension ctx is stale" on sessions B…N that are still live.
+ */
+
+export const STALE_EXTENSION_CTX_SNIPPET =
+  "extension ctx is stale after session replacement or reload";
+
+const STALE_EXTENSION_CTX_MESSAGE =
+  "This extension ctx is stale after session replacement or reload. Do not use a captured pi or command ctx after ctx.newSession(), ctx.fork(), ctx.switchSession(), or ctx.reload(). For newSession, fork, and switchSession, move post-replacement work into withSession and use the ctx passed to withSession. For reload, do not use the old ctx after await ctx.reload().";
+
+export function isStaleExtensionCtxError(error) {
+  const message = error instanceof Error ? error.message : String(error ?? "");
+  return message.includes(STALE_EXTENSION_CTX_SNIPPET);
+}
+
+/**
+ * Wrap `runner.invalidate` so a session that still has live siblings only
+ * marks *that* runner stale and leaves the shared runtime alone.
+ *
+ * `liveSessionCount` is read at invalidate-time. The host deletes the closing
+ * session from its map *before* calling `dispose()`, so the count is the
+ * number of remaining sessions (0 = this was the last one).
+ */
+export function shieldSharedRuntimeFromSessionDispose(runner, liveSessionCount) {
+  if (!runner || typeof runner.invalidate !== "function") return;
+  const orig = runner.invalidate.bind(runner);
+  runner.invalidate = (message) => {
+    const others = typeof liveSessionCount === "function" ? liveSessionCount() : liveSessionCount;
+    if (Number(others) > 0) {
+      if (!runner.staleMessage) {
+        runner.staleMessage = message ?? STALE_EXTENSION_CTX_MESSAGE;
+      }
+      return;
+    }
+    orig(message);
+  };
+}

--- a/apps/daemon/assets/pi-host/shared-runtime-guard.test.mjs
+++ b/apps/daemon/assets/pi-host/shared-runtime-guard.test.mjs
@@ -1,0 +1,80 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  isStaleExtensionCtxError,
+  shieldSharedRuntimeFromSessionDispose,
+} from "./shared-runtime-guard.mjs";
+
+const STALE =
+  "This extension ctx is stale after session replacement or reload. Do not use a captured pi or command ctx after ctx.newSession(), ctx.fork(), ctx.switchSession(), or ctx.reload().";
+
+function makeSharedRuntime() {
+  return {
+    invalidated: false,
+    invalidate() {
+      this.invalidated = true;
+    },
+  };
+}
+
+function makeRunner(runtime) {
+  return {
+    staleMessage: undefined,
+    runtime,
+    invalidate(message) {
+      if (!this.staleMessage) {
+        this.staleMessage = message;
+        this.runtime.invalidate(message);
+      }
+    },
+  };
+}
+
+test("isStaleExtensionCtxError matches pi's dispose/reload message", () => {
+  assert.equal(isStaleExtensionCtxError(new Error(STALE)), true);
+  assert.equal(isStaleExtensionCtxError("pi extension error: " + STALE), true);
+  assert.equal(isStaleExtensionCtxError(new Error("session_context_unavailable")), false);
+});
+
+test("disposing one session does not poison the shared runtime while siblings are live", () => {
+  const runtime = makeSharedRuntime();
+  const runnerA = makeRunner(runtime);
+  let liveSiblings = 1;
+  shieldSharedRuntimeFromSessionDispose(runnerA, () => liveSiblings);
+
+  runnerA.invalidate(STALE);
+
+  assert.equal(runnerA.staleMessage, STALE, "the closed session's own runner must still go stale");
+  assert.equal(
+    runtime.invalidated,
+    false,
+    "sibling sessions share this runtime; disposing A must not invalidate it",
+  );
+});
+
+test("disposing the last session still invalidates the shared runtime", () => {
+  const runtime = makeSharedRuntime();
+  const runnerA = makeRunner(runtime);
+  shieldSharedRuntimeFromSessionDispose(runnerA, () => 0);
+
+  runnerA.invalidate(STALE);
+
+  assert.equal(runnerA.staleMessage, STALE);
+  assert.equal(runtime.invalidated, true);
+});
+
+test("a live sibling runner can still registerTool after another session is disposed", () => {
+  const runtime = makeSharedRuntime();
+  const runnerA = makeRunner(runtime);
+  const runnerB = makeRunner(runtime);
+  shieldSharedRuntimeFromSessionDispose(runnerA, () => 1);
+  runnerA.invalidate(STALE);
+
+  // Mimic pi's ExtensionAPI.registerTool: it calls runtime.assertActive().
+  const assertActive = () => {
+    if (runtime.invalidated) throw new Error(STALE);
+  };
+  assert.doesNotThrow(assertActive);
+  assert.equal(runnerB.staleMessage, undefined);
+});

--- a/apps/daemon/src/runtime/pi_rpc/process.rs
+++ b/apps/daemon/src/runtime/pi_rpc/process.rs
@@ -624,6 +624,9 @@ const TEAMCLU_EXTENSION_TS: &str = include_str!("../../../assets/pi-extension/te
 
 /// The TeamClu multi-session host, embedded and materialized the same way.
 const TEAMCLU_HOST_MJS: &str = include_str!("../../../assets/pi-host/host.mjs");
+/// Sibling of `host.mjs` — imported at runtime; must land in the same directory.
+const TEAMCLU_HOST_GUARD_MJS: &str =
+    include_str!("../../../assets/pi-host/shared-runtime-guard.mjs");
 
 /// `cache/pi/` — machine-level pi runtime files (the materialized extension,
 /// host script, and per-worktree permission grants). Under `cache/` per the
@@ -676,7 +679,19 @@ fn materialize_extension() -> std::io::Result<PathBuf> {
 }
 
 fn materialize_host_script() -> std::io::Result<PathBuf> {
-    materialize(host_script_path(), TEAMCLU_HOST_MJS)
+    let path = host_script_path();
+    materialize(path.clone(), TEAMCLU_HOST_MJS)?;
+    let guard = path
+        .parent()
+        .map(|dir| dir.join("shared-runtime-guard.mjs"))
+        .ok_or_else(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "pi host script path has no parent directory",
+            )
+        })?;
+    materialize(guard, TEAMCLU_HOST_GUARD_MJS)?;
+    Ok(path)
 }
 
 /// Per-worktree permission rules file read by the TeamClu pi extension


### PR DESCRIPTION
## Summary
- Closing one pi host session (including LRU `close_session`) was invalidating the **shared** `ExtensionRuntime`, so remaining sessions repeatedly toasted `pi extension error: … extension ctx is stale after session replacement or reload`.
- Isolate dispose to the closed session's runner while siblings are still live, and fail open in the TeamClu extension if a stale `ctx` still appears.
- Materialize `shared-runtime-guard.mjs` next to `host.mjs`, and cover the guard + stale-ctx fail-open paths with Node tests (wired into CI).

## Test plan
- [x] `node --test apps/daemon/assets/pi-host/shared-runtime-guard.test.mjs apps/daemon/assets/pi-extension/session-context.test.mjs`
- [x] `cargo test --manifest-path apps/daemon/Cargo.toml --test pi_host -- --test-threads=1`
- [ ] Restart amuxd / local agent runtime, then open 2+ sessions in the same worktree, close or idle-evict one, and confirm the remaining session no longer repeatedly shows the stale-ctx service toast


Made with [Cursor](https://cursor.com)