### PR TITLE
feat(skills): probe ~/.agents/skills access and prompt when blocked

### DIFF
--- a/apps/desktop/src/commands/agents_skills.rs
+++ b/apps/desktop/src/commands/agents_skills.rs
@@ -2,8 +2,11 @@
 //! target for TeamClu skill packages, readable by Pi natively and wired into
 //! OpenCode / Claude Code via each runtime's `skills.paths` config.
 
+use serde::Serialize;
 use serde_json::{json, Value};
 use std::path::{Path, PathBuf};
+use tauri::AppHandle;
+use tauri_plugin_fs::FsExt;
 
 /// Canonical shared install root: `~/.agents/skills`.
 pub fn agents_skills_dir() -> Result<PathBuf, String> {
@@ -13,6 +16,193 @@ pub fn agents_skills_dir() -> Result<PathBuf, String> {
 
 fn ensure_dir(path: &Path) -> Result<(), String> {
     std::fs::create_dir_all(path).map_err(|e| format!("Failed to create {}: {}", path.display(), e))
+}
+
+/// Why `~/.agents/skills` is not ready for the webview / install paths.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentsSkillsAccessKind {
+    Ok,
+    HomeMissing,
+    CreateFailed,
+    OsPermission,
+    TauriScope,
+}
+
+/// Structured result of probing OS + Tauri fs-scope access to `~/.agents/skills`.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentsSkillsAccess {
+    pub path: String,
+    pub ok: bool,
+    pub kind: AgentsSkillsAccessKind,
+    pub message: String,
+    pub os_readable: bool,
+    pub os_writable: bool,
+    pub scope_granted: bool,
+}
+
+fn access_result(
+    path: PathBuf,
+    kind: AgentsSkillsAccessKind,
+    message: impl Into<String>,
+    os_readable: bool,
+    os_writable: bool,
+    scope_granted: bool,
+) -> AgentsSkillsAccess {
+    AgentsSkillsAccess {
+        path: path.to_string_lossy().into_owned(),
+        ok: kind == AgentsSkillsAccessKind::Ok,
+        kind,
+        message: message.into(),
+        os_readable,
+        os_writable,
+        scope_granted,
+    }
+}
+
+/// Create the directory (if needed) and probe a write/read/delete round-trip.
+///
+/// Returns `(readable, writable, create_error)`. A create error that looks like
+/// a permission problem is reported separately from a generic create failure so
+/// the UI can tell the user to fix ownership rather than "disk full".
+fn probe_os_access(dir: &Path) -> (bool, bool, Option<(AgentsSkillsAccessKind, String)>) {
+    if let Err(e) = std::fs::create_dir_all(dir) {
+        let kind = if e.kind() == std::io::ErrorKind::PermissionDenied {
+            AgentsSkillsAccessKind::OsPermission
+        } else {
+            AgentsSkillsAccessKind::CreateFailed
+        };
+        return (
+            false,
+            false,
+            Some((
+                kind,
+                format!("Failed to create {}: {e}", dir.display()),
+            )),
+        );
+    }
+
+    let probe = dir.join(format!(
+        ".teamclu-write-probe-{}",
+        std::process::id()
+    ));
+    let payload = b"teamclu-agents-skills-probe\n";
+
+    if let Err(e) = std::fs::write(&probe, payload) {
+        let _ = std::fs::remove_file(&probe);
+        return (
+            true,
+            false,
+            Some((
+                AgentsSkillsAccessKind::OsPermission,
+                format!(
+                    "Cannot write to {}: {e}. Check that your user owns ~/.agents/skills.",
+                    dir.display()
+                ),
+            )),
+        );
+    }
+
+    let readable = match std::fs::read(&probe) {
+        Ok(bytes) => bytes == payload,
+        Err(_) => false,
+    };
+    let _ = std::fs::remove_file(&probe);
+
+    if !readable {
+        return (
+            false,
+            true,
+            Some((
+                AgentsSkillsAccessKind::OsPermission,
+                format!(
+                    "Wrote a probe file under {} but could not read it back.",
+                    dir.display()
+                ),
+            )),
+        );
+    }
+
+    (true, true, None)
+}
+
+fn grant_and_check_scope(app: &AppHandle, skills: &Path) -> (bool, Option<String>) {
+    let agents_parent = skills.parent().unwrap_or(skills);
+    if let Err(e) = crate::fs_scope::allow_directory(app, agents_parent) {
+        return (false, Some(e));
+    }
+    if let Err(e) = crate::fs_scope::allow_directory(app, skills) {
+        return (false, Some(e));
+    }
+
+    let probe_child = skills.join(".teamclu-scope-probe");
+    let allowed = app.fs_scope().is_allowed(skills) || app.fs_scope().is_allowed(&probe_child);
+    if allowed {
+        (true, None)
+    } else {
+        (
+            false,
+            Some(format!(
+                "Tauri fs scope still rejects {} after granting ~/.agents",
+                skills.display()
+            )),
+        )
+    }
+}
+
+/// Probe OS writability of `~/.agents/skills` and (re)grant the webview fs scope.
+#[tauri::command]
+pub fn check_agents_skills_access(app: AppHandle) -> Result<AgentsSkillsAccess, String> {
+    let skills = match agents_skills_dir() {
+        Ok(p) => p,
+        Err(e) => {
+            return Ok(access_result(
+                PathBuf::from("~/.agents/skills"),
+                AgentsSkillsAccessKind::HomeMissing,
+                e,
+                false,
+                false,
+                false,
+            ));
+        }
+    };
+
+    let (os_readable, os_writable, os_err) = probe_os_access(&skills);
+    if let Some((kind, message)) = os_err {
+        let (scope_granted, _) = grant_and_check_scope(&app, &skills);
+        return Ok(access_result(
+            skills,
+            kind,
+            message,
+            os_readable,
+            os_writable,
+            scope_granted,
+        ));
+    }
+
+    let (scope_granted, scope_err) = grant_and_check_scope(&app, &skills);
+    if !scope_granted {
+        return Ok(access_result(
+            skills,
+            AgentsSkillsAccessKind::TauriScope,
+            scope_err.unwrap_or_else(|| {
+                "App filesystem scope does not allow ~/.agents/skills".into()
+            }),
+            os_readable,
+            os_writable,
+            false,
+        ));
+    }
+
+    Ok(access_result(
+        skills,
+        AgentsSkillsAccessKind::Ok,
+        "ok".to_string(),
+        os_readable,
+        os_writable,
+        true,
+    ))
 }
 
 fn read_json_object(path: &Path) -> Result<Value, String> {
@@ -168,5 +358,51 @@ mod tests {
             v.get("skills").is_none(),
             "workspace opencode.json must not gain a member skills.paths entry"
         );
+    }
+
+    #[test]
+    fn probe_os_access_creates_and_writes_in_empty_dir() {
+        let dir = tempdir().unwrap();
+        let skills = dir.path().join(".agents").join("skills");
+        let (readable, writable, err) = probe_os_access(&skills);
+        assert!(readable);
+        assert!(writable);
+        assert!(err.is_none());
+        assert!(skills.is_dir());
+        // Probe file must not linger.
+        let leftovers: Vec<_> = std::fs::read_dir(&skills)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter(|e| {
+                e.file_name()
+                    .to_string_lossy()
+                    .starts_with(".teamclu-write-probe-")
+            })
+            .collect();
+        assert!(leftovers.is_empty());
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn probe_os_access_reports_permission_on_readonly_dir() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempdir().unwrap();
+        let skills = dir.path().join("skills");
+        std::fs::create_dir_all(&skills).unwrap();
+        let mut perms = std::fs::metadata(&skills).unwrap().permissions();
+        perms.set_mode(0o555);
+        std::fs::set_permissions(&skills, perms).unwrap();
+
+        let (readable, writable, err) = probe_os_access(&skills);
+        // Restore before asserts so the tempdir can clean up.
+        let mut perms = std::fs::metadata(&skills).unwrap().permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&skills, perms).unwrap();
+
+        assert!(!writable);
+        let (kind, _) = err.expect("expected permission error");
+        assert_eq!(kind, AgentsSkillsAccessKind::OsPermission);
+        let _ = readable;
     }
 }

--- a/apps/desktop/src/lib.rs
+++ b/apps/desktop/src/lib.rs
@@ -550,6 +550,7 @@ pub fn run() {
             commands::team_skills::team_skill_retire_personal,
             commands::team_skills::team_skill_fork,
             commands::agents_skills::ensure_agents_skills_paths,
+            commands::agents_skills::check_agents_skills_access,
             commands::skillssh::import_skill_from_zip,
             commands::updater::check_update,
             commands::updater::download_and_install_update,

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -47,6 +47,8 @@ import { CloseToTrayHost } from "@/components/CloseToTrayDialog";
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { TelemetryConsentDialog } from "@/components/telemetry/TelemetryConsentDialog";
 import { RuntimeRefreshWorkspaceBanner } from "@/components/workspace/RuntimeRefreshBanner";
+import { AgentsSkillsAccessBanner } from "@/components/skills/AgentsSkillsAccessBanner";
+import { useAgentsSkillsAccessInit } from "@/hooks/use-agents-skills-access-init";
 import { useSessionStore } from "@/stores/session-store";
 import { useSessionListStore } from "@/stores/session-list-store";
 import { useSessionSelectionStore } from "@/stores/session-selection-store";
@@ -277,6 +279,7 @@ function AppContent() {
   useGitReposInit();
   useCronInit();
   useWorkspaceRuntimeRefreshPoll();
+  useAgentsSkillsAccessInit();
   useExternalLinkHandler();
   useFileTabSync();
   useEffect(() => {
@@ -721,6 +724,7 @@ function AppContent() {
           ) : null}
 
           <RuntimeRefreshWorkspaceBanner />
+          <AgentsSkillsAccessBanner />
 
           {/* Main content - Chat or file preview */}
           <div className="relative flex min-h-0 flex-1 flex-col overflow-hidden">

--- a/packages/app/src/components/settings/ClawHubMarketplace.tsx
+++ b/packages/app/src/components/settings/ClawHubMarketplace.tsx
@@ -225,6 +225,7 @@ export const ClawHubMarketplace = React.memo(function ClawHubMarketplace({
     async (slug: string) => {
       setInstallingSlugs((prev) => new Set(prev).add(slug))
       try {
+        await ensureAgentsSkillsPaths(workspacePath)
         await invoke<string>("clawhub_install", {
           workspacePath: workspacePath ?? null,
           slug,
@@ -232,7 +233,6 @@ export const ClawHubMarketplace = React.memo(function ClawHubMarketplace({
           force: false,
           isGlobal: true,
         })
-        await ensureAgentsSkillsPaths(workspacePath)
         setInstalledSlugs((prev) => new Set(prev).add(slug))
         await onInstalled?.()
       } catch (err) {

--- a/packages/app/src/components/settings/SkillsSection.tsx
+++ b/packages/app/src/components/settings/SkillsSection.tsx
@@ -273,12 +273,12 @@ export const SkillsSection = React.memo(function SkillsSection({
     setIsSaving(true)
     setError(null)
     try {
+      await ensureAgentsSkillsPaths(workspacePath)
       await invoke<string>('import_skill_from_zip', {
         workspacePath: workspacePath ?? null,
         zipPath: importZipPath,
         isGlobal: true,
       })
-      await ensureAgentsSkillsPaths(workspacePath)
       await loadSkills()
       onDataChange?.()
       useWorkspaceRuntimeRefreshStore.getState().noteLocalRefresh(['skills'])
@@ -300,6 +300,7 @@ export const SkillsSection = React.memo(function SkillsSection({
     setError(null)
 
     try {
+      await ensureAgentsSkillsPaths(workspacePath)
       const skillDirName = editingSkill?.filename ||
         skillName.toLowerCase().replace(/\s+/g, '-').replace(/[^a-z0-9-]/g, '')
 
@@ -338,7 +339,6 @@ ${skillContent.trim()}`
       }
 
       await writeTextFile(`${skillDir}/SKILL.md`, finalContent)
-      await ensureAgentsSkillsPaths(workspacePath)
       await loadSkills()
       onDataChange?.()
       useWorkspaceRuntimeRefreshStore.getState().noteLocalRefresh(['skills'])

--- a/packages/app/src/components/skills/AgentsSkillsAccessBanner.tsx
+++ b/packages/app/src/components/skills/AgentsSkillsAccessBanner.tsx
@@ -1,0 +1,106 @@
+import { useTranslation } from 'react-i18next'
+import { AlertCircle, FolderOpen, RefreshCw, X } from 'lucide-react'
+
+import { Button } from '@/components/ui/button'
+import { revealInFinder } from '@/components/workspace/file-tree-operations'
+import { cn } from '@/lib/utils'
+import { useAgentsSkillsAccessStore } from '@/stores/agents-skills-access-store'
+
+function kindMessage(
+  t: (key: string, fallback: string, opts?: Record<string, string>) => string,
+  kind: string | undefined,
+  path: string,
+  detail: string,
+): string {
+  switch (kind) {
+    case 'os_permission':
+      return t(
+        'skills.access.osPermissionBody',
+        'Your user account cannot read or write {{path}}. Fix ownership in Finder (Get Info → Sharing & Permissions), then retry.',
+        { path },
+      )
+    case 'tauri_scope':
+      return t(
+        'skills.access.tauriScopeBody',
+        'The app does not have filesystem access to {{path}}. Click Retry to re-authorize, or open the folder in Finder.',
+        { path },
+      )
+    case 'home_missing':
+      return t(
+        'skills.access.homeMissingBody',
+        'Could not resolve your home directory, so ~/.agents/skills is unavailable.',
+      )
+    case 'create_failed':
+      return t(
+        'skills.access.createFailedBody',
+        'Could not create {{path}}: {{detail}}',
+        { path, detail },
+      )
+    default:
+      return detail || t('skills.access.genericBody', 'Skills cannot be installed until ~/.agents/skills is accessible.')
+  }
+}
+
+export function AgentsSkillsAccessBanner() {
+  const { t } = useTranslation()
+  const access = useAgentsSkillsAccessStore((s) => s.access)
+  const dismissed = useAgentsSkillsAccessStore((s) => s.dismissed)
+  const checking = useAgentsSkillsAccessStore((s) => s.checking)
+  const check = useAgentsSkillsAccessStore((s) => s.check)
+  const dismiss = useAgentsSkillsAccessStore((s) => s.dismiss)
+
+  if (!access || access.ok || dismissed) {
+    return null
+  }
+
+  const path = access.path || '~/.agents/skills'
+  const body = kindMessage(t, access.kind, path, access.message)
+
+  return (
+    <div
+      className={cn(
+        'flex shrink-0 items-center gap-3 border-b border-destructive/30 bg-destructive/5 px-4 py-2.5 text-[13px] text-destructive',
+      )}
+      data-testid="agents-skills-access-banner"
+    >
+      <AlertCircle className="h-4 w-4 shrink-0 text-destructive" />
+      <div className="min-w-0 flex-1 text-ink-2">
+        <p className="font-medium text-foreground">
+          {t('skills.access.title', 'Cannot access skills folder')}
+        </p>
+        <p className="text-[12px] text-muted-foreground">{body}</p>
+      </div>
+      <Button
+        size="sm"
+        variant="outline"
+        className="h-7 shrink-0 gap-1 px-2 text-[12px]"
+        onClick={() => void revealInFinder(path)}
+        data-testid="agents-skills-access-reveal"
+      >
+        <FolderOpen className="h-3.5 w-3.5" />
+        {t('skills.access.reveal', 'Reveal in Finder')}
+      </Button>
+      <Button
+        size="sm"
+        variant="outline"
+        className="h-7 shrink-0 gap-1 px-2 text-[12px]"
+        disabled={checking}
+        onClick={() => void check()}
+        data-testid="agents-skills-access-retry"
+      >
+        <RefreshCw className={cn('h-3.5 w-3.5', checking && 'animate-spin')} />
+        {t('skills.access.retry', 'Retry')}
+      </Button>
+      <Button
+        size="sm"
+        variant="ghost"
+        className="h-7 shrink-0 gap-1 px-2 text-[12px] text-muted-foreground"
+        onClick={() => dismiss()}
+        data-testid="agents-skills-access-dismiss"
+      >
+        <X className="h-3.5 w-3.5" />
+        {t('skills.access.dismiss', 'Dismiss')}
+      </Button>
+    </div>
+  )
+}

--- a/packages/app/src/components/skills/__tests__/AgentsSkillsAccessBanner.test.tsx
+++ b/packages/app/src/components/skills/__tests__/AgentsSkillsAccessBanner.test.tsx
@@ -1,0 +1,64 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+const revealInFinder = vi.fn()
+vi.mock('@/components/workspace/file-tree-operations', () => ({
+  revealInFinder: (...args: unknown[]) => revealInFinder(...args),
+}))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (_key: string, fallback: string) => fallback,
+  }),
+}))
+
+import { AgentsSkillsAccessBanner } from '../AgentsSkillsAccessBanner'
+import { useAgentsSkillsAccessStore } from '@/stores/agents-skills-access-store'
+
+describe('AgentsSkillsAccessBanner', () => {
+  beforeEach(() => {
+    revealInFinder.mockReset()
+    useAgentsSkillsAccessStore.setState({
+      access: null,
+      checking: false,
+      dismissed: false,
+    })
+  })
+
+  it('renders nothing when access is ok', () => {
+    useAgentsSkillsAccessStore.setState({
+      access: {
+        path: '/Users/me/.agents/skills',
+        ok: true,
+        kind: 'ok',
+        message: 'ok',
+        osReadable: true,
+        osWritable: true,
+        scopeGranted: true,
+      },
+    })
+    const { container } = render(<AgentsSkillsAccessBanner />)
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('shows reveal and retry when blocked', async () => {
+    const user = userEvent.setup()
+    useAgentsSkillsAccessStore.setState({
+      access: {
+        path: '/Users/me/.agents/skills',
+        ok: false,
+        kind: 'os_permission',
+        message: 'denied',
+        osReadable: false,
+        osWritable: false,
+        scopeGranted: true,
+      },
+      dismissed: false,
+    })
+    render(<AgentsSkillsAccessBanner />)
+    expect(screen.getByTestId('agents-skills-access-banner')).toBeTruthy()
+    await user.click(screen.getByTestId('agents-skills-access-reveal'))
+    expect(revealInFinder).toHaveBeenCalledWith('/Users/me/.agents/skills')
+  })
+})

--- a/packages/app/src/hooks/use-agents-skills-access-init.ts
+++ b/packages/app/src/hooks/use-agents-skills-access-init.ts
@@ -1,0 +1,12 @@
+import { useEffect } from 'react'
+
+import { isTauri } from '@/lib/utils'
+import { useAgentsSkillsAccessStore } from '@/stores/agents-skills-access-store'
+
+/** One-shot startup probe for ~/.agents/skills OS + Tauri scope access. */
+export function useAgentsSkillsAccessInit() {
+  useEffect(() => {
+    if (!isTauri()) return
+    void useAgentsSkillsAccessStore.getState().check()
+  }, [])
+}

--- a/packages/app/src/lib/skills/__tests__/agents-skills-access.test.ts
+++ b/packages/app/src/lib/skills/__tests__/agents-skills-access.test.ts
@@ -1,0 +1,55 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const invoke = vi.fn()
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: (...args: unknown[]) => invoke(...args),
+}))
+
+vi.mock('@/lib/utils', () => ({
+  isTauri: () => true,
+}))
+
+describe('agents-skills-access', () => {
+  beforeEach(() => {
+    invoke.mockReset()
+    vi.resetModules()
+  })
+
+  it('returns the IPC payload from checkAgentsSkillsAccess', async () => {
+    invoke.mockResolvedValue({
+      path: '/Users/me/.agents/skills',
+      ok: true,
+      kind: 'ok',
+      message: 'ok',
+      osReadable: true,
+      osWritable: true,
+      scopeGranted: true,
+    })
+    const { checkAgentsSkillsAccess } = await import('../agents-skills-access')
+    const access = await checkAgentsSkillsAccess()
+    expect(invoke).toHaveBeenCalledWith('check_agents_skills_access')
+    expect(access.ok).toBe(true)
+  })
+
+  it('throws AgentsSkillsAccessError when assert fails', async () => {
+    invoke.mockResolvedValue({
+      path: '/Users/me/.agents/skills',
+      ok: false,
+      kind: 'os_permission',
+      message: 'Cannot write',
+      osReadable: true,
+      osWritable: false,
+      scopeGranted: true,
+    })
+    const { assertAgentsSkillsAccess, isAgentsSkillsAccessError } = await import(
+      '../agents-skills-access'
+    )
+    await expect(assertAgentsSkillsAccess()).rejects.toSatisfy((err: unknown) => {
+      expect(isAgentsSkillsAccessError(err)).toBe(true)
+      if (isAgentsSkillsAccessError(err)) {
+        expect(err.access.kind).toBe('os_permission')
+      }
+      return true
+    })
+  })
+})

--- a/packages/app/src/lib/skills/agents-skills-access.ts
+++ b/packages/app/src/lib/skills/agents-skills-access.ts
@@ -1,0 +1,62 @@
+import { invoke } from '@tauri-apps/api/core'
+import { isTauri } from '@/lib/utils'
+
+export type AgentsSkillsAccessKind =
+  | 'ok'
+  | 'home_missing'
+  | 'create_failed'
+  | 'os_permission'
+  | 'tauri_scope'
+
+export interface AgentsSkillsAccess {
+  path: string
+  ok: boolean
+  kind: AgentsSkillsAccessKind
+  message: string
+  osReadable: boolean
+  osWritable: boolean
+  scopeGranted: boolean
+}
+
+export class AgentsSkillsAccessError extends Error {
+  readonly access: AgentsSkillsAccess
+
+  constructor(access: AgentsSkillsAccess) {
+    super(access.message || 'Cannot access ~/.agents/skills')
+    this.name = 'AgentsSkillsAccessError'
+    this.access = access
+  }
+}
+
+export function isAgentsSkillsAccessError(err: unknown): err is AgentsSkillsAccessError {
+  return err instanceof AgentsSkillsAccessError
+}
+
+/** Probe OS + Tauri scope for ~/.agents/skills. No-op (ok) outside Tauri. */
+export async function checkAgentsSkillsAccess(): Promise<AgentsSkillsAccess> {
+  if (!isTauri()) {
+    return {
+      path: '~/.agents/skills',
+      ok: true,
+      kind: 'ok',
+      message: 'ok',
+      osReadable: true,
+      osWritable: true,
+      scopeGranted: true,
+    }
+  }
+  return invoke<AgentsSkillsAccess>('check_agents_skills_access')
+}
+
+/**
+ * Ensure the shared skills root is readable/writable and in the webview fs
+ * scope. Throws {@link AgentsSkillsAccessError} when blocked so callers can
+ * surface reveal-in-Finder + retry UI.
+ */
+export async function assertAgentsSkillsAccess(): Promise<AgentsSkillsAccess> {
+  const access = await checkAgentsSkillsAccess()
+  if (!access.ok) {
+    throw new AgentsSkillsAccessError(access)
+  }
+  return access
+}

--- a/packages/app/src/lib/skills/ensure-agents-paths.ts
+++ b/packages/app/src/lib/skills/ensure-agents-paths.ts
@@ -1,9 +1,11 @@
 import { invoke } from '@tauri-apps/api/core'
 import { isTauri } from '@/lib/utils'
+import { useAgentsSkillsAccessStore } from '@/stores/agents-skills-access-store'
 
-/** Ensure ~/.agents/skills exists and is registered in OpenCode + Claude skills.paths. */
+/** Ensure ~/.agents/skills exists, is writable, and is registered in OpenCode + Claude skills.paths. */
 export async function ensureAgentsSkillsPaths(workspacePath?: string | null): Promise<void> {
   if (!isTauri()) return
+  await useAgentsSkillsAccessStore.getState().assertAccess()
   await invoke('ensure_agents_skills_paths', {
     workspacePath: workspacePath?.trim() || null,
   })

--- a/packages/app/src/locales/en.json
+++ b/packages/app/src/locales/en.json
@@ -3288,6 +3288,17 @@
     }
   },
   "skills": {
+    "access": {
+      "title": "Cannot access skills folder",
+      "osPermissionBody": "Your user account cannot read or write {{path}}. Fix ownership in Finder (Get Info → Sharing & Permissions), then retry.",
+      "tauriScopeBody": "The app does not have filesystem access to {{path}}. Click Retry to re-authorize, or open the folder in Finder.",
+      "homeMissingBody": "Could not resolve your home directory, so ~/.agents/skills is unavailable.",
+      "createFailedBody": "Could not create {{path}}: {{detail}}",
+      "genericBody": "Skills cannot be installed until ~/.agents/skills is accessible.",
+      "reveal": "Reveal in Finder",
+      "retry": "Retry",
+      "dismiss": "Dismiss"
+    },
     "builtinLabel": "Built-in",
     "builtinPath": "~/.agents/skills/ ({{app}} built-in)",
     "roleManagedLabel": "Role"

--- a/packages/app/src/locales/zh-CN.json
+++ b/packages/app/src/locales/zh-CN.json
@@ -3288,6 +3288,17 @@
     }
   },
   "skills": {
+    "access": {
+      "title": "无法访问技能目录",
+      "osPermissionBody": "当前用户无法读写 {{path}}。请在访达中选中该文件夹 →「显示简介」→「共享与权限」修正所有者后重试。",
+      "tauriScopeBody": "应用尚未获得对 {{path}} 的文件系统访问。请点击「重试」重新授权，或在访达中打开该目录。",
+      "homeMissingBody": "无法解析用户主目录，因此无法使用 ~/.agents/skills。",
+      "createFailedBody": "无法创建 {{path}}：{{detail}}",
+      "genericBody": "在可以访问 ~/.agents/skills 之前，无法安装技能。",
+      "reveal": "在访达中显示",
+      "retry": "重试",
+      "dismiss": "关闭"
+    },
     "builtinLabel": "内置",
     "builtinPath": "~/.agents/skills/（{{app}} 内置）",
     "roleManagedLabel": "角色"

--- a/packages/app/src/stores/agents-skills-access-store.ts
+++ b/packages/app/src/stores/agents-skills-access-store.ts
@@ -1,0 +1,89 @@
+import { create } from 'zustand'
+
+import {
+  assertAgentsSkillsAccess,
+  checkAgentsSkillsAccess,
+  type AgentsSkillsAccess,
+  isAgentsSkillsAccessError,
+} from '@/lib/skills/agents-skills-access'
+import { isTauri } from '@/lib/utils'
+
+interface AgentsSkillsAccessState {
+  access: AgentsSkillsAccess | null
+  checking: boolean
+  dismissed: boolean
+  /** Run the probe; updates banner state. Returns whether access is ok. */
+  check: () => Promise<boolean>
+  /**
+   * Same as check, but throws AgentsSkillsAccessError when blocked so install
+   * callers can abort. Also refreshes the startup banner.
+   */
+  assertAccess: () => Promise<AgentsSkillsAccess>
+  dismiss: () => void
+  /** Clear a prior dismiss so a failed install resurfaces the banner. */
+  showBlocked: (access: AgentsSkillsAccess) => void
+}
+
+export const useAgentsSkillsAccessStore = create<AgentsSkillsAccessState>((set, get) => ({
+  access: null,
+  checking: false,
+  dismissed: false,
+
+  check: async () => {
+    if (!isTauri()) {
+      set({
+        access: {
+          path: '~/.agents/skills',
+          ok: true,
+          kind: 'ok',
+          message: 'ok',
+          osReadable: true,
+          osWritable: true,
+          scopeGranted: true,
+        },
+        checking: false,
+        dismissed: false,
+      })
+      return true
+    }
+    set({ checking: true })
+    try {
+      const access = await checkAgentsSkillsAccess()
+      set({
+        access,
+        checking: false,
+        dismissed: access.ok ? false : get().dismissed,
+      })
+      return access.ok
+    } catch (err) {
+      const access: AgentsSkillsAccess = {
+        path: '~/.agents/skills',
+        ok: false,
+        kind: 'create_failed',
+        message: err instanceof Error ? err.message : String(err),
+        osReadable: false,
+        osWritable: false,
+        scopeGranted: false,
+      }
+      set({ access, checking: false })
+      return false
+    }
+  },
+
+  assertAccess: async () => {
+    try {
+      const access = await assertAgentsSkillsAccess()
+      set({ access, dismissed: false })
+      return access
+    } catch (err) {
+      if (isAgentsSkillsAccessError(err)) {
+        get().showBlocked(err.access)
+      }
+      throw err
+    }
+  },
+
+  dismiss: () => set({ dismissed: true }),
+
+  showBlocked: (access) => set({ access, dismissed: false }),
+}))

--- a/packages/app/src/stores/team-share-browser.ts
+++ b/packages/app/src/stores/team-share-browser.ts
@@ -1049,6 +1049,7 @@ async function materializeSkill(
   // Download URLs are storage-presigned (S3/MinIO/Supabase). Passing a Bearer
   // JWT makes MinIO answer 400 "multiple authentication types" and is what
   // made marketplace auto-follow stuck on "Update failed — retry".
+  await ensureAgentsSkillsPaths(wsPath)
   const result = await invoke<{ archivedPath?: string }>('team_skill_install', {
     request: {
       workspacePath: wsPath,
@@ -1068,7 +1069,6 @@ async function materializeSkill(
       archiveUnmanaged: opts.archiveUnmanaged ?? false,
     },
   })
-  await ensureAgentsSkillsPaths(wsPath)
   return result ?? {}
 }
 
@@ -1611,6 +1611,7 @@ export const useTeamShareBrowserStore = create<TeamShareBrowserState>((set, get)
     // other member's copy gets. The pack would then differ from itself
     // depending on who installed it, and the publisher's conflict diff would
     // show a phantom deleted line they never touched.
+    await ensureAgentsSkillsPaths(wsPath)
     await invoke('team_skill_install_from_dir', {
       request: {
         workspacePath: wsPath,
@@ -1627,7 +1628,6 @@ export const useTeamShareBrowserStore = create<TeamShareBrowserState>((set, get)
         isGlobal: true,
       },
     })
-    await ensureAgentsSkillsPaths(wsPath)
 
     // Against the Agent, not the member. `team_skill_install_from_dir` above put
     // the pack in this machine's skills root, and the machine is an Agent — the


### PR DESCRIPTION
## Summary
- Add `check_agents_skills_access` IPC that probes OS read/write on `~/.agents/skills` and (re)grants the Tauri webview fs scope
- Show a dismissible startup banner with Reveal in Finder + Retry when access is blocked
- Gate ClawHub / team skill install / skill create-import through `ensureAgentsSkillsPaths` so installs fail early with the same auth UX

## Test plan
- [ ] Cold start with a writable `~/.agents/skills` — no banner
- [ ] Make `~/.agents/skills` unwritable (e.g. `chmod 555`), restart — banner appears; Reveal opens Finder; Retry still fails until permissions are restored
- [ ] Restore permissions, click Retry — banner clears
- [ ] With unwritable dir, try ClawHub install / New Skill / team skill install — operation blocked and banner resurfaces
- [ ] `pnpm rust:check -p teamclu` and agents_skills unit tests
- [ ] From `packages/app`: `pnpm exec vitest run src/lib/skills/__tests__/agents-skills-access.test.ts src/components/skills/__tests__/AgentsSkillsAccessBanner.test.tsx`


Made with [Cursor](https://cursor.com)