### PR TITLE
fix(app): match the pdf.js worker to react-pdf's API version

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -82,7 +82,7 @@
     "mermaid": "^11.17.2",
     "mqtt": "5.15.2",
     "nanoid": "^6.0.1",
-    "pdfjs-dist": "6.3.289",
+    "pdfjs-dist": "5.4.296",
     "qrcode.react": "^4.2.0",
     "radix-ui": "^1.6.7",
     "react": "^19.2.8",

--- a/packages/app/src/components/viewers/PDFViewer.tsx
+++ b/packages/app/src/components/viewers/PDFViewer.tsx
@@ -13,7 +13,14 @@ import {
   AlertCircle,
 } from "lucide-react";
 
-// Configure PDF.js worker - use local file via Vite ?url import
+// Configure PDF.js worker - use local file via Vite ?url import.
+//
+// The API above comes from react-pdf's own vendored pdfjs-dist; this worker
+// comes from our top-level one. pdf.js compares the two with `!==` and throws
+// `The API version "x" does not match the Worker version "y"` on ANY
+// difference, so our `pdfjs-dist` pin must stay equal to whatever react-pdf
+// depends on — bump the two together, never alone. `viewers/__tests__/
+// pdfjs-worker-version.test.ts` fails when they drift.
 pdfjs.GlobalWorkerOptions.workerSrc = new URL(
   "pdfjs-dist/build/pdf.worker.min.mjs",
   import.meta.url,

--- a/packages/app/src/components/viewers/__tests__/pdfjs-worker-version.test.ts
+++ b/packages/app/src/components/viewers/__tests__/pdfjs-worker-version.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'node:module';
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+
+/**
+ * PDFViewer takes the pdf.js *API* from `react-pdf` (which vendors its own
+ * exact `pdfjs-dist`) but points `GlobalWorkerOptions.workerSrc` at our
+ * top-level `pdfjs-dist`. pdf.js compares the two with `!==` and throws
+ *
+ *   The API version "x" does not match the Worker version "y".
+ *
+ * on any difference — not just a major one. So the two have to resolve to the
+ * same package, which only holds while our pin equals what react-pdf vendors.
+ *
+ * That drifted once already: react-pdf sat on 5.4.296 while dependabot walked
+ * our pin up through 6.x, and nothing caught it because no test loads a PDF.
+ * Nothing can, cheaply — importing pdf.js under jsdom dies on `DOMMatrix` —
+ * so this compares the two resolutions by their package metadata instead.
+ */
+describe('pdfjs-dist worker/API pinning', () => {
+  // Anchor on the package root rather than import.meta.url: vitest transforms
+  // this file for jsdom, where import.meta.url is an http:// URL that
+  // createRequire rejects.
+  const packageRoot = process.cwd();
+  const requireFromApp = createRequire(path.join(packageRoot, 'package.json'));
+
+  it('anchors on the app package (guards the assertions below)', () => {
+    expect(
+      existsSync(path.join(packageRoot, 'src/components/viewers/PDFViewer.tsx')),
+    ).toBe(true);
+  });
+
+  it('resolves the worker and the react-pdf API to the same pdfjs-dist version', () => {
+    // The specifier PDFViewer passes to `new URL(...)` for workerSrc.
+    const workerVersion = requireFromApp('pdfjs-dist/package.json').version;
+
+    // The pdfjs instance `import { pdfjs } from 'react-pdf'` actually hands us.
+    const requireFromReactPdf = createRequire(
+      requireFromApp.resolve('react-pdf'),
+    );
+    const apiVersion = requireFromReactPdf('pdfjs-dist/package.json').version;
+
+    expect(workerVersion).toBe(apiVersion);
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -350,8 +350,8 @@ importers:
         specifier: ^6.0.1
         version: 6.0.1
       pdfjs-dist:
-        specifier: 6.3.289
-        version: 6.3.289
+        specifier: 5.4.296
+        version: 5.4.296
       qrcode.react:
         specifier: ^4.2.0
         version: 4.2.0(react@19.2.8)
@@ -1647,20 +1647,8 @@ packages:
     cpu: [arm64]
     os: [android]
 
-  '@napi-rs/canvas-android-arm64@1.0.2':
-    resolution: {integrity: sha512-IMXKVQod0ol4vt3gmClUfXz4JAgHYESGPCUqmH3lQxBoL0K/2greJaQE1HVBVxWWFKfLc4OLZVdxg7kXVyXv+g==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [android]
-
   '@napi-rs/canvas-darwin-arm64@0.1.100':
     resolution: {integrity: sha512-2PcswRaC7Ly645DGt88///zuFDhJxJYdKAs1uU3mfk1atYkXufgcgLfBpk6Tm12nCQBaNt1wpybuPZ4qOhTo8A==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@napi-rs/canvas-darwin-arm64@1.0.2':
-    resolution: {integrity: sha512-Sc8tPi6cF+5lqOzCCKFALJHhDiRwyMzTPYm3bbhdXsOunU0lQO5f05ucyOzN2r55I23Hg5bsjH63uSCvWp3EgQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
@@ -1671,33 +1659,14 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@napi-rs/canvas-darwin-x64@1.0.2':
-    resolution: {integrity: sha512-niDXZ9LhKB1zLrUdYB64RHQFDGz9rr0eGx061qtJJU3U20EMMIx28ADF5fVYbhtOgkWQrBjFicfaye1yM0U62A==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [darwin]
-
   '@napi-rs/canvas-linux-arm-gnueabihf@0.1.100':
     resolution: {integrity: sha512-d5cDB48oWFGU8/XPhUOFAlySgb/VAu7D+s8fi55K1Pcfg8aPplHWqMgibhVLU8ky7Pyg/fuiVLz4Nf3JrSTuUA==}
     engines: {node: '>= 10'}
     cpu: [arm]
     os: [linux]
 
-  '@napi-rs/canvas-linux-arm-gnueabihf@1.0.2':
-    resolution: {integrity: sha512-sgatQL9JxGRH/Amzcvu0P3t8Am3duou74CisfuJ41Dwt8cWy723z/9KZ8LlgmxfypEwEZxSTNFJtU8d281lmhQ==}
-    engines: {node: '>= 10'}
-    cpu: [arm]
-    os: [linux]
-
   '@napi-rs/canvas-linux-arm64-gnu@0.1.100':
     resolution: {integrity: sha512-rDxgxRu69RvDlX/bh9o22DxLsGr8EqsNgotL9+RwQE1S0b0cqeatqsw6aW45mukm0B42DIAaAacKaYQ8cqS1nw==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
-
-  '@napi-rs/canvas-linux-arm64-gnu@1.0.2':
-    resolution: {integrity: sha512-dgKuX0peF3xwY6ZF5QxGS4wbfDqpoFAJYXiLSp+guZKARQUKMkRqZSDrXKj7nfrec3UCMzC0PFCPte0ES98AiA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
@@ -1710,22 +1679,8 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@napi-rs/canvas-linux-arm64-musl@1.0.2':
-    resolution: {integrity: sha512-qwROoDIC9upfvDoRLuPn2aNg9CGW1x0Ygr4k2Or+8paA9d0qBLwk87U+g8KQpoOviKoPoiwl97kvBYuYD7qZoA==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
-
   '@napi-rs/canvas-linux-riscv64-gnu@0.1.100':
     resolution: {integrity: sha512-mooqUBTIsccZpnoQC4NgrC1v6C1vof39etLNMnBwCY+p0gajWJvAHLGQ6g/gGyS5YrpDW+GefSN4+Cvcr08UWw==}
-    engines: {node: '>= 10'}
-    cpu: [riscv64]
-    os: [linux]
-    libc: [glibc]
-
-  '@napi-rs/canvas-linux-riscv64-gnu@1.0.2':
-    resolution: {integrity: sha512-fXRjnPihdnbO6qy1QQOgxAonb68A0TCEG7rj1x7v7rxNElsE8EVIKIEUTvyDtU+sthYSbX+8e7g3oZiLGnOmxw==}
     engines: {node: '>= 10'}
     cpu: [riscv64]
     os: [linux]
@@ -1738,22 +1693,8 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@napi-rs/canvas-linux-x64-gnu@1.0.2':
-    resolution: {integrity: sha512-nPR97DXhbWIAy7yazF3jc06kEPMqYMLmPzFOVNlwKPfIoSChnI+x7dc0hTLaihz3jxrjL6j4BbA7earxfx4X3g==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
-
   '@napi-rs/canvas-linux-x64-musl@0.1.100':
     resolution: {integrity: sha512-20arT6lnI19S68qNlii73TSEDbECNgzMz2EpldC1V3mZFuRkeujXkcebRk0LRJe9SEUAooYiLokfMViY8IX7yA==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
-
-  '@napi-rs/canvas-linux-x64-musl@1.0.2':
-    resolution: {integrity: sha512-l7zZY5+jL5qnBZtDz7CoBtY6p7EkHu422g/0zWwrOrzIwWyWxZFRfZZORY1UG7YApymPLx+UbOkN206xXn/c1Q==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
@@ -1765,30 +1706,14 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  '@napi-rs/canvas-win32-arm64-msvc@1.0.2':
-    resolution: {integrity: sha512-yE0koHCFF4PIbMc2o2SEALhnipz7WBISh5glLvQiomtIoCcW0np3H4Lw93ceJAfJttTTeIIWFbwH84F7EVzjMQ==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [win32]
-
   '@napi-rs/canvas-win32-x64-msvc@0.1.100':
     resolution: {integrity: sha512-MyT1j3mHC2+Lu4pBi9mKyMJhtP6U7k7EldY7sj/uS5gJA65gTXt8MefJQXLJo5d/vZbuWmfxzkEUNc/urV3pHA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
 
-  '@napi-rs/canvas-win32-x64-msvc@1.0.2':
-    resolution: {integrity: sha512-okU8/t2foV6C31n0GtvEMbfD5rOFc70+/6xUNME9Guld29sgSOIGUEDScAWFlcP3k5TYQRl9TNkwJEEjh15w8A==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [win32]
-
   '@napi-rs/canvas@0.1.100':
     resolution: {integrity: sha512-xglYA6q3XO5P3BNJYxVZ1IV7DLVjp1Py6nwag88YntrS+3vKHyYcMqXVS4ZztJmwz2uGvz1FWhI/4LgbR5uQDA==}
-    engines: {node: '>= 10'}
-
-  '@napi-rs/canvas@1.0.2':
-    resolution: {integrity: sha512-EYEqlMYaCbpZDz+IgDH5xp9MTd3ui4dmGqbQYryhMLnSRxrhHKq5KQWHHKxFUcEP4Hp8/BWgvqXocX4j7iSbOQ==}
     engines: {node: '>= 10'}
 
   '@noble/hashes@1.8.0':
@@ -7224,10 +7149,6 @@ packages:
     resolution: {integrity: sha512-DlOzet0HO7OEnmUmB6wWGJrrdvbyJKftI1bhMitK7O2N8W2gc757yyYBbINy9IDafXAV9wmKr9t7xsTaNKRG5Q==}
     engines: {node: '>=20.16.0 || >=22.3.0'}
 
-  pdfjs-dist@6.3.289:
-    resolution: {integrity: sha512-ZHjSVpDa3D6izMq8/04lvkhkATUmL9px6ChPaXc1k6nU2Mrhlg1/7F0bdUqCwUjw3NsPTfPZsMDUU6ZIcRaeQw==}
-    engines: {node: '>=22.13.0 || >=24'}
-
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -10187,67 +10108,34 @@ snapshots:
   '@napi-rs/canvas-android-arm64@0.1.100':
     optional: true
 
-  '@napi-rs/canvas-android-arm64@1.0.2':
-    optional: true
-
   '@napi-rs/canvas-darwin-arm64@0.1.100':
-    optional: true
-
-  '@napi-rs/canvas-darwin-arm64@1.0.2':
     optional: true
 
   '@napi-rs/canvas-darwin-x64@0.1.100':
     optional: true
 
-  '@napi-rs/canvas-darwin-x64@1.0.2':
-    optional: true
-
   '@napi-rs/canvas-linux-arm-gnueabihf@0.1.100':
-    optional: true
-
-  '@napi-rs/canvas-linux-arm-gnueabihf@1.0.2':
     optional: true
 
   '@napi-rs/canvas-linux-arm64-gnu@0.1.100':
     optional: true
 
-  '@napi-rs/canvas-linux-arm64-gnu@1.0.2':
-    optional: true
-
   '@napi-rs/canvas-linux-arm64-musl@0.1.100':
-    optional: true
-
-  '@napi-rs/canvas-linux-arm64-musl@1.0.2':
     optional: true
 
   '@napi-rs/canvas-linux-riscv64-gnu@0.1.100':
     optional: true
 
-  '@napi-rs/canvas-linux-riscv64-gnu@1.0.2':
-    optional: true
-
   '@napi-rs/canvas-linux-x64-gnu@0.1.100':
-    optional: true
-
-  '@napi-rs/canvas-linux-x64-gnu@1.0.2':
     optional: true
 
   '@napi-rs/canvas-linux-x64-musl@0.1.100':
     optional: true
 
-  '@napi-rs/canvas-linux-x64-musl@1.0.2':
-    optional: true
-
   '@napi-rs/canvas-win32-arm64-msvc@0.1.100':
     optional: true
 
-  '@napi-rs/canvas-win32-arm64-msvc@1.0.2':
-    optional: true
-
   '@napi-rs/canvas-win32-x64-msvc@0.1.100':
-    optional: true
-
-  '@napi-rs/canvas-win32-x64-msvc@1.0.2':
     optional: true
 
   '@napi-rs/canvas@0.1.100':
@@ -10263,21 +10151,6 @@ snapshots:
       '@napi-rs/canvas-linux-x64-musl': 0.1.100
       '@napi-rs/canvas-win32-arm64-msvc': 0.1.100
       '@napi-rs/canvas-win32-x64-msvc': 0.1.100
-    optional: true
-
-  '@napi-rs/canvas@1.0.2':
-    optionalDependencies:
-      '@napi-rs/canvas-android-arm64': 1.0.2
-      '@napi-rs/canvas-darwin-arm64': 1.0.2
-      '@napi-rs/canvas-darwin-x64': 1.0.2
-      '@napi-rs/canvas-linux-arm-gnueabihf': 1.0.2
-      '@napi-rs/canvas-linux-arm64-gnu': 1.0.2
-      '@napi-rs/canvas-linux-arm64-musl': 1.0.2
-      '@napi-rs/canvas-linux-riscv64-gnu': 1.0.2
-      '@napi-rs/canvas-linux-x64-gnu': 1.0.2
-      '@napi-rs/canvas-linux-x64-musl': 1.0.2
-      '@napi-rs/canvas-win32-arm64-msvc': 1.0.2
-      '@napi-rs/canvas-win32-x64-msvc': 1.0.2
     optional: true
 
   '@noble/hashes@1.8.0':
@@ -16114,10 +15987,6 @@ snapshots:
   pdfjs-dist@5.4.296:
     optionalDependencies:
       '@napi-rs/canvas': 0.1.100
-
-  pdfjs-dist@6.3.289:
-    optionalDependencies:
-      '@napi-rs/canvas': 1.0.2
 
   picocolors@1.1.1: {}
 


### PR DESCRIPTION
Opening any PDF in the app throws before it renders:

```
The API version "5.4.296" does not match the Worker version "6.3.289".
```

`PDFViewer.tsx` takes the pdf.js **API** from `react-pdf`, which vendors its own
exact `pdfjs-dist` (5.4.296), but points `GlobalWorkerOptions.workerSrc` at our
**top-level** `pdfjs-dist`. Those are two different packages, and pdf.js compares
them with `!==` — exact string equality, not a major-version check — so any
difference at all is fatal:

```js
const workerVersion = "6.3.289";
if (apiVersion !== workerVersion) {
  throw new Error(`The API version "${apiVersion}" does not match ` +
                  `the Worker version "${workerVersion}".`);
}
```

Confirmed against the real module resolution rather than inferred:

```
worker -> .pnpm/pdfjs-dist@6.3.289/node_modules/pdfjs-dist/build/pdf.worker.min.mjs
api    -> .pnpm/pdfjs-dist@5.4.296/node_modules/pdfjs-dist/build/pdf.mjs
```

## This is not new

It predates the recent dependabot batch. The Aug 19 build still sitting in
`packages/app/dist` shipped broken — its chunk sends `apiVersion:"5.4.296"`
against a 6.1.200 worker. #1292 (6.2.108 → 6.3.289) widened the gap; it did not
create it.

## Fix

Pin `pdfjs-dist` to `5.4.296`, the version `react-pdf` depends on, so both
specifiers resolve to one package and the versions match by construction.

The pin is a **constraint, not a preference** — it has to move together with
`react-pdf`, never on its own. That is now stated at the call site.

Deduping also drops a redundant `@napi-rs/canvas` native binary set that the
second pdfjs copy dragged in (135 lines out of the lockfile).

## Guard

`viewers/__tests__/pdfjs-worker-version.test.ts` compares the two resolutions.

It compares package metadata rather than importing pdf.js, because importing
pdf.js under jsdom dies on `DOMMatrix` — which is exactly why nothing caught
this: no test loads a PDF, and none cheaply can.

Verified it actually goes red on the real drift, not merely green on the fix —
re-pinning to 6.3.289 yields `expected '6.3.289' to be '5.4.296'`.

Dependabot will keep proposing the `pdfjs-dist` bump on its own; that PR now
fails CI instead of merging quietly. Deliberately **not** added to
`dependabot.yml`'s ignore list — that would suppress pdf.js security updates
too.

## Verification

- `pnpm typecheck` — clean
- `pnpm lint` — 0 errors, 47 warnings (unchanged baseline vs main)
- `pnpm test:unit` — 512 files / 3372 tests passed

Run twice, before and after merging current `main`, so it is confirmed under
both vitest 4 and the vitest 5 that just landed in #1291.

Not covered: no automated test opens an actual PDF, so this is verified at the
resolution level. Worth a manual check in the app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017LGh88cvMMZeMForNo45i1
