### PR TITLE
fix(daemon): persist turn-final replies before skills-refresh detach

### DIFF
--- a/apps/daemon/src/daemon/server/messaging.rs
+++ b/apps/daemon/src/daemon/server/messaging.rs
@@ -15,6 +15,15 @@ fn latency_probe_enabled() -> bool {
         .get_or_init(|| std::env::var("AMUX_LATENCY_PROBE").is_ok_and(|v| v == "1" || v == "true"))
 }
 
+fn is_active_to_idle(event: &amux::AcpEvent) -> bool {
+    matches!(
+        event.event.as_ref(),
+        Some(amux::acp_event::Event::StatusChange(sc))
+            if sc.old_status == amux::AgentStatus::Active as i32
+                && sc.new_status == amux::AgentStatus::Idle as i32
+    )
+}
+
 impl DaemonServer {
     /// Build merged agent list: active agents + historical (non-active) sessions.
     /// Now only used by `publish_all_agent_states` to iterate startup/reconnect state.
@@ -337,29 +346,21 @@ impl DaemonServer {
             }
         }
 
-        // Update agent status if this is a status change event
+        // Update agent status if this is a status change event.
+        // Active→Idle is deferred until ingest + persist below: marking Idle
+        // first lets a skills refresh detach the runtime and drop the
+        // turn-final AGENT_REPLY before it reaches cloud `messages`.
+        let defer_idle = is_active_to_idle(&acp_event);
         if let Some(amux::acp_event::Event::StatusChange(ref sc)) = acp_event.event {
-            let became_idle = sc.old_status == amux::AgentStatus::Active as i32
-                && sc.new_status == amux::AgentStatus::Idle as i32;
-            {
-                let mut agents = self.agents.lock().await;
-                if let Some(handle) = agents.get_handle_mut(agent_id) {
-                    handle.status = amux::AgentStatus::try_from(sc.new_status)
-                        .unwrap_or(amux::AgentStatus::Unknown);
+            if !defer_idle {
+                {
+                    let mut agents = self.agents.lock().await;
+                    if let Some(handle) = agents.get_handle_mut(agent_id) {
+                        handle.status = amux::AgentStatus::try_from(sc.new_status)
+                            .unwrap_or(amux::AgentStatus::Unknown);
+                    }
                 }
-            }
-            self.publish_runtime_state_by_id(agent_id).await;
-            if became_idle {
-                self.remote_tool_turn_contexts
-                    .lock()
-                    .await
-                    .clear_runtime(agent_id);
-                self.flush_pending_remote_tools_mcp_refresh(agent_id).await;
-                // No `learn_session_model` here any more. It existed to give a
-                // fresh install's device MRU a first entry by asking the backend
-                // what an unpinned start had settled on — and ADR-0007 removes
-                // both the MRU and unpinned starts, since every entry point now
-                // pins a model when it is created.
+                self.publish_runtime_state_by_id(agent_id).await;
             }
 
             // Status transitions used to upsert `agent_runtimes` here. The
@@ -386,7 +387,7 @@ impl DaemonServer {
         // emitted messages (cloud `messages.sequence`). The envelope
         // append below uses the same value, keeping a 1:1 link between an
         // ACP event boundary and the messages that flowed from it.
-        let (mut emitted, turn_id, seq, reply_to_message_id, clear_reply_to) = {
+        let (emitted, turn_id, seq, reply_to_message_id) = {
             let mut agents = self.agents.lock().await;
             let seq = agents
                 .get_handle_mut(agent_id)
@@ -396,12 +397,6 @@ impl DaemonServer {
                 .get_handle(agent_id)
                 .and_then(|h| h.pending_reply_to_message_id.clone())
                 .unwrap_or_default();
-            let clear_reply_to = matches!(
-                acp_event.event.as_ref(),
-                Some(amux::acp_event::Event::StatusChange(sc))
-                    if sc.old_status == amux::AgentStatus::Active as i32
-                        && sc.new_status == amux::AgentStatus::Idle as i32
-            );
             let turn_id_before = agents
                 .aggregator(agent_id)
                 .and_then(|a| a.current_turn_id())
@@ -441,8 +436,9 @@ impl DaemonServer {
                 crate::runtime::apply_violations_to_emitted(&mut emitted, &violations, &tid);
             }
             let turn_id = turn_id_before.unwrap_or_default();
-            (emitted, turn_id, seq, reply_to_message_id, clear_reply_to)
+            (emitted, turn_id, seq, reply_to_message_id)
         };
+        let mut persist_failed = false;
         if !collab_sessions.is_empty() && !emitted.is_empty() {
             if let Some(tc) = self.teamclu.as_ref() {
                 let actor_id = self.actor_id.clone();
@@ -501,6 +497,9 @@ impl DaemonServer {
                             )
                             .await;
                         cloud_ok = cloud_ok && ok;
+                        if persist && !ok {
+                            persist_failed = true;
+                        }
                     }
                     // Harden cursor when a turn ends as interrupted: send_prompt
                     // may have returned Err and skipped persist_runtime_cursor.
@@ -513,9 +512,26 @@ impl DaemonServer {
                 }
             }
         }
-        if clear_reply_to {
-            if let Some(handle) = self.agents.lock().await.get_handle_mut(agent_id) {
-                handle.pending_reply_to_message_id = None;
+        if defer_idle {
+            if persist_failed {
+                tracing::warn!(
+                    agent_id,
+                    "turn-final AGENT_REPLY persist failed; keeping runtime Active"
+                );
+            } else {
+                {
+                    let mut agents = self.agents.lock().await;
+                    if let Some(handle) = agents.get_handle_mut(agent_id) {
+                        handle.status = amux::AgentStatus::Idle;
+                        handle.pending_reply_to_message_id = None;
+                    }
+                }
+                self.publish_runtime_state_by_id(agent_id).await;
+                self.remote_tool_turn_contexts
+                    .lock()
+                    .await
+                    .clear_runtime(agent_id);
+                self.flush_pending_remote_tools_mcp_refresh(agent_id).await;
             }
         }
 

--- a/apps/daemon/src/runtime/manager.rs
+++ b/apps/daemon/src/runtime/manager.rs
@@ -1170,6 +1170,8 @@ impl RuntimeManager {
 
     /// Like [`send_prompt`], but stamps turn-scoped requester / reply_to onto the
     /// ACP prompt job (bound when the prompt worker starts the turn).
+    /// Occupancy is marked `Active` before dispatch so a skills refresh cannot
+    /// detach the runtime in the window while the prompt is in flight.
     pub async fn send_prompt_with_requester(
         &mut self,
         agent_id: &str,
@@ -1178,43 +1180,53 @@ impl RuntimeManager {
         requester_actor_id: Option<String>,
         reply_to_message_id: Option<String>,
     ) -> crate::error::Result<Vec<String>> {
-        let (final_text, drained_ids, drained_messages, drained_injected, drained_next_context) =
-            if let Some(handle) = self.agents.get_mut(agent_id) {
-                let drained_messages = handle.pending_silent.clone();
-                let drained_injected = handle.injected_context.clone();
-                let drained_next_context = std::mem::take(&mut handle.next_prompt_context);
-                let (injected_prefix, _) = if super::instruction_delivery::skips_buffered_inject(
-                    handle.instruction_delivery,
-                ) {
-                    (String::new(), Vec::new())
-                } else {
-                    handle.flush_injected_context()
-                };
-                let (silent_prefix, drained) = handle.flush_pending_silent();
-                let next_context_prefix = if drained_next_context.is_empty() {
-                    String::new()
-                } else {
-                    format!("{drained_next_context}\n\n")
-                };
-                let prefix = format!("{injected_prefix}{next_context_prefix}{silent_prefix}");
-                let final_text = if prefix.is_empty() {
-                    text.to_string()
-                } else {
-                    format!("{prefix}{text}")
-                };
-                (
-                    final_text,
-                    drained,
-                    drained_messages,
-                    drained_injected,
-                    drained_next_context,
-                )
+        let (
+            final_text,
+            drained_ids,
+            drained_messages,
+            drained_injected,
+            drained_next_context,
+            previous_status,
+        ) = if let Some(handle) = self.agents.get_mut(agent_id) {
+            let drained_messages = handle.pending_silent.clone();
+            let drained_injected = handle.injected_context.clone();
+            let drained_next_context = std::mem::take(&mut handle.next_prompt_context);
+            let (injected_prefix, _) = if super::instruction_delivery::skips_buffered_inject(
+                handle.instruction_delivery,
+            ) {
+                (String::new(), Vec::new())
             } else {
-                return Err(crate::error::AmuxError::Agent(format!(
-                    "agent {} not found",
-                    agent_id
-                )));
+                handle.flush_injected_context()
             };
+            let (silent_prefix, drained) = handle.flush_pending_silent();
+            let next_context_prefix = if drained_next_context.is_empty() {
+                String::new()
+            } else {
+                format!("{drained_next_context}\n\n")
+            };
+            let prefix = format!("{injected_prefix}{next_context_prefix}{silent_prefix}");
+            let final_text = if prefix.is_empty() {
+                text.to_string()
+            } else {
+                format!("{prefix}{text}")
+            };
+            let previous_status = handle.status;
+            handle.status = amux::AgentStatus::Active;
+            handle.current_prompt = text.to_string();
+            (
+                final_text,
+                drained,
+                drained_messages,
+                drained_injected,
+                drained_next_context,
+                previous_status,
+            )
+        } else {
+            return Err(crate::error::AmuxError::Agent(format!(
+                "agent {} not found",
+                agent_id
+            )));
+        };
 
         if let Err(err) = self
             .send_prompt_raw(
@@ -1227,6 +1239,7 @@ impl RuntimeManager {
             .await
         {
             if let Some(handle) = self.agents.get_mut(agent_id) {
+                handle.status = previous_status;
                 if !drained_injected.is_empty() {
                     handle.injected_context = drained_injected;
                 }
@@ -1240,10 +1253,6 @@ impl RuntimeManager {
                 }
             }
             return Err(err);
-        }
-        if let Some(handle) = self.agents.get_mut(agent_id) {
-            handle.status = amux::AgentStatus::Active;
-            handle.current_prompt = text.to_string();
         }
         Ok(drained_ids)
     }
@@ -1937,6 +1946,26 @@ impl RuntimeManager {
         h.workspace_id = workspace_id.to_string();
         h.status = status;
         self.agents.insert(runtime_id.to_string(), h);
+    }
+
+    /// Open a TurnAggregator turn for `runtime_id` without flipping handle status.
+    /// Used to prove occupancy treats an uncommitted turn as busy.
+    pub fn open_test_aggregator_turn(&mut self, runtime_id: &str) {
+        let mut agg = TurnAggregator::new();
+        agg.ingest(&amux::AcpEvent {
+            event: Some(amux::acp_event::Event::StatusChange(
+                amux::AcpStatusChange {
+                    old_status: amux::AgentStatus::Idle as i32,
+                    new_status: amux::AgentStatus::Active as i32,
+                },
+            )),
+            model: String::new(),
+        });
+        assert!(
+            agg.current_turn_id().is_some(),
+            "Idle→Active ingest must open a turn"
+        );
+        self.aggregators.insert(runtime_id.to_string(), agg);
     }
 
     pub fn set_test_runtime_status(&mut self, runtime_id: &str, status: amux::AgentStatus) {
@@ -2837,6 +2866,21 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn send_prompt_marks_active_before_return() {
+        let mut mgr = RuntimeManager::test_dummy_with_runtime("rt1");
+        assert_eq!(
+            mgr.get_handle("rt1").unwrap().status,
+            amux::AgentStatus::Starting
+        );
+        mgr.send_prompt("rt1", "hello", vec![]).await.unwrap();
+        assert_eq!(
+            mgr.get_handle("rt1").unwrap().status,
+            amux::AgentStatus::Active
+        );
+        assert_eq!(mgr.get_handle("rt1").unwrap().current_prompt, "hello");
+    }
+
+    #[tokio::test]
     async fn send_prompt_returns_err_for_missing_runtime() {
         let mut mgr = RuntimeManager::new(RuntimeManager::test_launch_configs(), None);
         let result = mgr.send_prompt("nonexistent", "hello", vec![]).await;
@@ -2860,6 +2904,11 @@ mod tests {
         assert_eq!(
             mgr.get_handle("rt1").unwrap().next_prompt_context,
             "remote ctx"
+        );
+        assert_eq!(
+            mgr.get_handle("rt1").unwrap().status,
+            amux::AgentStatus::Starting,
+            "failed send must restore the pre-dispatch status"
         );
         assert!(mgr.last_sent_to("rt1").is_none());
     }

--- a/apps/daemon/src/runtime/manager/workspace_query.rs
+++ b/apps/daemon/src/runtime/manager/workspace_query.rs
@@ -9,6 +9,7 @@
 
 use crate::proto::amux;
 use crate::runtime::handle::RuntimeHandle;
+use crate::runtime::turn_aggregator::TurnAggregator;
 
 use super::RuntimeManager;
 
@@ -55,16 +56,30 @@ impl RuntimeManager {
         })
     }
 
-    /// True while any runtime in this workspace is currently executing a turn.
+    /// True while this runtime is executing a turn or has not yet committed
+    /// the turn-final `AGENT_REPLY`.
     ///
     /// `Active` is the normal ACP status during a turn. `event_rx == None`
     /// covers the checkout path used by HTTP/gateway/cron turn drivers; while
     /// checked out, the owner is awaiting the turn and `poll_events` must not
-    /// drain that channel.
+    /// drain that channel. A held `turn_lock` or an open aggregator turn
+    /// covers the Idle-before-commit window: the ACP status may already be
+    /// Idle while the reply is still being ingested / persisted.
+    fn runtime_has_active_turn(
+        handle: &RuntimeHandle,
+        aggregator: Option<&TurnAggregator>,
+    ) -> bool {
+        matches!(handle.status, amux::AgentStatus::Active)
+            || handle.event_rx.is_none()
+            || handle.turn_lock.try_lock().is_err()
+            || aggregator.and_then(|a| a.current_turn_id()).is_some()
+    }
+
+    /// True while any runtime in this workspace is currently executing a turn.
     pub fn workspace_has_active_turn(&self, workspace_path: &str, workspace_id: &str) -> bool {
-        self.agents.iter().any(|(_, handle)| {
+        self.agents.iter().any(|(id, handle)| {
             Self::workspace_runtime_matches(handle, workspace_path, workspace_id)
-                && (matches!(handle.status, amux::AgentStatus::Active) || handle.event_rx.is_none())
+                && Self::runtime_has_active_turn(handle, self.aggregators.get(id))
         })
     }
 
@@ -132,8 +147,9 @@ impl RuntimeManager {
     /// config refreshes therefore accumulates draining generations until the
     /// global host cap is exhausted. Idle runtimes can be reconstructed from
     /// their persisted backend session on the next message, so release those
-    /// leases before rolling the host. Active and checked-out turns remain on
-    /// their current generation and are never interrupted.
+    /// leases before rolling the host. Active, checked-out, and uncommitted
+    /// turns (open aggregator / held turn_lock) remain on their current
+    /// generation and are never interrupted.
     pub async fn stop_idle_runtimes_for_workspace(
         &mut self,
         workspace_path: &str,
@@ -142,10 +158,11 @@ impl RuntimeManager {
         let ids: Vec<String> = self
             .agents
             .iter()
-            .filter(|(_, handle)| {
+            .filter(|(id, handle)| {
                 Self::workspace_runtime_matches(handle, workspace_path, workspace_id)
                     && handle.status == amux::AgentStatus::Idle
                     && handle.event_rx.is_some()
+                    && !Self::runtime_has_active_turn(handle, self.aggregators.get(id.as_str()))
             })
             .map(|(id, _)| id.clone())
             .collect();
@@ -231,6 +248,70 @@ mod tests {
         assert_eq!(
             manager.workspace_occupancy("/tmp/missing", "ws-missing"),
             WorkspaceOccupancy::Cold
+        );
+    }
+
+    #[test]
+    fn occupancy_treats_open_aggregator_turn_as_active_even_when_idle() {
+        let mut manager = RuntimeManager::new(RuntimeManager::test_launch_configs(), None);
+        manager.add_test_workspace_runtime(
+            "idle-open-turn",
+            "/tmp/open-turn",
+            "ws-open-turn",
+            amux::AgentStatus::Idle,
+        );
+        manager.open_test_aggregator_turn("idle-open-turn");
+
+        assert_eq!(
+            manager.workspace_occupancy("/tmp/open-turn", "ws-open-turn"),
+            WorkspaceOccupancy::Active
+        );
+        assert!(manager.workspace_has_active_turn("/tmp/open-turn", "ws-open-turn"));
+    }
+
+    #[tokio::test]
+    async fn occupancy_treats_held_turn_lock_as_active_even_when_idle() {
+        let mut manager = RuntimeManager::new(RuntimeManager::test_launch_configs(), None);
+        manager.add_test_workspace_runtime(
+            "idle-locked",
+            "/tmp/locked",
+            "ws-locked",
+            amux::AgentStatus::Idle,
+        );
+        let lock = manager
+            .get_handle("idle-locked")
+            .expect("test runtime")
+            .turn_lock
+            .clone();
+        let _guard = lock.lock().await;
+
+        assert_eq!(
+            manager.workspace_occupancy("/tmp/locked", "ws-locked"),
+            WorkspaceOccupancy::Active
+        );
+        assert!(manager.workspace_has_active_turn("/tmp/locked", "ws-locked"));
+    }
+
+    #[tokio::test]
+    async fn refresh_cleanup_does_not_stop_idle_runtime_with_open_aggregator_turn() {
+        let mut manager = RuntimeManager::new(RuntimeManager::test_launch_configs(), None);
+        manager.add_test_workspace_runtime(
+            "idle-open-turn",
+            "/tmp/target",
+            "ws-target",
+            amux::AgentStatus::Idle,
+        );
+        manager.open_test_aggregator_turn("idle-open-turn");
+
+        assert_eq!(
+            manager
+                .stop_idle_runtimes_for_workspace("/tmp/target", "ws-target")
+                .await,
+            0
+        );
+        assert!(
+            manager.agent_ids().iter().any(|id| id == "idle-open-turn"),
+            "must not detach a WarmIdle runtime whose turn reply is still uncommitted"
         );
     }
 }

--- a/apps/daemon/src/runtime/supervisor.rs
+++ b/apps/daemon/src/runtime/supervisor.rs
@@ -1493,11 +1493,18 @@ impl RuntimeSupervisor {
         );
         prepare_workspace(workspace_path)?;
 
+        // Re-check occupancy under the same lock as stop. A turn can start
+        // (or a turn-final reply can still be uncommitted) between the
+        // pre-prepare snapshot and here; detaching in that window drops the
+        // AGENT_REPLY before cloud persist.
         let stopped = if evict_provider_hosts {
             self.request_workspace_host_refresh(workspace_id, workspace_path)
                 .await
         } else {
             let mut manager = self.agents.lock().await;
+            if manager.workspace_has_active_turn(&workspace_path_str, workspace_id) {
+                return Err(WorkspaceControlError::ActiveTurn(workspace_id.to_owned()));
+            }
             manager
                 .stop_runtimes_for_workspace(&workspace_path_str, workspace_id)
                 .await
@@ -2100,6 +2107,82 @@ mod tests {
             err,
             WorkspaceControlError::ActiveTurn(ref id) if id == &workspace_id
         ));
+    }
+
+    #[tokio::test]
+    async fn reload_workspace_rejects_open_aggregator_turn() {
+        let dir = tempfile::tempdir().unwrap();
+        let workspace_id = refresh_watch::workspace_runtime_id(dir.path());
+        let supervisor = RuntimeSupervisor::new(Arc::new(AsyncMutex::new(RuntimeManager::new(
+            RuntimeManager::default_launch_configs(),
+            None,
+        ))));
+        {
+            let mut manager = supervisor.agents.lock().await;
+            manager.add_test_workspace_runtime(
+                "rt-finalizing",
+                &dir.path().to_string_lossy(),
+                &workspace_id,
+                amux::AgentStatus::Idle,
+            );
+            manager.open_test_aggregator_turn("rt-finalizing");
+        }
+
+        let err = supervisor
+            .reload_workspace(&workspace_id, dir.path(), false)
+            .await
+            .expect_err("reload must wait until the turn-final reply is committed");
+        assert!(matches!(
+            err,
+            WorkspaceControlError::ActiveTurn(ref id) if id == &workspace_id
+        ));
+    }
+
+    #[tokio::test]
+    async fn skills_refresh_defers_when_aggregator_turn_is_open() {
+        let dir = tempfile::tempdir().unwrap();
+        let workspace_id = refresh_watch::workspace_runtime_id(dir.path());
+        let supervisor = RuntimeSupervisor::new(Arc::new(AsyncMutex::new(RuntimeManager::new(
+            RuntimeManager::default_launch_configs(),
+            None,
+        ))));
+        {
+            let mut manager = supervisor.agents.lock().await;
+            manager.add_test_workspace_runtime(
+                "rt-finalizing",
+                &dir.path().to_string_lossy(),
+                &workspace_id,
+                amux::AgentStatus::Idle,
+            );
+            manager.open_test_aggregator_turn("rt-finalizing");
+        }
+
+        supervisor
+            .refresh_coordinator()
+            .record_change(
+                &workspace_id,
+                dir.path(),
+                refresh::RefreshChangeKind::Skills,
+                refresh::RefreshSource::FilesystemWatch,
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(supervisor.auto_apply_pending_refreshes().await, 0);
+        let dto = supervisor
+            .refresh_coordinator()
+            .runtime_refresh_dto(&workspace_id)
+            .await;
+        assert_eq!(dto.status, "pending");
+        assert!(dto.auto_apply_blocked_by_active_runtime);
+        let manager = supervisor.agents.lock().await;
+        assert_eq!(
+            manager
+                .active_handles_for_workspace(&dir.path().to_string_lossy(), &workspace_id)
+                .count(),
+            1,
+            "must not detach a runtime whose turn reply is still uncommitted"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Description

Skills-only runtime refresh can detach a WarmIdle Pi session in the window after ACP reports Idle but before the turn-final `AGENT_REPLY` is ingested and written to cloud `messages`. Pi still has the reply (jsonl / `close_session`); the desktop never sees it.

This PR keeps the runtime busy until that reply is committed:

- Occupancy treats an open aggregator turn and a held `turn_lock` as Active, even when handle status is already Idle.
- `reload_workspace` re-checks occupancy under the same lock as stop, so a turn cannot sneak in during `prepare_workspace`.
- `forward_agent_event` defers Active→Idle until ingest + cloud persist succeed (persist failure stays Active).
- `send_prompt` marks Active before dispatch and restores the previous status on send failure.

## Related Issue

N/A (race observed on skills refresh vs turn-final persist)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Test plan

- [x] `cargo test -p amuxd --bin amuxd occupancy_treats_`
- [x] `reload_workspace_rejects` (active turn + open aggregator turn)
- [x] `skills_refresh_defers_when_aggregator_turn_is_open`
- [x] `send_prompt_marks_active_before_return` / `send_prompt_restores_injected_when_send_fails`
- [x] `refresh_cleanup` idle-stop skips uncommitted turns
- [ ] Manual: send a prompt, trigger team-skills refresh on WarmIdle apply, confirm the turn-final reply still appears in the desktop thread

## Additional Notes

Does not kill Pi, salvage jsonl, or add a “skills refreshed” banner. QoS0 stream drops are unchanged.


Made with [Cursor](https://cursor.com)