### PR TITLE
fix(skills): keep publish summary within the 200-character cap

### DIFF
--- a/packages/app/src/components/teamshare/skill-detail/PublishVersionSheet.tsx
+++ b/packages/app/src/components/teamshare/skill-detail/PublishVersionSheet.tsx
@@ -5,6 +5,11 @@ import { Button } from '@/components/ui/button'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { type TeamSkillItem, type TeamSkillDraftMetadata } from '@/stores/team-share-browser'
 import { TEAM_SKILL_CATEGORIES, type TeamSkillCategory } from '@/lib/backend/cloud-api/team-skills'
+import {
+  TEAM_SKILL_SUMMARY_MAX,
+  clipTeamSkillSummary,
+  hydrateTeamSkillPublishFields,
+} from '@/lib/skills/team-skill-summary'
 import { ModalShell } from './ModalShell'
 
 export function PublishVersionSheet({
@@ -47,20 +52,28 @@ export function PublishVersionSheet({
   const [whenToUse, setWhenToUse] = React.useState(item.whenToUse ?? '')
   const [whenNotToUse, setWhenNotToUse] = React.useState(item.whenNotToUse ?? '')
   const [requiresText, setRequiresText] = React.useState((item.requires ?? []).join(', '))
+  const [summaryWasClipped, setSummaryWasClipped] = React.useState(false)
   const [metadataLoading, setMetadataLoading] = React.useState(false)
   const [metadataReady, setMetadataReady] = React.useState(false)
   const [metadataError, setMetadataError] = React.useState<string | null>(null)
 
   React.useEffect(() => {
     if (!open) return
+    const initial = hydrateTeamSkillPublishFields({
+      draftSummary: item.summary,
+      draftWhenToUse: item.whenToUse,
+      registrySummary: item.summary,
+      registryWhenToUse: item.whenToUse,
+    })
     setChangelog('')
-    setSummary(item.summary ?? '')
+    setSummary(initial.summary)
+    setSummaryWasClipped(initial.summaryWasClipped)
     setCategory(
       (TEAM_SKILL_CATEGORIES.includes(item.category as TeamSkillCategory)
         ? item.category
         : 'general') as TeamSkillCategory,
     )
-    setWhenToUse(item.whenToUse ?? '')
+    setWhenToUse(initial.whenToUse)
     setWhenNotToUse(item.whenNotToUse ?? '')
     setRequiresText((item.requires ?? []).join(', '))
     setMetadataLoading(true)
@@ -68,14 +81,21 @@ export function PublishVersionSheet({
     setMetadataError(null)
     void onLoadDraftMetadata()
       .then((draft) => {
-        if (typeof draft.summary === 'string') setSummary(draft.summary)
+        const hydrated = hydrateTeamSkillPublishFields({
+          draftSummary: typeof draft.summary === 'string' ? draft.summary : item.summary,
+          draftWhenToUse: typeof draft.whenToUse === 'string' ? draft.whenToUse : item.whenToUse,
+          registrySummary: item.summary,
+          registryWhenToUse: item.whenToUse,
+        })
+        setSummary(hydrated.summary)
+        setWhenToUse(hydrated.whenToUse)
+        setSummaryWasClipped(hydrated.summaryWasClipped)
         if (
           typeof draft.category === 'string' &&
           TEAM_SKILL_CATEGORIES.includes(draft.category as TeamSkillCategory)
         ) {
           setCategory(draft.category as TeamSkillCategory)
         }
-        if (typeof draft.whenToUse === 'string') setWhenToUse(draft.whenToUse)
         if (typeof draft.whenNotToUse === 'string') setWhenNotToUse(draft.whenNotToUse)
         if (draft.requires !== undefined) setRequiresText((draft.requires ?? []).join(', '))
         setMetadataReady(true)
@@ -139,6 +159,7 @@ export function PublishVersionSheet({
             disabled={
               !changelog.trim() ||
               !summary.trim() ||
+              summary.trim().length > TEAM_SKILL_SUMMARY_MAX ||
               busy ||
               metadataLoading ||
               !metadataReady ||
@@ -147,7 +168,7 @@ export function PublishVersionSheet({
             onClick={() =>
               void onSubmit({
                 changelog: changelog.trim(),
-                summary: summary.trim(),
+                summary: clipTeamSkillSummary(summary),
                 category,
                 whenToUse: whenToUse.trim(),
                 whenNotToUse: whenNotToUse.trim(),
@@ -215,9 +236,28 @@ export function PublishVersionSheet({
       <label className="block space-y-1">
         <span className={label}>
           {t('teamShare.skillShareSummary', 'Summary')}
+          <span className="ml-2 font-mono font-normal normal-case tracking-normal">
+            {summary.length}/{TEAM_SKILL_SUMMARY_MAX}
+          </span>
           {metaHint(summary, item.summary)}
         </span>
-        <input value={summary} onChange={(e) => setSummary(e.target.value)} maxLength={200} className={field} />
+        <input
+          value={summary}
+          onChange={(e) => {
+            setSummary(e.target.value)
+            setSummaryWasClipped(false)
+          }}
+          maxLength={TEAM_SKILL_SUMMARY_MAX}
+          className={field}
+        />
+        {summaryWasClipped && (
+          <p className="text-[12px] leading-relaxed text-muted-foreground">
+            {t(
+              'teamShare.skillPublishSummaryClipped',
+              'Shortened to 200 characters so it can be published.',
+            )}
+          </p>
+        )}
       </label>
       <label className="block space-y-1">
         <span className={label}>

--- a/packages/app/src/components/teamshare/skill-detail/ShareSheet.tsx
+++ b/packages/app/src/components/teamshare/skill-detail/ShareSheet.tsx
@@ -6,6 +6,11 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { cn } from '@/lib/utils'
 import { type TeamSkillItem } from '@/stores/team-share-browser'
 import { TEAM_SKILL_CATEGORIES, type TeamSkillCategory } from '@/lib/backend/cloud-api/team-skills'
+import {
+  TEAM_SKILL_SUMMARY_MAX,
+  clipTeamSkillSummary,
+  hydrateTeamSkillPublishFields,
+} from '@/lib/skills/team-skill-summary'
 
 export function ShareSheet({
   item,
@@ -41,17 +46,23 @@ export function ShareSheet({
   const [whenToUse, setWhenToUse] = React.useState(item.whenToUse ?? '')
   const [whenNotToUse, setWhenNotToUse] = React.useState(item.whenNotToUse ?? '')
   const [changelog, setChangelog] = React.useState('v1: shared from personal skill')
+  const [summaryWasClipped, setSummaryWasClipped] = React.useState(false)
 
   React.useEffect(() => {
     if (!open) return
+    const hydrated = hydrateTeamSkillPublishFields({
+      draftSummary: item.summary,
+      draftWhenToUse: item.whenToUse,
+    })
     setSlug(item.slug)
-    setSummary(item.summary ?? '')
+    setSummary(hydrated.summary)
+    setSummaryWasClipped(hydrated.summaryWasClipped)
     setCategory(
       (TEAM_SKILL_CATEGORIES.includes(item.category as TeamSkillCategory)
         ? item.category
         : 'general') as TeamSkillCategory,
     )
-    setWhenToUse(item.whenToUse ?? '')
+    setWhenToUse(hydrated.whenToUse)
     setWhenNotToUse(item.whenNotToUse ?? '')
     setChangelog('v1: shared from personal skill')
   }, [open, item])
@@ -66,7 +77,13 @@ export function ShareSheet({
   // Guidance fields are not gates. Requiring them mostly bought placeholder
   // text, which reads as guidance without being any — worse than a blank the
   // author can come back and fill in.
-  const canSubmit = slug.trim() && !slugTaken && summary.trim() && changelog.trim() && !busy
+  const canSubmit =
+    slug.trim() &&
+    !slugTaken &&
+    summary.trim() &&
+    summary.trim().length <= TEAM_SKILL_SUMMARY_MAX &&
+    changelog.trim() &&
+    !busy
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/30 p-4">
@@ -113,13 +130,27 @@ export function ShareSheet({
           <label className="block space-y-1">
             <span className="text-[11px] font-semibold uppercase tracking-wide text-faint">
               {t('teamShare.skillShareSummary', 'Summary')}
+              <span className="ml-2 font-mono font-normal normal-case tracking-normal">
+                {summary.length}/{TEAM_SKILL_SUMMARY_MAX}
+              </span>
             </span>
             <input
               value={summary}
-              onChange={(e) => setSummary(e.target.value)}
-              maxLength={200}
+              onChange={(e) => {
+                setSummary(e.target.value)
+                setSummaryWasClipped(false)
+              }}
+              maxLength={TEAM_SKILL_SUMMARY_MAX}
               className="w-full rounded-[8px] border border-border bg-background px-3 py-2 text-[13px] outline-none focus:border-coral/60"
             />
+            {summaryWasClipped && (
+              <p className="text-[12px] leading-relaxed text-muted-foreground">
+                {t(
+                  'teamShare.skillPublishSummaryClipped',
+                  'Shortened to 200 characters so it can be published.',
+                )}
+              </p>
+            )}
           </label>
           <label className="block space-y-1">
             <span className="text-[11px] font-semibold uppercase tracking-wide text-faint">
@@ -182,7 +213,7 @@ export function ShareSheet({
             onClick={() =>
               void onSubmit({
                 slug: slug.trim(),
-                summary: summary.trim(),
+                summary: clipTeamSkillSummary(summary),
                 category,
                 whenToUse: whenToUse.trim(),
                 whenNotToUse: whenNotToUse.trim(),

--- a/packages/app/src/components/teamshare/skill-detail/__tests__/PublishVersionSheet.test.tsx
+++ b/packages/app/src/components/teamshare/skill-detail/__tests__/PublishVersionSheet.test.tsx
@@ -1,0 +1,100 @@
+import * as React from 'react'
+import { describe, expect, it, vi } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import { TEAM_SKILL_SUMMARY_MAX, clipTeamSkillSummary } from '@/lib/skills/team-skill-summary'
+import { PublishVersionSheet } from '../PublishVersionSheet'
+import type { TeamSkillItem } from '@/stores/team-share-browser'
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (_k: string, d?: string) => d ?? _k }),
+}))
+
+const longDescription =
+  'Use when the user wants to get or query 抖音来客 (life.douyin.com) merchant order and 核销 data — e.g. asks about store orders, refunds, redemptions, or sales, or wants to set up scraping of their Douyin Life merchant account across stores and date ranges.'
+
+const item: TeamSkillItem = {
+  id: 'douyin-life-orders',
+  slug: 'douyin-life-orders',
+  name: 'douyin-life-orders',
+  invocationName: 'douyin-life-orders',
+  category: 'general',
+  content: '',
+  dirPath: '/skills/douyin-life-orders',
+  filename: 'douyin-life-orders',
+  origin: 'registry',
+  kind: 'team-installed',
+  personalSource: null,
+  personalSourceLabel: null,
+  summary: '抖音来客订单查询',
+  whenToUse: null,
+  whenNotToUse: null,
+  requires: null,
+  status: 'published',
+  supersededBy: null,
+  ownerActorId: 'actor-1',
+  latestVersion: 1,
+  installed: true,
+  installedVersion: 1,
+  hasUpdate: false,
+  createdAt: null,
+  updatedAt: null,
+}
+
+describe('PublishVersionSheet draft summary', () => {
+  it('does not dump a long SKILL.md description into the summary field', async () => {
+    render(
+      <PublishVersionSheet
+        item={item}
+        nextVersion={2}
+        baseVersion={1}
+        open
+        busy={false}
+        onLoadDraftMetadata={async () => ({
+          summary: longDescription,
+          whenToUse: '',
+          whenNotToUse: '',
+          requires: [],
+        })}
+        onClose={() => {}}
+        onSubmit={async () => {}}
+      />,
+    )
+
+    await waitFor(() => {
+      expect(screen.queryByText('Reading draft metadata…')).toBeNull()
+    })
+
+    const summary = screen.getByDisplayValue('抖音来客订单查询') as HTMLInputElement
+    expect(summary.value.length).toBeLessThanOrEqual(TEAM_SKILL_SUMMARY_MAX)
+    expect(screen.getByDisplayValue(longDescription)).toBeTruthy()
+    expect(screen.queryByText('Shortened to 200 characters so it can be published.')).toBeNull()
+  })
+
+  it('clips a long description when the registry has no short summary', async () => {
+    render(
+      <PublishVersionSheet
+        item={{ ...item, summary: null }}
+        nextVersion={2}
+        baseVersion={1}
+        open
+        busy={false}
+        onLoadDraftMetadata={async () => ({
+          summary: longDescription,
+          whenToUse: '',
+          whenNotToUse: '',
+          requires: [],
+        })}
+        onClose={() => {}}
+        onSubmit={async () => {}}
+      />,
+    )
+
+    await waitFor(() => {
+      expect(screen.queryByText('Reading draft metadata…')).toBeNull()
+    })
+
+    expect(screen.getByDisplayValue(clipTeamSkillSummary(longDescription))).toBeTruthy()
+    expect(screen.getByDisplayValue(longDescription)).toBeTruthy()
+    expect(screen.getByText('Shortened to 200 characters so it can be published.')).toBeTruthy()
+  })
+})

--- a/packages/app/src/lib/skills/__tests__/team-skill-summary.test.ts
+++ b/packages/app/src/lib/skills/__tests__/team-skill-summary.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from 'vitest'
+import {
+  TEAM_SKILL_SUMMARY_MAX,
+  clipTeamSkillSummary,
+  hydrateTeamSkillPublishFields,
+} from '@/lib/skills/team-skill-summary'
+
+const longDescription =
+  'Use when the user wants to get or query 抖音来客 (life.douyin.com) merchant order and 核销 data — e.g. asks about store orders, refunds, redemptions, or sales, or wants to set up scraping of their Douyin Life merchant account across stores and date ranges.'
+
+describe('clipTeamSkillSummary', () => {
+  it('uses a description that actually exceeds the registry cap', () => {
+    expect(longDescription.length).toBeGreaterThan(TEAM_SKILL_SUMMARY_MAX)
+  })
+  it('leaves a short summary alone', () => {
+    expect(clipTeamSkillSummary('发布前检查')).toBe('发布前检查')
+  })
+
+  it('never returns more than 200 characters', () => {
+    const clipped = clipTeamSkillSummary(longDescription)
+    expect(clipped.length).toBeLessThanOrEqual(TEAM_SKILL_SUMMARY_MAX)
+    expect(clipped.length).toBeGreaterThan(0)
+    expect(longDescription.startsWith(clipped)).toBe(true)
+  })
+
+  it('breaks on whitespace instead of mid-word when it can', () => {
+    const text = `${'word '.repeat(50)}end`
+    const clipped = clipTeamSkillSummary(text)
+    expect(clipped.length).toBeLessThanOrEqual(TEAM_SKILL_SUMMARY_MAX)
+    expect(clipped.endsWith(' ')).toBe(false)
+    expect(clipped.includes('word')).toBe(true)
+  })
+
+  it('hard-clips Chinese with no spaces', () => {
+    const text = '甲'.repeat(240)
+    expect(clipTeamSkillSummary(text)).toBe('甲'.repeat(TEAM_SKILL_SUMMARY_MAX))
+  })
+})
+
+describe('hydrateTeamSkillPublishFields', () => {
+  it('uses a short draft summary as-is', () => {
+    expect(
+      hydrateTeamSkillPublishFields({
+        draftSummary: '  发布前检查  ',
+        draftWhenToUse: '发布前确认 CI 绿',
+        registrySummary: '旧简介',
+        registryWhenToUse: '旧时机',
+      }),
+    ).toEqual({
+      summary: '发布前检查',
+      whenToUse: '发布前确认 CI 绿',
+      summaryWasClipped: false,
+    })
+  })
+
+  it('clips a long SKILL.md description and parks the full text in when-to-use', () => {
+    const result = hydrateTeamSkillPublishFields({
+      draftSummary: longDescription,
+      draftWhenToUse: '',
+      registrySummary: '',
+      registryWhenToUse: '',
+    })
+    expect(result.summaryWasClipped).toBe(true)
+    expect(result.summary.length).toBeLessThanOrEqual(TEAM_SKILL_SUMMARY_MAX)
+    expect(result.whenToUse).toBe(longDescription)
+  })
+
+  it('keeps an existing when-to-use instead of overwriting it with the long description', () => {
+    const result = hydrateTeamSkillPublishFields({
+      draftSummary: longDescription,
+      draftWhenToUse: '只在查订单时用',
+      registrySummary: '',
+      registryWhenToUse: '',
+    })
+    expect(result.whenToUse).toBe('只在查订单时用')
+    expect(result.summary.length).toBeLessThanOrEqual(TEAM_SKILL_SUMMARY_MAX)
+  })
+
+  it('prefers the registry summary when the draft description is too long', () => {
+    const result = hydrateTeamSkillPublishFields({
+      draftSummary: longDescription,
+      draftWhenToUse: '',
+      registrySummary: '抖音来客订单查询',
+      registryWhenToUse: '',
+    })
+    expect(result.summary).toBe('抖音来客订单查询')
+    expect(result.whenToUse).toBe(longDescription)
+    expect(result.summaryWasClipped).toBe(false)
+  })
+
+  it('falls back to registry fields when the draft has nothing', () => {
+    expect(
+      hydrateTeamSkillPublishFields({
+        draftSummary: null,
+        draftWhenToUse: undefined,
+        registrySummary: 'registry 简介',
+        registryWhenToUse: 'registry 时机',
+      }),
+    ).toEqual({
+      summary: 'registry 简介',
+      whenToUse: 'registry 时机',
+      summaryWasClipped: false,
+    })
+  })
+})

--- a/packages/app/src/lib/skills/team-skill-summary.ts
+++ b/packages/app/src/lib/skills/team-skill-summary.ts
@@ -1,0 +1,54 @@
+/** Registry / OpenAPI cap on `summary`. Matches `char_length(summary) <= 200`. */
+export const TEAM_SKILL_SUMMARY_MAX = 200
+
+/**
+ * Fit a SKILL.md `description` (or any draft blurb) into the registry summary
+ * field. Prefers a whitespace break so a clipped English sentence is still
+ * readable; Chinese has no spaces and is hard-clipped.
+ */
+export function clipTeamSkillSummary(
+  value: string,
+  max = TEAM_SKILL_SUMMARY_MAX,
+): string {
+  const trimmed = value.trim()
+  if (trimmed.length <= max) return trimmed
+  const slice = trimmed.slice(0, max)
+  const breakAt = Math.max(slice.lastIndexOf(' '), slice.lastIndexOf('\n'))
+  if (breakAt >= Math.floor(max * 0.6)) return slice.slice(0, breakAt).trimEnd()
+  return slice
+}
+
+/**
+ * Prefill the publish/share form from disk frontmatter + the registry row.
+ *
+ * Agent Skills put a long "Use when…" matching blob in `description`. The
+ * registry's `summary` is 200 characters, so dumping the blob into the
+ * 简介 field makes every submit fail. If that blob is too long and
+ * `when_to_use` is empty, the full text belongs in 什么时候用 instead.
+ */
+export function hydrateTeamSkillPublishFields(input: {
+  draftSummary?: string | null
+  draftWhenToUse?: string | null
+  registrySummary?: string | null
+  registryWhenToUse?: string | null
+}): { summary: string; whenToUse: string; summaryWasClipped: boolean } {
+  const draftSummary = (input.draftSummary ?? '').trim()
+  const registrySummary = (input.registrySummary ?? '').trim()
+  const draftWhenToUse = (input.draftWhenToUse ?? '').trim()
+  const registryWhenToUse = (input.registryWhenToUse ?? '').trim()
+
+  const whenToUse = draftWhenToUse || registryWhenToUse
+  const rawSummary = draftSummary || registrySummary
+
+  if (rawSummary.length <= TEAM_SKILL_SUMMARY_MAX) {
+    return { summary: rawSummary, whenToUse, summaryWasClipped: false }
+  }
+
+  const registryFits =
+    registrySummary.length > 0 && registrySummary.length <= TEAM_SKILL_SUMMARY_MAX
+  return {
+    summary: registryFits ? registrySummary : clipTeamSkillSummary(rawSummary),
+    whenToUse: whenToUse || rawSummary,
+    summaryWasClipped: !registryFits,
+  }
+}

--- a/packages/app/src/locales/en.json
+++ b/packages/app/src/locales/en.json
@@ -169,6 +169,7 @@
     "skillPublishLoadingDraft": "Reading draft metadata…",
     "skillPublishDraftMetadataFailed": "Could not read draft metadata: {{msg}}",
     "skillPublishDraftDiff": "differs from registry",
+    "skillPublishSummaryClipped": "Shortened to 200 characters so it can be published.",
     "skillDraftRecoveryTitle": "Recent draft recoveries",
     "skillDraftRecoveryBody": "Discarded drafts are kept for 7 days. Restore one to pick up where you left off.",
     "skillDraftRecoveryRestore": "Restore draft",

--- a/packages/app/src/locales/zh-CN.json
+++ b/packages/app/src/locales/zh-CN.json
@@ -169,6 +169,7 @@
     "skillPublishLoadingDraft": "正在读取草稿元数据…",
     "skillPublishDraftMetadataFailed": "无法读取草稿元数据：{{msg}}",
     "skillPublishDraftDiff": "与 registry 不同",
+    "skillPublishSummaryClipped": "已缩短到 200 字，否则无法发布。",
     "skillDraftRecoveryTitle": "近期草稿恢复",
     "skillDraftRecoveryBody": "丢弃的草稿会保留 7 天。可恢复后继续编辑。",
     "skillDraftRecoveryRestore": "恢复草稿",


### PR DESCRIPTION
## Summary
- Publishing a team skill dumped `SKILL.md`'s `description` into 简介. Agent Skills descriptions are often long "Use when…" blobs, which exceed the registry's 200-character `summary` limit and made every submit fail.
- The publish and share sheets now keep a short registry summary when one exists, otherwise clip to 200 characters, and park the full text in 什么时候用 when that field is empty.
- 简介 shows a `n/200` counter so the cap is visible before submit.

## Test plan
- [x] Unit tests for clip/hydrate (`team-skill-summary.test.ts`)
- [x] Publish sheet: long draft + short registry summary stays short; overflow goes to When to use
- [x] Publish sheet: long draft with no registry summary is clipped and still submittable
- [ ] Open 发布 on a skill whose `SKILL.md` description is >200 chars, confirm 简介 is ≤200 and Publish no longer errors with `summary must be 200 characters or fewer`
- [ ] Share a personal skill with a long description and confirm the same cap handling


Made with [Cursor](https://cursor.com)