### PR TITLE
fix(fc): resolve the app's hostname from the request, not only from Host

### DIFF
--- a/services/fc/src/app.ts
+++ b/services/fc/src/app.ts
@@ -24,6 +24,37 @@ function sendLegacy(_c: any, r: { statusCode: number; headers?: Record<string, s
   });
 }
 
+/**
+ * The hostname the caller actually asked for.
+ *
+ * `Host` alone is not enough on every deploy target. Behind Caddy (self-host)
+ * the node server sees the real Host, but on Alibaba Function Compute the
+ * request is reconstructed from the trigger event by `hono/aws-lambda`, which
+ * builds the URL from `requestContext.domainName` and carries headers
+ * separately — so an app served through the `*.<APPS_PUBLIC_DOMAIN>` custom
+ * domain arrived with a Host that did not parse, the middleware fell through,
+ * and every vanity URL answered the API's own "Route not found" instead of the
+ * app. `/internal/caddy/ask`, which takes the name as a query parameter, kept
+ * working the whole time — which is what proved the parser and the lookup were
+ * fine and the input was not.
+ *
+ * Order: the forwarding header a proxy sets, then Host, then the request URL
+ * the adapter composed. `requestOrigin` in team-llm-defaults.ts reads the first
+ * two for the same reason; the URL is the one that survives the Lambda-shaped
+ * event.
+ */
+function vanityRequestHost(c: { req: { header: (n: string) => string | undefined; url: string } }): string | undefined {
+  const forwarded = c.req.header("x-forwarded-host")?.split(",")[0]?.trim();
+  if (forwarded) return forwarded;
+  const host = c.req.header("host")?.trim();
+  if (host) return host;
+  try {
+    return new URL(c.req.url).host;
+  } catch {
+    return undefined;
+  }
+}
+
 export function createApp(deps: AppDeps): Hono {
   const app = new Hono();
 
@@ -51,7 +82,7 @@ export function createApp(deps: AppDeps): Hono {
     });
 
     app.use("*", async (c, next) => {
-      const host = c.req.header("host");
+      const host = vanityRequestHost(c);
       if (!parseAppPublicHost(host)) return next();
       const target = await lookup(host!);
       // A hostname whose app exists but has never deployed is a real app with

--- a/services/fc/test/vanity-host-resolution.test.ts
+++ b/services/fc/test/vanity-host-resolution.test.ts
@@ -1,0 +1,81 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../src/app.js";
+
+/**
+ * The vanity middleware used to read `Host` and nothing else. On Alibaba
+ * Function Compute the request is rebuilt from the trigger event by
+ * hono/aws-lambda, and the app's own hostname reached the handler on the URL
+ * rather than as a Host header — so every `*.<APPS_PUBLIC_DOMAIN>` URL fell
+ * through to the API router and answered "Route not found" instead of the app.
+ */
+const APP = {
+  id: "402c71eb-de8e-410b-8d8e-981953ce306f",
+  slug: "todo-list",
+  fcEndpoint: "http://todo-list-402c71eb.fc-apps.mx5.cn",
+  fcStatus: "live",
+};
+
+function appWithLookup(seen: string[]) {
+  return createApp({
+    createRepository: () => ({}) as any,
+    createAuthRepository: () => ({}) as any,
+    lookupVanityApp: async (host: string) => {
+      seen.push(host);
+      return host.startsWith("todo-list-402c71eb.") ? APP : null;
+    },
+  } as any);
+}
+
+const withDomain = async (fn: () => Promise<void>) => {
+  const prev = process.env.APPS_PUBLIC_DOMAIN;
+  process.env.APPS_PUBLIC_DOMAIN = "apps.mx5.cn";
+  try { await fn(); } finally {
+    if (prev === undefined) delete process.env.APPS_PUBLIC_DOMAIN;
+    else process.env.APPS_PUBLIC_DOMAIN = prev;
+  }
+};
+
+test("resolves the app host from the Host header", async () => {
+  await withDomain(async () => {
+    const seen: string[] = [];
+    const res = await appWithLookup(seen).request("http://placeholder/", {
+      headers: { host: "todo-list-402c71eb.apps.mx5.cn" },
+    });
+    assert.deepEqual(seen, ["todo-list-402c71eb.apps.mx5.cn"]);
+    assert.notEqual(res.status, 404, "must not fall through to the API router");
+  });
+});
+
+test("resolves it from the request URL when no Host header survives (the FC shape)", async () => {
+  await withDomain(async () => {
+    const seen: string[] = [];
+    // hono/aws-lambda composes the URL from requestContext.domainName; the Host
+    // header is not what carries the name on that path.
+    const res = await appWithLookup(seen).request("https://todo-list-402c71eb.apps.mx5.cn/");
+    assert.deepEqual(seen, ["todo-list-402c71eb.apps.mx5.cn"]);
+    assert.notEqual(res.status, 404);
+  });
+});
+
+test("x-forwarded-host wins over a proxy-rewritten Host", async () => {
+  await withDomain(async () => {
+    const seen: string[] = [];
+    await appWithLookup(seen).request("http://placeholder/", {
+      headers: {
+        host: "internal-proxy.example",
+        "x-forwarded-host": "todo-list-402c71eb.apps.mx5.cn, other.example",
+      },
+    });
+    assert.deepEqual(seen, ["todo-list-402c71eb.apps.mx5.cn"]);
+  });
+});
+
+test("a non-app host still falls through to the API router", async () => {
+  await withDomain(async () => {
+    const seen: string[] = [];
+    const res = await appWithLookup(seen).request("https://teamclaw-api.ucar.cc/definitely-not-a-route");
+    assert.deepEqual(seen, [], "lookup must not be consulted for a non-app host");
+    assert.equal(res.status, 404);
+  });
+});


### PR DESCRIPTION
## Description

Every `*.<APPS_PUBLIC_DOMAIN>` URL answered the API's own `{"code":"not_found","message":"Route not found"}` instead of the app it names. On belayo that meant a deployed app was unreachable at its public address even though the app itself was healthy.

The vanity middleware read `c.req.header("host")` and nothing else:

```ts
const host = c.req.header("host");
if (!parseAppPublicHost(host)) return next();
```

Behind Caddy — the self-host shape — a real Node HTTP server sees the real Host, so this held everywhere it had been exercised. On **Alibaba Function Compute** the request is rebuilt from the trigger event by `hono/aws-lambda`, which composes the URL from `requestContext.domainName` and carries headers separately. The name the caller asked for did not arrive as a `Host` header, `parseAppPublicHost` returned null, the middleware called `next()`, and the request fell through to the API router.

### How it was isolated

`/internal/caddy/ask` kept working the whole time, because it takes the name as a **query parameter** rather than from the request. Against the live deployment:

| query | response |
|---|---|
| `?domain=todo-list-402c71eb.apps.mx5.cn` | `ok` (200) |
| `?domain=nope-deadbeef.apps.mx5.cn` | `no such app` |
| `?domain=todo-list-402c71eb.wrong.example` | `not an app host` |

The parser and the database lookup were both fine on the exact hostname that 404'd — which left the input as the only thing that could be wrong.

### The change

`vanityRequestHost` reads `x-forwarded-host`, then `Host`, then the URL the adapter composed. `requestOrigin` in `team-llm-defaults.ts` already reads the first two for the same reason; the third is the one that survives a Lambda-shaped event, and is what makes this work on FC.

## Related Issue

None — found while bringing the apps module up on belayo.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

**Verified on the live deployment** after deploying this build to belayo: `todo-list-402c71eb.apps.mx5.cn` and the punycode `xn---37530102-4m4qt752a.apps.mx5.cn` both serve their app (200), while `teamclaw-api.ucar.cc` keeps answering its own routes and still 404s unknown ones — the fall-through for non-app hosts is unchanged.

Four tests: `Host`; URL-only (the FC shape); `x-forwarded-host` winning over a proxy-rewritten `Host`; and a non-app host falling through **without consulting the lookup at all**, so the change cannot start hitting the database for ordinary API traffic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017LGh88cvMMZeMForNo45i1
