### PR TITLE
feat(belayo): open the apps module entry point

### DIFF
--- a/services/fc/src/lib/feature-profiles.ts
+++ b/services/fc/src/lib/feature-profiles.ts
@@ -144,7 +144,13 @@ export const FEATURE_PROFILES: Record<string, FeatureFlags> = {
   belayo: {
     auth: { google: false, wechat: false, phone: true, password: false, webSSO: true },
     channels: { discord: true, feishu: true, email: true, kook: true, wecom: true, wechat: true, seatalk: true },
-    apps: false,
+    // Entry point only, same as self-host. Creating an app needs GITEA_*, which
+    // this deployment now has (its own Gitea, reached over the VPC). Deploying
+    // one additionally needs ACCESS_KEY_ID + APPS_FC_ENDPOINT, which it does
+    // NOT have yet — so the deploy step answers 503 naming the empty variable
+    // while creating, listing and pushing work. That is the intended rollout
+    // order, not an oversight.
+    apps: true,
     lockLlmConfig: false,
     allowNewOrg: true,
   },


### PR DESCRIPTION
## Description

`belayo.apps` was `false`, which hides the nav entry and the create/browse surface entirely. That deployment now has what the entry point needs, so it is on.

**What works with this flag on:**

belayo got its own Gitea today — a dedicated ECS with no public IP, reached over the VPC, with the repos on a 60G data disk and the metadata in its own `gitea` database on the existing RDS. `GITEA_URL` / `GITEA_TOKEN` / `GITEA_OWNER` are set on the function (org `teamclaw-apps`, a `teamclu-bot` user holding a scoped token — the same shape self-host uses). Creating an app, provisioning its repo and pushing to it all work.

**What this flag does not claim:**

Deploying an app is a separate gate. It needs the `APPS_*` block, which belayo now also has for the static path (`APPS_OSS_BUCKET`, the FC endpoint derived from `ROLE_ARN`, `APP_SECRETS_ENCRYPTION_KEY`) — but the vanity hostnames are still waiting on DNS for `*.apps.mx5.cn` and `*.fc-apps.mx5.cn`, and `data_app` still has no `APPS_DB_*`. With any of those unset FC answers 503 naming the empty variable while creating, listing and pushing keep working. self-host carries the same comment for the same reason: **the flag is an entry point, not a readiness claim.**

## Related Issue

None — follows from opening the apps module on belayo.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

No new test: this flips one boolean in a profile table. `config-route.test.ts` already covers how profiles resolve and merge, and none of its cases assert `belayo.apps === false`.

## Additional Notes

**The branding repo half is already merged** — `teamclu-enterprise-branding#10` added `"apps": true` to `brands/betly/build.config.json`. That file is what this profile mirrors, and the header of `feature-profiles.ts` says the two are kept in sync by hand; landing only one of them is exactly the drift it warns about. Worth noting `apps` was *absent* there while this file said `false`, so the "mirror" was already one-sided before today.

**⚠️ Remove the live override when this ships.** The deployment was flipped ahead of this commit with `APP_FEATURES_JSON='{"apps":true}'`, which merges over the profile rather than replacing it (`mergeFeatures` spreads, with a nested merge for `auth`/`channels`), so webSSO and phone auth were untouched. It exists so the rollout could be tested and reverted in a single deploy. Once this lands, that env var should be cleared — otherwise the code and the environment disagree and only the environment is real.

Verification: FC suite **929 passed / 0 failed / 13 skipped**; `config-route.test.ts` 22/22; `npm run build` (the tsc pass the deploy image runs) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017LGh88cvMMZeMForNo45i1
