### PR TITLE
feat(fc): 把 http:// 的应用老链接送到 https 地址

### DIFF
--- a/services/fc/src/app.ts
+++ b/services/fc/src/app.ts
@@ -6,7 +6,7 @@ import { createHonoRouterAdapter } from "./lib/hono-adapter.js";
 import { isRateLimited, resolveClientIp } from "./lib/rate-limit.js";
 import { handleSyncRequest } from "./lib/legacy-sync.js";
 import * as admin from "./lib/admin-handlers.js";
-import { isServable, proxyToApp, type LookupVanityApp } from "./lib/apps-vanity.js";
+import { httpsRedirect, isServable, proxyToApp, type LookupVanityApp } from "./lib/apps-vanity.js";
 import { parseAppPublicHost } from "./lib/apps-public-host.js";
 
 export type AppDeps = {
@@ -90,6 +90,10 @@ export function createApp(deps: AppDeps): Hono {
       if (!isServable(target)) {
         return c.text(target ? "app is not deployed yet" : "no such app", 404);
       }
+      // After the lookup, so an HTTP link to a hostname that is not an app
+      // still gets its 404 rather than a redirect to an HTTPS 404.
+      const toHttps = httpsRedirect(c.req.raw, host!);
+      if (toHttps) return toHttps;
       return proxyToApp(c.req.raw, target.fcEndpoint);
     });
   }

--- a/services/fc/src/lib/apps-vanity.ts
+++ b/services/fc/src/lib/apps-vanity.ts
@@ -175,6 +175,78 @@ function stripForcedDownload(headers: Headers): Headers {
 }
 
 /**
+ * Marks a browser as having been sent to HTTPS already, so a wrong guess costs
+ * one redirect instead of an endless loop. Deliberately short-lived and not
+ * `Secure`: it has to be readable on the HTTP request that follows.
+ */
+const REDIRECT_ONCE_COOKIE = "_tc_https";
+
+/** Sec-Fetch metadata, which browsers send to trustworthy origins only. */
+function hasFetchMetadata(headers: Headers): boolean {
+  for (const name of headers.keys()) {
+    if (name.startsWith("sec-fetch-")) return true;
+  }
+  return false;
+}
+
+/**
+ * Send a plain-HTTP page load to the HTTPS address of the same app, or null to
+ * serve the request as it came.
+ *
+ * Apps were reachable over HTTP alone until their domain got a certificate, so
+ * every link handed out until then — bookmarks, QR codes, links pasted into
+ * chats — is an `http://` one. This turns those into the HTTPS page, which
+ * matters beyond tidiness: over HTTPS the browser sends `Sec-Fetch-Site` itself
+ * and the app's own CSRF check works without anything filled in for it.
+ *
+ * Deciding whether the client spoke HTTPS is the hard part, because TLS
+ * terminates at the FC gateway and nothing inside the container can observe it
+ * directly. Rather than trusting one header, this refuses to redirect whenever
+ * ANY of these says otherwise:
+ *
+ *   * `x-forwarded-proto: https` — the direct answer, when the gateway gives one.
+ *   * any `Sec-Fetch-*` header — browsers attach these to trustworthy origins
+ *     only, so their presence means the page was already loaded over HTTPS.
+ *     This is what makes a loop impossible for a current browser even if the
+ *     forwarded header is missing or wrong: after the redirect the request
+ *     carries them, and this returns null.
+ *   * the one-shot cookie — a browser too old for Sec-Fetch metadata (Safari
+ *     before 16.4) would otherwise be sent round forever. It gets exactly one
+ *     redirect, lands on HTTPS, and is served normally from there.
+ *
+ * Only document navigations are touched. A server function POST or an API call
+ * is left alone: redirecting those would change a request the app is in the
+ * middle of, and they work over either scheme anyway.
+ *
+ * 302, not 301: a permanent redirect is cached by the browser and would be
+ * painful to walk back if a deployment ever serves apps over HTTP on purpose.
+ */
+export function httpsRedirect(request: Request, host: string): Response | null {
+  if (request.method !== "GET" && request.method !== "HEAD") return null;
+
+  const headers = request.headers;
+  if (headers.get("x-forwarded-proto")?.split(",")[0]?.trim().toLowerCase() === "https") return null;
+  if (hasFetchMetadata(headers)) return null;
+  if (headers.get("cookie")?.includes(`${REDIRECT_ONCE_COOKIE}=`)) return null;
+
+  // A page load, not a fetch for data: `Accept` is the only thing that
+  // separates them once the Sec-Fetch headers are gone.
+  if (!headers.get("accept")?.includes("text/html")) return null;
+
+  const incoming = new URL(request.url);
+  return new Response(null, {
+    status: 302,
+    headers: {
+      location: `https://${host}${incoming.pathname}${incoming.search}`,
+      "set-cookie": `${REDIRECT_ONCE_COOKIE}=1; Path=/; Max-Age=60; SameSite=Lax`,
+      // The address depends on request headers, so a shared cache must not
+      // hand this redirect to the next visitor.
+      "cache-control": "no-store",
+    },
+  });
+}
+
+/**
  * Proxy one request to the app's FC trigger, streaming both ways.
  *
  * Response headers pass through untouched apart from hop-by-hop ones: the app

--- a/services/fc/test/apps-vanity.test.ts
+++ b/services/fc/test/apps-vanity.test.ts
@@ -13,7 +13,7 @@ import { fileURLToPath } from "node:url";
 import { createApp } from "../src/app.js";
 import { appPublicUrl, appPublicLabel, parseAppPublicHost } from "../src/lib/apps-public-host.js";
 import {
-  isServable, proxyToApp, selectByIdPrefix, makeSupabaseVanityLookup, makeVanityLookup,
+  isServable, proxyToApp, httpsRedirect, selectByIdPrefix, makeSupabaseVanityLookup, makeVanityLookup,
 } from "../src/lib/apps-vanity.js";
 
 const DOMAIN = "apps.teamclu-dev.ucar.cc";
@@ -469,4 +469,94 @@ test("an opaque origin is not treated as same-origin", async () => {
     body: "{}",
   }));
   assert.equal(headers.get("sec-fetch-site"), null);
+});
+
+// --- sending old http:// links to https ------------------------------------
+
+const HTML = "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8";
+
+/** A page load as a browser sends it over plain HTTP: no Sec-Fetch metadata. */
+function pageLoad(url: string, headers: Record<string, string> = {}): Request {
+  return new Request(url, { headers: { accept: HTML, ...headers } });
+}
+
+test("an http page load is sent to the https address, path and query kept", async () => {
+  // Apps were HTTP-only until their domain got a certificate, so every link
+  // handed out until then — bookmarks, QR codes, links pasted into chats — is
+  // an http:// one.
+  const res = httpsRedirect(pageLoad(`http://website-18e4ecad.${DOMAIN}/todos?filter=open`), `website-18e4ecad.${DOMAIN}`);
+  assert.equal(res?.status, 302);
+  assert.equal(res?.headers.get("location"), `https://website-18e4ecad.${DOMAIN}/todos?filter=open`);
+  assert.equal(res?.headers.get("cache-control"), "no-store", "the target depends on request headers");
+});
+
+test("a request already carrying Sec-Fetch metadata is served, not redirected", async () => {
+  // This is what makes a loop impossible on a current browser: over HTTPS the
+  // browser attaches these itself, so the request that arrives after the
+  // redirect is recognised as already-secure without trusting any proxy header.
+  assert.equal(
+    httpsRedirect(pageLoad(`http://website-18e4ecad.${DOMAIN}/`, { "sec-fetch-mode": "navigate" }), `website-18e4ecad.${DOMAIN}`),
+    null,
+  );
+});
+
+test("x-forwarded-proto: https settles it directly when the gateway sends one", async () => {
+  assert.equal(
+    httpsRedirect(pageLoad(`http://website-18e4ecad.${DOMAIN}/`, { "x-forwarded-proto": "https" }), `website-18e4ecad.${DOMAIN}`),
+    null,
+  );
+  // Some proxies append rather than replace.
+  assert.equal(
+    httpsRedirect(pageLoad(`http://website-18e4ecad.${DOMAIN}/`, { "x-forwarded-proto": "https, http" }), `website-18e4ecad.${DOMAIN}`),
+    null,
+  );
+});
+
+test("the one-shot cookie stops a browser too old for Sec-Fetch looping forever", async () => {
+  // Safari before 16.4 sends no Sec-Fetch headers even over HTTPS. Without
+  // this it would be redirected to a page that redirects it again. It gets one
+  // redirect, lands on HTTPS, and is served from there.
+  const first = httpsRedirect(pageLoad(`http://website-18e4ecad.${DOMAIN}/`), `website-18e4ecad.${DOMAIN}`);
+  assert.equal(first?.status, 302);
+  const cookie = first!.headers.get("set-cookie") ?? "";
+  assert.match(cookie, /^_tc_https=1;/);
+  assert.doesNotMatch(cookie, /Secure/, "it has to be readable on the http request that follows");
+
+  const second = httpsRedirect(
+    pageLoad(`http://website-18e4ecad.${DOMAIN}/`, { cookie: "_tc_https=1" }),
+    `website-18e4ecad.${DOMAIN}`,
+  );
+  assert.equal(second, null, "a second redirect would be a loop");
+});
+
+test("a server function call is left alone", async () => {
+  // Redirecting a POST mid-flight would change a request the app is in the
+  // middle of, and it works over either scheme anyway.
+  const post = new Request(`http://website-18e4ecad.${DOMAIN}/_serverFn/abc`, {
+    method: "POST", headers: { accept: HTML }, body: "{}",
+  });
+  assert.equal(httpsRedirect(post, `website-18e4ecad.${DOMAIN}`), null);
+});
+
+test("an API GET that is not a page load is left alone", async () => {
+  // `Accept` is all that separates a data fetch from a navigation once the
+  // Sec-Fetch headers are gone.
+  const res = httpsRedirect(
+    new Request(`http://website-18e4ecad.${DOMAIN}/api/todos`, { headers: { accept: "application/json" } }),
+    `website-18e4ecad.${DOMAIN}`,
+  );
+  assert.equal(res, null);
+});
+
+test("a hostname that is not an app still 404s instead of redirecting", async () => {
+  // Otherwise a mistyped link would answer 302 and send the visitor to an
+  // https 404, hiding which of the two things went wrong.
+  await withDomain(async () => {
+    const app = createApp(deps(async (host: string) => (host.startsWith("known-18e4ecad.") ? {
+      id: APP_ID, slug: "known", fcEndpoint: "http://up.example", fcStatus: "live",
+    } : null)));
+    const res = await app.request(`http://missing-18e4ecad.${DOMAIN}/`, { headers: { accept: HTML } });
+    assert.equal(res.status, 404);
+    assert.equal(res.headers.get("location"), null);
+  });
 });


### PR DESCRIPTION
## 为什么

应用的通配符域名拿到证书之前只能走 HTTP，所以在那之前发出去的每一条链接——书签、二维码、贴在聊天里的地址——都是 `http://` 的。

这件事的价值不只是整洁：走 HTTPS 时浏览器会自己发 `Sec-Fetch-Site`，应用自带的 CSRF 校验不需要任何人替它补就能正常工作（#1314 补的那一层就是为了在明文 HTTP 下顶着）。

## 难点：这一跳看不见客户端用的什么 scheme

TLS 在 FC 网关就终止了，容器里观察不到。仓库里已核实 FC 会传 `x-forwarded-proto`（`app.ts` 里限流那段的注释），但**没人知道它的值是什么**。如果它恒为 `http`，那么走 https 的用户也会被"重定向到 https"，无限循环，整个 apps 区直接不可用。

我试过几种零成本确证的办法都不成立：SSR 出来的 HTML 里没有绝对 URL（http/https 两次抓取的差异只是时间戳）；想用应用侧的 CSRF 行为反推，又被 #1314 自己补的 `Sec-Fetch-Site` 挡住了；剩下的路子要么得往测试函数部署（会用生产密钥覆写它的环境变量表），要么得自签 JWT 连库。

**所以这个设计不依赖知道答案**：那个头的每一种失效方式都落在「不重定向」上，而不是循环。

## 判据

只要有任何一条说明请求已经是安全的，就不跳：

- `x-forwarded-proto: https` —— 网关给了答案就用它。
- **任何 `Sec-Fetch-*` 头** —— 浏览器只对可信来源附加这些头，这正是本仓库正在绕开的那个事实，反过来用就是一个可靠的「已经是 HTTPS」证明。**这一条让现代浏览器结构上不可能循环**：跳转之后的那个请求必然带着它们。
- 一个 60 秒的一次性 cookie —— 给 Safari 16.4 以前那些即使在 HTTPS 下也不发 Sec-Fetch 的浏览器兜底，否则它们会被一直转圈。它们最多跳一次，落到 HTTPS 上之后就正常服务。

## 边界

- **只动文档导航。** server function 的 POST、以及 `Accept` 不含 `text/html` 的 API GET 都放行——半路改写一个应用正在发的请求没有道理，而且它们两种 scheme 下都能用。
- **302 不是 301。** 永久重定向会被浏览器缓存，将来某个部署真想用 HTTP 提供应用时会非常难退回来。
- **不是 app 的域名仍然 404**，不会变成「跳到一个 https 的 404」，免得一条打错的链接看不出是哪一步出的问题。
- 响应带 `Cache-Control: no-store`：目标地址取决于请求头，共享缓存不能把这个重定向交给下一个访客。

## 验证

`services/fc` 全量 964 个用例通过，`build` 与 `typecheck` 均绿。新增 7 个用例覆盖：跳转保留 path+query、带 Sec-Fetch 不跳、`x-forwarded-proto: https`（含 `https, http` 这种追加写法）不跳、cookie 防循环（并断言它没有 `Secure`，否则在后续的 http 请求上读不到）、POST 不跳、非 HTML 的 GET 不跳、不存在的应用仍 404。

真实浏览器的验证要等部署——尤其是「https 页面加载不循环」这一条，顺带也就能知道 FC 在 `x-forwarded-proto` 里到底放了什么。

## 上线

同 #1314：`apps.mx5.cn` 路由到阿里云 FC 上的 `teamclaw-belayo-live-api`，是手工 `s deploy`，不走 main 的自动部署。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NyP9iUmUfBXVkJ8UPXdsim