### PR TITLE
fix(daemon): stop session title from using stale pi ctx

### DIFF
--- a/apps/daemon/assets/pi-extension/session-context.test.mjs
+++ b/apps/daemon/assets/pi-extension/session-context.test.mjs
@@ -1,5 +1,7 @@
 import assert from "node:assert/strict";
+import fs from "node:fs";
 import test from "node:test";
+import { fileURLToPath } from "node:url";
 
 /** Mirrors `backendSessionIdFromContext` in teamclu.ts */
 function backendSessionIdFromContext(ctx) {
@@ -426,7 +428,7 @@ async function llmSessionTitle(ctx, prompt) {
   return text;
 }
 
-async function maybeGenerateSessionTitle(pi, event, ctx, deps = {}) {
+async function maybeGenerateSessionTitle(event, ctx, deps = {}) {
   const sessionId = backendSessionIdFromContext(ctx);
   if (!sessionId) return;
   const titleMarkers = deps.titleMarkers ?? new Map();
@@ -435,7 +437,6 @@ async function maybeGenerateSessionTitle(pi, event, ctx, deps = {}) {
   const inFlight = deps.inFlight ?? new Set();
   if (hasMarker(sessionId)) return;
   if (inFlight.has(sessionId)) return;
-  if (String(pi.getSessionName?.() ?? "").trim()) return;
 
   const raw = String(event.prompt ?? "");
   if (isCronJobPrompt(raw)) return;
@@ -449,7 +450,6 @@ async function maybeGenerateSessionTitle(pi, event, ctx, deps = {}) {
     model: ctx.model,
     registry: ctx.modelRegistry,
     setTitle: ui.setTitle?.bind(ui),
-    hadSessionNameAtStart: false,
     llmTitle: deps.llmTitle,
   };
 
@@ -463,7 +463,7 @@ async function maybeGenerateSessionTitle(pi, event, ctx, deps = {}) {
       } catch {
         title = "";
       }
-      if (!title || job.hadSessionNameAtStart) return;
+      if (!title) return;
       job.setTitle?.(title);
       writeMarker(sessionId, title);
     } finally {
@@ -503,10 +503,8 @@ test("session title treats cron run tokens as cron, not chat tokens", () => {
 test("session title does not run for cron job prompts", async () => {
   let llmCalled = false;
   const titleMarkers = new Map();
-  const pi = { getSessionName: () => "" };
   const ctx = { ui: { sessionId: "pi:/tmp/cron.json", setTitle() {} } };
   await maybeGenerateSessionTitle(
-    pi,
     {
       prompt:
         "[SYSTEM] Reply token for this run: tok\nPass it as `reply_token`\n\nnightly sync",
@@ -548,7 +546,6 @@ test("session title strips silent context wrappers", () => {
 test("session title sends unwrapped user text to the LLM", async () => {
   const seen = [];
   const titles = [];
-  const pi = { getSessionName: () => "" };
   const ctx = {
     ui: {
       sessionId: "pi:/tmp/wrap.json",
@@ -561,7 +558,7 @@ test("session title sends unwrapped user text to the LLM", async () => {
     "",
     "帮我查一下深圳美食",
   ].join("\n");
-  await maybeGenerateSessionTitle(pi, { prompt: wrapped }, ctx, {
+  await maybeGenerateSessionTitle({ prompt: wrapped }, ctx, {
     llmTitle: async (_ctx, prompt) => {
       seen.push(prompt);
       return "深圳美食推荐";
@@ -733,14 +730,13 @@ test("session title fire-and-forget does not wait for the LLM", async () => {
       release = resolve;
     });
   const pending = [];
-  const pi = { getSessionName: () => "" };
   const ctx = {
     ui: {
       sessionId: "pi:/tmp/defer.json",
       setTitle: (title) => titles.push(title),
     },
   };
-  await maybeGenerateSessionTitle(pi, { prompt: "帮我查一下深圳美食" }, ctx, {
+  await maybeGenerateSessionTitle({ prompt: "帮我查一下深圳美食" }, ctx, {
     fireAndForget: true,
     pending,
     llmTitle,
@@ -753,14 +749,13 @@ test("session title fire-and-forget does not wait for the LLM", async () => {
 
 test("session title uses LLM result and setTitle", async () => {
   const titles = [];
-  const pi = { getSessionName: () => "" };
   const ctx = {
     ui: {
       sessionId: "pi:/tmp/a.json",
       setTitle: (title) => titles.push(title),
     },
   };
-  await maybeGenerateSessionTitle(pi, { prompt: "帮我写一份发布计划" }, ctx, {
+  await maybeGenerateSessionTitle({ prompt: "帮我写一份发布计划" }, ctx, {
     llmTitle: async () => '"Launch Plan"',
   });
   assert.deepEqual(titles, ["Launch Plan"]);
@@ -768,14 +763,13 @@ test("session title uses LLM result and setTitle", async () => {
 
 test("session title does not set a title when LLM returns nothing", async () => {
   const titles = [];
-  const pi = { getSessionName: () => "" };
   const ctx = {
     ui: {
       sessionId: "pi:/tmp/b.json",
       setTitle: (title) => titles.push(title),
     },
   };
-  await maybeGenerateSessionTitle(pi, { prompt: "帮我查一下深圳美食" }, ctx, {
+  await maybeGenerateSessionTitle({ prompt: "帮我查一下深圳美食" }, ctx, {
     llmTitle: async () => "",
   });
   assert.deepEqual(titles, []);
@@ -784,7 +778,6 @@ test("session title does not set a title when LLM returns nothing", async () => 
 test("session title does not run twice for the same session", async () => {
   let calls = 0;
   const titleMarkers = new Map();
-  const pi = { getSessionName: () => "" };
   const ctx = { ui: { sessionId: "pi:/tmp/c.json", setTitle() {} } };
   const deps = {
     titleMarkers,
@@ -793,23 +786,32 @@ test("session title does not run twice for the same session", async () => {
       return "Once";
     },
   };
-  await maybeGenerateSessionTitle(pi, { prompt: "hello" }, ctx, deps);
-  await maybeGenerateSessionTitle(pi, { prompt: "hello again" }, ctx, deps);
+  await maybeGenerateSessionTitle({ prompt: "hello" }, ctx, deps);
+  await maybeGenerateSessionTitle({ prompt: "hello again" }, ctx, deps);
   assert.equal(calls, 1);
   assert.equal(titleMarkers.get("pi:/tmp/c.json"), "Once");
 });
 
-test("session title skips when pi already has a session name", async () => {
-  let llmCalled = false;
-  const pi = { getSessionName: () => "Already Named", setSessionName() {} };
-  const ctx = { ui: { sessionId: "pi:/tmp/d.json", setTitle() {} } };
-  await maybeGenerateSessionTitle(pi, { prompt: "hello" }, ctx, {
-    llmTitle: async () => {
-      llmCalled = true;
-      return "Nope";
+test("session title source never calls pi.getSessionName or setSessionName", () => {
+  const src = fs.readFileSync(fileURLToPath(new URL("./teamclu.ts", import.meta.url)), "utf8");
+  assert.doesNotMatch(src, /pi\.getSessionName\s*\??\s*\(/);
+  assert.doesNotMatch(src, /pi\.setSessionName\s*\??\s*\(/);
+});
+
+test("session title still runs when a session already has a pi name", async () => {
+  // Skip is sidecar-only. Reading pi.getSessionName() hits the shared
+  // ExtensionRuntime, which any session dispose() marks stale.
+  const titles = [];
+  const ctx = {
+    ui: {
+      sessionId: "pi:/tmp/d.json",
+      setTitle: (title) => titles.push(title),
     },
+  };
+  await maybeGenerateSessionTitle({ prompt: "hello" }, ctx, {
+    llmTitle: async () => "From Prompt",
   });
-  assert.equal(llmCalled, false);
+  assert.deepEqual(titles, ["From Prompt"]);
 });
 
 test("before_agent_start strips pi self-documentation for anthropic provider", async () => {

--- a/apps/daemon/assets/pi-extension/teamclu.ts
+++ b/apps/daemon/assets/pi-extension/teamclu.ts
@@ -90,8 +90,6 @@ type ExtensionContext = {
   };
 };
 type ExtensionAPI = {
-  getSessionName?(): string | undefined;
-  setSessionName?(name: string, source?: string): void;
   on(
     event: "tool_call",
     handler: (
@@ -1241,11 +1239,11 @@ function registerQuestionTool(pi: ExtensionAPI, ownTools: Set<string>): void {
 // ---------------------------------------------------------------------------
 // Fire-and-forget on `before_agent_start`: capture model / setTitle while
 // ctx is active, then `complete()` without awaiting so the first turn is
-// not blocked. Only `ui.setTitle` runs after the hook — never async
-// `pi.getSessionName` / `setSessionName` (stale ctx). Sync hook may still
-// read `getSessionName()` to skip sessions pi already named. A sidecar file
-// `<pi-session-file>-teamclu-title` sidecar is written only after a successful
-// setTitle so host restarts skip re-generation and LLM failures can retry.
+// not blocked. Never touch `pi.getSessionName` / `setSessionName` — those
+// go through the process-wide ExtensionRuntime, which any session
+// dispose() marks stale. Skip only via the sidecar
+// `<pi-session-file>-teamclu-title` (written after a successful setTitle)
+// so host restarts skip re-generation and LLM failures can retry.
 
 const SESSION_TITLE_MAX_LEN = 80;
 const SESSION_TITLE_MAX_INPUT = 2000;
@@ -1312,8 +1310,6 @@ type SessionTitleJob = {
   model: unknown;
   registry: ExtensionContext["modelRegistry"];
   setTitle?: (title: string) => void;
-  /** Snapshot from sync `getSessionName()` in the hook — do not re-read pi async. */
-  hadSessionNameAtStart: boolean;
 };
 
 function stripMentionsForSessionTitle(content: string): string {
@@ -1477,7 +1473,6 @@ async function llmSessionTitle(ctx: TitleLlmCtx, prompt: string): Promise<string
 }
 
 function startSessionTitle(
-  pi: ExtensionAPI,
   event: { prompt?: string },
   ctx: ExtensionContext,
 ): void {
@@ -1485,7 +1480,6 @@ function startSessionTitle(
   if (!sessionId) return;
   if (hasSessionTitleMarker(sessionId)) return;
   if (titleInFlightSessionIds.has(sessionId)) return;
-  if (String(pi.getSessionName?.() ?? "").trim()) return;
 
   const raw = String(event.prompt ?? "");
   if (isCronJobPrompt(raw)) return;
@@ -1511,7 +1505,6 @@ function startSessionTitle(
     model,
     registry,
     setTitle: ui.setTitle?.bind(ui),
-    hadSessionNameAtStart: false,
   }).finally(() => {
     titleInFlightSessionIds.delete(sessionId);
   });
@@ -1526,7 +1519,7 @@ async function applySessionTitle(job: SessionTitleJob): Promise<void> {
   } catch (e) {
     console.error(`[teamclu] session title LLM failed: ${e}`);
   }
-  if (!title || job.hadSessionNameAtStart) return;
+  if (!title) return;
 
   try {
     job.setTitle?.(title);
@@ -1561,7 +1554,7 @@ export default async function (pi: ExtensionAPI) {
 
   // -- Permission gate -------------------------------------------------------
   pi.on("before_agent_start", async (event, ctx) => {
-    startSessionTitle(pi, event, ctx);
+    startSessionTitle(event, ctx);
 
     const original = String(event.systemPrompt ?? "").trim();
     let base = original;


### PR DESCRIPTION
## Summary
- Session title no longer calls `pi.getSessionName()` / `setSessionName()`. Those go through the process-wide ExtensionRuntime, which any session `dispose()` (close, LRU evict, reopen) marks stale and then throws `This extension ctx is stale after session replacement or reload`.
- Skip generation only via the existing `-teamclu-title` sidecar (and in-flight / cron / slash-command guards). `#1297` already stopped the async `setSessionName` path; this removes the leftover sync read that still blew up after a session was replaced.
- Sessions that already have a pi name but no sidecar may get one more LLM title on the next prompt.

## Test plan
- [x] `node --test apps/daemon/assets/pi-extension/session-context.test.mjs` (36 pass)
- [ ] Close or switch a session, then send a first message in another session on the same worktree — no `pi extension error: This extension ctx is stale...`
- [ ] New session still gets an auto title; a session with an existing sidecar does not regenerate


Made with [Cursor](https://cursor.com)