### PR TITLE
fix(desktop): 修 main 上的 clippy 红灯（test-only 的 conn() 被判死代码）

### DIFF
--- a/apps/desktop/src/local_cache/store/mod.rs
+++ b/apps/desktop/src/local_cache/store/mod.rs
@@ -149,7 +149,14 @@ impl LocalCacheStore {
         Ok(instance)
     }
 
-    /// Get a locked reference to the raw connection (rarely needed externally).
+    /// Get a locked reference to the raw connection.
+    ///
+    /// Test-only since #1301 removed `session_export`, which was the last
+    /// caller outside `mod tests`. CI checks `--all-targets`, and the lib
+    /// target is compiled without `cfg(test)`, so leaving it ungated is a
+    /// `dead_code` error there while a plain `cargo check` only warns. Drop
+    /// the gate the moment production code needs the raw connection again.
+    #[cfg(test)]
     pub async fn conn(&self) -> tokio::sync::MutexGuard<'_, Connection> {
         self.conn.lock().await
     }


### PR DESCRIPTION
main 现在是红的：`Rust Format & Clippy` 在每一条 PR 上都挂，报的是

```
error: method `conn` is never used
  --> apps/desktop/src/local_cache/store/mod.rs:153:18
  = note: `-D dead-code` implied by `-D warnings`
```

（main HEAD `9a6e6114b` 自己的 CI run 也是这个：
https://github.com/different-ai-studio/teamclu/actions/runs/34187161985）

## 根因

#1301 删掉了 `apps/desktop/src/session_export/**`，那里面是
`LocalCacheStore::conn()` 在 **`mod tests` 之外的最后一个调用方**。剩下两个调用方
（`store/mod.rs:166`、`store/schema.rs:417`）都在 `#[cfg(test)]` 里，而 CI 跑的是
`--all-targets`——lib target 是**不带** `cfg(test)` 单独编一遍的，在那一遍里这个方法
确实没人用。

## 修法

给它加 `#[cfg(test)]`，如实说明「现在只有测试用」，两个测试照常编译。

**没有用 `allow(dead_code)`**：等哪天生产代码又需要这个裸连接，把 gate 去掉就行，
不会留下一个永久静音的 lint。

## 一个容易踩的地方

本地 `cargo check`（也就是 `pnpm rust:check` 跑的）对这个只报 **warning**，所以本地
是「过」的、CI 才红。能复现的是这条：

```
cargo clippy --manifest-path apps/desktop/Cargo.toml --all-targets -- -D warnings
```

## 测试

上面那条 clippy 和 `cargo fmt --check` 在本分支都是干净的（clippy 退出码 0，
2m20s）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nm8GmdWAaJSqfyCbY2yiBU
