### PR TITLE
fix(wecom): treat channel turn timeout as idle silence, not wall-clock

### DIFF
--- a/apps/daemon/src/channels/agent_handle.rs
+++ b/apps/daemon/src/channels/agent_handle.rs
@@ -660,6 +660,20 @@ Your text reply needs no tool — it is delivered on its own."
 /// side, so updates are coalesced into at most one per interval.
 const STREAM_UPDATE_INTERVAL: std::time::Duration = std::time::Duration::from_millis(700);
 
+/// How much of the idle budget is left.
+///
+/// Silence is measured from the last ACP event, not from the prompt. A WeCom
+/// scrape that ran nine minutes and then queried would expire a wall-clock
+/// 10-minute cap while still working; an idle budget resets on every event
+/// and only fires after the channel's patience of actual quiet.
+fn idle_remaining_at(
+    last_activity: std::time::Instant,
+    idle: std::time::Duration,
+    now: std::time::Instant,
+) -> std::time::Duration {
+    idle.saturating_sub(now.saturating_duration_since(last_activity))
+}
+
 /// Decide what a timed-out gateway turn should return (issue #555). If the
 /// agent already produced reply text, hand it back as the turn result rather
 /// than failing — OpenCode may have finished while the ACP adapter never sent
@@ -834,7 +848,12 @@ impl AmuxdAgentHandle {
         let mut last_update = std::time::Instant::now();
         let mut sent_update = String::new();
 
-        let deadline = std::time::Instant::now() + turn_timeout;
+        // Idle, not wall-clock: each ACP event resets the budget. A 10-minute
+        // scrape with a tool-result at minute 9 used to expire the WeCom
+        // 600s cap and close the stream on "现在查询当日数据：", while the
+        // runtime kept going and wrote the real answer 15s later — desktop
+        // saw it, WeCom did not.
+        let mut last_activity = std::time::Instant::now();
         // On a turn-level timeout, salvage any reply text the agent already
         // produced instead of failing the whole turn (issue #555): OpenCode can
         // finish and persist its final assistant text while the ACP adapter
@@ -852,14 +871,18 @@ impl AmuxdAgentHandle {
         };
         let mut timed_out = false;
         let result: Result<String, AgentError> = loop {
-            let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+            let remaining =
+                idle_remaining_at(last_activity, turn_timeout, std::time::Instant::now());
             if remaining.is_zero() {
                 timed_out = true;
                 break salvage_on_timeout(&segments, &live);
             }
             let next = tokio::time::timeout(remaining, event_rx.recv()).await;
             let event = match next {
-                Ok(Some(ev)) => ev,
+                Ok(Some(ev)) => {
+                    last_activity = std::time::Instant::now();
+                    ev
+                }
                 Ok(None) => {
                     // The agent detached mid-turn (event channel closed) before
                     // any Active→Idle. If it had already produced reply text,
@@ -878,7 +901,10 @@ impl AmuxdAgentHandle {
                         )),
                     };
                 }
-                Err(_) => break salvage_on_timeout(&segments, &live),
+                Err(_) => {
+                    timed_out = true;
+                    break salvage_on_timeout(&segments, &live);
+                }
             };
             if let Some(crate::proto::amux::acp_event::Event::Error(err)) = &event.event.event {
                 let details = if err.details.is_empty() {
@@ -1892,6 +1918,31 @@ pub(crate) mod tests {
         let segments = segments_from(&[tool_use("Bash"), turn_end()]);
         assert!(segments.is_empty());
         assert_eq!(compose_reply(&segments, ""), "");
+    }
+
+    #[test]
+    fn idle_budget_resets_from_the_last_event_not_the_prompt() {
+        // The GMV scrape: prompt at t0, tool still running at t=9min, query
+        // events at t=9min. A wall-clock 10-minute cap would expire ~15s
+        // before the real answer; idle remaining from the last event is the
+        // full 10 minutes again.
+        let t0 = std::time::Instant::now();
+        let idle = std::time::Duration::from_secs(600);
+        let nine_min = t0 + std::time::Duration::from_secs(9 * 60);
+        assert_eq!(
+            idle_remaining_at(nine_min, idle, nine_min),
+            idle,
+            "a just-received event restores the full silence budget"
+        );
+        assert_eq!(
+            idle_remaining_at(t0, idle, nine_min),
+            std::time::Duration::from_secs(60),
+            "silence from the prompt would have only a minute left — that is the old bug"
+        );
+        assert_eq!(
+            idle_remaining_at(nine_min, idle, nine_min + idle),
+            std::time::Duration::ZERO
+        );
     }
 
     #[test]

--- a/crates/teamclu-gateway/src/agent.rs
+++ b/crates/teamclu-gateway/src/agent.rs
@@ -89,10 +89,12 @@ pub trait AgentHandle: Send + Sync + 'static {
     /// Send a user prompt and wait for the agent's reply text. Equivalent to
     /// v1's `prompt_async` + SSE polling, but synchronous and in-process.
     ///
-    /// `timeout` is the channel's own patience, from
-    /// [`ChannelCaps::turn_timeout_secs`](crate::driver::ChannelCaps): a mail
-    /// round trip and an IM bubble have nothing in common, and the value used
-    /// to be a constant in the daemon that no channel could influence.
+    /// `timeout` is the channel's idle patience, from
+    /// [`ChannelCaps::turn_timeout_secs`](crate::driver::ChannelCaps): how long
+    /// the turn may stay silent (no ACP event) before the gateway stops
+    /// waiting. A mail round trip and an IM bubble have nothing in common, and
+    /// the value used to be a constant in the daemon that no channel could
+    /// influence.
     async fn send_prompt(
         &self,
         session: &AmuxSessionId,

--- a/crates/teamclu-gateway/src/driver.rs
+++ b/crates/teamclu-gateway/src/driver.rs
@@ -150,7 +150,9 @@ pub struct ChannelCaps {
     pub threading: Threading,
     /// Hard limit per outbound message; the core splits above it.
     pub max_chars: usize,
-    /// How long one turn may take before the queue gives up on it.
+    /// How long a turn may stay *silent* (no ACP event) before the gateway
+    /// gives up on it. Activity resets the budget — a nine-minute scrape
+    /// followed by a query is still one turn, not a timeout.
     ///
     /// Per-channel because it is a property of the medium, not of the agent: a
     /// mail round trip that takes four minutes is normal, and the IM-shaped

--- a/crates/teamclu-gateway/src/wecom.rs
+++ b/crates/teamclu-gateway/src/wecom.rs
@@ -834,10 +834,11 @@ pub fn wecom_caps() -> driver::ChannelCaps {
         interactive: true,
         threading: driver::Threading::Inline,
         max_chars: 2048,
-        // Ten minutes. A chat bot that searches, reads files and writes an
-        // answer routinely runs past the old two-minute cap — and when it did,
-        // the sender got "timed out, please retry" for a turn that was working
-        // fine, while the runtime kept going and starved the next message.
+        // Ten minutes of *silence* (idle, not wall-clock from the prompt).
+        // A scrape that ran nine minutes then queried used to expire a
+        // start-to-finish 600s cap and close the WeCom stream on the last
+        // progress line, while the runtime wrote the real answer seconds
+        // later — desktop saw it, WeCom did not. Each ACP event resets this.
         turn_timeout_secs: 600,
     }
 }


### PR DESCRIPTION
## Description

WeCom's 600s `turn_timeout_secs` was a wall-clock cap from the prompt. A scrape that ran ~9 minutes, then started querying, expired that cap and closed the stream on the last progress line (`采集完成，现在查询当日数据：`) while the runtime kept going and wrote the real GMV tables ~15s later — desktop saw the answer, WeCom did not.

`run_turn` now measures silence from the last ACP event (idle budget, reset on every event). The tokio timeout path also sets `timed_out` so the still-running runtime is cancelled instead of writing a second, later reply only the desktop can see.

Follow-up to #1275 / #1276 (same WeCom vs desktop mismatch class).

## Related Issue

n/a — live WeCom DM session `5e12484c-64f3-494e-8853-2af4b31ca49f`

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

Verified: `node scripts/daemon-cargo.js test --bin amuxd channels::agent_handle::tests` — 27 passed, 0 failed.

A tool that stays silent longer than the channel patience (WeCom 600s, Discord 180s, …) still times out; that is intentional.


Made with [Cursor](https://cursor.com)