### PR TITLE
fix(skills): keep get_draft as a catalog and cap tool results

### DIFF
--- a/apps/daemon/assets/pi-extension/session-context.test.mjs
+++ b/apps/daemon/assets/pi-extension/session-context.test.mjs
@@ -919,3 +919,82 @@ test("before_agent_start strips pi docs but keeps project_context", async () => 
   assert.match(result.systemPrompt, /Use TypeScript strict mode/);
   assert.match(result.systemPrompt, /Current working directory: \/tmp/);
 });
+
+/** Mirrors `capToolText` / `toPiContent` in teamclu.ts */
+const MAX_TOOL_RESULT_BYTES = 128 * 1024;
+
+function budgetExceededEnvelope(originalBytes) {
+  return JSON.stringify({
+    truncated: true,
+    reason: "response_budget_exceeded",
+    originalBytes,
+    hint: "Use a narrower query or read_draft_file with a specific path",
+  });
+}
+
+function capToolText(text) {
+  const bytes = new TextEncoder().encode(text);
+  if (bytes.length <= MAX_TOOL_RESULT_BYTES) return text;
+  return budgetExceededEnvelope(bytes.length);
+}
+
+function toPiContent(result) {
+  const out = [];
+  for (const part of Array.isArray(result?.content) ? result.content : []) {
+    if (!part || typeof part !== "object") continue;
+    if (part.type === "text" && typeof part.text === "string") {
+      out.push({ type: "text", text: capToolText(part.text) });
+    } else if (part.type === "image" && typeof part.data === "string") {
+      out.push({ type: "image", data: part.data, mimeType: part.mimeType || "image/png" });
+    } else if (part.type === "resource" && typeof part.resource?.text === "string") {
+      out.push({ type: "text", text: capToolText(part.resource.text) });
+    } else {
+      out.push({ type: "text", text: capToolText(JSON.stringify(part)) });
+    }
+  }
+  if (out.length === 0 && result?.structuredContent !== undefined) {
+    out.push({ type: "text", text: capToolText(JSON.stringify(result.structuredContent)) });
+  }
+  if (out.length === 0) {
+    out.push({ type: "text", text: capToolText(JSON.stringify(result ?? null)) });
+  }
+  return out;
+}
+
+test("toPiContent source uses a structured 128KB fuse instead of slicing JSON", () => {
+  const src = fs.readFileSync(fileURLToPath(new URL("./teamclu.ts", import.meta.url)), "utf8");
+  assert.match(src, /MAX_TOOL_RESULT_BYTES\s*=\s*128\s*\*\s*1024/);
+  assert.match(src, /function capToolText/);
+  assert.match(src, /response_budget_exceeded/);
+  assert.doesNotMatch(src, /showing first \$\{end\} bytes/);
+  assert.doesNotMatch(src, /capToolText\(part\.data\)/);
+});
+
+test("toPiContent leaves small text and images alone", () => {
+  assert.deepEqual(toPiContent({ content: [{ type: "text", text: "hello" }] }), [
+    { type: "text", text: "hello" },
+  ]);
+  const image = { type: "image", data: "x".repeat(MAX_TOOL_RESULT_BYTES + 8), mimeType: "image/png" };
+  assert.deepEqual(toPiContent({ content: [image] }), [
+    { type: "image", data: image.data, mimeType: "image/png" },
+  ]);
+});
+
+test("toPiContent replaces oversized text with a structured envelope", () => {
+  const big = "x".repeat(MAX_TOOL_RESULT_BYTES + 40);
+  const textOut = toPiContent({ content: [{ type: "text", text: big }] });
+  assert.equal(textOut.length, 1);
+  const parsed = JSON.parse(textOut[0].text);
+  assert.equal(parsed.truncated, true);
+  assert.equal(parsed.reason, "response_budget_exceeded");
+  assert.equal(parsed.originalBytes, MAX_TOOL_RESULT_BYTES + 40);
+  assert.ok(!textOut[0].text.includes("xxxx"));
+
+  const resourceOut = toPiContent({
+    content: [{ type: "resource", resource: { text: big } }],
+  });
+  assert.match(resourceOut[0].text, /response_budget_exceeded/);
+
+  const structuredOut = toPiContent({ structuredContent: { blob: big } });
+  assert.match(structuredOut[0].text, /response_budget_exceeded/);
+});

--- a/apps/daemon/assets/pi-extension/teamclu.ts
+++ b/apps/daemon/assets/pi-extension/teamclu.ts
@@ -610,29 +610,52 @@ class McpBridge {
   }
 }
 
+/** Last-resort cap so any MCP tool that inlines too much still cannot blow
+ *  the model context. Introspect get_draft stays under 64 KiB; this fuse is
+ *  128 KiB and replaces the payload with a structured envelope — never a
+ *  sliced JSON string. */
+const MAX_TOOL_RESULT_BYTES = 128 * 1024;
+
+function budgetExceededEnvelope(originalBytes: number): string {
+  return JSON.stringify({
+    truncated: true,
+    reason: "response_budget_exceeded",
+    originalBytes,
+    hint: "Use a narrower query or read_draft_file with a specific path",
+  });
+}
+
+function capToolText(text: string): string {
+  const bytes = new TextEncoder().encode(text);
+  if (bytes.length <= MAX_TOOL_RESULT_BYTES) return text;
+  return budgetExceededEnvelope(bytes.length);
+}
+
 /** MCP tool result → pi tool result content. */
 function toPiContent(result: any): PiToolContent[] {
   const out: PiToolContent[] = [];
   for (const part of Array.isArray(result?.content) ? result.content : []) {
     if (!part || typeof part !== "object") continue;
     if (part.type === "text" && typeof part.text === "string") {
-      out.push({ type: "text", text: part.text });
+      out.push({ type: "text", text: capToolText(part.text) });
     } else if (part.type === "image" && typeof part.data === "string") {
       // pi accepts image content in tool results and normalizes oversized ones
       // (`normalizeToolResultImages`, which names MCP bridges as a source).
       // Stringifying these — what this bridge used to do — turned a screenshot
-      // into a wall of base64 JSON.
+      // into a wall of base64 JSON. Do not cap image payloads here.
       out.push({ type: "image", data: part.data, mimeType: part.mimeType || "image/png" });
     } else if (part.type === "resource" && typeof part.resource?.text === "string") {
-      out.push({ type: "text", text: part.resource.text });
+      out.push({ type: "text", text: capToolText(part.resource.text) });
     } else {
-      out.push({ type: "text", text: JSON.stringify(part) });
+      out.push({ type: "text", text: capToolText(JSON.stringify(part)) });
     }
   }
   if (out.length === 0 && result?.structuredContent !== undefined) {
-    out.push({ type: "text", text: JSON.stringify(result.structuredContent) });
+    out.push({ type: "text", text: capToolText(JSON.stringify(result.structuredContent)) });
   }
-  if (out.length === 0) out.push({ type: "text", text: JSON.stringify(result ?? null) });
+  if (out.length === 0) {
+    out.push({ type: "text", text: capToolText(JSON.stringify(result ?? null)) });
+  }
   return out;
 }
 

--- a/apps/daemon/src/config/managed_skill_writer.rs
+++ b/apps/daemon/src/config/managed_skill_writer.rs
@@ -19,8 +19,10 @@ use super::roles_skills::is_inherent_skill;
 const GLOBAL_SKILLS_REL: &str = ".agents/skills";
 pub(crate) const SKILL_MD: &str = "SKILL.md";
 pub(crate) const MAX_PACK_FILES: usize = 500;
-pub(crate) const MAX_SINGLE_FILE_BYTES: usize = 1024 * 1024;
-pub(crate) const MAX_PACK_TOTAL_BYTES: usize = 5 * 1024 * 1024;
+/// Publish/write cap: 0.5 MiB per file. Distinct from the get_draft JSON budget.
+pub(crate) const MAX_SINGLE_FILE_BYTES: usize = 512 * 1024;
+/// Publish/write cap: 2.5 MiB pack total.
+pub(crate) const MAX_PACK_TOTAL_BYTES: usize = 2560 * 1024;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "snake_case")]
@@ -96,6 +98,8 @@ pub struct CreatePackRequest {
 #[serde(rename_all = "camelCase")]
 pub struct UpdatePackRequest {
     pub slug: String,
+    /// Full SKILL.md. Empty/omitted on `update_draft` keeps the existing file.
+    #[serde(default)]
     pub content: String,
     #[serde(default)]
     pub files: Vec<PackFileInput>,
@@ -647,12 +651,20 @@ pub fn update_pack(
             format!("invalid slug {:?}", req.slug),
         ));
     }
-    validate_strict_frontmatter(&req.content, &req.slug)?;
-    if req.content.len() > MAX_SINGLE_FILE_BYTES {
+    if req.content.is_empty() && req.files.is_empty() && req.delete_files.is_empty() {
         return Err(ManagedSkillError::new(
-            ManagedSkillErrorCode::SkillPackTooLarge,
-            "SKILL.md exceeds size limit",
+            ManagedSkillErrorCode::InvalidSkillFilePath,
+            "update requires at least one of content, files, or deleteFiles",
         ));
+    }
+    if !req.content.is_empty() {
+        validate_strict_frontmatter(&req.content, &req.slug)?;
+        if req.content.len() > MAX_SINGLE_FILE_BYTES {
+            return Err(ManagedSkillError::new(
+                ManagedSkillErrorCode::SkillPackTooLarge,
+                "SKILL.md exceeds size limit",
+            ));
+        }
     }
 
     let mut patch_files = Vec::new();
@@ -710,7 +722,9 @@ pub fn update_pack(
 
     let temp = TempPackGuard::new(skills_root.join(format!(".teamclu-update-{}", Uuid::new_v4())));
     copy_pack_tree(&target, temp.path())?;
-    fs::write(temp.path().join(SKILL_MD), req.content.as_bytes()).map_err(io_managed)?;
+    if !req.content.is_empty() {
+        fs::write(temp.path().join(SKILL_MD), req.content.as_bytes()).map_err(io_managed)?;
+    }
     apply_patch_files(temp.path(), &patch_files)?;
     apply_delete_files(temp.path(), &req.delete_files)?;
     verify_final_skill_md(temp.path(), &req.slug)?;
@@ -1413,5 +1427,51 @@ mod tests {
         let root = home.path().join(".agents/skills/trim");
         assert!(!root.join("assets/base-0.bin").exists());
         assert!(root.join("assets/extra-0.bin").exists());
+    }
+
+    #[test]
+    fn update_can_patch_sidecar_without_rewriting_skill_md() {
+        let home = tempfile::tempdir().unwrap();
+        let _guard = crate::test_brand_env::BrandEnvGuard::set_with_home("teamclu", home.path());
+        let ws = tempfile::tempdir().unwrap();
+        create_pack(
+            ws.path(),
+            home.path(),
+            &CreatePackRequest {
+                slug: "keep-md".into(),
+                content: "---\nname: keep-md\ndescription: Keep.\n---\n\n# Keep\n".into(),
+                files: vec![PackFileInput {
+                    path: "notes.md".into(),
+                    content: "v1\n".into(),
+                    encoding: None,
+                }],
+            },
+            &ClaimedTeamContext::NoTeam,
+        )
+        .unwrap();
+
+        update_pack(
+            ws.path(),
+            home.path(),
+            &UpdatePackRequest {
+                slug: "keep-md".into(),
+                content: String::new(),
+                files: vec![PackFileInput {
+                    path: "notes.md".into(),
+                    content: "v2\n".into(),
+                    encoding: None,
+                }],
+                expected_digest: None,
+                delete_files: vec![],
+            },
+            &ClaimedTeamContext::NoTeam,
+        )
+        .unwrap();
+
+        let root = home.path().join(".agents/skills/keep-md");
+        assert!(fs::read_to_string(root.join("SKILL.md"))
+            .unwrap()
+            .contains("# Keep"));
+        assert_eq!(fs::read_to_string(root.join("notes.md")).unwrap(), "v2\n");
     }
 }

--- a/apps/daemon/src/config/mod.rs
+++ b/apps/daemon/src/config/mod.rs
@@ -30,6 +30,7 @@ pub use daemon_config::{
 // Only test fixtures build a `DaemonConfig` field by field.
 #[cfg(test)]
 pub use daemon_config::{ActorConfig, AgentBackendConfig, AgentsConfig, MqttConfig};
+pub use knowledge_scaffold::{domain_index_template, scaffold_knowledge, ScaffoldReport};
 pub use managed_skill_writer::{
     create_pack, get_pack, pack_digest, update_pack, ClaimedTeamContext, CreatePackRequest,
     ManageSkillResponse, ManagedSkillError, ManagedSkillErrorCode, UpdatePackRequest,
@@ -46,9 +47,9 @@ pub use skill_creation_policy::{
     append_policy_to_prompt, materialize_policy_file, SKILL_CREATION_POLICY,
 };
 pub use team_skill_draft::{
-    get_team_skill_draft, update_team_skill_draft, TeamSkillDraftUpdateResult, TeamSkillDraftView,
+    get_team_skill_draft, read_team_skill_draft_file, update_team_skill_draft, DraftFileRead,
+    TeamSkillDraftUpdateResult, TeamSkillDraftView,
 };
-pub use knowledge_scaffold::{domain_index_template, scaffold_knowledge, ScaffoldReport};
 pub use workspace_control::{
     decode_workspace_path, encode_workspace_path, ApplyOutcome, OpenCodeCompatStore,
     ProviderAuthRequest, ProviderModelConfig, WorkspaceControlStore,

--- a/apps/daemon/src/config/team_skill_draft.rs
+++ b/apps/daemon/src/config/team_skill_draft.rs
@@ -7,8 +7,8 @@
 use std::fs;
 use std::path::{Path, PathBuf};
 
-use base64::Engine as _;
 use serde::Serialize;
+use sha2::{Digest, Sha256};
 use teamclu_skillpack::{inspect, read_origin, DirtyState, SkillOrigin, ORIGIN_DIR, SOURCE_TEAM};
 use uuid::Uuid;
 use walkdir::WalkDir;
@@ -17,11 +17,16 @@ use crate::backend::TeamSkillRow;
 use crate::runtime::team_skills::team_cloud_skills_dir;
 
 use super::managed_skill_writer::{
-    apply_delete_files, apply_patch_files, copy_pack_tree, pack_digest, publish_temp_dir,
-    reject_symlink, validate_pack_tree_limits, verify_final_skill_md, ManagedSkillError,
-    ManagedSkillErrorCode, RuntimeActivation, TempPackGuard, UpdatePackRequest, MAX_PACK_FILES,
-    MAX_PACK_TOTAL_BYTES, MAX_SINGLE_FILE_BYTES, SKILL_MD,
+    apply_delete_files, apply_patch_files, copy_pack_tree, normalize_pack_rel_path, pack_digest,
+    publish_temp_dir, reject_symlink, validate_pack_tree_limits, verify_final_skill_md,
+    ManagedSkillError, ManagedSkillErrorCode, RuntimeActivation, TempPackGuard, UpdatePackRequest,
+    MAX_PACK_FILES, MAX_SINGLE_FILE_BYTES, SKILL_MD,
 };
+
+/// Serialized `get_draft` JSON must stay inside this budget (model context).
+pub(crate) const GET_DRAFT_MAX_JSON_BYTES: usize = 64 * 1024;
+pub(crate) const READ_DRAFT_FILE_DEFAULT_BYTES: usize = 16 * 1024;
+pub(crate) const READ_DRAFT_FILE_MAX_BYTES: usize = 32 * 1024;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "kebab-case")]
@@ -61,13 +66,13 @@ pub fn effective_team_skill_dir(
 #[serde(rename_all = "camelCase")]
 pub struct DraftPackFile {
     pub path: String,
+    /// Sidecar bodies are never inlined on `get_draft`. Use `read_draft_file`.
     #[serde(skip_serializing_if = "String::is_empty")]
     pub content: String,
-    /// `utf8` (default) or `base64` for non-text assets.
+    /// `utf8` (default) or `base64` for non-text assets — only on `read_draft_file`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub encoding: Option<String>,
-    /// Present when `content` was withheld so the tool result stays inside
-    /// the write-path pack limits (`too_large` or `too_many`).
+    /// Present when this file cannot be published (`too_large` / `too_many`).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub omitted: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -88,7 +93,32 @@ pub struct TeamSkillDraftView {
     pub content: String,
     pub files: Vec<DraftPackFile>,
     pub source: String,
+    pub file_count: usize,
+    pub total_bytes: u64,
+    /// True when SKILL.md or file listing was dropped to stay under the JSON budget.
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    pub truncated: bool,
     /// Publish/update_draft will reject this working copy when non-empty.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub warnings: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DraftFileRead {
+    pub path: String,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub content: String,
+    pub size: u64,
+    pub offset: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub next_offset: Option<u64>,
+    pub complete: bool,
+    pub digest: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub encoding: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub omitted: Option<String>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub warnings: Vec<String>,
 }
@@ -165,6 +195,33 @@ fn compute_state_for_team(
     compute_state(origin, dirty, latest_version)
 }
 
+fn sha256_hex(bytes: &[u8]) -> String {
+    format!("sha256:{:x}", Sha256::digest(bytes))
+}
+
+fn empty_draft_view(
+    slug: &str,
+    base_version: i64,
+    latest_version: i64,
+    state: String,
+    source: String,
+) -> TeamSkillDraftView {
+    TeamSkillDraftView {
+        slug: slug.to_string(),
+        base_version,
+        latest_version,
+        state,
+        digest: String::new(),
+        content: String::new(),
+        files: Vec::new(),
+        source,
+        file_count: 0,
+        total_bytes: 0,
+        truncated: false,
+        warnings: Vec::new(),
+    }
+}
+
 fn read_skill_md(target: &Path) -> Result<(String, Option<String>), ManagedSkillError> {
     let path = target.join(SKILL_MD);
     let len = fs::metadata(&path).map_err(io_err)?.len();
@@ -172,8 +229,15 @@ fn read_skill_md(target: &Path) -> Result<(String, Option<String>), ManagedSkill
         return Ok((
             String::new(),
             Some(format!(
-                "SKILL.md exceeds size limit ({len} bytes > {MAX_SINGLE_FILE_BYTES}); publish will be rejected. Read it at {} with the read tool",
-                path.display()
+                "SKILL.md exceeds size limit ({len} bytes > {MAX_SINGLE_FILE_BYTES}); publish will be rejected. Use read_draft_file with path {SKILL_MD}"
+            )),
+        ));
+    }
+    if len as usize > GET_DRAFT_MAX_JSON_BYTES {
+        return Ok((
+            String::new(),
+            Some(format!(
+                "SKILL.md omitted from get_draft ({len} bytes > response budget); use read_draft_file with path {SKILL_MD}"
             )),
         ));
     }
@@ -182,19 +246,7 @@ fn read_skill_md(target: &Path) -> Result<(String, Option<String>), ManagedSkill
 
 struct ListedPackFile {
     rel: String,
-    abs: PathBuf,
     size: u64,
-}
-
-fn omitted_pack_file(rel: String, abs: &Path, size: u64, reason: &'static str) -> DraftPackFile {
-    DraftPackFile {
-        path: rel,
-        content: String::new(),
-        encoding: None,
-        omitted: Some(reason.into()),
-        size: Some(size),
-        hint: Some(format!("read it at {} with the read tool", abs.display())),
-    }
 }
 
 fn collect_pack_file_entries(target: &Path) -> Result<Vec<ListedPackFile>, ManagedSkillError> {
@@ -216,65 +268,99 @@ fn collect_pack_file_entries(target: &Path) -> Result<Vec<ListedPackFile>, Manag
             continue;
         }
         let size = fs::metadata(entry.path()).map_err(io_err)?.len();
-        files.push(ListedPackFile {
-            rel: rel_str,
-            abs: entry.path().to_path_buf(),
-            size,
-        });
+        files.push(ListedPackFile { rel: rel_str, size });
     }
     files.sort_by(|a, b| a.rel.cmp(&b.rel));
     Ok(files)
 }
 
-fn list_pack_files(target: &Path) -> Result<(Vec<DraftPackFile>, Vec<String>), ManagedSkillError> {
+fn list_pack_files(
+    target: &Path,
+) -> Result<(Vec<DraftPackFile>, Vec<String>, u64), ManagedSkillError> {
     let entries = collect_pack_file_entries(target)?;
-    let skill_md_len = fs::metadata(target.join(SKILL_MD))
-        .map(|m| m.len() as usize)
-        .unwrap_or(0);
-    let mut total_bytes = skill_md_len.min(MAX_SINGLE_FILE_BYTES);
-    let max_sidecars = MAX_PACK_FILES.saturating_sub(1);
     let mut warnings = Vec::new();
-    let listed = if entries.len() > max_sidecars {
+    let total_sidecar_bytes: u64 = entries.iter().map(|e| e.size).sum();
+    if entries.len() + 1 > MAX_PACK_FILES {
         warnings.push(format!(
-            "{} additional files were not listed (pack exceeds file count limit)",
-            entries.len() - max_sidecars
+            "pack has {} files (limit {MAX_PACK_FILES}); publish will be rejected",
+            entries.len() + 1
         ));
-        &entries[..max_sidecars]
-    } else {
-        &entries[..]
-    };
+    }
 
-    let mut out = Vec::with_capacity(listed.len());
-    for entry in listed {
-        let size = entry.size as usize;
-        if size > MAX_SINGLE_FILE_BYTES || total_bytes.saturating_add(size) > MAX_PACK_TOTAL_BYTES {
-            out.push(omitted_pack_file(
-                entry.rel.clone(),
-                &entry.abs,
-                entry.size,
-                "too_large",
-            ));
-            continue;
-        }
-        let bytes = fs::read(&entry.abs).map_err(io_err)?;
-        total_bytes = total_bytes.saturating_add(bytes.len());
-        let (content, encoding) = match String::from_utf8(bytes) {
-            Ok(text) => (text, None),
-            Err(err) => (
-                base64::engine::general_purpose::STANDARD.encode(err.into_bytes()),
-                Some("base64".to_string()),
-            ),
-        };
+    let mut out = Vec::with_capacity(entries.len());
+    for entry in &entries {
+        let too_large = entry.size as usize > MAX_SINGLE_FILE_BYTES;
         out.push(DraftPackFile {
             path: entry.rel.clone(),
-            content,
-            encoding,
-            omitted: None,
+            content: String::new(),
+            encoding: None,
+            omitted: too_large.then(|| "too_large".into()),
             size: Some(entry.size),
-            hint: None,
+            hint: too_large.then(|| {
+                format!(
+                    "use read_draft_file with path {} (publish will reject this file)",
+                    entry.rel
+                )
+            }),
         });
     }
-    Ok((out, warnings))
+    Ok((out, warnings, total_sidecar_bytes))
+}
+
+fn serialized_draft_len(view: &TeamSkillDraftView) -> usize {
+    serde_json::to_vec(view)
+        .map(|v| v.len())
+        .unwrap_or(usize::MAX)
+}
+
+fn fit_draft_view(mut view: TeamSkillDraftView) -> TeamSkillDraftView {
+    if serialized_draft_len(&view) <= GET_DRAFT_MAX_JSON_BYTES {
+        return view;
+    }
+    view.truncated = true;
+    if !view.content.is_empty() {
+        let len = view.content.len();
+        view.content.clear();
+        view.warnings.push(format!(
+            "SKILL.md omitted from get_draft ({len} bytes > response budget); use read_draft_file with path {SKILL_MD}"
+        ));
+        if serialized_draft_len(&view) <= GET_DRAFT_MAX_JSON_BYTES {
+            return view;
+        }
+    }
+    let mut dropped = 0usize;
+    while serialized_draft_len(&view) > GET_DRAFT_MAX_JSON_BYTES && !view.files.is_empty() {
+        view.files.pop();
+        dropped += 1;
+    }
+    if dropped > 0 {
+        let msg = format!(
+            "{dropped} file listing entries omitted to stay under get_draft response budget; use read_draft_file with a specific path"
+        );
+        if let Some(last) = view
+            .warnings
+            .iter_mut()
+            .find(|w| w.contains("file listing entries omitted"))
+        {
+            *last = msg;
+        } else {
+            view.warnings.push(msg);
+        }
+        while serialized_draft_len(&view) > GET_DRAFT_MAX_JSON_BYTES && !view.files.is_empty() {
+            view.files.pop();
+            dropped += 1;
+            if let Some(last) = view
+                .warnings
+                .iter_mut()
+                .find(|w| w.contains("file listing entries omitted"))
+            {
+                *last = format!(
+                    "{dropped} file listing entries omitted to stay under get_draft response budget; use read_draft_file with a specific path"
+                );
+            }
+        }
+    }
+    view
 }
 
 fn ensure_writable_team_pack(
@@ -350,17 +436,13 @@ pub fn get_team_skill_draft(
     };
 
     if !target.is_dir() {
-        return Ok(TeamSkillDraftView {
-            slug: slug.to_string(),
-            base_version: 0,
+        return Ok(empty_draft_view(
+            slug,
+            0,
             latest_version,
-            state: "missing".into(),
-            digest: String::new(),
-            content: String::new(),
-            files: Vec::new(),
-            source: source.as_str().into(),
-            warnings: Vec::new(),
-        });
+            "missing".into(),
+            source.as_str().into(),
+        ));
     }
 
     reject_symlink(&target)?;
@@ -370,20 +452,16 @@ pub fn get_team_skill_draft(
     let state = compute_state_for_team(origin.as_ref(), &dirty, latest_version, team_id);
 
     if state == "missing" || state == "foreign" {
-        return Ok(TeamSkillDraftView {
-            slug: slug.to_string(),
-            base_version: origin
+        return Ok(empty_draft_view(
+            slug,
+            origin
                 .as_ref()
                 .and_then(|o| o.installed_version.parse().ok())
                 .unwrap_or(0),
             latest_version,
             state,
-            digest: String::new(),
-            content: String::new(),
-            files: Vec::new(),
-            source: source.as_str().into(),
-            warnings: Vec::new(),
-        });
+            source.as_str().into(),
+        ));
     }
 
     let base_version = origin
@@ -393,15 +471,23 @@ pub fn get_team_skill_draft(
         .unwrap_or(0);
     let digest = pack_digest(&target)?;
     let (content, skill_warning) = read_skill_md(&target)?;
-    let (files, mut warnings) = list_pack_files(&target)?;
+    let truncated_skill = skill_warning
+        .as_ref()
+        .is_some_and(|w| w.contains("response budget"));
+    let (files, mut warnings, sidecar_bytes) = list_pack_files(&target)?;
     if let Some(warning) = skill_warning {
         warnings.push(warning);
     }
     if let Err(err) = validate_pack_tree_limits(&target) {
         warnings.push(format!("this draft cannot be published: {}", err.message));
     }
+    let skill_md_len = fs::metadata(target.join(SKILL_MD))
+        .map(|m| m.len())
+        .unwrap_or(0);
+    let file_count = files.len() + 1;
+    let total_bytes = skill_md_len.saturating_add(sidecar_bytes);
 
-    Ok(TeamSkillDraftView {
+    Ok(fit_draft_view(TeamSkillDraftView {
         slug: slug.to_string(),
         base_version,
         latest_version,
@@ -410,8 +496,11 @@ pub fn get_team_skill_draft(
         content,
         files,
         source: source.as_str().into(),
+        file_count,
+        total_bytes,
+        truncated: truncated_skill,
         warnings,
-    })
+    }))
 }
 
 pub fn update_team_skill_draft(
@@ -449,12 +538,21 @@ pub fn update_team_skill_draft(
         ));
     }
 
+    if req.content.is_empty() && req.files.is_empty() && req.delete_files.is_empty() {
+        return Err(ManagedSkillError::new(
+            ManagedSkillErrorCode::InvalidSkillFilePath,
+            "update_draft requires at least one of content, files, or deleteFiles",
+        ));
+    }
+
     let parent = target.parent().ok_or_else(|| {
         ManagedSkillError::new(ManagedSkillErrorCode::SkillWriteFailed, "no parent")
     })?;
     let temp = TempPackGuard::new(parent.join(format!(".teamclu-draft-{}", Uuid::new_v4())));
     copy_pack_tree(&target, temp.path())?;
-    fs::write(temp.path().join(SKILL_MD), req.content.as_bytes()).map_err(io_err)?;
+    if !req.content.is_empty() {
+        fs::write(temp.path().join(SKILL_MD), req.content.as_bytes()).map_err(io_err)?;
+    }
 
     let mut patch_files = Vec::new();
     for file in &req.files {
@@ -499,10 +597,140 @@ pub fn update_team_skill_draft(
     })
 }
 
+fn normalize_draft_read_path(raw: &str) -> Result<PathBuf, ManagedSkillError> {
+    let trimmed = raw.trim();
+    if trimmed == SKILL_MD {
+        return Ok(PathBuf::from(SKILL_MD));
+    }
+    let rel = normalize_pack_rel_path(trimmed)?;
+    let rel_str = rel.to_string_lossy().replace('\\', "/");
+    if rel_str == ORIGIN_DIR || rel_str.starts_with(&format!("{ORIGIN_DIR}/")) {
+        return Err(ManagedSkillError::new(
+            ManagedSkillErrorCode::InvalidSkillFilePath,
+            "origin metadata is not readable via read_draft_file",
+        ));
+    }
+    Ok(rel)
+}
+
+fn utf8_chunk(bytes: &[u8], offset: usize, limit: usize) -> (String, usize, bool) {
+    if offset >= bytes.len() {
+        return (String::new(), bytes.len(), true);
+    }
+    let mut start = offset;
+    while start < bytes.len() && (bytes[start] & 0xc0) == 0x80 {
+        start += 1;
+    }
+    if start >= bytes.len() {
+        return (String::new(), bytes.len(), true);
+    }
+    let mut end = start.saturating_add(limit).min(bytes.len());
+    if end < bytes.len() {
+        while end > start && (bytes[end] & 0xc0) == 0x80 {
+            end -= 1;
+        }
+    }
+    if end == start && start < bytes.len() {
+        end = start + 1;
+        while end < bytes.len() && (bytes[end] & 0xc0) == 0x80 {
+            end += 1;
+        }
+    }
+    let chunk = bytes[start..end].to_vec();
+    let content = String::from_utf8(chunk).unwrap_or_default();
+    (content, end, end >= bytes.len())
+}
+
+pub fn read_team_skill_draft_file(
+    home: &Path,
+    team_id: &str,
+    row: &TeamSkillRow,
+    path: &str,
+    offset: u64,
+    limit: Option<usize>,
+) -> Result<DraftFileRead, ManagedSkillError> {
+    let slug = row.slug.as_str();
+    if !row.installed {
+        return Err(ManagedSkillError::new(
+            ManagedSkillErrorCode::SkillNotFound,
+            format!("team skill {slug} is not installed for this agent"),
+        ));
+    }
+    let (target, _) = effective_team_skill_dir(team_id, slug, home);
+    if !target.is_dir() {
+        return Err(ManagedSkillError::new(
+            ManagedSkillErrorCode::SkillNotFound,
+            format!("team skill {slug} working copy is missing"),
+        ));
+    }
+    reject_symlink(&target)?;
+    let origin = read_origin(&target).ok_or_else(|| {
+        ManagedSkillError::new(
+            ManagedSkillErrorCode::SkillNotFound,
+            format!("team skill {slug} has no install record"),
+        )
+    })?;
+    if origin.registry != SOURCE_TEAM || belongs_to_another_team(&origin, team_id) {
+        return Err(ManagedSkillError::new(
+            ManagedSkillErrorCode::InvalidSkillFilePath,
+            format!("skill {slug} is not this team's working copy"),
+        ));
+    }
+
+    let rel = normalize_draft_read_path(path)?;
+    let abs = target.join(&rel);
+    reject_symlink(&abs)?;
+    let rel_str = rel.to_string_lossy().replace('\\', "/");
+    if !abs.is_file() {
+        return Err(ManagedSkillError::new(
+            ManagedSkillErrorCode::SkillNotFound,
+            format!("file {rel_str} not found in draft"),
+        ));
+    }
+    let bytes = fs::read(&abs).map_err(io_err)?;
+    let digest = sha256_hex(&bytes);
+    let size = bytes.len() as u64;
+    let limit = limit
+        .filter(|n| *n > 0)
+        .unwrap_or(READ_DRAFT_FILE_DEFAULT_BYTES)
+        .min(READ_DRAFT_FILE_MAX_BYTES);
+    let offset = offset as usize;
+
+    match std::str::from_utf8(&bytes) {
+        Ok(_) => {
+            let (content, end, complete) = utf8_chunk(&bytes, offset, limit);
+            Ok(DraftFileRead {
+                path: rel_str,
+                content,
+                size,
+                offset: offset as u64,
+                next_offset: (!complete).then_some(end as u64),
+                complete,
+                digest,
+                encoding: None,
+                omitted: None,
+                warnings: Vec::new(),
+            })
+        }
+        Err(_) => Ok(DraftFileRead {
+            path: rel_str,
+            content: String::new(),
+            size,
+            offset: 0,
+            next_offset: None,
+            complete: true,
+            digest,
+            encoding: Some("binary".into()),
+            omitted: Some("binary".into()),
+            warnings: vec!["binary files are not inlined; inspect them on disk".into()],
+        }),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::super::managed_skill_writer::{
-        ManagedSkillErrorCode, UpdatePackRequest, MAX_SINGLE_FILE_BYTES,
+        ManagedSkillErrorCode, PackFileInput, UpdatePackRequest, MAX_SINGLE_FILE_BYTES,
     };
     use super::*;
     use teamclu_skillpack::{write_origin, ORIGIN_VERSION};
@@ -594,7 +822,7 @@ mod tests {
     }
 
     #[test]
-    fn get_draft_returns_binary_files_as_base64() {
+    fn get_draft_lists_sidecars_without_bodies() {
         let tmp = tempfile::tempdir().unwrap();
         let home = tmp.path();
         let team = "team-bin";
@@ -607,21 +835,37 @@ mod tests {
         )
         .unwrap();
         fs::write(skill.join("logo.png"), [0x89, 0x50, 0x4e, 0x47]).unwrap();
+        fs::write(skill.join("notes.md"), "# keep me\n").unwrap();
         stamp_team_origin(&skill, slug, team, 1, true);
 
         let view = get_team_skill_draft(home, team, &row(slug, 1, true)).unwrap();
+        assert!(view.content.contains("# Demo"));
+        assert_eq!(view.file_count, 3);
+        let encoded = serde_json::to_vec(&view).unwrap();
+        assert!(
+            encoded.len() <= GET_DRAFT_MAX_JSON_BYTES,
+            "get_draft JSON was {} bytes",
+            encoded.len()
+        );
         let asset = view
             .files
             .iter()
             .find(|f| f.path == "logo.png")
             .expect("binary asset listed");
-        assert_eq!(asset.encoding.as_deref(), Some("base64"));
-        assert!(!asset.content.is_empty());
-        assert_eq!(asset.omitted, None);
+        assert!(asset.content.is_empty());
+        assert_eq!(asset.encoding, None);
+        assert_eq!(asset.size, Some(4));
+        let notes = view
+            .files
+            .iter()
+            .find(|f| f.path == "notes.md")
+            .expect("text sidecar listed");
+        assert!(notes.content.is_empty());
+        assert!(!notes.content.contains("keep me"));
     }
 
     #[test]
-    fn get_draft_omits_sidecar_over_single_file_limit() {
+    fn get_draft_never_inlines_sidecar_bodies() {
         let tmp = tempfile::tempdir().unwrap();
         let home = tmp.path();
         let team = "team-big";
@@ -633,39 +877,156 @@ mod tests {
             "---\nname: issue-investigator\ndescription: Demo\n---\n\n# Demo\n",
         )
         .unwrap();
-        let dump_size = MAX_SINGLE_FILE_BYTES + 1;
+        let dump_size = 3 * 1024 * 1024;
+        assert!(dump_size > MAX_SINGLE_FILE_BYTES);
         fs::write(skill.join("dump.txt"), vec![b'x'; dump_size]).unwrap();
-        fs::write(skill.join("notes.md"), "# keep me\n").unwrap();
+        for i in 0..3 {
+            fs::write(skill.join(format!("chunk-{i}.txt")), vec![b'y'; 400_000]).unwrap();
+        }
         stamp_team_origin(&skill, slug, team, 1, true);
 
         let view = get_team_skill_draft(home, team, &row(slug, 1, true)).unwrap();
-        let notes = view
-            .files
-            .iter()
-            .find(|f| f.path == "notes.md")
-            .expect("small sidecar listed");
-        assert_eq!(notes.omitted, None);
-        assert!(notes.content.contains("keep me"));
+        assert!(
+            view.files.iter().all(|f| f.content.is_empty()),
+            "get_draft must not inline sidecar bodies"
+        );
         let dump = view
             .files
             .iter()
             .find(|f| f.path == "dump.txt")
             .expect("oversized sidecar listed");
-        assert!(
-            dump.content.is_empty(),
-            "get_draft must not inline files over {MAX_SINGLE_FILE_BYTES} bytes"
-        );
         assert_eq!(dump.omitted.as_deref(), Some("too_large"));
         assert_eq!(dump.size, Some(dump_size as u64));
-        let hint = dump.hint.as_deref().unwrap_or_default();
         assert!(
-            hint.contains("dump.txt"),
-            "hint should point at the file: {hint}"
-        );
-        assert!(
-            view.warnings.iter().any(|w| w.contains("dump.txt")),
+            view.warnings
+                .iter()
+                .any(|w| w.contains("dump.txt") || w.contains("cannot be published")),
             "expected a publish-will-fail warning, got {:?}",
             view.warnings
+        );
+        let encoded = serde_json::to_vec(&view).unwrap();
+        assert!(encoded.len() <= GET_DRAFT_MAX_JSON_BYTES);
+    }
+
+    #[test]
+    fn get_draft_omits_skill_md_when_json_budget_exceeded() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path();
+        let team = "team-budget";
+        let slug = "fat-skill";
+        let skill = home.join(".agents/skills").join(slug);
+        fs::create_dir_all(&skill).unwrap();
+        let mut skill_md = String::from("---\nname: fat-skill\ndescription: Demo 中文\n---\n\n");
+        skill_md.push_str(&"字".repeat(40_000));
+        fs::write(skill.join("SKILL.md"), &skill_md).unwrap();
+        stamp_team_origin(&skill, slug, team, 1, true);
+
+        let view = get_team_skill_draft(home, team, &row(slug, 1, true)).unwrap();
+        assert!(
+            view.content.is_empty(),
+            "oversized SKILL.md must not be inlined"
+        );
+        assert!(view.truncated);
+        assert!(
+            view.warnings
+                .iter()
+                .any(|w| w.contains("read_draft_file") && w.contains("SKILL.md")),
+            "expected read_draft_file hint, got {:?}",
+            view.warnings
+        );
+        let encoded = serde_json::to_vec(&view).unwrap();
+        assert!(encoded.len() <= GET_DRAFT_MAX_JSON_BYTES);
+        let read = read_team_skill_draft_file(home, team, &row(slug, 1, true), "SKILL.md", 0, None)
+            .unwrap();
+        assert!(read.content.contains("name: fat-skill"));
+        assert!(!read.complete);
+        assert!(read.content.len() <= READ_DRAFT_FILE_DEFAULT_BYTES);
+        assert!(read.content.is_char_boundary(read.content.len()));
+    }
+
+    #[test]
+    fn read_draft_file_chunks_utf8_and_skips_binary() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path();
+        let team = "team-read";
+        let slug = "chunked";
+        let skill = home.join(".agents/skills").join(slug);
+        fs::create_dir_all(skill.join("scripts")).unwrap();
+        fs::write(
+            skill.join("SKILL.md"),
+            "---\nname: chunked\ndescription: Demo\n---\n\n# Demo\n",
+        )
+        .unwrap();
+        let body = "é".repeat(20_000);
+        fs::write(skill.join("scripts/run.py"), &body).unwrap();
+        fs::write(skill.join("logo.png"), [0x89, 0x50, 0x4e, 0x47, 0x0d]).unwrap();
+        stamp_team_origin(&skill, slug, team, 1, true);
+
+        let first =
+            read_team_skill_draft_file(home, team, &row(slug, 1, true), "scripts/run.py", 0, None)
+                .unwrap();
+        assert_eq!(first.offset, 0);
+        assert!(!first.complete);
+        assert_eq!(
+            first.next_offset,
+            Some(READ_DRAFT_FILE_DEFAULT_BYTES as u64)
+        );
+        assert!(first.content.is_char_boundary(first.content.len()));
+
+        let second = read_team_skill_draft_file(
+            home,
+            team,
+            &row(slug, 1, true),
+            "scripts/run.py",
+            first.next_offset.unwrap(),
+            Some(READ_DRAFT_FILE_MAX_BYTES + 8),
+        )
+        .unwrap();
+        assert!(second.content.len() <= READ_DRAFT_FILE_MAX_BYTES);
+        assert!(second.complete);
+
+        let bin = read_team_skill_draft_file(home, team, &row(slug, 1, true), "logo.png", 0, None)
+            .unwrap();
+        assert!(bin.content.is_empty());
+        assert_eq!(bin.omitted.as_deref(), Some("binary"));
+        assert_eq!(bin.encoding.as_deref(), Some("binary"));
+    }
+
+    #[test]
+    fn update_draft_can_patch_sidecar_without_skill_md() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path();
+        let team = "team-patch";
+        let slug = "patch-one";
+        let skill = home.join(".agents/skills").join(slug);
+        fs::create_dir_all(skill.join("scripts")).unwrap();
+        fs::write(
+            skill.join("SKILL.md"),
+            "---\nname: patch-one\ndescription: One\n---\n\n# One\n",
+        )
+        .unwrap();
+        fs::write(skill.join("scripts/run.py"), "print(1)\n").unwrap();
+        stamp_team_origin(&skill, slug, team, 1, true);
+        let digest = pack_digest(&skill).unwrap();
+
+        let req = UpdatePackRequest {
+            slug: slug.into(),
+            content: String::new(),
+            files: vec![PackFileInput {
+                path: "scripts/run.py".into(),
+                content: "print(2)\n".into(),
+                encoding: None,
+            }],
+            expected_digest: Some(digest),
+            delete_files: vec![],
+        };
+        update_team_skill_draft(home, team, &row(slug, 1, true), &req).unwrap();
+        assert!(fs::read_to_string(skill.join("SKILL.md"))
+            .unwrap()
+            .contains("# One"));
+        assert_eq!(
+            fs::read_to_string(skill.join("scripts/run.py")).unwrap(),
+            "print(2)\n"
         );
     }
 
@@ -693,5 +1054,49 @@ mod tests {
         };
         let err = update_team_skill_draft(home, team, &row(slug, 1, true), &req).unwrap_err();
         assert_eq!(err.code, ManagedSkillErrorCode::SkillChanged);
+    }
+
+    #[test]
+    fn update_pack_request_deserializes_without_content() {
+        let req: UpdatePackRequest = serde_json::from_value(serde_json::json!({
+            "slug": "demo",
+            "files": [{ "path": "notes.md", "content": "hi" }],
+            "expectedDigest": "sha256:abc"
+        }))
+        .unwrap();
+        assert!(req.content.is_empty());
+        assert_eq!(req.files.len(), 1);
+        assert_eq!(req.expected_digest.as_deref(), Some("sha256:abc"));
+    }
+
+    #[test]
+    fn read_draft_file_rejects_missing_and_origin() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path();
+        let team = "team-read";
+        let slug = "guarded";
+        let skill = home.join(".agents/skills").join(slug);
+        fs::create_dir_all(&skill).unwrap();
+        fs::write(
+            skill.join("SKILL.md"),
+            "---\nname: guarded\ndescription: Demo\n---\n\n# Demo\n",
+        )
+        .unwrap();
+        stamp_team_origin(&skill, slug, team, 1, true);
+
+        let missing = read_team_skill_draft_file(home, team, &row(slug, 1, true), "nope.md", 0, None)
+            .unwrap_err();
+        assert_eq!(missing.code, ManagedSkillErrorCode::SkillNotFound);
+
+        let origin = read_team_skill_draft_file(
+            home,
+            team,
+            &row(slug, 1, true),
+            ".clawhub/origin.json",
+            0,
+            None,
+        )
+        .unwrap_err();
+        assert_eq!(origin.code, ManagedSkillErrorCode::InvalidSkillFilePath);
     }
 }

--- a/apps/daemon/src/http/routes.rs
+++ b/apps/daemon/src/http/routes.rs
@@ -295,6 +295,10 @@ pub fn build(state: HttpState) -> Router {
             get(team_sync::get_team_skill_draft_handler)
                 .put(team_sync::update_team_skill_draft_handler),
         )
+        .route(
+            "/v1/team/skills/:slug/draft/file",
+            get(team_sync::read_team_skill_draft_file_handler),
+        )
         // Pull team MCP / team env from Cloud API into the daemon cache now
         // (desktop calls this after a successful env-secret write/delete).
         .route(

--- a/apps/daemon/src/http/team_sync.rs
+++ b/apps/daemon/src/http/team_sync.rs
@@ -434,9 +434,7 @@ fn managed_skill_error(err: crate::config::ManagedSkillError) -> HttpError {
     use crate::config::ManagedSkillErrorCode;
     use crate::http::errors::ErrorCode;
     match err.code {
-        ManagedSkillErrorCode::SkillChanged => {
-            HttpError::new(ErrorCode::Conflict, err.message)
-        }
+        ManagedSkillErrorCode::SkillChanged => HttpError::new(ErrorCode::Conflict, err.message),
         ManagedSkillErrorCode::SkillNotFound => HttpError::not_found(err.message),
         ManagedSkillErrorCode::InvalidSkillSlug
         | ManagedSkillErrorCode::InvalidSkillFrontmatter
@@ -462,8 +460,8 @@ pub async fn get_team_skill_draft_handler(
     let (backend, team_id) = daemon_backend_and_team(&state)?;
     let row = lookup_team_skill_row(backend, &team_id, &slug).await?;
     let home = dirs::home_dir().ok_or_else(|| HttpError::internal("home directory not found"))?;
-    let view = crate::config::get_team_skill_draft(&home, &team_id, &row)
-        .map_err(managed_skill_error)?;
+    let view =
+        crate::config::get_team_skill_draft(&home, &team_id, &row).map_err(managed_skill_error)?;
     Ok(Json(view))
 }
 
@@ -495,6 +493,35 @@ pub async fn update_team_skill_draft_handler(
     )
     .await;
     Ok(Json(result))
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct DraftFileQuery {
+    path: String,
+    #[serde(default)]
+    offset: u64,
+    limit: Option<usize>,
+}
+
+/// `GET /v1/team/skills/:slug/draft/file` — read one draft file in a UTF-8 chunk.
+pub async fn read_team_skill_draft_file_handler(
+    principal: Principal,
+    State(state): State<HttpState>,
+    Path(slug): Path<String>,
+    Query(q): Query<DraftFileQuery>,
+) -> Result<Json<crate::config::DraftFileRead>, HttpError> {
+    require_scope(&principal, "workspace:read")?;
+    let path = q.path.trim();
+    if path.is_empty() {
+        return Err(HttpError::validation("path is required"));
+    }
+    let (backend, team_id) = daemon_backend_and_team(&state)?;
+    let row = lookup_team_skill_row(backend, &team_id, &slug).await?;
+    let home = dirs::home_dir().ok_or_else(|| HttpError::internal("home directory not found"))?;
+    let view =
+        crate::config::read_team_skill_draft_file(&home, &team_id, &row, path, q.offset, q.limit)
+            .map_err(managed_skill_error)?;
+    Ok(Json(view))
 }
 
 fn daemon_backend_and_team(

--- a/apps/desktop/crates/teamclu-introspect/src/main.rs
+++ b/apps/desktop/crates/teamclu-introspect/src/main.rs
@@ -351,19 +351,33 @@ fn tool_definitions() -> Value {
         },
         {
             "name": "manage_team_skills",
-            "description": "List the team's Skills catalog, install/uninstall a team Skill for this Agent, or edit the local working copy draft of an installed team Skill. Draft edits affect only this machine until published from the team Skills page; new sessions pick up draft changes, the current session keeps its prior content. Use get_draft before update_draft and pass expectedDigest for optimistic concurrency. Cannot target another Actor and cannot manage MCP servers.",
+            "description": "List the team's Skills catalog, install/uninstall a team Skill for this Agent, or edit the local working copy draft of an installed team Skill. Draft edits affect only this machine until published from the team Skills page; new sessions pick up draft changes, the current session keeps its prior content. get_draft returns SKILL.md plus a file listing (no sidecar bodies). Use read_draft_file with a specific path to fetch a chunk. Then update_draft with expectedDigest; content is optional when only files or deleteFiles change. Cannot target another Actor and cannot manage MCP servers.",
             "inputSchema": {
                 "type": "object",
                 "properties": {
                     "action": {
                         "type": "string",
-                        "enum": ["list", "install", "uninstall", "get_draft", "update_draft"]
+                        "enum": ["list", "install", "uninstall", "get_draft", "read_draft_file", "update_draft"]
                     },
                     "slug": { "type": "string", "description": "Required except for list." },
                     "version": { "type": "integer", "minimum": 1, "description": "Required for install." },
+                    "path": {
+                        "type": "string",
+                        "description": "Skill-relative file path. Required for read_draft_file (e.g. scripts/run.py or SKILL.md)."
+                    },
+                    "offset": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "description": "Byte offset for read_draft_file. Defaults to 0."
+                    },
+                    "limit": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "description": "Max bytes for read_draft_file. Defaults to 16384, capped at 32768."
+                    },
                     "content": {
                         "type": "string",
-                        "description": "Full SKILL.md content with YAML frontmatter. Required for update_draft."
+                        "description": "Full SKILL.md with YAML frontmatter. Optional on update_draft when patching files or deleteFiles only."
                     },
                     "files": {
                         "type": "array",
@@ -392,7 +406,11 @@ fn tool_definitions() -> Value {
                 "allOf": [
                     {
                         "if": { "properties": { "action": { "const": "update_draft" } } },
-                        "then": { "required": ["slug", "content", "expectedDigest"] }
+                        "then": { "required": ["slug", "expectedDigest"] }
+                    },
+                    {
+                        "if": { "properties": { "action": { "const": "read_draft_file" } } },
+                        "then": { "required": ["slug", "path"] }
                     }
                 ]
             }
@@ -511,16 +529,45 @@ fn mcp_error(id: &Value, code: i64, message: &str) -> Value {
 }
 
 fn tool_ok(text: &str) -> Value {
-    json!({
-        "content": [{"type": "text", "text": text}]
-    })
+    enforce_tool_budget(text, false)
 }
 
 fn tool_err(text: &str) -> Value {
-    json!({
-        "content": [{"type": "text", "text": text}],
-        "isError": true
-    })
+    enforce_tool_budget(text, true)
+}
+
+/// Last-resort cap so any introspect tool that inlines too much still cannot
+/// blow the model context. get_draft itself stays under 64 KiB; this fuse is
+/// 128 KiB and returns a structured envelope instead of slicing JSON.
+const MAX_TOOL_RESULT_BYTES: usize = 128 * 1024;
+
+fn tool_payload(text: &str, is_error: bool) -> Value {
+    if is_error {
+        json!({
+            "content": [{"type": "text", "text": text}],
+            "isError": true
+        })
+    } else {
+        json!({
+            "content": [{"type": "text", "text": text}]
+        })
+    }
+}
+
+fn enforce_tool_budget(text: &str, is_error: bool) -> Value {
+    let candidate = tool_payload(text, is_error);
+    let encoded = serde_json::to_vec(&candidate).unwrap_or_default();
+    if encoded.len() <= MAX_TOOL_RESULT_BYTES {
+        return candidate;
+    }
+    let envelope = json!({
+        "truncated": true,
+        "reason": "response_budget_exceeded",
+        "originalBytes": encoded.len(),
+        "hint": "Use a narrower query or read_draft_file with a specific path"
+    });
+    let text = serde_json::to_string(&envelope).unwrap_or_default();
+    tool_payload(&text, true)
 }
 
 // ---------------------------------------------------------------------------
@@ -766,4 +813,43 @@ async fn main() {
     }
 
     eprintln!("[introspect] stdin closed, exiting");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tool_ok_leaves_small_payloads_alone() {
+        let ok = tool_ok("hello");
+        assert_eq!(ok["content"][0]["text"], "hello");
+        assert!(ok.get("isError").is_none());
+    }
+
+    #[test]
+    fn tool_ok_returns_structured_envelope_when_over_budget() {
+        let big = "x".repeat(MAX_TOOL_RESULT_BYTES + 100);
+        let ok = tool_ok(&big);
+        let text = ok["content"][0]["text"].as_str().unwrap();
+        let parsed: Value = serde_json::from_str(text).unwrap();
+        assert_eq!(parsed["truncated"], true);
+        assert_eq!(parsed["reason"], "response_budget_exceeded");
+        assert!(parsed["originalBytes"].as_u64().unwrap() > MAX_TOOL_RESULT_BYTES as u64);
+        assert!(parsed["hint"].as_str().unwrap().contains("read_draft_file"));
+        assert_eq!(ok["isError"], true);
+        assert!(
+            serde_json::to_vec(&ok).unwrap().len() < MAX_TOOL_RESULT_BYTES,
+            "envelope itself must fit the budget"
+        );
+        assert!(!text.contains(&"x".repeat(64)));
+    }
+
+    #[test]
+    fn tool_err_also_uses_structured_envelope() {
+        let big = "y".repeat(MAX_TOOL_RESULT_BYTES + 8);
+        let err = tool_err(&big);
+        let text = err["content"][0]["text"].as_str().unwrap();
+        assert!(text.contains("response_budget_exceeded"));
+        assert_eq!(err["isError"], true);
+    }
 }

--- a/apps/desktop/crates/teamclu-introspect/src/team_skills.rs
+++ b/apps/desktop/crates/teamclu-introspect/src/team_skills.rs
@@ -11,9 +11,12 @@ pub async fn handle(_api_port: u16, arguments: &Value) -> Result<Value, String> 
         .unwrap_or("list");
     if !matches!(
         action,
-        "list" | "install" | "uninstall" | "get_draft" | "update_draft"
+        "list" | "install" | "uninstall" | "get_draft" | "read_draft_file" | "update_draft"
     ) {
-        return Err("action must be list, install, uninstall, get_draft, or update_draft".into());
+        return Err(
+            "action must be list, install, uninstall, get_draft, read_draft_file, or update_draft"
+                .into(),
+        );
     }
     let slug = arguments
         .get("slug")
@@ -57,17 +60,49 @@ pub async fn handle(_api_port: u16, arguments: &Value) -> Result<Value, String> 
             vec!["workspace:read"],
             None,
         ),
+        "read_draft_file" => {
+            let file_path = arguments
+                .get("path")
+                .and_then(Value::as_str)
+                .map(str::trim)
+                .filter(|path| !path.is_empty())
+                .ok_or_else(|| "path is required for read_draft_file".to_string())?;
+            let offset = arguments.get("offset").and_then(Value::as_u64).unwrap_or(0);
+            let mut qs = format!(
+                "/v1/team/skills/{}/draft/file?path={}",
+                urlencode(slug),
+                urlencode(file_path)
+            );
+            if offset > 0 {
+                qs.push_str(&format!("&offset={offset}"));
+            }
+            if let Some(limit) = arguments.get("limit").and_then(Value::as_u64) {
+                qs.push_str(&format!("&limit={limit}"));
+            }
+            (reqwest::Method::GET, qs, vec!["workspace:read"], None)
+        }
         "update_draft" => {
-            let content = arguments
+            let files = arguments.get("files").cloned().unwrap_or(json!([]));
+            let delete_files = arguments.get("deleteFiles").cloned().unwrap_or(json!([]));
+            let has_content = arguments
                 .get("content")
                 .and_then(Value::as_str)
-                .ok_or_else(|| "content is required for update_draft".to_string())?;
+                .is_some_and(|c| !c.is_empty());
+            let has_files = files.as_array().is_some_and(|a| !a.is_empty());
+            let has_deletes = delete_files.as_array().is_some_and(|a| !a.is_empty());
+            if !has_content && !has_files && !has_deletes {
+                return Err(
+                    "update_draft requires at least one of content, files, or deleteFiles".into(),
+                );
+            }
             let mut body = json!({
                 "slug": slug,
-                "content": content,
-                "files": arguments.get("files").cloned().unwrap_or(json!([])),
-                "deleteFiles": arguments.get("deleteFiles").cloned().unwrap_or(json!([])),
+                "files": files,
+                "deleteFiles": delete_files,
             });
+            if has_content {
+                body["content"] = arguments.get("content").cloned().unwrap_or(Value::Null);
+            }
             if let Some(digest) = arguments.get("expectedDigest") {
                 body["expectedDigest"] = digest.clone();
             }
@@ -85,4 +120,38 @@ pub async fn handle(_api_port: u16, arguments: &Value) -> Result<Value, String> 
 
 fn urlencode(value: &str) -> String {
     crate::daemon_http::urlencode(value)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn rejects_unknown_action() {
+        let err = handle(0, &json!({ "action": "delete" })).await.unwrap_err();
+        assert!(err.contains("read_draft_file"));
+    }
+
+    #[tokio::test]
+    async fn read_draft_file_requires_path() {
+        let err = handle(0, &json!({ "action": "read_draft_file", "slug": "demo" }))
+            .await
+            .unwrap_err();
+        assert!(err.contains("path is required"));
+    }
+
+    #[tokio::test]
+    async fn update_draft_requires_a_change() {
+        let err = handle(
+            0,
+            &json!({
+                "action": "update_draft",
+                "slug": "demo",
+                "expectedDigest": "sha256:abc"
+            }),
+        )
+        .await
+        .unwrap_err();
+        assert!(err.contains("content, files, or deleteFiles"));
+    }
 }


### PR DESCRIPTION
## Description

Follow-up to #1299 for [#1282](https://github.com/different-ai-studio/teamclu/issues/1282). `get_draft` still listed oversized files but could inline every sidecar body, which produced multi-megabyte tool results and overflowed the model context.

- `get_draft` now returns SKILL.md plus a file listing (no sidecar bodies), capped at 64 KiB JSON. Oversized SKILL.md is omitted with a `read_draft_file` hint.
- New `read_draft_file` action / `GET /v1/team/skills/:slug/draft/file` for UTF-8 chunks (default 16 KiB, max 32 KiB). Binary files return metadata only.
- `update_draft.content` is optional so sidecar patches do not rewrite SKILL.md.
- Publish limits are 0.5 MiB per file and 2.5 MiB pack total (separate from the get_draft budget).
- Introspect and pi MCP fuses return a structured `{truncated, reason: "response_budget_exceeded"}` envelope instead of slicing JSON.

## Related Issue

Fixes #1282

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

`files[].content` is no longer inlined on `get_draft`. Desktop already listed metadata only; agents that expected sidecar bodies must call `read_draft_file`.

## Test plan

- [x] `node scripts/daemon-cargo.js test --bin amuxd team_skill_draft` (10 passed)
- [x] `node scripts/daemon-cargo.js test --bin amuxd managed_skill_writer` (18 passed)
- [x] `cargo test -p teamclu-introspect --bin teamclu-introspect tests::` (58 passed)
- [x] `node --test apps/daemon/assets/pi-extension/session-context.test.mjs` (39 passed)
- [ ] Call `manage_team_skills` `get_draft` on a pack with a large sidecar and confirm the body is not inlined
- [ ] `read_draft_file` a text sidecar in chunks, then a binary asset (metadata only)
- [ ] `update_draft` a sidecar without sending `content` and confirm SKILL.md is unchanged

## Additional Notes

Deferred from this issue: pack ignore / `.skillignore`, runtime artifact dir, listing pagination, replaying already-polluted local skills.


Made with [Cursor](https://cursor.com)