### PR TITLE
fix(daemon): pi thread fork_session API mismatch

### DIFF
--- a/apps/daemon/assets/pi-host/host.mjs
+++ b/apps/daemon/assets/pi-host/host.mjs
@@ -797,16 +797,17 @@ async function handleCommand(command) {
         return fail(id, "fork_session", "forkLeafId is required");
       }
       const parentManager = pi.SessionManager.open(command.parentSessionPath, sessionDir);
-      const branchedManager = parentManager.createBranchedSession(command.forkLeafId);
-      const newPath = branchedManager.getSessionFile();
+      // pi 0.84.x: createBranchedSession returns the new jsonl path, not a SessionManager.
+      const newPath = parentManager.createBranchedSession(command.forkLeafId);
       if (!newPath) {
         return fail(id, "fork_session", "createBranchedSession returned no session file");
       }
+      const branchedManager = pi.SessionManager.open(newPath, sessionDir);
       const sessionId = `pi:${newPath}`;
       return ok(id, "fork_session", {
         sessionId,
         sessionFile: newPath,
-        leafId: branchedManager.getLeafId() ?? undefined,
+        leafId: branchedManager.getLeafId() ?? command.forkLeafId ?? undefined,
       });
     }
 

--- a/apps/daemon/tests/fixtures/pi-host-stub/dist/index.js
+++ b/apps/daemon/tests/fixtures/pi-host-stub/dist/index.js
@@ -118,7 +118,7 @@ export class SessionManager {
       newFile,
       [JSON.stringify(header), ...subset.map((e) => JSON.stringify(e))].join("\n") + "\n",
     );
-    return new SessionManager(this.cwd, newFile, subset);
+    return newFile;
   }
 }
 


### PR DESCRIPTION
## Summary
- Fix `fork_session` in the pi multi-session host: pi 0.84.x `createBranchedSession()` returns the new jsonl path, not a `SessionManager`.
- Open the branched file to resolve `leafId` instead of calling `.getSessionFile()` on the return value.
- Align the pi-host test stub with the real SDK so integration tests catch this mismatch.

## Test plan
- [x] `cargo test -p amuxd fork_session_branches_jsonl`
- [ ] Restart amuxd and fork a thread from an agent reply in the desktop app


Made with [Cursor](https://cursor.com)