### PR TITLE
fix(desktop): unbreak main — LocalCacheStore::conn is test-only now

### DIFF
--- a/apps/desktop/src/local_cache/store/mod.rs
+++ b/apps/desktop/src/local_cache/store/mod.rs
@@ -149,7 +149,15 @@ impl LocalCacheStore {
         Ok(instance)
     }
 
-    /// Get a locked reference to the raw connection (rarely needed externally).
+    /// Get a locked reference to the raw connection.
+    ///
+    /// Test-only since #1301 removed the last production caller. `--all-targets`
+    /// builds the lib WITHOUT `cfg(test)`, so a method reachable only from
+    /// `#[cfg(test)]` code is dead there and `-D warnings` fails the build —
+    /// which is what turned main red. `#[cfg(test)]` rather than
+    /// `#[allow(dead_code)]`: the allow would also hide the next method that
+    /// really does become unused.
+    #[cfg(test)]
     pub async fn conn(&self) -> tokio::sync::MutexGuard<'_, Connection> {
         self.conn.lock().await
     }


### PR DESCRIPTION
## Description

**`Rust Format & Clippy` is red on `main`**, and every open PR inherits it.

```
error: method `conn` is never used
  --> apps/desktop/src/local_cache/store/mod.rs:153:18
  = note: `-D dead-code` implied by `-D warnings`
```

#1301 (*export complete pi session transcripts*) trimmed 20 lines from `local_cache/store/messages.rs` and took the last production caller of `LocalCacheStore::conn` with them. The only two remaining callers are inside `#[cfg(test)]` modules — `mod.rs:166` and `schema.rs:417`.

### Why it got through

CI runs `cargo clippy --all-targets`, which builds the **lib as its own target, without `cfg(test)`**. A method reachable only from test code is dead in that target, and `-D warnings` makes it a build failure. `cargo clippy --lib` — the shorter command it is easy to reach for locally — does not compile tests as a separate concern and shows nothing.

### The fix

`#[cfg(test)]` on the method, not `#[allow(dead_code)]`. The allow would also silence the next method that genuinely stops being used; this one is honestly test-only and has no production role left to protect.

## Related Issue

Regression from #1301.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

No new test: this changes when a method is compiled, not what it does. The existing tests are its only callers and still exercise it.

## Additional Notes

Verified with the exact command CI runs — `cargo clippy --manifest-path apps/desktop/Cargo.toml --all-targets -- -D warnings` — clean; `cargo fmt --check` clean.

Blocks #1305 and #1306, which fail this job for this reason and no other.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017LGh88cvMMZeMForNo45i1