### PR TITLE
fix(ai-gateway): scope the backfill sweep so parallel test suites stop crediting each other

### DIFF
--- a/services/ai-gateway/src/credits.ts
+++ b/services/ai-gateway/src/credits.ts
@@ -314,16 +314,29 @@ export type BackfillResult = { scanned: number; granted: number; vanished: numbe
  * Safe to re-run: the per-team idempotency key means a second pass grants
  * nothing. Safe to run while serving, too — each team is its own transaction,
  * so a large backfill never holds a long lock.
+ *
+ * `onlyTeamIds` narrows the sweep. Production leaves it unset — covering every
+ * team is the entire point. Tests set it, because the suites run as parallel
+ * processes against one database: an unscoped sweep credits whatever teams the
+ * *other* suites happen to have uncredited at that instant, landing a grant in
+ * the middle of their arithmetic. That is not hypothetical, it broke main —
+ * `e2e.test.ts` resets a team to 1000 and refunds 5000 expecting -4000, and a
+ * concurrent unscoped backfill of 777 made it -3223.
  */
 export async function backfillSignupGrants(
   sql: Sql,
   amountCredits: number = SIGNUP_GRANT_CREDITS,
+  onlyTeamIds?: readonly string[],
 ): Promise<BackfillResult> {
   // Through a security-definer function: amux.teams carries RLS, and a plain
   // select returns zero rows for the gateway's role -- a backfill that grants
   // nothing and exits 0, right before enforcement is switched on.
-  const teams = await sql<{ team_id: string }[]>`
-    select team_id from amux.ai_gateway_teams_missing_signup_grant()`;
+  const teams = onlyTeamIds
+    ? await sql<{ team_id: string }[]>`
+        select team_id from amux.ai_gateway_teams_missing_signup_grant()
+        where team_id = any(${onlyTeamIds as string[]}::uuid[])`
+    : await sql<{ team_id: string }[]>`
+        select team_id from amux.ai_gateway_teams_missing_signup_grant()`;
   let granted = 0;
   let vanished = 0;
   for (const t of teams) {

--- a/services/ai-gateway/test/credits.test.ts
+++ b/services/ai-gateway/test/credits.test.ts
@@ -378,10 +378,13 @@ test("concurrent deliveries of the same purchase credit once", { skip: !DB }, as
 test("backfill grants every team that has never been credited", { skip: !DB }, async () => {
   await admin`delete from amux.credit_ledger where team_id = ${teamId}::uuid`;
   await admin`delete from amux.team_credit_balance where team_id = ${teamId}::uuid`;
-  await backfillSignupGrants(sql, 777);
+  await backfillSignupGrants(sql, 777, [teamId]);
 
   // Asserts THIS team, not a global count: the backfill sweeps every team on
   // the deployment, and other suites create and delete their own concurrently.
+  // Scoping the sweep is the other half of that — asserting only our own team
+  // kept the assertion honest, but an unscoped sweep still landed 777 in the
+  // other suites' teams mid-arithmetic.
   const [bal] = await sql<{ balance_credits: string }[]>`
     select balance_credits from amux.team_credit_balance where team_id = ${teamId}::uuid`;
   assert.equal(Number(bal.balance_credits), 777, "the un-credited team was granted");
@@ -398,8 +401,11 @@ test("a team deleted mid-backfill is skipped, not fatal", { skip: !DB }, async (
 
   await admin`delete from amux.credit_ledger where team_id = ${teamId}::uuid`;
   await admin`delete from amux.team_credit_balance where team_id = ${teamId}::uuid`;
-  // Does not throw, and our team is still granted.
-  await backfillSignupGrants(sql, 555);
+  // Does not throw, and our team is still granted. `doomed` stays in scope so
+  // the sweep is still asked about it — though note it is already deleted from
+  // amux.teams by now, and the scan selects `from amux.teams`, so it does not
+  // come back in the list and the 23503 branch is not what makes this pass.
+  await backfillSignupGrants(sql, 555, [teamId, doomed]);
   const [bal] = await sql<{ balance_credits: string }[]>`
     select balance_credits from amux.team_credit_balance where team_id = ${teamId}::uuid`;
   assert.equal(Number(bal.balance_credits), 555);
@@ -410,11 +416,11 @@ test("backfill is safe to re-run", { skip: !DB }, async () => {
   // ahead of time, again after new teams appear, again if it half-failed.
   await admin`delete from amux.credit_ledger where team_id = ${teamId}::uuid`;
   await admin`delete from amux.team_credit_balance where team_id = ${teamId}::uuid`;
-  await backfillSignupGrants(sql, 777);
+  await backfillSignupGrants(sql, 777, [teamId]);
   const [before] = await sql<{ balance_credits: string }[]>`
     select balance_credits from amux.team_credit_balance where team_id = ${teamId}::uuid`;
 
-  const second = await backfillSignupGrants(sql, 777);
+  const second = await backfillSignupGrants(sql, 777, [teamId]);
   const [after] = await sql<{ balance_credits: string }[]>`
     select balance_credits from amux.team_credit_balance where team_id = ${teamId}::uuid`;
 
@@ -431,10 +437,45 @@ test("backfill does not top up a team that already has credit", { skip: !DB }, a
   await topUp(sql, {
     teamId, amountCredits: 50, kind: "grant", idempotencyKey: `signup_grant:${teamId}`,
   });
-  await backfillSignupGrants(sql, 777);
+  await backfillSignupGrants(sql, 777, [teamId]);
   const [bal] = await sql<{ balance_credits: string }[]>`
     select balance_credits from amux.team_credit_balance where team_id = ${teamId}::uuid`;
   assert.equal(Number(bal.balance_credits), 50, "an existing signup grant is left alone");
+});
+
+test("a scoped backfill leaves teams outside the scope alone", { skip: !DB }, async () => {
+  // The six suites run as parallel processes against one database, so an
+  // unscoped sweep credits whatever teams the *others* have uncredited at that
+  // instant — landing 777 in the middle of their arithmetic. That is what made
+  // e2e.test.ts's "1000, refund 5000, expect -4000" come out at -3223 and turn
+  // main red. The sweep must touch only what it was asked about.
+  const [{ id: bystander }] = await admin<{ id: string }[]>`
+    insert into amux.teams (slug, name)
+    values (${`bystander-${Date.now()}`}, 'bystander') returning id`;
+  try {
+    // A team that genuinely qualifies for the grant: no ledger row at all.
+    await admin`delete from amux.credit_ledger where team_id = ${bystander}::uuid`;
+    await admin`
+      insert into amux.team_credit_balance (team_id, balance_credits)
+      values (${bystander}::uuid, 1000)
+      on conflict (team_id) do update set balance_credits = 1000`;
+
+    await admin`delete from amux.credit_ledger where team_id = ${teamId}::uuid`;
+    await admin`delete from amux.team_credit_balance where team_id = ${teamId}::uuid`;
+    await backfillSignupGrants(sql, 777, [teamId]);
+
+    const [bal] = await sql<{ balance_credits: string }[]>`
+      select balance_credits from amux.team_credit_balance where team_id = ${bystander}::uuid`;
+    assert.equal(
+      Number(bal.balance_credits),
+      1000,
+      "a scoped sweep credited a team it was not asked about",
+    );
+  } finally {
+    await admin`delete from amux.credit_ledger where team_id = ${bystander}::uuid`;
+    await admin`delete from amux.team_credit_balance where team_id = ${bystander}::uuid`;
+    await admin`delete from amux.teams where id = ${bystander}::uuid`;
+  }
 });
 
 test("reconcile is silent when balance and ledger agree", { skip: !DB }, async () => {

--- a/services/ai-gateway/test/credits.test.ts
+++ b/services/ai-gateway/test/credits.test.ts
@@ -397,18 +397,43 @@ test("a team deleted mid-backfill is skipped, not fatal", { skip: !DB }, async (
   // the one outcome that must not happen quietly.
   const [{ id: doomed }] = await admin<{ id: string }[]>`
     insert into amux.teams (slug, name) values (${`doomed-${Date.now()}`}, 'doomed') returning id`;
-  await admin`delete from amux.teams where id = ${doomed}::uuid`;
 
   await admin`delete from amux.credit_ledger where team_id = ${teamId}::uuid`;
   await admin`delete from amux.team_credit_balance where team_id = ${teamId}::uuid`;
-  // Does not throw, and our team is still granted. `doomed` stays in scope so
-  // the sweep is still asked about it — though note it is already deleted from
-  // amux.teams by now, and the scan selects `from amux.teams`, so it does not
-  // come back in the list and the 23503 branch is not what makes this pass.
-  await backfillSignupGrants(sql, 555, [teamId, doomed]);
+
+  // The deletion has to land BETWEEN the scan and the grant. Deleting up front
+  // proves nothing: the scan selects `from amux.teams`, so an already-deleted
+  // team never comes back in the list and the 23503 branch is never reached —
+  // the test passes because there is no second team, not because the skip
+  // works. Hooking the scan reproduces the real ordering deterministically.
+  let scanned = false;
+  const vanishAfterScan = new Proxy(sql as unknown as (...a: unknown[]) => unknown, {
+    apply(target, thisArg, args) {
+      const pending = Reflect.apply(target, thisArg, args) as Promise<unknown>;
+      if (scanned) return pending;
+      scanned = true;
+      return (async () => {
+        const rows = await pending;
+        await admin`delete from amux.teams where id = ${doomed}::uuid`;
+        return rows;
+      })();
+    },
+    get(target, prop) {
+      const v = Reflect.get(target, prop) as unknown;
+      // Methods (notably `sql.begin`, which topUp uses) must stay bound to the
+      // real client, or postgres.js loses its internal state.
+      return typeof v === "function" ? (v as (...a: unknown[]) => unknown).bind(target) : v;
+    },
+  }) as unknown as typeof sql;
+
+  const result = await backfillSignupGrants(vanishAfterScan, 555, [teamId, doomed]);
+
+  // This is the assertion the test was named for: the grant for `doomed` hit
+  // the foreign key, was caught, and the sweep carried on.
+  assert.equal(result.vanished, 1, "the deleted team was counted as vanished, not fatal");
   const [bal] = await sql<{ balance_credits: string }[]>`
     select balance_credits from amux.team_credit_balance where team_id = ${teamId}::uuid`;
-  assert.equal(Number(bal.balance_credits), 555);
+  assert.equal(Number(bal.balance_credits), 555, "the surviving team is still granted");
 });
 
 test("backfill is safe to re-run", { skip: !DB }, async () => {


### PR DESCRIPTION
Main went red on `6d84b2d1` in the pgTAP job:

```
not ok 47 - a refund is accepted as a NEGATIVE amount and may drive the balance below zero
  expected: -4000
  actual:   -3223
```

It looks like a flake, and it was rerun as one. It is not. Both failures
reported the *identical* number — a fixed value with variable timing is a race,
not noise.

## Root cause

`backfillSignupGrants` grants every uncredited team on the deployment. That is
the point of a backfill. But `npm test` is `node --test test/*.test.ts`, which
runs the six suites as **parallel processes against one database**, so the sweep
also credits whatever teams the *other* suites have uncredited right then.

`e2e.test.ts` resets its team to 1000 and refunds 5000, expecting -4000. A
concurrent backfill of 777 lands in the middle:

```
1000 + 777 - 5000 = -3223
```

`credits.test.ts` had already defended the **assertion** side — it asserts its
own team rather than a global count, with a comment saying exactly why other
suites make a global count meaningless. The missing half was the **effect**
side: scoping the sweep so it does not reach into their teams.

## Fix

`backfillSignupGrants` takes an optional `onlyTeamIds`. Production leaves it
unset and still sweeps everything — the route in `app.ts` is untouched. The five
test call sites pass their own team.

## Second commit: a test that was passing for the wrong reason

While scoping the call sites I found that `"a team deleted mid-backfill is
skipped, not fatal"` never tested what it claims. It deleted the team **before**
calling the sweep, and the scan selects `from amux.teams` — so the team never
came back in the list, the grant was never attempted, the foreign key was never
violated, and the `23503` catch it is named for never ran. It passed because
there was only one team left to grant.

The deletion has to land *between* the scan and the grant, which is the real
production race the catch exists for. Since `backfillSignupGrants` takes `sql`
as a parameter, a Proxy over it deletes the team right after the scan resolves —
deterministic, no timing. It now asserts `result.vanished === 1`, which is only
reachable through the handler.

## Verification

Against the CI Postgres image locally (`supabase/postgres:17.6.1.106`, same
`ci-bootstrap.sql` + same migrations), so these are real runs, not reasoning:

Both new assertions were confirmed to **fail without their fix**, not merely
pass with it:

| Test | Without the fix |
|---|---|
| `a scoped backfill leaves teams outside the scope alone` | `actual: 1777, expected: 1000` — the +777 that produced -3223 |
| `a team deleted mid-backfill is skipped, not fatal` | `actual: 0, expected: 1` — the 23503 branch never ran |

With both fixes: **72 tests, 69 pass, 0 fail, 5/5 consecutive clean runs**,
typecheck and build clean — re-run after merging current `main`.

## Checked and deliberately not changed

`pruneUsage` and `reconcile` are deployment-wide too, but neither can
contaminate a parallel suite: prune only touches rows older than 13 months,
which no other suite creates, and reconcile is read-only in tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017LGh88cvMMZeMForNo45i1
