### PR TITLE
feat(apps): 应用日志 + agent 自己部署/查日志/管数据

### DIFF
--- a/apps/daemon/src/http/apps.rs
+++ b/apps/daemon/src/http/apps.rs
@@ -467,6 +467,10 @@ fn map_seed_error(err: anyhow::Error) -> HttpError {
     if msg.contains("deployKeyPem requires")
         || msg.contains("git repo URL")
         || msg.starts_with("git clone failed")
+        // A clone that ran out of time is the remote's or the machine's
+        // problem, not a fault in this daemon — an opaque 500 sends the user
+        // looking at logs instead of at their credentials.
+        || msg.starts_with(crate::sync::app_clone::ERR_CLONE_TIMEOUT)
         || msg.contains("refusing to clone")
     {
         HttpError::validation(msg)
@@ -1236,6 +1240,19 @@ mod tests {
     #[test]
     fn map_seed_error_marks_clone_failures_as_validation() {
         let err = map_seed_error(anyhow::anyhow!("git clone failed: repo not found"));
+        assert!(matches!(err.code, ErrorCode::ValidationFailed));
+    }
+
+    #[test]
+    fn map_seed_error_marks_a_clone_timeout_as_the_callers_problem() {
+        // Not an internal fault: the machine is waiting on something — most
+        // often a credential helper with nowhere to draw its window — and the
+        // user is the only one who can do anything about it. A 500 sends them
+        // to the logs instead.
+        let err = map_seed_error(anyhow::anyhow!(
+            "{}",
+            crate::sync::app_clone::ERR_CLONE_TIMEOUT
+        ));
         assert!(matches!(err.code, ErrorCode::ValidationFailed));
     }
 

--- a/apps/daemon/src/sync/app_build.rs
+++ b/apps/daemon/src/sync/app_build.rs
@@ -8,8 +8,8 @@ use crate::sync::app_git::{self, SshEnv};
 use serde::{Deserialize, Serialize};
 use std::io::Write;
 use std::path::Path;
-use std::process::{Command, Output, Stdio};
-use std::time::{Duration, Instant};
+use std::process::{Command, Output};
+use std::time::Duration;
 
 /// OSS object key for an app's built code artifact.
 pub fn oss_object_key(app_id: &str) -> String {
@@ -141,91 +141,22 @@ fn run_with_timeout(
         .no_window()
         .args(args)
         .current_dir(cwd)
-        .env("GIT_TERMINAL_PROMPT", "0")
-        .stdin(Stdio::null())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped());
+        .env("GIT_TERMINAL_PROMPT", "0");
 
-    #[cfg(unix)]
-    {
-        use std::os::unix::process::CommandExt;
-        command.process_group(0);
+    // The spawn, the pipe draining and the kill live in `bounded_proc`: the
+    // clone path needs exactly the same thing, and two copies of a poll loop
+    // that kills process groups is one copy too many.
+    let out = crate::sync::bounded_proc::run_bounded(command, timeout, timeout_msg)?;
+    if !out.status.success() {
+        let msg = map_pnpm_failure(
+            cmd,
+            args,
+            &String::from_utf8_lossy(&out.stdout),
+            &String::from_utf8_lossy(&out.stderr),
+        );
+        anyhow::bail!("{msg}");
     }
-
-    let mut child = command
-        .spawn()
-        .map_err(|e| anyhow::anyhow!("could not run {cmd}: {e}"))?;
-
-    // Drain both pipes on their own threads for the whole life of the child.
-    // Reading them only after it exits deadlocks any build that writes more
-    // than a pipe buffer (`pnpm install` on the tanstack template is well over
-    // 64 KiB): the child blocks on a full pipe, never exits, and the poll loop
-    // below spins until the 10-minute timeout kills it.
-    let stdout_pipe = child.stdout.take();
-    let stderr_pipe = child.stderr.take();
-    let stdout_reader = std::thread::spawn(move || {
-        let mut buf = Vec::new();
-        if let Some(mut pipe) = stdout_pipe {
-            let _ = std::io::Read::read_to_end(&mut pipe, &mut buf);
-        }
-        buf
-    });
-    let stderr_reader = std::thread::spawn(move || {
-        let mut buf = Vec::new();
-        if let Some(mut pipe) = stderr_pipe {
-            let _ = std::io::Read::read_to_end(&mut pipe, &mut buf);
-        }
-        buf
-    });
-    let join = |h: std::thread::JoinHandle<Vec<u8>>| h.join().unwrap_or_default();
-
-    let start = Instant::now();
-    loop {
-        if let Some(status) = child.try_wait()? {
-            // Both pipes are closed now, so the readers finish on their own.
-            let out = Output {
-                status,
-                stdout: join(stdout_reader),
-                stderr: join(stderr_reader),
-            };
-            if !out.status.success() {
-                let msg = map_pnpm_failure(
-                    cmd,
-                    args,
-                    &String::from_utf8_lossy(&out.stdout),
-                    &String::from_utf8_lossy(&out.stderr),
-                );
-                anyhow::bail!("{msg}");
-            }
-            return Ok(out);
-        }
-        if start.elapsed() >= timeout {
-            kill_process_tree(&mut child);
-            let _ = join(stdout_reader);
-            let _ = join(stderr_reader);
-            anyhow::bail!("{timeout_msg}");
-        }
-        std::thread::sleep(Duration::from_millis(100));
-    }
-}
-
-#[cfg(unix)]
-fn kill_process_tree(child: &mut std::process::Child) {
-    let pid = child.id() as i32;
-    unsafe {
-        let pgid = libc::getpgid(pid);
-        if pgid > 1 {
-            let _ = libc::kill(-pgid, libc::SIGKILL);
-        }
-    }
-    let _ = child.kill();
-    let _ = child.wait();
-}
-
-#[cfg(not(unix))]
-fn kill_process_tree(child: &mut std::process::Child) {
-    let _ = child.kill();
-    let _ = child.wait();
+    Ok(out)
 }
 
 /// Message on the commit a deploy makes for work the agent left uncommitted.

--- a/apps/daemon/src/sync/app_clone.rs
+++ b/apps/daemon/src/sync/app_clone.rs
@@ -11,8 +11,23 @@
 use crate::process_util::CommandNoWindow;
 use std::path::Path;
 use std::process::Command;
+use std::time::Duration;
 
 use crate::sync::app_git;
+use crate::sync::bounded_proc::run_bounded;
+
+/// How long a clone may take before it is killed.
+///
+/// Generous for a real clone over a slow link, short enough that a machine
+/// waiting on something invisible gives an answer while the user is still
+/// looking at the screen. Five minutes of nothing is a failure worth reporting;
+/// a repo that genuinely needs longer is one to clone by hand and import as a
+/// local folder.
+const CLONE_TIMEOUT: Duration = Duration::from_secs(5 * 60);
+
+/// Marker the desktop turns into an explanation. Kept as one string so the
+/// mapping cannot drift from what is thrown.
+pub const ERR_CLONE_TIMEOUT: &str = "git clone timed out after 5 minutes";
 
 /// Whether `dir` has anything in it (a missing directory counts as empty).
 fn is_empty_dir(dir: &Path) -> bool {
@@ -31,7 +46,8 @@ fn is_empty_dir(dir: &Path) -> bool {
 /// Runs non-interactively. A private repo the machine has no credential for
 /// must fail with an error the user can read, not park a `git` process on a
 /// password prompt no one can see — hence `GIT_TERMINAL_PROMPT=0` and ssh's
-/// `BatchMode`.
+/// `BatchMode`, and the time limit in [`run_clone`] for the prompts those two
+/// cannot reach.
 pub fn clone_app_repo(url: &str, workdir: &Path) -> anyhow::Result<()> {
     let url = app_git::validate_remote_url(url)?;
     if !is_empty_dir(workdir) {
@@ -106,9 +122,7 @@ fn run_clone(remote: &str, workdir: &Path, ssh: Option<&app_git::SshEnv>) -> any
     } else {
         cmd.env("GIT_SSH_COMMAND", "ssh -oBatchMode=yes");
     }
-    let out = cmd
-        .output()
-        .map_err(|e| anyhow::anyhow!("could not run git ({git}): {e}"))?;
+    let out = run_bounded(cmd, CLONE_TIMEOUT, ERR_CLONE_TIMEOUT)?;
     if !out.status.success() {
         let stderr = String::from_utf8_lossy(&out.stderr);
         // git prints the URL back in most failures; that is the user's own

--- a/apps/daemon/src/sync/bounded_proc.rs
+++ b/apps/daemon/src/sync/bounded_proc.rs
@@ -1,0 +1,180 @@
+//! Run a child process under a hard time limit.
+//!
+//! `Command::output()` waits forever, which is right for a program that always
+//! exits and wrong for anything that can sit on a prompt nobody can answer.
+//! `git clone` over https is the case that matters: `GIT_TERMINAL_PROMPT=0`
+//! stops git from asking for a password itself, but it does not stop the
+//! machine's **credential helper** from running, and a helper that opens a
+//! window (git-credential-manager) blocks until someone clicks it — on a screen
+//! the daemon does not have. Without a bound, the seed request never answers
+//! and the app sits at "初始化中" forever.
+//!
+//! Both pipes are drained on their own threads for the whole life of the child.
+//! Reading them only after it exits deadlocks any process that writes more than
+//! a pipe buffer: the child blocks on a full pipe, never exits, and the poll
+//! loop spins until the timeout kills work that was doing fine.
+
+use std::process::{Child, Command, Output, Stdio};
+use std::time::{Duration, Instant};
+
+/// How often the loop checks whether the child is done.
+const POLL_INTERVAL: Duration = Duration::from_millis(100);
+
+/// Spawn `command`, wait at most `timeout`, and hand back its output.
+///
+/// Takes over stdio (stdin null, both outputs piped) because draining is what
+/// makes the bound safe. A non-zero exit is NOT an error here — the caller owns
+/// that decision, exactly as with `Command::output()`. Only the timeout is,
+/// and it reports `timeout_msg` verbatim so callers can hand the user a
+/// sentence about their own operation rather than about processes.
+pub fn run_bounded(
+    mut command: Command,
+    timeout: Duration,
+    timeout_msg: &str,
+) -> anyhow::Result<Output> {
+    command
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+
+    // Its own process group, so the kill below reaches whatever the child
+    // spawned. git runs its credential helper as a child; killing only git
+    // leaves the helper (and its window) behind.
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt;
+        command.process_group(0);
+    }
+
+    let program = command.get_program().to_string_lossy().into_owned();
+    let mut child = command
+        .spawn()
+        .map_err(|e| anyhow::anyhow!("could not run {program}: {e}"))?;
+
+    let stdout_pipe = child.stdout.take();
+    let stderr_pipe = child.stderr.take();
+    let stdout_reader = std::thread::spawn(move || {
+        let mut buf = Vec::new();
+        if let Some(mut pipe) = stdout_pipe {
+            let _ = std::io::Read::read_to_end(&mut pipe, &mut buf);
+        }
+        buf
+    });
+    let stderr_reader = std::thread::spawn(move || {
+        let mut buf = Vec::new();
+        if let Some(mut pipe) = stderr_pipe {
+            let _ = std::io::Read::read_to_end(&mut pipe, &mut buf);
+        }
+        buf
+    });
+    let join = |h: std::thread::JoinHandle<Vec<u8>>| h.join().unwrap_or_default();
+
+    let start = Instant::now();
+    loop {
+        if let Some(status) = child.try_wait()? {
+            // Both pipes are closed now, so the readers finish on their own.
+            return Ok(Output {
+                status,
+                stdout: join(stdout_reader),
+                stderr: join(stderr_reader),
+            });
+        }
+        if start.elapsed() >= timeout {
+            kill_process_tree(&mut child);
+            let _ = join(stdout_reader);
+            let _ = join(stderr_reader);
+            anyhow::bail!("{timeout_msg}");
+        }
+        std::thread::sleep(POLL_INTERVAL);
+    }
+}
+
+#[cfg(unix)]
+pub fn kill_process_tree(child: &mut Child) {
+    let pid = child.id() as i32;
+    unsafe {
+        let pgid = libc::getpgid(pid);
+        if pgid > 1 {
+            let _ = libc::kill(-pgid, libc::SIGKILL);
+        }
+    }
+    let _ = child.kill();
+    let _ = child.wait();
+}
+
+#[cfg(not(unix))]
+pub fn kill_process_tree(child: &mut Child) {
+    let _ = child.kill();
+    let _ = child.wait();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn returns_output_and_leaves_the_exit_status_to_the_caller() {
+        let mut ok = Command::new("sh");
+        ok.arg("-c").arg("printf out; printf err >&2; exit 3");
+        let out = run_bounded(ok, Duration::from_secs(30), "unused").unwrap();
+        assert_eq!(out.status.code(), Some(3), "a failure is not an error here");
+        assert_eq!(String::from_utf8_lossy(&out.stdout), "out");
+        assert_eq!(String::from_utf8_lossy(&out.stderr), "err");
+    }
+
+    #[test]
+    fn a_process_that_never_exits_is_killed_and_reported() {
+        let mut hang = Command::new("sh");
+        hang.arg("-c").arg("sleep 30");
+        let start = Instant::now();
+        let err = run_bounded(hang, Duration::from_millis(300), "took too long").unwrap_err();
+        assert_eq!(format!("{err}"), "took too long");
+        assert!(start.elapsed() < Duration::from_secs(10), "did not give up");
+    }
+
+    #[test]
+    fn output_larger_than_a_pipe_buffer_does_not_deadlock() {
+        // The reason the readers are threads: 1 MiB is well past the 64 KiB a
+        // pipe holds, so a child whose output is read only after it exits would
+        // never exit at all.
+        let mut chatty = Command::new("sh");
+        chatty.arg("-c").arg("dd if=/dev/zero bs=1024 count=1024 2>/dev/null");
+        let out = run_bounded(chatty, Duration::from_secs(30), "unused").unwrap();
+        assert_eq!(out.stdout.len(), 1024 * 1024);
+    }
+
+    #[test]
+    fn a_child_that_outlives_its_parent_is_killed_too() {
+        // git spawns its credential helper; killing only git would leave the
+        // helper holding the terminal (or a window) open.
+        let dir = tempfile::tempdir().unwrap();
+        let marker = dir.path().join("still-alive");
+        let mut parent = Command::new("sh");
+        parent
+            .arg("-c")
+            .arg(format!(
+                "sh -c 'sleep 2; touch {}' & sleep 30",
+                marker.display()
+            ));
+        let _ = run_bounded(parent, Duration::from_millis(200), "gone").unwrap_err();
+        std::thread::sleep(Duration::from_secs(3));
+        assert!(
+            !marker.exists(),
+            "the grandchild survived the timeout and kept working"
+        );
+    }
+
+    #[test]
+    fn a_missing_program_names_itself() {
+        let err = run_bounded(
+            Command::new("definitely-not-a-real-binary"),
+            Duration::from_secs(1),
+            "unused",
+        )
+        .unwrap_err();
+        assert!(
+            format!("{err}").contains("definitely-not-a-real-binary"),
+            "{err}"
+        );
+    }
+}

--- a/apps/daemon/src/sync/bounded_proc.rs
+++ b/apps/daemon/src/sync/bounded_proc.rs
@@ -138,7 +138,9 @@ mod tests {
         // pipe holds, so a child whose output is read only after it exits would
         // never exit at all.
         let mut chatty = Command::new("sh");
-        chatty.arg("-c").arg("dd if=/dev/zero bs=1024 count=1024 2>/dev/null");
+        chatty
+            .arg("-c")
+            .arg("dd if=/dev/zero bs=1024 count=1024 2>/dev/null");
         let out = run_bounded(chatty, Duration::from_secs(30), "unused").unwrap();
         assert_eq!(out.stdout.len(), 1024 * 1024);
     }
@@ -150,12 +152,10 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let marker = dir.path().join("still-alive");
         let mut parent = Command::new("sh");
-        parent
-            .arg("-c")
-            .arg(format!(
-                "sh -c 'sleep 2; touch {}' & sleep 30",
-                marker.display()
-            ));
+        parent.arg("-c").arg(format!(
+            "sh -c 'sleep 2; touch {}' & sleep 30",
+            marker.display()
+        ));
         let _ = run_bounded(parent, Duration::from_millis(200), "gone").unwrap_err();
         std::thread::sleep(Duration::from_secs(3));
         assert!(

--- a/apps/daemon/src/sync/mod.rs
+++ b/apps/daemon/src/sync/mod.rs
@@ -9,6 +9,7 @@ pub mod app_git;
 pub mod app_seed;
 pub mod app_templates;
 pub mod app_workdir;
+pub mod bounded_proc;
 pub mod dispatch;
 pub mod oss;
 pub mod scheduler;

--- a/apps/desktop/crates/teamclu-introspect/src/apps.rs
+++ b/apps/desktop/crates/teamclu-introspect/src/apps.rs
@@ -1,0 +1,242 @@
+//! `manage_app` / `manage_app_data` — publish an app, read why it broke, and
+//! look at what it stored.
+//!
+//! Thin clients over the desktop loopback API, which owns both halves of the
+//! work: only the app holds the signed-in user's cloud bearer (so the Cloud API
+//! decides what this agent may do — `admin` to deploy or write a row, `prompt`
+//! to read one) and only it can reach the local daemon that builds the artifact.
+//! This binary shapes arguments and rejects the mistakes that do not need a
+//! round trip.
+//!
+//! The app is named by `app_id`, or by `app_name` when that matches exactly one
+//! app in the current team. Deploying publishes to the public internet and
+//! `update_row` writes production data, so an ambiguous name comes back as the
+//! candidate list rather than acting on a guess.
+
+use serde_json::{json, Value};
+
+const MANAGE_ACTIONS: [&str; 4] = ["list", "status", "deploy", "logs"];
+const DATA_ACTIONS: [&str; 4] = ["tables", "rows", "update_row", "delete_row"];
+
+fn str_arg(arguments: &Value, key: &str) -> Option<String> {
+    arguments
+        .get(key)
+        .and_then(|v| v.as_str())
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+}
+
+fn require_action(arguments: &Value, allowed: &[&str]) -> Result<String, String> {
+    let action = str_arg(arguments, "action").unwrap_or_default();
+    if !allowed.contains(&action.as_str()) {
+        return Err(format!(
+            "action must be one of: {}. Got: {}",
+            allowed.join(", "),
+            if action.is_empty() {
+                "(missing)"
+            } else {
+                &action
+            }
+        ));
+    }
+    Ok(action)
+}
+
+/// Copy the app selector onto the outgoing body, refusing both forms at once.
+fn attach_app_selector(arguments: &Value, body: &mut Value) -> Result<(), String> {
+    match (str_arg(arguments, "app_id"), str_arg(arguments, "app_name")) {
+        (Some(_), Some(_)) => Err("pass app_id or app_name, not both".to_string()),
+        (None, None) => Err(
+            "app_id or app_name is required — run manage_app with action \"list\" to see this team's apps"
+                .to_string(),
+        ),
+        (Some(id), None) => {
+            body["app_id"] = json!(id);
+            Ok(())
+        }
+        (None, Some(name)) => {
+            body["app_name"] = json!(name);
+            Ok(())
+        }
+    }
+}
+
+/// Forward the arguments the desktop reads for one action, and nothing else.
+fn copy_args(arguments: &Value, body: &mut Value, keys: &[&str]) {
+    for key in keys {
+        if let Some(value) = arguments.get(*key) {
+            if !value.is_null() {
+                body[*key] = value.clone();
+            }
+        }
+    }
+}
+
+pub async fn handle_manage(api_port: u16, arguments: &Value) -> Result<Value, String> {
+    let action = require_action(arguments, &MANAGE_ACTIONS)?;
+    let mut body = json!({ "action": action });
+
+    if action != "list" {
+        attach_app_selector(arguments, &mut body)?;
+    }
+    if action == "logs" {
+        copy_args(
+            arguments,
+            &mut body,
+            &["since_minutes", "limit", "kind", "contains", "request_id"],
+        );
+    }
+
+    crate::desktop_api::post(api_port, "/app-manage", &body).await
+}
+
+pub async fn handle_data(api_port: u16, arguments: &Value) -> Result<Value, String> {
+    let action = require_action(arguments, &DATA_ACTIONS)?;
+    let mut body = json!({ "action": action });
+    attach_app_selector(arguments, &mut body)?;
+
+    if action != "tables" {
+        let table = str_arg(arguments, "table").ok_or_else(|| {
+            format!("{action} needs `table` — run action \"tables\" first to see what exists")
+        })?;
+        body["table"] = json!(table);
+    }
+
+    match action.as_str() {
+        "rows" => copy_args(
+            arguments,
+            &mut body,
+            &[
+                "limit",
+                "after",
+                "direction",
+                "filter_column",
+                "filter_op",
+                "filter_value",
+            ],
+        ),
+        "update_row" | "delete_row" => {
+            // Addressed by primary key only. `key` is the column → value map for
+            // this row's primary key; `row_key` is the opaque form a previous
+            // reply handed back, accepted so a caller can pass one straight
+            // through.
+            if arguments.get("key").is_none() && str_arg(arguments, "row_key").is_none() {
+                return Err(format!(
+                    "{action} needs `key` — an object of the row's primary-key columns, e.g. {{\"id\": 42}}"
+                ));
+            }
+            if action == "update_row" && !arguments.get("patch").is_some_and(Value::is_object) {
+                return Err(
+                    "update_row needs `patch` — an object of column → new value".to_string()
+                );
+            }
+            copy_args(arguments, &mut body, &["key", "row_key", "patch"]);
+        }
+        _ => {}
+    }
+
+    crate::desktop_api::post(api_port, "/app-data", &body).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const APP: &str = "0c0a97bf-d615-47f1-b471-45cb717f1629";
+
+    #[tokio::test]
+    async fn unknown_action_is_rejected_before_anything_else() {
+        // Checked first on purpose: a typo'd action must not reach the desktop
+        // and must not read as "the app is missing".
+        let err = handle_manage(1, &json!({ "action": "publish" }))
+            .await
+            .unwrap_err();
+        assert!(err.contains("action must be one of"), "{err}");
+    }
+
+    #[tokio::test]
+    async fn deploy_without_a_target_names_the_way_out() {
+        let err = handle_manage(1, &json!({ "action": "deploy" }))
+            .await
+            .unwrap_err();
+        assert!(err.contains("app_id or app_name"), "{err}");
+        assert!(err.contains("list"), "{err}");
+    }
+
+    #[tokio::test]
+    async fn deploy_refuses_both_target_forms() {
+        let err = handle_manage(
+            1,
+            &json!({ "action": "deploy", "app_id": APP, "app_name": "记账" }),
+        )
+        .await
+        .unwrap_err();
+        assert!(err.contains("not both"), "{err}");
+    }
+
+    #[tokio::test]
+    async fn rows_needs_a_table() {
+        let err = handle_data(1, &json!({ "action": "rows", "app_id": APP }))
+            .await
+            .unwrap_err();
+        assert!(err.contains("needs `table`"), "{err}");
+    }
+
+    #[tokio::test]
+    async fn update_row_needs_a_key() {
+        let err = handle_data(
+            1,
+            &json!({
+                "action": "update_row", "app_id": APP,
+                "table": "entries", "patch": { "title": "x" }
+            }),
+        )
+        .await
+        .unwrap_err();
+        assert!(err.contains("needs `key`"), "{err}");
+    }
+
+    #[tokio::test]
+    async fn update_row_needs_a_patch_object() {
+        let err = handle_data(
+            1,
+            &json!({
+                "action": "update_row", "app_id": APP,
+                "table": "entries", "key": { "id": 42 }, "patch": "title=x"
+            }),
+        )
+        .await
+        .unwrap_err();
+        assert!(err.contains("needs `patch`"), "{err}");
+    }
+
+    #[tokio::test]
+    async fn delete_row_needs_no_patch() {
+        // Reaches the desktop (and fails to connect on port 1) rather than being
+        // rejected here: the argument check must not demand a patch to delete.
+        let err = handle_data(
+            1,
+            &json!({
+                "action": "delete_row", "app_id": APP,
+                "table": "entries", "key": { "id": 42 }
+            }),
+        )
+        .await
+        .unwrap_err();
+        assert!(!err.contains("needs `patch`"), "{err}");
+    }
+
+    #[test]
+    fn copy_args_skips_absent_and_null() {
+        let mut body = json!({ "action": "logs" });
+        copy_args(
+            &json!({ "limit": 20, "contains": Value::Null }),
+            &mut body,
+            &["limit", "contains", "kind"],
+        );
+        assert_eq!(body["limit"], json!(20));
+        assert!(body.get("contains").is_none());
+        assert!(body.get("kind").is_none());
+    }
+}

--- a/apps/desktop/crates/teamclu-introspect/src/main.rs
+++ b/apps/desktop/crates/teamclu-introspect/src/main.rs
@@ -1,3 +1,4 @@
+mod apps;
 mod capabilities;
 mod channels;
 mod config;
@@ -501,6 +502,67 @@ fn tool_definitions() -> Value {
                     }
                 }
             }
+        },
+        {
+            "name": "manage_app",
+            "description": "Work with a TeamClu app: list this team's apps, read one's status, deploy it, or read the deployed app's logs. `deploy` runs the full publish (build the checkout on the local machine, upload it, put it live) and PUBLISHES TO THE PUBLIC INTERNET — an app whose auth_mode is \"none\" is readable by anyone with the URL. `logs` reads what the running app printed, which is how you find out why it 500s. Requires the TeamClu desktop app to be running and signed in; the user's own permissions apply (deploying needs admin on the app).",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "action": {
+                        "type": "string",
+                        "enum": ["list", "status", "deploy", "logs"],
+                        "description": "list: this team's apps. status: one app, plus where its checkout is on this machine. deploy: build and publish. logs: the deployed app's own output."
+                    },
+                    "app_id": { "type": "string", "description": "The app's UUID. Give this or app_name (not both); not needed for list." },
+                    "app_name": { "type": "string", "description": "The app's name, when it identifies exactly one app in this team." },
+                    "since_minutes": { "type": "integer", "description": "logs: how far back to read. Default 30, max 10080 (7 days)." },
+                    "limit": { "type": "integer", "description": "logs: how many entries. Default 100, max 200." },
+                    "kind": {
+                        "type": "string",
+                        "enum": ["app", "request", "all"],
+                        "description": "logs: `app` is what the app printed (default), `request` is one line per HTTP request with status and duration, `all` is both."
+                    },
+                    "contains": { "type": "string", "description": "logs: only entries whose message contains this text." },
+                    "request_id": { "type": "string", "description": "logs: only entries from this request id — the way to see one failing request end to end." }
+                },
+                "required": ["action"]
+            }
+        },
+        {
+            "name": "manage_app_data",
+            "description": "Read and edit the rows in a deployed app's own database — its real production data. Use it to check what the app actually stored, or to fix one bad row. Reads need `prompt` permission on the app and writes need `admin`; only apps with a database (data_app) that have been deployed have one. Writes address exactly one row by primary key; there is no bulk update or delete.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "action": {
+                        "type": "string",
+                        "enum": ["tables", "rows", "update_row", "delete_row"],
+                        "description": "tables: what tables exist, with their columns and primary key. rows: one page of rows. update_row / delete_row: change exactly one row."
+                    },
+                    "app_id": { "type": "string", "description": "The app's UUID. Give this or app_name, not both." },
+                    "app_name": { "type": "string", "description": "The app's name, when it identifies exactly one app in this team." },
+                    "table": { "type": "string", "description": "Table name, as reported by action \"tables\". Required for everything but tables." },
+                    "limit": { "type": "integer", "description": "rows: page size. Default 50, max 100." },
+                    "after": { "type": "string", "description": "rows: the previous page's next_cursor. Omit for the first page." },
+                    "direction": { "type": "string", "enum": ["asc", "desc"], "description": "rows: order along the primary key. Default asc." },
+                    "filter_column": { "type": "string", "description": "rows: column to filter on. Give with filter_op." },
+                    "filter_op": { "type": "string", "enum": ["eq", "contains", "isNull", "notNull"], "description": "rows: how to compare." },
+                    "filter_value": { "type": "string", "description": "rows: the value to compare against. Ignored by isNull / notNull." },
+                    "key": {
+                        "type": "object",
+                        "description": "update_row / delete_row: the row's primary-key columns and values, e.g. {\"id\": 42}. Read them off the row you got from action \"rows\".",
+                        "additionalProperties": true
+                    },
+                    "row_key": { "type": "string", "description": "Alternative to `key`: the opaque row key form, if you already have one." },
+                    "patch": {
+                        "type": "object",
+                        "description": "update_row: column → new value. Primary-key columns cannot be changed here.",
+                        "additionalProperties": true
+                    }
+                },
+                "required": ["action"]
+            }
         }
     ])
 }
@@ -737,6 +799,20 @@ async fn handle_request(
                         Err(e) => tool_err(&e),
                     }
                 }
+                "manage_app" => match apps::handle_manage(api_port, &arguments).await {
+                    Ok(v) => {
+                        let text = serde_json::to_string_pretty(&v).unwrap_or_default();
+                        tool_ok(&text)
+                    }
+                    Err(e) => tool_err(&e),
+                },
+                "manage_app_data" => match apps::handle_data(api_port, &arguments).await {
+                    Ok(v) => {
+                        let text = serde_json::to_string_pretty(&v).unwrap_or_default();
+                        tool_ok(&text)
+                    }
+                    Err(e) => tool_err(&e),
+                },
                 unknown => tool_err(&format!("Unknown tool: {unknown}")),
             };
 

--- a/apps/desktop/src/commands/introspect_api.rs
+++ b/apps/desktop/src/commands/introspect_api.rs
@@ -1346,9 +1346,12 @@ async fn finish_app_deploy(
     if let Some(sha) = built_sha {
         finalize_body["gitCommitSha"] = serde_json::json!(sha);
     }
-    fc.post_json(&format!("/v1/apps/{enc_id}/deploy/finalize"), &finalize_body)
-        .await
-        .map_err(|e| format!("Cloud API deploy finalize failed: {e}"))
+    fc.post_json(
+        &format!("/v1/apps/{enc_id}/deploy/finalize"),
+        &finalize_body,
+    )
+    .await
+    .map_err(|e| format!("Cloud API deploy finalize failed: {e}"))
 }
 
 /// The whole deploy, the same three legs the desktop UI runs: mint the upload
@@ -1559,7 +1562,9 @@ async fn read_app_logs(
     let since_minutes = u64_body_field(v, "since_minutes", "sinceMinutes")
         .unwrap_or(30)
         .clamp(1, 7 * 24 * 60);
-    let limit = u64_body_field(v, "limit", "limit").unwrap_or(100).clamp(1, 200);
+    let limit = u64_body_field(v, "limit", "limit")
+        .unwrap_or(100)
+        .clamp(1, 200);
     let kind = str_body_field(v, "kind", "kind").unwrap_or_else(|| "app".to_string());
     if !matches!(kind.as_str(), "app" | "request" | "all") {
         return Err(format!(
@@ -1702,7 +1707,9 @@ async fn handle_app_data(app: &AppHandle, body: &[u8]) -> Result<String, String>
 
     match action.as_str() {
         "rows" => {
-            let limit = u64_body_field(&v, "limit", "limit").unwrap_or(50).clamp(1, 100);
+            let limit = u64_body_field(&v, "limit", "limit")
+                .unwrap_or(50)
+                .clamp(1, 100);
             let mut query = format!("?limit={limit}");
             if let Some(after) = str_body_field(&v, "after", "after") {
                 query.push_str(&format!("&after={}", urlencoding::encode(&after)));
@@ -2168,7 +2175,10 @@ mod tests {
             "publicUrl": "https://notes-0c0a97bf.apps.example.com",
             "fcEndpoint": "https://raw-suffix.fcapp.run",
         });
-        assert_eq!(app_brief(&with_vanity)["url"], "https://notes-0c0a97bf.apps.example.com");
+        assert_eq!(
+            app_brief(&with_vanity)["url"],
+            "https://notes-0c0a97bf.apps.example.com"
+        );
 
         let no_vanity = serde_json::json!({
             "id": "app-1", "publicUrl": serde_json::Value::Null,
@@ -2187,7 +2197,10 @@ mod tests {
         assert!(!safe.contains("Signature="), "{safe}");
         assert!(!safe.contains("OSSAccessKeyId="), "{safe}");
         // Still says where it failed, or the message is useless.
-        assert!(safe.contains("bucket.oss-cn-shenzhen.aliyuncs.com/apps/1/code.zip"), "{safe}");
+        assert!(
+            safe.contains("bucket.oss-cn-shenzhen.aliyuncs.com/apps/1/code.zip"),
+            "{safe}"
+        );
         assert!(safe.contains("403"), "{safe}");
     }
 

--- a/apps/desktop/src/commands/introspect_api.rs
+++ b/apps/desktop/src/commands/introspect_api.rs
@@ -10,6 +10,8 @@
 //   POST /mcp-put           — replace workspace MCP map (daemon)
 //   POST /session-archive   — archive a cloud session (PATCH archivedAt)
 //   POST /session-participants — list/add/remove a session's participants
+//   POST /app-manage        — list/status/deploy an app, or read its logs
+//   POST /app-data          — browse and edit a deployed app's own database
 //
 // Served by axum. STR-10: this used to be a raw `TcpStream` with hand-rolled
 // request parsing — a fixed 64 KiB header read, a `\r\n\r\n` scan, a
@@ -282,6 +284,8 @@ fn router(app: AppHandle, token: Arc<str>) -> Router {
             post_route!(handle_session_participants),
         )
         .route("/session-archive", post_route!(handle_session_archive))
+        .route("/app-manage", post_route!(handle_app_manage))
+        .route("/app-data", post_route!(handle_app_data))
         .fallback(not_found)
         .with_state(app)
         // `layer`, not `route_layer`: this has to wrap the fallback too, or an
@@ -1115,6 +1119,678 @@ async fn handle_session_participants(app: &AppHandle, body: &[u8]) -> Result<Str
     }
 }
 
+// ─── Apps: deploy, logs, and the app's own database ──────────────────────────
+//
+// `manage_app` and `manage_app_data` hand an agent the three things it needs to
+// own an app it is writing: publish it, read why it broke, and look at what it
+// stored. Every call goes out on the signed-in user's bearer through
+// [`introspect_fc_client`], so the Cloud API enforces app permissions exactly
+// as it does for the desktop UI (`admin` to deploy or write a row, `prompt` to
+// read one) — nothing here escalates past what the user may do themselves.
+
+/// The app-row fields worth an agent's context window.
+///
+/// `publicUrl` is the address the product hands out; `fcEndpoint` is the raw FC
+/// hostname and is only the app's address on a deployment with no apps domain.
+/// One `url` rather than both, so the agent cannot quote the wrong one.
+fn app_brief(row: &serde_json::Value) -> serde_json::Value {
+    let f = |k: &str| row.get(k).cloned().unwrap_or(serde_json::Value::Null);
+    let url = row
+        .get("publicUrl")
+        .filter(|v| v.is_string())
+        .or_else(|| row.get("fcEndpoint"))
+        .cloned()
+        .unwrap_or(serde_json::Value::Null);
+    serde_json::json!({
+        "id": f("id"),
+        "name": f("name"),
+        "type": f("type"),
+        "url": url,
+        "provision_status": f("provisionStatus"),
+        "fc_status": f("fcStatus"),
+        "auth_mode": f("authMode"),
+        "auth_mode_pending_redeploy": f("authModePendingRedeploy"),
+        "git_commit_sha": f("gitCommitSha"),
+    })
+}
+
+async fn list_team_apps(
+    fc: &super::oss_sync::fc_client::FcClient,
+    team_id: &str,
+) -> Result<Vec<serde_json::Value>, String> {
+    let listing = fc
+        .get_json(&format!(
+            "/v1/apps?teamId={}&limit=200",
+            urlencoding::encode(team_id)
+        ))
+        .await
+        .map_err(|e| format!("Cloud API app list failed: {e}"))?;
+    Ok(items_of(&listing))
+}
+
+/// Resolve the `app_id` / `app_name` argument to exactly one app row.
+///
+/// A name is accepted only when it names one app in the current team. Deploying
+/// publishes to the internet and `update_row` writes production data, so a
+/// fuzzy match is not worth the effect: zero or several matches come back as
+/// the candidate list with nothing done.
+async fn resolve_app_row(
+    app: &AppHandle,
+    fc: &super::oss_sync::fc_client::FcClient,
+    v: &serde_json::Value,
+) -> Result<serde_json::Value, String> {
+    if let Some(id) = str_body_field(v, "app_id", "appId") {
+        return fc
+            .get_json(&format!("/v1/apps/{}", urlencoding::encode(&id)))
+            .await
+            .map_err(|e| format!("Cloud API app read failed: {e}"));
+    }
+    let name = str_body_field(v, "app_name", "appName")
+        .ok_or("Missing field: app_id or app_name is required")?;
+    let team_id = introspect_current_team(app).await?;
+    let apps = list_team_apps(fc, &team_id).await?;
+    let wanted = name.to_lowercase();
+    let matches: Vec<&serde_json::Value> = apps
+        .iter()
+        .filter(|a| {
+            ["name", "slug"].iter().any(|k| {
+                a.get(*k)
+                    .and_then(|x| x.as_str())
+                    .map(|n| n.trim().to_lowercase() == wanted)
+                    .unwrap_or(false)
+            })
+        })
+        .collect();
+    match matches.len() {
+        1 => Ok(matches[0].clone()),
+        0 => Err(format!(
+            "No app named {:?} in this team. Apps: {}",
+            name,
+            serde_json::Value::Array(apps.iter().map(app_brief).collect())
+        )),
+        n => Err(format!(
+            "{:?} matches {} apps — pass app_id instead. Matches: {}",
+            name,
+            n,
+            serde_json::Value::Array(matches.iter().map(|a| app_brief(a)).collect())
+        )),
+    }
+}
+
+/// Strip presigned-URL query strings out of anything on its way into a stored
+/// field or a tool reply.
+///
+/// The upload handle minted by `/deploy` is a bearer credential for the app's
+/// OSS object, and the daemon's build errors quote the URL they failed on. That
+/// text ends up in `deployError`, which every reader of the app row can see.
+fn redact_deploy_secrets(reason: &str) -> String {
+    let mut out = String::with_capacity(reason.len());
+    for (i, chunk) in reason.split_whitespace().enumerate() {
+        if i > 0 {
+            out.push(' ');
+        }
+        let looks_presigned = chunk.contains("Signature=")
+            || chunk.contains("OSSAccessKeyId=")
+            || chunk.contains("x-oss-signature");
+        if looks_presigned {
+            // Keep the scheme+host so the message still says where it failed.
+            let head = chunk.split('?').next().unwrap_or("");
+            out.push_str(head);
+            out.push_str("?<redacted>");
+        } else {
+            out.push_str(chunk);
+        }
+    }
+    const MAX: usize = 800;
+    if out.chars().count() > MAX {
+        out = out.chars().take(MAX).collect::<String>() + "…";
+    }
+    out
+}
+
+/// Kick the local daemon's build-and-upload leg.
+///
+/// 20 minutes: the daemon allows a `pnpm install` plus a 10-minute `pnpm build`,
+/// and a client timeout shorter than the work it waits on turns a slow build
+/// into a phantom failure — one that has already uploaded the artifact.
+async fn daemon_build_app(body: &serde_json::Value) -> Result<serde_json::Value, String> {
+    use crate::daemon_client::{self as daemon, RequestSpec};
+    daemon::call_discovered::<_, serde_json::Value>(
+        RequestSpec::post("/v1/apps/build", &["workspace:write"])
+            .timeout(std::time::Duration::from_secs(20 * 60)),
+        Some(body),
+    )
+    .await
+    .map_err(|e| {
+        if e.is_unavailable() {
+            "The local amuxd is not connected, so nothing can build this app.".to_string()
+        } else {
+            redact_deploy_secrets(&format!("Daemon build failed: {e}"))
+        }
+    })
+}
+
+/// Everything after `/deploy` has minted the upload handle: credential the
+/// build, run it, hand the credential back, publish.
+#[allow(clippy::too_many_arguments)]
+async fn finish_app_deploy(
+    fc: &super::oss_sync::fc_client::FcClient,
+    enc_id: &str,
+    app_id: &str,
+    team_id: &str,
+    via_gitea: bool,
+    git_commit_sha: Option<String>,
+    deploy_token: &str,
+    presigned_put: &str,
+) -> Result<serde_json::Value, String> {
+    let mut git_remote_url = String::new();
+    let mut deploy_key_pem = String::new();
+    let mut deploy_key_id: Option<i64> = None;
+    if via_gitea {
+        let cred = fc
+            .get_json(&format!("/v1/apps/{enc_id}/git-credential"))
+            .await
+            .map_err(|e| format!("Cloud API deploy credential failed: {e}"))?;
+        git_remote_url = cred
+            .get("remoteUrl")
+            .and_then(|x| x.as_str())
+            .unwrap_or_default()
+            .to_string();
+        deploy_key_pem = cred
+            .get("privateKeyPem")
+            .and_then(|x| x.as_str())
+            .unwrap_or_default()
+            .to_string();
+        deploy_key_id = cred.get("deployKeyId").and_then(|x| x.as_i64());
+        if git_remote_url.is_empty() || deploy_key_pem.is_empty() {
+            return Err("Could not mint a Gitea deploy credential for this app.".to_string());
+        }
+    }
+
+    let mut build_body = serde_json::json!({
+        "appId": app_id,
+        "teamId": team_id,
+        "presignedPut": presigned_put,
+    });
+    if via_gitea {
+        build_body["gitRemoteUrl"] = serde_json::json!(git_remote_url);
+        build_body["deployKeyPem"] = serde_json::json!(deploy_key_pem);
+        if let Some(sha) = &git_commit_sha {
+            build_body["gitCommitSha"] = serde_json::json!(sha);
+        }
+    }
+
+    let build = daemon_build_app(&build_body).await;
+
+    // The daemon only needs the key for the fetch inside the build; hand it back
+    // whether that succeeded or not, exactly as the desktop's `finally` does.
+    if let Some(key_id) = deploy_key_id {
+        let _ = fc
+            .delete_json(&format!("/v1/apps/{enc_id}/git-credential/{key_id}"))
+            .await;
+    }
+    let build = build?;
+
+    // What the daemon built, not what we asked for: a deploy publishes work the
+    // agent left uncommitted, so HEAD can sit past the sha read off Gitea before
+    // any of this started.
+    let built_sha = build
+        .get("gitCommitSha")
+        .and_then(|x| x.as_str())
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(|s| s.to_string())
+        .or(git_commit_sha);
+
+    let mut finalize_body = serde_json::json!({ "deployToken": deploy_token });
+    if let Some(sha) = built_sha {
+        finalize_body["gitCommitSha"] = serde_json::json!(sha);
+    }
+    fc.post_json(&format!("/v1/apps/{enc_id}/deploy/finalize"), &finalize_body)
+        .await
+        .map_err(|e| format!("Cloud API deploy finalize failed: {e}"))
+}
+
+/// The whole deploy, the same three legs the desktop UI runs: mint the upload
+/// handle, have the local daemon build and upload the artifact, publish it.
+///
+/// It lives in this process because the middle leg needs the local daemon and
+/// the outer two need the user's cloud bearer, and this is the only process
+/// holding both. A failure after `/deploy` must report `deploy_error` back:
+/// nothing server-side can observe that the local build never finished, and a
+/// row left at `awaiting_build` blocks every later deploy for 30 minutes.
+async fn run_app_deploy(
+    fc: &super::oss_sync::fc_client::FcClient,
+    row: &serde_json::Value,
+) -> Result<serde_json::Value, String> {
+    let app_id = row
+        .get("id")
+        .and_then(|x| x.as_str())
+        .unwrap_or_default()
+        .to_string();
+    if app_id.is_empty() {
+        return Err("app row has no id".to_string());
+    }
+    let team_id = row
+        .get("teamId")
+        .and_then(|x| x.as_str())
+        .unwrap_or_default()
+        .to_string();
+    let provision = row
+        .get("provisionStatus")
+        .and_then(|x| x.as_str())
+        .unwrap_or_default();
+    if provision != "ready" {
+        return Err(format!(
+            "This app is not ready to deploy (provisionStatus={provision}). Its checkout has to be seeded first."
+        ));
+    }
+    let via_gitea = row.get("gitAuthKind").and_then(|x| x.as_str()) == Some("gitea_deploy_key");
+    let enc_id = urlencoding::encode(&app_id).into_owned();
+
+    // Only a Gitea-managed app deploys a commit off the forge. An app imported
+    // from someone else's repo has no repo of ours and no credential for the one
+    // it came from, so it deploys its checkout as it sits.
+    let mut git_commit_sha: Option<String> = None;
+    if via_gitea {
+        let head = fc
+            .get_json(&format!("/v1/apps/{enc_id}/git-head"))
+            .await
+            .map_err(|e| format!("Cloud API git-head read failed: {e}"))?;
+        let sha = head
+            .get("sha")
+            .and_then(|x| x.as_str())
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .ok_or("The app's Gitea repo has no HEAD — commit and push before deploying.")?;
+        git_commit_sha = Some(sha.to_string());
+    }
+
+    let mut start_body = serde_json::json!({});
+    if let Some(sha) = &git_commit_sha {
+        start_body["gitCommitSha"] = serde_json::json!(sha);
+    }
+    let started = fc
+        .post_json(&format!("/v1/apps/{enc_id}/deploy"), &start_body)
+        .await
+        .map_err(|e| format!("Cloud API deploy start failed: {e}"))?;
+    let deploy_token = started
+        .get("deployToken")
+        .and_then(|x| x.as_str())
+        .unwrap_or_default()
+        .to_string();
+    let presigned_put = started
+        .get("presignedPut")
+        .and_then(|x| x.as_str())
+        .unwrap_or_default()
+        .to_string();
+    if deploy_token.is_empty() || presigned_put.is_empty() {
+        return Err("deploy start returned no upload handle".to_string());
+    }
+
+    // From here the server has written `awaiting_build` and this call owns it.
+    match finish_app_deploy(
+        fc,
+        &enc_id,
+        &app_id,
+        &team_id,
+        via_gitea,
+        git_commit_sha,
+        &deploy_token,
+        &presigned_put,
+    )
+    .await
+    {
+        Ok(finished) => Ok(finished),
+        Err(reason) => {
+            let reason = redact_deploy_secrets(&reason);
+            let _ = fc
+                .patch_json(
+                    &format!("/v1/apps/{enc_id}"),
+                    &serde_json::json!({
+                        "fcStatus": "deploy_error",
+                        "deployError": reason,
+                    }),
+                )
+                .await;
+            Err(reason)
+        }
+    }
+}
+
+/// `manage_app` — list the team's apps, read one, deploy it, or read its logs.
+async fn handle_app_manage(app: &AppHandle, body: &[u8]) -> Result<String, String> {
+    let v: serde_json::Value =
+        serde_json::from_slice(body).map_err(|e| format!("JSON parse error: {}", e))?;
+    let action = str_body_field(&v, "action", "action").ok_or("Missing field: action")?;
+    let fc = introspect_fc_client(app, &v, "manage_app").await?;
+
+    match action.as_str() {
+        "list" => {
+            let team_id = introspect_current_team(app).await?;
+            let apps = list_team_apps(&fc, &team_id).await?;
+            Ok(serde_json::json!({
+                "action": "list",
+                "team_id": team_id,
+                "apps": apps.iter().map(app_brief).collect::<Vec<_>>(),
+            })
+            .to_string())
+        }
+        "status" => {
+            let row = resolve_app_row(app, &fc, &v).await?;
+            let mut out = app_brief(&row);
+            if let Some(workdir) = app_workdir_on_this_machine(&row).await {
+                out["workdir"] = serde_json::json!(workdir);
+            }
+            Ok(serde_json::json!({ "action": "status", "app": out }).to_string())
+        }
+        "deploy" => {
+            let row = resolve_app_row(app, &fc, &v).await?;
+            let finished = run_app_deploy(&fc, &row).await?;
+            Ok(serde_json::json!({
+                "ok": true,
+                "action": "deploy",
+                "app": app_brief(&finished),
+            })
+            .to_string())
+        }
+        "logs" => {
+            let row = resolve_app_row(app, &fc, &v).await?;
+            let out = read_app_logs(&fc, &row, &v).await?;
+            Ok(out.to_string())
+        }
+        other => Err(format!(
+            "Unknown action: {other} (expected list, status, deploy or logs)"
+        )),
+    }
+}
+
+/// Where this machine keeps the app's checkout, or `None` when it holds none.
+/// Best-effort: a daemon that is down means "not here", which is what an agent
+/// needs to know either way.
+async fn app_workdir_on_this_machine(row: &serde_json::Value) -> Option<String> {
+    use crate::daemon_client::{self as daemon, RequestSpec, NO_BODY};
+    let app_id = row.get("id").and_then(|x| x.as_str())?;
+    let team_id = row.get("teamId").and_then(|x| x.as_str()).unwrap_or("");
+    let path = format!("/v1/apps/{}/workdir", urlencoding::encode(app_id));
+    let query = format!("?teamId={}", urlencoding::encode(team_id));
+    let out: serde_json::Value = daemon::call_discovered(
+        RequestSpec::get(&path, &["workspace:read"])
+            .query(&query)
+            .timeout(std::time::Duration::from_secs(10)),
+        NO_BODY,
+    )
+    .await
+    .ok()?;
+    out.get("workdir")
+        .and_then(|x| x.as_str())
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(|s| s.to_string())
+}
+
+fn u64_body_field(v: &serde_json::Value, snake: &str, camel: &str) -> Option<u64> {
+    v.get(snake)
+        .or_else(|| v.get(camel))
+        .and_then(|x| x.as_u64().or_else(|| x.as_str()?.trim().parse().ok()))
+}
+
+/// `manage_app` action `logs` — the deployed function's own output.
+///
+/// The window and the row cap are bounded here as well as server-side: an app
+/// under load writes more in ten minutes than a turn can hold, and a tool result
+/// large enough to blow the context is worse than no logs at all.
+async fn read_app_logs(
+    fc: &super::oss_sync::fc_client::FcClient,
+    row: &serde_json::Value,
+    v: &serde_json::Value,
+) -> Result<serde_json::Value, String> {
+    let app_id = row
+        .get("id")
+        .and_then(|x| x.as_str())
+        .ok_or("app row has no id")?;
+    let fc_status = row.get("fcStatus").and_then(|x| x.as_str()).unwrap_or("");
+    if fc_status.is_empty() || fc_status == "not_deployed" {
+        return Err(
+            "This app has never been deployed, so it has no logs yet. Deploy it first.".to_string(),
+        );
+    }
+
+    let since_minutes = u64_body_field(v, "since_minutes", "sinceMinutes")
+        .unwrap_or(30)
+        .clamp(1, 7 * 24 * 60);
+    let limit = u64_body_field(v, "limit", "limit").unwrap_or(100).clamp(1, 200);
+    let kind = str_body_field(v, "kind", "kind").unwrap_or_else(|| "app".to_string());
+    if !matches!(kind.as_str(), "app" | "request" | "all") {
+        return Err(format!(
+            "Unknown kind: {kind} (expected app, request or all)"
+        ));
+    }
+
+    let mut query = format!("?sinceMinutes={since_minutes}&limit={limit}&kind={kind}");
+    if let Some(contains) = str_body_field(v, "contains", "contains") {
+        query.push_str(&format!("&contains={}", urlencoding::encode(&contains)));
+    }
+    if let Some(request_id) = str_body_field(v, "request_id", "requestId") {
+        query.push_str(&format!("&requestId={}", urlencoding::encode(&request_id)));
+    }
+
+    let out = fc
+        .get_json(&format!(
+            "/v1/apps/{}/logs{query}",
+            urlencoding::encode(app_id)
+        ))
+        .await
+        .map_err(|e| format!("Cloud API app logs failed: {e}"))?;
+
+    Ok(serde_json::json!({
+        "action": "logs",
+        "app_id": app_id,
+        "since_minutes": since_minutes,
+        "kind": kind,
+        "entries": out.get("items").cloned().unwrap_or(serde_json::json!([])),
+        "truncated": out.get("truncated").cloned().unwrap_or(serde_json::json!(false)),
+    }))
+}
+
+/// Opaque row key: unpadded base64url of the JSON array of primary-key values,
+/// in the order the table's catalog reports them.
+///
+/// Mirrors `appDataRowKey` in the frontend and `decodeRowKey` on the server. The
+/// agent passes a column → value map and this orders it, because a composite key
+/// silently ordered wrong addresses a different row, not an error.
+fn encode_app_data_row_key(
+    primary_key: &[String],
+    key: &serde_json::Value,
+) -> Result<String, String> {
+    use base64::Engine as _;
+    let values: Vec<serde_json::Value> = match key {
+        serde_json::Value::Array(a) => {
+            if a.len() != primary_key.len() {
+                return Err(format!(
+                    "key must have {} value(s), in this order: {}",
+                    primary_key.len(),
+                    primary_key.join(", ")
+                ));
+            }
+            a.clone()
+        }
+        serde_json::Value::Object(map) => {
+            let mut out = Vec::with_capacity(primary_key.len());
+            for column in primary_key {
+                let value = map.get(column).ok_or_else(|| {
+                    format!(
+                        "key is missing primary-key column {column:?} (needs: {})",
+                        primary_key.join(", ")
+                    )
+                })?;
+                out.push(value.clone());
+            }
+            out
+        }
+        _ => return Err("key must be an object of primary-key columns, or an array".to_string()),
+    };
+    let json = serde_json::to_string(&values).map_err(|e| format!("cannot encode key: {e}"))?;
+    Ok(base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(json))
+}
+
+/// The table's primary key, read from the app's own catalog rather than guessed.
+async fn app_data_primary_key(
+    fc: &super::oss_sync::fc_client::FcClient,
+    enc_id: &str,
+    table: &str,
+) -> Result<Vec<String>, String> {
+    let tables = fc
+        .get_json(&format!("/v1/apps/{enc_id}/data/tables"))
+        .await
+        .map_err(|e| format!("Cloud API app tables failed: {e}"))?;
+    let entry = items_of(&tables)
+        .into_iter()
+        .find(|t| t.get("name").and_then(|x| x.as_str()) == Some(table))
+        .ok_or_else(|| format!("No table named {table:?} in this app's database."))?;
+    let pk: Vec<String> = entry
+        .get("primaryKey")
+        .and_then(|x| x.as_array())
+        .map(|a| {
+            a.iter()
+                .filter_map(|x| x.as_str().map(str::to_string))
+                .collect()
+        })
+        .unwrap_or_default();
+    if pk.is_empty() {
+        return Err(format!(
+            "Table {table:?} has no primary key, so a single row cannot be addressed."
+        ));
+    }
+    Ok(pk)
+}
+
+/// `manage_app_data` — read and edit the rows in a deployed app's own database.
+///
+/// Reads need `prompt` on the app and writes need `admin`; both are the Cloud
+/// API's call, not this handler's. Writes address exactly one row by primary
+/// key — there is no bulk path on purpose, this is production data.
+async fn handle_app_data(app: &AppHandle, body: &[u8]) -> Result<String, String> {
+    let v: serde_json::Value =
+        serde_json::from_slice(body).map_err(|e| format!("JSON parse error: {}", e))?;
+    let action = str_body_field(&v, "action", "action").ok_or("Missing field: action")?;
+    let fc = introspect_fc_client(app, &v, "manage_app_data").await?;
+    let row = resolve_app_row(app, &fc, &v).await?;
+    let app_id = row
+        .get("id")
+        .and_then(|x| x.as_str())
+        .ok_or("app row has no id")?
+        .to_string();
+    let enc_id = urlencoding::encode(&app_id).into_owned();
+
+    if action == "tables" {
+        let out = fc
+            .get_json(&format!("/v1/apps/{enc_id}/data/tables"))
+            .await
+            .map_err(|e| format!("Cloud API app tables failed: {e}"))?;
+        return Ok(serde_json::json!({
+            "action": "tables",
+            "app_id": app_id,
+            "tables": out.get("items").cloned().unwrap_or(serde_json::json!([])),
+        })
+        .to_string());
+    }
+
+    let table = str_body_field(&v, "table", "table").ok_or("Missing field: table")?;
+    let enc_table = urlencoding::encode(&table).into_owned();
+    let rows_path = format!("/v1/apps/{enc_id}/data/tables/{enc_table}/rows");
+
+    match action.as_str() {
+        "rows" => {
+            let limit = u64_body_field(&v, "limit", "limit").unwrap_or(50).clamp(1, 100);
+            let mut query = format!("?limit={limit}");
+            if let Some(after) = str_body_field(&v, "after", "after") {
+                query.push_str(&format!("&after={}", urlencoding::encode(&after)));
+            }
+            if let Some(direction) = str_body_field(&v, "direction", "direction") {
+                query.push_str(&format!("&direction={}", urlencoding::encode(&direction)));
+            }
+            // All three filter parts or none: the API ignores a value with no
+            // column, which reads to an agent as "the filter did nothing".
+            let column = str_body_field(&v, "filter_column", "filterColumn");
+            let op = str_body_field(&v, "filter_op", "filterOp");
+            if let (Some(column), Some(op)) = (column.as_ref(), op.as_ref()) {
+                query.push_str(&format!(
+                    "&filterColumn={}&filterOp={}",
+                    urlencoding::encode(column),
+                    urlencoding::encode(op)
+                ));
+                if let Some(value) = str_body_field(&v, "filter_value", "filterValue") {
+                    query.push_str(&format!("&filterValue={}", urlencoding::encode(&value)));
+                }
+            } else if column.is_some() != op.is_some() {
+                return Err(
+                    "filter_column and filter_op must be given together (ops: eq, contains, isNull, notNull)"
+                        .to_string(),
+                );
+            }
+            let out = fc
+                .get_json(&format!("{rows_path}{query}"))
+                .await
+                .map_err(|e| format!("Cloud API app rows failed: {e}"))?;
+            Ok(serde_json::json!({
+                "action": "rows",
+                "app_id": app_id,
+                "table": table,
+                "primary_key": out.get("primaryKey").cloned().unwrap_or(serde_json::json!([])),
+                "editable": out.get("editable").cloned().unwrap_or(serde_json::json!(false)),
+                "rows": out.get("rows").cloned().unwrap_or(serde_json::json!([])),
+                "next_cursor": out.get("nextCursor").cloned().unwrap_or(serde_json::Value::Null),
+            })
+            .to_string())
+        }
+        "update_row" | "delete_row" => {
+            let row_key = match str_body_field(&v, "row_key", "rowKey") {
+                Some(opaque) => opaque,
+                None => {
+                    let key = v
+                        .get("key")
+                        .ok_or("Missing field: key (the row's primary-key columns)")?;
+                    let pk = app_data_primary_key(&fc, &enc_id, &table).await?;
+                    encode_app_data_row_key(&pk, key)?
+                }
+            };
+            let path = format!("{rows_path}/{}", urlencoding::encode(&row_key));
+            if action == "delete_row" {
+                fc.delete_json(&path)
+                    .await
+                    .map_err(|e| format!("Cloud API row delete failed: {e}"))?;
+                return Ok(serde_json::json!({
+                    "ok": true, "action": "delete_row",
+                    "app_id": app_id, "table": table,
+                })
+                .to_string());
+            }
+            let patch = v
+                .get("patch")
+                .filter(|p| p.is_object())
+                .ok_or("Missing field: patch (an object of column → new value)")?;
+            let out = fc
+                .patch_json(&path, &serde_json::json!({ "patch": patch }))
+                .await
+                .map_err(|e| format!("Cloud API row update failed: {e}"))?;
+            Ok(serde_json::json!({
+                "ok": true,
+                "action": "update_row",
+                "app_id": app_id,
+                "table": table,
+                // The row as the database stored it: triggers and defaults may
+                // have rewritten what was submitted.
+                "row": out.get("row").cloned().unwrap_or(serde_json::Value::Null),
+            })
+            .to_string())
+        }
+        other => Err(format!(
+            "Unknown action: {other} (expected tables, rows, update_row or delete_row)"
+        )),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1478,5 +2154,85 @@ mod tests {
             let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
             assert_eq!(mode, 0o600);
         }
+    }
+
+    // --- Apps ---------------------------------------------------------------
+
+    #[test]
+    fn app_brief_prefers_the_public_url_over_the_raw_function_host() {
+        // `fcEndpoint` carries a random suffix and is not the address the
+        // product hands out. Reporting both would have the agent quote the one
+        // that stops working the moment a vanity domain exists.
+        let with_vanity = serde_json::json!({
+            "id": "app-1", "name": "Notes",
+            "publicUrl": "https://notes-0c0a97bf.apps.example.com",
+            "fcEndpoint": "https://raw-suffix.fcapp.run",
+        });
+        assert_eq!(app_brief(&with_vanity)["url"], "https://notes-0c0a97bf.apps.example.com");
+
+        let no_vanity = serde_json::json!({
+            "id": "app-1", "publicUrl": serde_json::Value::Null,
+            "fcEndpoint": "https://raw-suffix.fcapp.run",
+        });
+        assert_eq!(no_vanity["fcEndpoint"], app_brief(&no_vanity)["url"]);
+    }
+
+    #[test]
+    fn deploy_errors_do_not_carry_the_upload_credential() {
+        // The presigned PUT is a bearer for the app's OSS object, the daemon
+        // quotes the URL it failed on, and `deployError` is readable by anyone
+        // who can see the app row.
+        let leaked = "Daemon build failed: PUT https://bucket.oss-cn-shenzhen.aliyuncs.com/apps/1/code.zip?OSSAccessKeyId=LTAI5t&Signature=abc%3D&Expires=1788 returned 403";
+        let safe = redact_deploy_secrets(leaked);
+        assert!(!safe.contains("Signature="), "{safe}");
+        assert!(!safe.contains("OSSAccessKeyId="), "{safe}");
+        // Still says where it failed, or the message is useless.
+        assert!(safe.contains("bucket.oss-cn-shenzhen.aliyuncs.com/apps/1/code.zip"), "{safe}");
+        assert!(safe.contains("403"), "{safe}");
+    }
+
+    #[test]
+    fn redaction_leaves_an_ordinary_message_alone_and_bounds_it() {
+        let plain = "pnpm build timed out after 10 minutes";
+        assert_eq!(redact_deploy_secrets(plain), plain);
+        let huge = "x".repeat(5000);
+        assert!(redact_deploy_secrets(&huge).chars().count() <= 801);
+    }
+
+    #[test]
+    fn row_key_orders_values_by_the_table_s_own_primary_key() {
+        use base64::Engine as _;
+        let pk = vec!["tenant".to_string(), "id".to_string()];
+        // Deliberately supplied in the other order: a composite key silently
+        // ordered wrong addresses a DIFFERENT row, which is not an error the
+        // caller would ever see.
+        let key = serde_json::json!({ "id": 42, "tenant": "acme" });
+        let encoded = encode_app_data_row_key(&pk, &key).unwrap();
+        let decoded = base64::engine::general_purpose::URL_SAFE_NO_PAD
+            .decode(&encoded)
+            .unwrap();
+        assert_eq!(String::from_utf8(decoded).unwrap(), r#"["acme",42]"#);
+    }
+
+    #[test]
+    fn row_key_refuses_a_half_specified_composite_key() {
+        let pk = vec!["tenant".to_string(), "id".to_string()];
+        let err = encode_app_data_row_key(&pk, &serde_json::json!({ "id": 42 })).unwrap_err();
+        assert!(err.contains("tenant"), "{err}");
+
+        let err = encode_app_data_row_key(&pk, &serde_json::json!([42])).unwrap_err();
+        assert!(err.contains("2 value(s)"), "{err}");
+    }
+
+    #[test]
+    fn row_key_matches_what_the_frontend_and_the_server_agree_on() {
+        // `appDataRowKey` in the web app and `decodeRowKey` in the Cloud API
+        // both use unpadded base64url of the JSON array. Padding here would be
+        // a 400 from the server, only for keys whose length lands wrong.
+        let pk = vec!["id".to_string()];
+        assert_eq!(
+            encode_app_data_row_key(&pk, &serde_json::json!({ "id": 1 })).unwrap(),
+            "WzFd",
+        );
     }
 }

--- a/deploy/self-host/.env.example
+++ b/deploy/self-host/.env.example
@@ -250,6 +250,18 @@ APPS_ACCESS_KEY_SECRET=
 APPS_OSS_BUCKET=
 APPS_REGION=
 APPS_OSS_ENDPOINT=
+# Where deployed apps send their logs (Alibaba SLS, same account as the keys
+# above). A function with no log config keeps NO logs anywhere, so leaving both
+# blank is fine only if nobody ever needs to know why an app 500s.
+#
+# Blank = derived: project `teamclu-apps-<accountId>`, logstore `app-logs`,
+# both created on the next deploy if the key may create them (an SLS project
+# name is globally unique, which is why the account id is in it). Set
+# APPS_SLS_PROJECT to reuse a project that already exists — such as the
+# `serverless-<region>-<uuid>` one the Function Compute console generates the
+# first time somebody switches logs on by hand.
+APPS_SLS_PROJECT=
+APPS_SLS_LOGSTORE=
 # Parent domain for per-app vanity hostnames: an app is reachable at
 # <slug>-<id8>.<this>, proxied by Caddy to its Function Compute trigger (whose
 # own hostname carries a random suffix and is not guessable).

--- a/deploy/self-host/docker-compose.yml
+++ b/deploy/self-host/docker-compose.yml
@@ -375,6 +375,15 @@ services:
       # Defaults to https://oss-<APPS_REGION>.aliyuncs.com; override only for a
       # VPC/internal OSS endpoint.
       APPS_OSS_ENDPOINT: "${APPS_OSS_ENDPOINT:-}"
+      # Where deployed apps send their logs (Alibaba SLS, same account as the
+      # profile above). Both optional: the project defaults to
+      # `teamclu-apps-<accountId>` and the logstore to `app-logs`, and the
+      # deploy creates them if the key is allowed to. Set the project to point
+      # at one that already exists instead — e.g. the `serverless-<region>-…`
+      # project the FC console generates. Deploys still work with no logs if
+      # neither can be created; the app just has nothing to read afterwards.
+      APPS_SLS_PROJECT: "${APPS_SLS_PROJECT:-}"
+      APPS_SLS_LOGSTORE: "${APPS_SLS_LOGSTORE:-}"
       # Parent domain for per-app vanity hostnames
       # (<slug>-<id8>.<this>). Blank = feature off: apps keep their raw
       # Function Compute trigger URL and Caddy never asks about a certificate.

--- a/docs/openapi/teamclu-api.v1.yaml
+++ b/docs/openapi/teamclu-api.v1.yaml
@@ -5912,6 +5912,74 @@ paths:
           $ref: "#/components/responses/Error"
         "503":
           $ref: "#/components/responses/Error"
+  /v1/apps/{appId}/logs:
+    get:
+      operationId: readAppLogs
+      summary: Read the deployed app's own logs
+      description: |
+        What the running function printed, and one entry per HTTP request with
+        its status code and duration. Requires `prompt` or `admin` on the app;
+        `view` and non-members receive 404, exactly as the data browser does —
+        a log line carries whatever the app decided to print, which is its
+        users' data.
+
+        Function Compute keeps no logs at all for a function deployed before
+        log delivery was configured; those apps answer with an empty `items`
+        until their next deploy, which is what points them at the logstore.
+
+        `contains` and `requestId` filter the entries read from the window, not
+        all of history: an app's own output carries no request id (the id
+        appears only in Function Compute's framing lines, which this endpoint
+        reads to attach it), and a substring search is done here rather than as
+        a log-service query, whose tokenizer silently drops terms containing
+        punctuation. A window whose scan budget was reached comes back with
+        `truncated: true`.
+      tags: [Apps]
+      parameters:
+        - $ref: "#/components/parameters/AppId"
+        - name: sinceMinutes
+          in: query
+          required: false
+          description: How far back to read. Clamped to the 14-day retention period.
+          schema: { type: integer, minimum: 1, maximum: 10080, default: 30 }
+        - name: limit
+          in: query
+          required: false
+          schema: { type: integer, minimum: 1, maximum: 200, default: 100 }
+        - name: kind
+          in: query
+          required: false
+          description: >-
+            `app` is what the application printed; `request` is Function
+            Compute's per-request row (status, duration, cold start); `all` is
+            both, interleaved.
+          schema: { type: string, enum: [app, request, all], default: app }
+        - name: contains
+          in: query
+          required: false
+          description: Case-insensitive substring the entry's message must contain.
+          schema: { type: string }
+        - name: requestId
+          in: query
+          required: false
+          description: Only entries belonging to this request — the way to read one failing request end to end.
+          schema: { type: string }
+      responses:
+        "200":
+          description: Log entries, newest first.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/AppLogsPage" }
+        "401":
+          $ref: "#/components/responses/Error"
+        "404":
+          $ref: "#/components/responses/Error"
+        "409":
+          $ref: "#/components/responses/Error"
+        "502":
+          $ref: "#/components/responses/Error"
+        "503":
+          $ref: "#/components/responses/Error"
   /v1/apps/{appId}/membership:
     get:
       operationId: getAppMembership
@@ -6901,6 +6969,52 @@ components:
           type: string
           format: date-time
           description: Informational TTL (~15m); the key remains until deleted on Gitea.
+    AppLogEntry:
+      type: object
+      required: [ts, kind, level, message]
+      properties:
+        ts: { type: string, format: date-time }
+        kind:
+          type: string
+          enum: [app, request]
+          description: "`app`: printed by the application. `request`: Function Compute's own per-request row."
+        level:
+          type: string
+          enum: [info, warn, error]
+          description: >-
+            For an `app` entry this is inferred from the text — Function Compute
+            adds no level of its own. For a `request` entry it follows the
+            status code.
+        message: { type: string }
+        requestId:
+          type: [string, "null"]
+          description: >-
+            Present on every `request` entry, and on an `app` entry whose
+            invocation could be identified from the surrounding framing lines.
+        instanceId: { type: [string, "null"] }
+        statusCode: { type: [integer, "null"] }
+        durationMs: { type: [number, "null"] }
+        method: { type: [string, "null"] }
+        path: { type: [string, "null"] }
+        coldStart: { type: [boolean, "null"] }
+    AppLogsPage:
+      type: object
+      required: [items, truncated]
+      properties:
+        items:
+          type: array
+          items:
+            $ref: "#/components/schemas/AppLogEntry"
+        truncated:
+          type: boolean
+          description: More entries matched than `limit`, or the scan budget ended the window early.
+        from:
+          type: [string, "null"]
+          format: date-time
+          description: Start of the window actually read. Null when the app has no logstore yet.
+        to:
+          type: [string, "null"]
+          format: date-time
     AppGitHead:
       type: object
       required: [sha]

--- a/packages/app/src/components/apps/AppControlPanel.tsx
+++ b/packages/app/src/components/apps/AppControlPanel.tsx
@@ -38,6 +38,7 @@ import { useAppsStore } from '@/stores/apps-store'
 import { AppDataSection } from './AppDataSection'
 import { AppAuthSection } from './AppAuthSection'
 import { AppCustomDomainSection } from './AppCustomDomainSection'
+import { AppLogsSection } from './AppLogsSection'
 import type { AppMemberAccessRow, AppPermissionLevel, AppRow } from '@/lib/backend/types'
 
 const PERMISSION_LEVELS: AppPermissionLevel[] = ['view', 'prompt', 'admin']
@@ -653,6 +654,9 @@ export function AppControlPanel({ app }: AppControlPanelProps) {
                 access list is readable only by the creator or an app admin, which
                 is exactly the tier design §6 lets edit data. */}
             <AppDataSection app={app} canEdit={canManageAccess} />
+          </Field>
+          <Field label={t('apps.logs.section', '运行日志')}>
+            <AppLogsSection app={app} />
           </Field>
           <Field label={t('apps.controlPanel.customDomain', '自定义域名')}>
             <AppCustomDomainSection app={app} />

--- a/packages/app/src/components/apps/AppLogsSection.tsx
+++ b/packages/app/src/components/apps/AppLogsSection.tsx
@@ -1,0 +1,50 @@
+import { useTranslation } from 'react-i18next'
+import { ScrollText } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { openAppLogs } from '@/lib/tabs/app-tabs'
+import type { AppRow } from '@/lib/backend/types'
+
+interface AppLogsSectionProps {
+  app: AppRow
+}
+
+/**
+ * Entry point to the logs tab, in the control panel.
+ *
+ * Costs no request: whether logs can exist at all is already on the app row
+ * (`fcStatus`), and everything else — how far back, which stream, what to
+ * search for — belongs to the tab, which has room for it. A section that
+ * previewed the last few lines here would fetch on every app selection to show
+ * text nobody can read in a 280px column.
+ */
+export function AppLogsSection({ app }: AppLogsSectionProps) {
+  const { t } = useTranslation()
+  const deployed = Boolean(app.fcStatus) && app.fcStatus !== 'not_deployed'
+
+  if (!deployed) {
+    return (
+      <p className="text-[12.5px] text-muted-foreground" data-testid="app-logs-state-not-deployed">
+        {t('apps.logs.notDeployed', '这个应用还没有部署过，部署之后才会有日志。')}
+      </p>
+    )
+  }
+
+  return (
+    <div className="flex items-center justify-between gap-2">
+      <span className="min-w-0 truncate text-[12.5px] text-muted-foreground">
+        {t('apps.logs.hint', '应用打印的内容与每次请求')}
+      </span>
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        className="h-7 shrink-0 gap-1.5 rounded-[7px] px-2.5 text-[11.5px]"
+        data-testid="app-logs-open"
+        onClick={() => openAppLogs(app, t('apps.logs.tabLabel', '日志'))}
+      >
+        <ScrollText className="h-3 w-3" />
+        {t('apps.logs.open', '查看日志')}
+      </Button>
+    </div>
+  )
+}

--- a/packages/app/src/components/apps/AppLogsTabContent.tsx
+++ b/packages/app/src/components/apps/AppLogsTabContent.tsx
@@ -1,0 +1,324 @@
+import * as React from 'react'
+import { useTranslation } from 'react-i18next'
+import { Loader2, RotateCcw, ScrollText, X } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { cn } from '@/lib/utils'
+import { getBackend } from '@/lib/backend'
+import { useAppsStore } from '@/stores/apps-store'
+import type { AppLogEntry, AppLogsResult } from '@/lib/backend/types'
+
+interface AppLogsTabContentProps {
+  appId: string
+}
+
+type Kind = 'app' | 'request' | 'all'
+
+/** Windows worth offering. Anything longer is a search, not a look. */
+const WINDOWS = [15, 60, 6 * 60, 24 * 60, 7 * 24 * 60] as const
+
+function windowLabel(minutes: number): string {
+  if (minutes < 60) return `${minutes}m`
+  if (minutes < 24 * 60) return `${minutes / 60}h`
+  return `${minutes / (24 * 60)}d`
+}
+
+/** Wall-clock only: every entry in view is from the same window, so the date
+ *  would be the same string repeated down the whole column. */
+function clock(ts: string): string {
+  const d = new Date(ts)
+  if (Number.isNaN(d.getTime())) return '--:--:--'
+  return d.toLocaleTimeString(undefined, { hour12: false })
+}
+
+const LEVEL_CLASS: Record<AppLogEntry['level'], string> = {
+  error: 'text-destructive',
+  warn: 'text-amber-600 dark:text-amber-400',
+  info: 'text-ink-2',
+}
+
+/**
+ * The deployed app's own logs, in a main-column tab.
+ *
+ * Read-only and deliberately plain: the value is in the text and in being able
+ * to pull one request out of it, not in a chart. The request-id chip is the
+ * point — an app's own output has no request id of its own, so the server
+ * reconstructs it from Function Compute's framing, and this is what makes that
+ * reachable: click it and the view narrows to that one request.
+ */
+export function AppLogsTabContent({ appId }: AppLogsTabContentProps) {
+  const { t } = useTranslation()
+  const app = useAppsStore((s) => s.items.find((a) => a.id === appId) ?? null)
+
+  const [kind, setKind] = React.useState<Kind>('app')
+  const [sinceMinutes, setSinceMinutes] = React.useState<number>(60)
+  const [search, setSearch] = React.useState('')
+  const [contains, setContains] = React.useState('')
+  const [requestId, setRequestId] = React.useState<string | null>(null)
+  const [result, setResult] = React.useState<AppLogsResult | null | 'loading'>('loading')
+  const [error, setError] = React.useState<string | null>(null)
+
+  const load = React.useCallback(async () => {
+    setResult('loading')
+    setError(null)
+    try {
+      setResult(
+        await getBackend().apps.readAppLogs(appId, {
+          kind,
+          sinceMinutes,
+          limit: 200,
+          contains: contains || null,
+          requestId,
+        }),
+      )
+    } catch (e) {
+      setResult(null)
+      setError(e instanceof Error ? e.message : String(e))
+    }
+  }, [appId, kind, sinceMinutes, contains, requestId])
+
+  React.useEffect(() => {
+    void load()
+  }, [load])
+
+  const entries = result && result !== 'loading' && result.status === 'ok' ? result.entries : []
+
+  return (
+    <div className="flex h-full min-h-0 flex-col bg-background">
+      <header className="shrink-0 border-b border-border-soft px-4 py-3">
+        <h2 className="flex items-center gap-2 text-[13px] font-semibold text-foreground">
+          <ScrollText className="h-4 w-4" />
+          {t('apps.logs.title', '运行日志')}
+        </h2>
+        <p className="mt-0.5 text-[12px] text-muted-foreground">
+          {t('apps.logs.subtitle', '{{name}} 线上运行时打印的内容。', {
+            name: app?.name ?? appId,
+          })}
+        </p>
+      </header>
+
+      <div className="flex shrink-0 flex-wrap items-center gap-2 border-b border-border-soft px-3 py-2">
+        <div className="flex items-center gap-0.5 rounded-[7px] bg-paper p-0.5">
+          {(['app', 'request', 'all'] as const).map((k) => (
+            <button
+              key={k}
+              type="button"
+              onClick={() => setKind(k)}
+              data-testid={`app-logs-kind-${k}`}
+              className={cn(
+                'rounded-[5px] px-2 py-0.5 text-[11.5px]',
+                kind === k
+                  ? 'bg-background font-medium text-foreground shadow-sm'
+                  : 'text-muted-foreground hover:text-foreground',
+              )}
+            >
+              {k === 'app'
+                ? t('apps.logs.kindApp', '应用输出')
+                : k === 'request'
+                  ? t('apps.logs.kindRequest', '请求')
+                  : t('apps.logs.kindAll', '全部')}
+            </button>
+          ))}
+        </div>
+
+        <div className="flex items-center gap-0.5 rounded-[7px] bg-paper p-0.5">
+          {WINDOWS.map((m) => (
+            <button
+              key={m}
+              type="button"
+              onClick={() => setSinceMinutes(m)}
+              data-testid={`app-logs-window-${m}`}
+              className={cn(
+                'rounded-[5px] px-2 py-0.5 font-mono text-[11.5px]',
+                sinceMinutes === m
+                  ? 'bg-background font-medium text-foreground shadow-sm'
+                  : 'text-muted-foreground hover:text-foreground',
+              )}
+            >
+              {windowLabel(m)}
+            </button>
+          ))}
+        </div>
+
+        <form
+          className="flex min-w-0 flex-1 items-center gap-1.5"
+          onSubmit={(e) => {
+            e.preventDefault()
+            setContains(search.trim())
+          }}
+        >
+          <Input
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder={t('apps.logs.searchPlaceholder', '搜索日志内容，回车确认')}
+            className="h-7 min-w-[140px] flex-1 rounded-[7px] text-[12px]"
+            data-testid="app-logs-search"
+          />
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="h-7 shrink-0 gap-1 rounded-[7px] text-[12px]"
+            disabled={result === 'loading'}
+            onClick={() => void load()}
+            data-testid="app-logs-refresh"
+          >
+            <RotateCcw className="h-3 w-3" />
+            {t('common.refresh', '刷新')}
+          </Button>
+        </form>
+      </div>
+
+      {requestId && (
+        <div className="flex shrink-0 items-center gap-2 border-b border-border-soft bg-paper px-3 py-1.5">
+          <span className="text-[11.5px] text-muted-foreground">
+            {t('apps.logs.filteredByRequest', '只看这一次请求')}
+          </span>
+          <code className="truncate font-mono text-[11px] text-ink-2">{requestId}</code>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="h-6 gap-1 rounded-[6px] px-1.5 text-[11px]"
+            onClick={() => setRequestId(null)}
+            data-testid="app-logs-clear-request"
+          >
+            <X className="h-3 w-3" />
+            {t('apps.logs.clearRequest', '清除')}
+          </Button>
+        </div>
+      )}
+
+      <div className="min-h-0 flex-1 overflow-auto">
+        <LogsBody
+          result={result}
+          error={error}
+          entries={entries}
+          onPickRequest={setRequestId}
+        />
+      </div>
+    </div>
+  )
+}
+
+function LogsBody({
+  result,
+  error,
+  entries,
+  onPickRequest,
+}: {
+  result: AppLogsResult | null | 'loading'
+  error: string | null
+  entries: AppLogEntry[]
+  onPickRequest: (requestId: string) => void
+}) {
+  const { t } = useTranslation()
+
+  if (result === 'loading') {
+    return (
+      <div className="flex items-center gap-2 p-4 text-[12.5px] text-muted-foreground">
+        <Loader2 className="h-3.5 w-3.5 animate-spin" />
+        {t('common.loading', 'Loading…')}
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <p className="p-4 text-[12.5px] text-destructive" data-testid="app-logs-error">
+        {error}
+      </p>
+    )
+  }
+
+  // Null is a 404: the app is gone, or this member may not read its logs. Both
+  // are "there is nothing here for you", and neither should read as a bug.
+  if (result === null) {
+    return (
+      <p className="p-4 text-[12.5px] text-muted-foreground" data-testid="app-logs-state-none">
+        {t('apps.logs.notFound', '看不到这个应用的日志。')}
+      </p>
+    )
+  }
+
+  if (result.status === 'not_deployed') {
+    return (
+      <p className="p-4 text-[12.5px] text-muted-foreground" data-testid="app-logs-state-not-deployed">
+        {t('apps.logs.notDeployed', '这个应用还没有部署过，部署之后才会有日志。')}
+      </p>
+    )
+  }
+
+  if (result.status === 'unavailable') {
+    return (
+      <p className="p-4 text-[12.5px] text-muted-foreground" data-testid="app-logs-state-unavailable">
+        {t('apps.logs.unavailable', '暂时读不到日志：{{reason}}', { reason: result.reason })}
+      </p>
+    )
+  }
+
+  if (entries.length === 0) {
+    return (
+      <p className="p-4 text-[12.5px] text-muted-foreground" data-testid="app-logs-empty">
+        {/* Deliberately about the window, not about the app: "no logs" reads as
+            "logging is broken", and the usual cause is a quiet ten minutes. */}
+        {t('apps.logs.empty', '这段时间里没有日志。换个时间范围，或者去访问一下应用再看。')}
+      </p>
+    )
+  }
+
+  return (
+    <>
+      {result.truncated && (
+        <p
+          className="border-b border-border-soft px-3 py-1.5 text-[11.5px] text-faint"
+          data-testid="app-logs-truncated"
+        >
+          {t('apps.logs.truncated', '结果被截断了，只显示最近的一部分。缩短时间范围可以看得更全。')}
+        </p>
+      )}
+      <ol className="divide-y divide-border-soft/60">
+        {entries.map((entry, i) => (
+          <li
+            key={`${entry.ts}-${i}`}
+            className="flex items-start gap-2 px-3 py-1 hover:bg-paper/60"
+            data-testid="app-logs-entry"
+          >
+            <time className="shrink-0 pt-px font-mono text-[11px] text-faint">
+              {clock(entry.ts)}
+            </time>
+            {entry.kind === 'request' && (
+              <span
+                className={cn(
+                  'shrink-0 rounded-[4px] bg-paper px-1 py-px font-mono text-[10.5px]',
+                  LEVEL_CLASS[entry.level],
+                )}
+              >
+                {entry.statusCode ?? '—'}
+              </span>
+            )}
+            <span
+              className={cn(
+                'min-w-0 flex-1 whitespace-pre-wrap break-words font-mono text-[11.5px]',
+                LEVEL_CLASS[entry.level],
+              )}
+            >
+              {entry.message}
+            </span>
+            {entry.requestId && (
+              <button
+                type="button"
+                onClick={() => onPickRequest(entry.requestId!)}
+                title={entry.requestId}
+                data-testid="app-logs-request-chip"
+                className="shrink-0 rounded-[4px] px-1 font-mono text-[10.5px] text-faint hover:bg-paper hover:text-ink-2"
+              >
+                {entry.requestId.slice(-8)}
+              </button>
+            )}
+          </li>
+        ))}
+      </ol>
+    </>
+  )
+}

--- a/packages/app/src/components/apps/__tests__/AppLogsSection.test.tsx
+++ b/packages/app/src/components/apps/__tests__/AppLogsSection.test.tsx
@@ -1,0 +1,84 @@
+import { beforeEach, expect, it, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import React from 'react'
+import { AppLogsSection } from '../AppLogsSection'
+import type { AppRow } from '@/lib/backend/types'
+
+const openAppLogs = vi.hoisted(() => vi.fn())
+
+vi.mock('@/lib/tabs/app-tabs', () => ({
+  openAppLogs: (...args: unknown[]) => openAppLogs(...args),
+}))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, fallback?: string, opts?: Record<string, unknown>) => {
+      let text = fallback ?? key
+      if (opts) {
+        for (const [k, v] of Object.entries(opts)) text = text.replace(`{{${k}}}`, String(v))
+      }
+      return text
+    },
+  }),
+}))
+
+const APP = {
+  id: 'app-1',
+  teamId: 'team-1',
+  name: 'Demo',
+  slug: 'demo',
+  type: 'fullstack_tanstack_postgres',
+  visibility: 'team',
+  workspaceId: null,
+  gitRemoteUrl: null,
+  gitAuthKind: null,
+  gitCommitSha: null,
+  runtime: 'node',
+  authMode: 'none',
+  authModePendingRedeploy: false,
+  oauthClientId: null,
+  provisionStatus: 'ready',
+  fcStatus: 'live',
+  fcEndpoint: 'https://x.fcapp.run',
+  fcFunctionName: 'tc-app-1',
+  fcRegion: 'cn-shenzhen',
+  publicUrl: null,
+  createdAt: '2026-09-08T00:00:00Z',
+  updatedAt: '2026-09-08T00:00:00Z',
+} as AppRow
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+it('opens the logs tab for this app', async () => {
+  render(<AppLogsSection app={APP} />)
+  await userEvent.click(screen.getByTestId('app-logs-open'))
+  expect(openAppLogs).toHaveBeenCalledWith(APP, '日志')
+})
+
+it('offers no entry for an app that was never deployed', () => {
+  // There is nothing to open: Function Compute keeps no logs for a function
+  // that does not exist yet, and a button that always answers "empty" reads as
+  // a broken feature.
+  render(<AppLogsSection app={{ ...APP, fcStatus: null } as AppRow} />)
+  expect(screen.queryByTestId('app-logs-open')).not.toBeInTheDocument()
+  screen.getByTestId('app-logs-state-not-deployed')
+})
+
+it('offers the entry for an app whose last deploy failed', () => {
+  // `deploy_error` is exactly when the logs are worth reading — the function
+  // may well be live on its previous code, and the failure is in them.
+  render(<AppLogsSection app={{ ...APP, fcStatus: 'deploy_error' } as AppRow} />)
+  screen.getByTestId('app-logs-open')
+})
+
+it('makes no request to render', () => {
+  // The panel re-renders on every app selection; whether logs can exist at all
+  // is already on the row.
+  const fetchSpy = vi.spyOn(globalThis, 'fetch')
+  render(<AppLogsSection app={APP} />)
+  expect(fetchSpy).not.toHaveBeenCalled()
+  fetchSpy.mockRestore()
+})

--- a/packages/app/src/components/apps/__tests__/AppLogsTabContent.test.tsx
+++ b/packages/app/src/components/apps/__tests__/AppLogsTabContent.test.tsx
@@ -1,0 +1,160 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import React from 'react'
+import { AppLogsTabContent } from '../AppLogsTabContent'
+import type { AppLogEntry } from '@/lib/backend/types'
+
+const backend = vi.hoisted(() => ({ readAppLogs: vi.fn() }))
+
+vi.mock('@/lib/backend', () => ({
+  getBackend: () => ({ apps: backend }),
+}))
+
+vi.mock('@/stores/apps-store', () => ({
+  useAppsStore: (selector: (s: unknown) => unknown) =>
+    selector({ items: [{ id: 'app-1', name: 'Demo' }] }),
+}))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, fallback?: string, opts?: Record<string, unknown>) => {
+      let text = fallback ?? key
+      if (opts) {
+        for (const [k, v] of Object.entries(opts)) text = text.replace(`{{${k}}}`, String(v))
+      }
+      return text
+    },
+  }),
+}))
+
+function entry(over: Partial<AppLogEntry> = {}): AppLogEntry {
+  return {
+    ts: '2026-09-08T10:00:00.000Z',
+    kind: 'app',
+    level: 'info',
+    message: 'listening on 9000',
+    ...over,
+  }
+}
+
+function ok(entries: AppLogEntry[], over: Record<string, unknown> = {}) {
+  return { status: 'ok', entries, truncated: false, from: null, to: null, ...over }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  backend.readAppLogs.mockResolvedValue(ok([]))
+})
+
+it('reads the app stream over the last hour by default', async () => {
+  render(<AppLogsTabContent appId="app-1" />)
+  await waitFor(() => expect(backend.readAppLogs).toHaveBeenCalled())
+  expect(backend.readAppLogs).toHaveBeenCalledWith(
+    'app-1',
+    expect.objectContaining({ kind: 'app', sinceMinutes: 60, requestId: null }),
+  )
+})
+
+it('shows each line and colours the failures', async () => {
+  backend.readAppLogs.mockResolvedValue(
+    ok([entry(), entry({ level: 'error', message: 'TypeError: x is not a function' })]),
+  )
+  render(<AppLogsTabContent appId="app-1" />)
+  const rows = await screen.findAllByTestId('app-logs-entry')
+  expect(rows).toHaveLength(2)
+  expect(screen.getByText('TypeError: x is not a function')).toBeInTheDocument()
+})
+
+it('narrows to one request when its id is clicked, and can undo it', async () => {
+  // The point of the whole feature: an app's own output has no request id, so
+  // the server reconstructs it — this is what makes that reachable.
+  backend.readAppLogs.mockResolvedValue(ok([entry({ requestId: 'req-abcdefgh' })]))
+  render(<AppLogsTabContent appId="app-1" />)
+  await userEvent.click(await screen.findByTestId('app-logs-request-chip'))
+  await waitFor(() =>
+    expect(backend.readAppLogs).toHaveBeenLastCalledWith(
+      'app-1',
+      expect.objectContaining({ requestId: 'req-abcdefgh' }),
+    ),
+  )
+  await userEvent.click(screen.getByTestId('app-logs-clear-request'))
+  await waitFor(() =>
+    expect(backend.readAppLogs).toHaveBeenLastCalledWith(
+      'app-1',
+      expect.objectContaining({ requestId: null }),
+    ),
+  )
+})
+
+it('switches stream and window without losing the search', async () => {
+  render(<AppLogsTabContent appId="app-1" />)
+  await waitFor(() => expect(backend.readAppLogs).toHaveBeenCalled())
+
+  await userEvent.type(screen.getByTestId('app-logs-search'), 'user_sessions{Enter}')
+  await waitFor(() =>
+    expect(backend.readAppLogs).toHaveBeenLastCalledWith(
+      'app-1',
+      expect.objectContaining({ contains: 'user_sessions' }),
+    ),
+  )
+
+  await userEvent.click(screen.getByTestId('app-logs-kind-request'))
+  await waitFor(() =>
+    expect(backend.readAppLogs).toHaveBeenLastCalledWith(
+      'app-1',
+      expect.objectContaining({ kind: 'request', contains: 'user_sessions' }),
+    ),
+  )
+
+  await userEvent.click(screen.getByTestId('app-logs-window-15'))
+  await waitFor(() =>
+    expect(backend.readAppLogs).toHaveBeenLastCalledWith(
+      'app-1',
+      expect.objectContaining({ sinceMinutes: 15, kind: 'request' }),
+    ),
+  )
+})
+
+describe('the states are told apart', () => {
+  it('an app that was never deployed', async () => {
+    backend.readAppLogs.mockResolvedValue({ status: 'not_deployed' })
+    render(<AppLogsTabContent appId="app-1" />)
+    await screen.findByTestId('app-logs-state-not-deployed')
+  })
+
+  it('a deployment that cannot reach its log service', async () => {
+    backend.readAppLogs.mockResolvedValue({
+      status: 'unavailable',
+      reason: 'APPS_ACCESS_KEY_ID is not set',
+    })
+    render(<AppLogsTabContent appId="app-1" />)
+    const el = await screen.findByTestId('app-logs-state-unavailable')
+    expect(el.textContent).toMatch(/APPS_ACCESS_KEY_ID/)
+  })
+
+  it('a quiet window is about the window, not about the app', async () => {
+    render(<AppLogsTabContent appId="app-1" />)
+    const el = await screen.findByTestId('app-logs-empty')
+    expect(el.textContent).toMatch(/时间范围/)
+  })
+
+  it('a truncated result says so', async () => {
+    backend.readAppLogs.mockResolvedValue(ok([entry()], { truncated: true }))
+    render(<AppLogsTabContent appId="app-1" />)
+    await screen.findByTestId('app-logs-truncated')
+  })
+
+  it('a 404 does not read as a crash', async () => {
+    backend.readAppLogs.mockResolvedValue(null)
+    render(<AppLogsTabContent appId="app-1" />)
+    await screen.findByTestId('app-logs-state-none')
+  })
+
+  it('a thrown error is shown as itself', async () => {
+    backend.readAppLogs.mockRejectedValue(new Error('network down'))
+    render(<AppLogsTabContent appId="app-1" />)
+    const el = await screen.findByTestId('app-logs-error')
+    expect(el.textContent).toMatch(/network down/)
+  })
+})

--- a/packages/app/src/components/main-content/NativeContent.tsx
+++ b/packages/app/src/components/main-content/NativeContent.tsx
@@ -9,7 +9,12 @@ import {
   decodeTeamShareTarget,
   decodeVersionHistoryTarget,
 } from "@/lib/tabs/teamshare-target"
-import { decodeAppDataTarget, isAppCreateTarget, isAppLibraryTarget } from "@/lib/tabs/app-tabs"
+import {
+  decodeAppDataTarget,
+  decodeAppLogsTarget,
+  isAppCreateTarget,
+  isAppLibraryTarget,
+} from "@/lib/tabs/app-tabs"
 
 // Every native tab body is a large, rarely opened subtree (team share, apps,
 // knowledge versioning). They load on first render so the tab bar itself
@@ -37,6 +42,10 @@ const TeamShareTabContent = lazyNamed(
 const AppDataTabContent = lazyNamed(
   () => import("@/components/apps/AppDataTabContent"),
   "AppDataTabContent",
+)
+const AppLogsTabContent = lazyNamed(
+  () => import("@/components/apps/AppLogsTabContent"),
+  "AppLogsTabContent",
 )
 const AppLibraryView = lazyNamed(
   () => import("@/components/apps/AppLibraryView"),
@@ -82,6 +91,9 @@ function resolveNativeBody(target: string) {
 
   const appData = decodeAppDataTarget(target)
   if (appData) return <AppDataTabContent target={target} />
+
+  const appLogs = decodeAppLogsTarget(target)
+  if (appLogs) return <AppLogsTabContent appId={appLogs.appId} />
 
   if (isAppLibraryTarget(target)) return <AppLibraryView />
 

--- a/packages/app/src/lib/backend/cloud-api/apps.ts
+++ b/packages/app/src/lib/backend/cloud-api/apps.ts
@@ -4,6 +4,9 @@ import type {
   AppDataRowsPage,
   AppDataRowsQuery,
   AppDataTable,
+  AppLogEntry,
+  AppLogsQuery,
+  AppLogsResult,
   AppSessionRow,
   AppGitCredential,
   AppGitHead,
@@ -245,6 +248,41 @@ export function createAppsModule(client: CloudApiClient): AppsBackend {
       await client.delete<{ ok: true }>(
         `/v1/apps/${encodeURIComponent(appId)}/data/tables/${encodeURIComponent(table)}/rows/${encodeURIComponent(rowKey)}`,
       );
+    },
+
+    async readAppLogs(appId, query: AppLogsQuery = {}): Promise<AppLogsResult | null> {
+      const params = new URLSearchParams();
+      if (query.sinceMinutes) params.set("sinceMinutes", String(query.sinceMinutes));
+      if (query.limit) params.set("limit", String(query.limit));
+      if (query.kind) params.set("kind", query.kind);
+      if (query.contains) params.set("contains", query.contains);
+      if (query.requestId) params.set("requestId", query.requestId);
+      const qs = params.toString();
+      try {
+        const page = await client.get<{
+          items: AppLogEntry[];
+          truncated: boolean;
+          from?: string | null;
+          to?: string | null;
+        }>(`/v1/apps/${encodeURIComponent(appId)}/logs${qs ? `?${qs}` : ""}`);
+        return {
+          status: "ok",
+          entries: page.items ?? [],
+          truncated: page.truncated ?? false,
+          from: page.from ?? null,
+          to: page.to ?? null,
+        };
+      } catch (e) {
+        if (!(e instanceof CloudApiError)) throw e;
+        if (e.status === 404) return null;
+        // Translated rather than thrown, as with listAppDataTables: each is a
+        // state the view explains in its own sentence.
+        if (e.code === "app_not_deployed") return { status: "not_deployed" };
+        if (e.status === 503 || e.status === 502) {
+          return { status: "unavailable", reason: e.message };
+        }
+        throw e;
+      }
     },
   };
 }

--- a/packages/app/src/lib/backend/types.ts
+++ b/packages/app/src/lib/backend/types.ts
@@ -1158,6 +1158,43 @@ export type AppDataTablesResult =
   | { status: "not_deployed" }
   | { status: "unavailable"; reason: string };
 
+/** One line of a deployed app's output, or one of its requests. */
+export interface AppLogEntry {
+  ts: string;
+  /** `app`: printed by the application. `request`: Function Compute's own row. */
+  kind: "app" | "request";
+  level: "info" | "warn" | "error";
+  message: string;
+  requestId?: string | null;
+  instanceId?: string | null;
+  statusCode?: number | null;
+  durationMs?: number | null;
+  method?: string | null;
+  path?: string | null;
+  coldStart?: boolean | null;
+}
+
+export interface AppLogsQuery {
+  /** How far back to read. Server clamps to the retention period. */
+  sinceMinutes?: number;
+  limit?: number;
+  kind?: "app" | "request" | "all";
+  /** Case-insensitive substring on the message, applied within the window. */
+  contains?: string | null;
+  requestId?: string | null;
+}
+
+/**
+ * Same shape as {@link AppDataTablesResult} and for the same reason: an app
+ * that was never deployed, one whose deployment cannot reach a log service,
+ * and one that simply printed nothing are three different sentences, and
+ * flattening them into an empty list makes the first two read as the third.
+ */
+export type AppLogsResult =
+  | { status: "ok"; entries: AppLogEntry[]; truncated: boolean; from: string | null; to: string | null }
+  | { status: "not_deployed" }
+  | { status: "unavailable"; reason: string };
+
 type AppDataFilterOp = "eq" | "contains" | "isNull" | "notNull";
 
 export interface AppDataRowsQuery {
@@ -1258,6 +1295,14 @@ export interface AppsBackend {
   ): Promise<Record<string, unknown>>;
   /** Delete one row by key. */
   deleteAppDataRow(appId: string, table: string, rowKey: string): Promise<void>;
+
+  /**
+   * What the deployed function printed, newest first. Null on 404.
+   *
+   * Same tier as the data browser: a log line carries whatever the app decided
+   * to print, which is its users' data.
+   */
+  readAppLogs(appId: string, query?: AppLogsQuery): Promise<AppLogsResult | null>;
 }
 
 export interface ActorDirectorySyncRow {

--- a/packages/app/src/lib/tabs/app-tabs.ts
+++ b/packages/app/src/lib/tabs/app-tabs.ts
@@ -29,6 +29,30 @@ export function openAppDataTable(app: AppRow, table: string): void {
   })
 }
 
+const APP_LOGS_PREFIX = 'app-logs:'
+
+export function decodeAppLogsTarget(target: string): { appId: string } | null {
+  if (!target.startsWith(APP_LOGS_PREFIX)) return null
+  const appId = target.slice(APP_LOGS_PREFIX.length)
+  return appId ? { appId } : null
+}
+
+/**
+ * The deployed app's own logs, in the main column.
+ *
+ * A tab and not a panel section: reading logs means scrolling a lot of text and
+ * changing the window while the control panel stays where it is — and the
+ * question it answers ("why is the live site broken") is usually asked next to
+ * the site itself, which is also a tab.
+ */
+export function openAppLogs(app: AppRow, label: string): void {
+  useTabsStore.getState().openTab({
+    type: 'native',
+    target: `${APP_LOGS_PREFIX}${app.id}`,
+    label: `${app.name} · ${label}`,
+  })
+}
+
 /** Open the deployed site in the main content area (webview tab). */
 export function openAppPreview(app: AppRow): void {
   const url = app.publicUrl ?? app.fcEndpoint

--- a/packages/app/src/locales/en.json
+++ b/packages/app/src/locales/en.json
@@ -1322,6 +1322,25 @@
       "invalidTarget": "Invalid table address",
       "appNotFound": "App not found"
     },
+    "logs": {
+      "section": "Runtime logs",
+      "hint": "What the app printed, and every request",
+      "open": "View logs",
+      "tabLabel": "logs",
+      "title": "Runtime logs",
+      "subtitle": "What {{name}} printed while running live.",
+      "kindApp": "App output",
+      "kindRequest": "Requests",
+      "kindAll": "Everything",
+      "searchPlaceholder": "Search the log text, press Enter",
+      "filteredByRequest": "Showing one request",
+      "clearRequest": "Clear",
+      "notDeployed": "This app has never been deployed, so it has no logs yet.",
+      "notFound": "These logs are not visible to you.",
+      "unavailable": "Logs are not readable right now: {{reason}}",
+      "empty": "Nothing was logged in this window. Try a longer one, or visit the app and look again.",
+      "truncated": "Truncated — only the most recent entries are shown. A shorter window shows more of them."
+    },
     "controlPanel": {
       "title": "App settings",
       "reseedHint": "Rewrite the template or clone the repo again. Use only when seeding failed or the folder is empty.",

--- a/packages/app/src/locales/en.json
+++ b/packages/app/src/locales/en.json
@@ -1427,6 +1427,9 @@
     "deleteFailed": "Delete failed",
     "deleteDenied": "App not found, or you cannot delete it",
     "deleted": "App deleted",
+    "seedErrorReason": {
+      "cloneTimeout": "The clone timed out. Most often this machine's git credential helper is waiting on a sign-in window that has nowhere to appear — clone the repo once in a terminal, then try again."
+    },
     "deployErrorReason": {
       "uncommitted": "The workspace has uncommitted or unpushed changes. Commit and push, then deploy.",
       "pushRejected": "The repo has commits this machine does not. Pull and resolve them, then deploy again.",

--- a/packages/app/src/locales/zh-CN.json
+++ b/packages/app/src/locales/zh-CN.json
@@ -1322,6 +1322,25 @@
       "invalidTarget": "无效的数据表地址",
       "appNotFound": "找不到这个应用"
     },
+    "logs": {
+      "section": "运行日志",
+      "hint": "应用打印的内容与每次请求",
+      "open": "查看日志",
+      "tabLabel": "日志",
+      "title": "运行日志",
+      "subtitle": "{{name}} 线上运行时打印的内容。",
+      "kindApp": "应用输出",
+      "kindRequest": "请求",
+      "kindAll": "全部",
+      "searchPlaceholder": "搜索日志内容，回车确认",
+      "filteredByRequest": "只看这一次请求",
+      "clearRequest": "清除",
+      "notDeployed": "这个应用还没有部署过，部署之后才会有日志。",
+      "notFound": "看不到这个应用的日志。",
+      "unavailable": "暂时读不到日志：{{reason}}",
+      "empty": "这段时间里没有日志。换个时间范围，或者去访问一下应用再看。",
+      "truncated": "结果被截断了，只显示最近的一部分。缩短时间范围可以看得更全。"
+    },
     "controlPanel": {
       "title": "应用设置",
       "reseedHint": "重新写入模板或克隆仓库。仅在初始化失败或目录为空时使用。",

--- a/packages/app/src/locales/zh-CN.json
+++ b/packages/app/src/locales/zh-CN.json
@@ -1427,6 +1427,9 @@
     "deleteFailed": "删除失败",
     "deleteDenied": "应用不存在或无权删除",
     "deleted": "应用已删除",
+    "seedErrorReason": {
+      "cloneTimeout": "克隆超时。多半是这台机器的 git 凭证助手在等一个弹不出来的登录框；先在终端里 clone 一次这个仓库，再回来重试。"
+    },
     "deployErrorReason": {
       "uncommitted": "工作区有未提交或未推送的改动，请先 commit 并 push 后再部署。",
       "pushRejected": "仓库里有本机没有的提交。请先拉取并解决冲突，然后重新部署。",

--- a/packages/app/src/stores/apps-store.test.ts
+++ b/packages/app/src/stores/apps-store.test.ts
@@ -355,6 +355,48 @@ describe("apps-store", () => {
     );
   });
 
+  it("create: the clone gets the address the user typed, not the stored one", async () => {
+    // `POST /v1/apps` strips credentials before writing the row, so the row
+    // comes back without them. The clone still has to authenticate, and this
+    // one call is the only place the typed credential exists — losing it here
+    // is how importing a private repo silently stops working.
+    mocks.createApp.mockResolvedValueOnce(
+      appRow({ provisionStatus: "pending", gitRemoteUrl: "https://github.com/owner/private.git" }),
+    );
+    mocks.updateAppProvisionStatus.mockImplementation(async (_id, st) => appRow({ provisionStatus: st }));
+    mocks.seedDaemonApp.mockResolvedValueOnce(seedResult("seeded"));
+    const { useAppsStore } = await import("./apps-store");
+    await useAppsStore.getState().create({
+      teamId: "team-1",
+      name: "N",
+      type: "static_web",
+      visibility: "team",
+      gitRemoteUrl: "https://x:ghp_token@github.com/owner/private.git",
+    });
+    const seedArgs = mocks.seedDaemonApp.mock.calls.at(-1);
+    expect(seedArgs?.[4]).toBe("https://x:ghp_token@github.com/owner/private.git");
+  });
+
+  it("create: a clone that timed out explains what the raw error does not", async () => {
+    mocks.createApp.mockResolvedValueOnce(
+      appRow({ provisionStatus: "pending", gitRemoteUrl: "https://github.com/owner/private.git" }),
+    );
+    mocks.updateAppProvisionStatus.mockImplementation(async (_id, st) => appRow({ provisionStatus: st }));
+    mocks.seedDaemonApp.mockResolvedValueOnce(
+      seedResult("failed", { error: '{"error":{"message":"git clone timed out after 5 minutes"}}' }),
+    );
+    const { useAppsStore } = await import("./apps-store");
+    await useAppsStore.getState().create({
+      teamId: "team-1",
+      name: "N",
+      type: "static_web",
+      visibility: "team",
+      gitRemoteUrl: "https://github.com/owner/private.git",
+    });
+    const [, opts] = mocks.toastError.mock.calls.at(-1) ?? [];
+    expect(String((opts as any)?.description)).toMatch(/凭证助手/);
+  });
+
   it("create: repo_created fetches deploy key and seeds with push", async () => {
     mocks.createApp.mockResolvedValueOnce(
       appRow({

--- a/packages/app/src/stores/apps-store.ts
+++ b/packages/app/src/stores/apps-store.ts
@@ -314,7 +314,37 @@ function mapCloudDeployError(e: unknown): string {
  * A clone that fails is the one case worth interrupting the user for: they
  * typed the URL, and the app is empty until they fix it.
  */
-async function runSeed(set: SetState, app: AppRow, adoptExisting = false): Promise<void> {
+/**
+ * Explain a seed failure the raw daemon text does not.
+ *
+ * A clone that ran out of time is the one failure whose cause is invisible:
+ * git was not asked anything and printed nothing, because it is the machine's
+ * credential helper that is waiting — often on a window that has nowhere to
+ * appear. Everything else git says is already the answer.
+ */
+function mapSeedErrorReason(raw: string | null): string | undefined {
+  if (!raw) return undefined;
+  if (raw.includes("git clone timed out")) {
+    return i18n.t(
+      "apps.seedErrorReason.cloneTimeout",
+      "克隆超时。多半是这台机器的 git 凭证助手在等一个弹不出来的登录框；先在终端里 clone 一次这个仓库，再回来重试。",
+    );
+  }
+  return raw;
+}
+
+/**
+ * @param cloneUrl the address to clone from, when it differs from the stored
+ * one. Credentials pasted into a repo URL are stripped before the row is
+ * written, so the create path passes what the user actually typed — that copy
+ * lives for the length of one call and is never persisted.
+ */
+async function runSeed(
+  set: SetState,
+  app: AppRow,
+  adoptExisting = false,
+  cloneUrl?: string | null,
+): Promise<void> {
   let deployKeyPem: string | null = null;
   let deployKeyId: number | null = null;
   // Keyed on how the repo is authenticated, not on the status the row happens
@@ -349,7 +379,7 @@ async function runSeed(set: SetState, app: AppRow, adoptExisting = false): Promi
       app.teamId,
       app.name,
       app.type,
-      app.gitRemoteUrl,
+      cloneUrl?.trim() || app.gitRemoteUrl,
       deployKeyPem,
       adoptExisting,
     );
@@ -369,7 +399,7 @@ async function runSeed(set: SetState, app: AppRow, adoptExisting = false): Promi
   } else if (result.outcome === "failed") {
     await patchStatus(set, app.id, "error");
     if (app.gitRemoteUrl) {
-      await toastError("仓库克隆失败", result.error ?? undefined);
+      await toastError("仓库克隆失败", mapSeedErrorReason(result.error));
     }
   }
   // unreachable → no status change; reseed remains available.
@@ -557,7 +587,10 @@ export const useAppsStore = create<AppsState>((set, get) => ({
       // daemon, which writes its own embedded template. Non-fatal — a daemon
       // that is down (unreachable) leaves the row `pending` so the user can
       // reseed.
-      await runSeed(set, row, !!adoptLocalDir?.trim());
+      // The typed address, not the stored one: `POST /v1/apps` strips any
+      // credential out of it before writing the row, and this is the one call
+      // that still needs it.
+      await runSeed(set, row, !!adoptLocalDir?.trim(), input.gitRemoteUrl);
     }
     await get().refreshLocalApps(input.teamId);
     // Return the row as it stands AFTER seeding — the caller decides what to do

--- a/services/fc/package-lock.json
+++ b/services/fc/package-lock.json
@@ -11,6 +11,7 @@
         "@alicloud/dysmsapi20170525": "^4.5.1",
         "@alicloud/fc20230330": "^4.7.6",
         "@alicloud/openapi-client": "^0.4.12",
+        "@alicloud/sls20201230": "^5.11.0",
         "@aws-sdk/client-s3": "^3.600.0",
         "@aws-sdk/s3-request-presigner": "^3.600.0",
         "@hono/node-server": "^1.19.14",
@@ -148,6 +149,34 @@
         "@alicloud/tea-util": "^1.4.8"
       }
     },
+    "node_modules/@alicloud/gateway-sls": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@alicloud/gateway-sls/-/gateway-sls-0.3.2.tgz",
+      "integrity": "sha512-h156ZrGNKmEUORMWCNPNSuz+02xn98XG/Tg9P+6Cy/2IyIy+EUhkXQM2VxvFdR/ckuVazFS/MLq0sGNHMiG3Bw==",
+      "license": "ISC",
+      "dependencies": {
+        "@alicloud/credentials": "^2.3.1",
+        "@alicloud/darabonba-array": "^0.1.0",
+        "@alicloud/darabonba-encode-util": "^0.0.2",
+        "@alicloud/darabonba-map": "^0.0.1",
+        "@alicloud/darabonba-signature-util": "^0.0.4",
+        "@alicloud/darabonba-string": "^1.0.2",
+        "@alicloud/gateway-sls-util": "^0.3.1",
+        "@alicloud/gateway-spi": "^0.0.8",
+        "@alicloud/openapi-util": "^0.3.2",
+        "@alicloud/tea-typescript": "^1.7.1",
+        "@alicloud/tea-util": "^1.4.9"
+      }
+    },
+    "node_modules/@alicloud/gateway-sls-util": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@alicloud/gateway-sls-util/-/gateway-sls-util-0.3.1.tgz",
+      "integrity": "sha512-z9JHVMCGJT6AJXXzFjhixqo5IHiE0tb8QeYw1WcmZVBAd6CfzF1QcoU9NLgc4zZYAjgJcLPFtW3OZdYw0OWDbA==",
+      "license": "ISC",
+      "dependencies": {
+        "lz4-napi": "^2.9.0"
+      }
+    },
     "node_modules/@alicloud/gateway-spi": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/@alicloud/gateway-spi/-/gateway-spi-0.0.8.tgz",
@@ -173,16 +202,16 @@
       }
     },
     "node_modules/@alicloud/openapi-core": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/@alicloud/openapi-core/-/openapi-core-1.0.7.tgz",
-      "integrity": "sha512-I80PQVfmlzRiXGHwutMp2zTpiqUVv8ts30nWAfksfHUSTIapk3nj9IXaPbULMPGNV6xqEyshO2bj2a+pmwc2tQ==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@alicloud/openapi-core/-/openapi-core-1.0.8.tgz",
+      "integrity": "sha512-xs8LdgMDcEUqv13kZ4nl+Vd+Fc1mixTF0g1lm5QSrNWDaLUUD5vqpuMtvUZnKNnq9PITfUQ+8KunAvNQJpFo8g==",
       "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {
         "@alicloud/credentials": "^2.4.2",
         "@alicloud/gateway-pop": "0.0.6",
         "@alicloud/gateway-spi": "^0.0.8",
-        "@darabonba/typescript": "^1.0.2"
+        "@darabonba/typescript": "^1.0.5"
       }
     },
     "node_modules/@alicloud/openapi-util": {
@@ -195,6 +224,17 @@
         "@alicloud/tea-util": "^1.3.0",
         "kitx": "^2.1.0",
         "sm3": "^1.0.3"
+      }
+    },
+    "node_modules/@alicloud/sls20201230": {
+      "version": "5.11.0",
+      "resolved": "https://registry.npmjs.org/@alicloud/sls20201230/-/sls20201230-5.11.0.tgz",
+      "integrity": "sha512-kYMAZE1+k0IVhwIwLKBuxANYxlY9GGngZ2mqzJ/Vh9gz4oluaPzUU6pALQ4UsN0TfiomU5gL4wjfADBlzSzlYw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@alicloud/gateway-sls": "^0.3.0",
+        "@alicloud/openapi-core": "^1.0.8",
+        "@darabonba/typescript": "^1.0.0"
       }
     },
     "node_modules/@alicloud/tea-typescript": {
@@ -232,6 +272,299 @@
         "@alicloud/tea-typescript": "^1",
         "@types/xml2js": "^0.4.5",
         "xml2js": "^0.6.0"
+      }
+    },
+    "node_modules/@antoniomuso/lz4-napi-android-arm-eabi": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@antoniomuso/lz4-napi-android-arm-eabi/-/lz4-napi-android-arm-eabi-2.10.0.tgz",
+      "integrity": "sha512-BmVivZ5OwdM5IogpqHEKGoMEOJ98ZhIf35cBAKlt5axZR1nCy8X6O8B1noyQZETSXw0901Z/uAx0/23+ulyxuQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@antoniomuso/lz4-napi-android-arm64": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@antoniomuso/lz4-napi-android-arm64/-/lz4-napi-android-arm64-2.10.0.tgz",
+      "integrity": "sha512-Oi2nIJvxG0ckK+lQYuuDtBI7mrQoj+glnNp4c19rhm0D0utkuRuI2bzqXOp5uth/IFNlP+W3pepfOCULeydKJw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@antoniomuso/lz4-napi-darwin-arm64": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@antoniomuso/lz4-napi-darwin-arm64/-/lz4-napi-darwin-arm64-2.10.0.tgz",
+      "integrity": "sha512-rrP5B4CJkSgHBAZ8jP/xGdXULDjDMF/DiUPxtBdo23CfkIOvf2VYGDF2vWO+1LDFMqlV4Mu4dZWwvOWklP4t4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@antoniomuso/lz4-napi-darwin-x64": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@antoniomuso/lz4-napi-darwin-x64/-/lz4-napi-darwin-x64-2.10.0.tgz",
+      "integrity": "sha512-NytV3XbMC6JCX0uxiYgJV7cTUEWczT6e/rjfnIATsRuOOZLn1nNn1TIpGsAwLPcWoTgBsG0JcvLA1D+t3CLhAQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@antoniomuso/lz4-napi-freebsd-x64": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@antoniomuso/lz4-napi-freebsd-x64/-/lz4-napi-freebsd-x64-2.10.0.tgz",
+      "integrity": "sha512-CB7u672akKGZJr0MgH9qrBjcTRRf0yyPCBD0HjSChx+GfKJtQrMXEWLO68X+gTPjnlceywyqmzDA/t6zOavSYw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@antoniomuso/lz4-napi-linux-arm-gnueabihf": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@antoniomuso/lz4-napi-linux-arm-gnueabihf/-/lz4-napi-linux-arm-gnueabihf-2.10.0.tgz",
+      "integrity": "sha512-fjUVOWP0YYiaqXsrNAXa5pxdf+C6ql0sJFOZ/LZeID6fx8qle/+zjpJOYK/vE4dFOfxYFpMWXFYr+M/DfFhUdQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@antoniomuso/lz4-napi-linux-arm64-gnu": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@antoniomuso/lz4-napi-linux-arm64-gnu/-/lz4-napi-linux-arm64-gnu-2.10.0.tgz",
+      "integrity": "sha512-Ai0MfalUR4par5YI0AciKUUGCuMeshU3KLzaCavEgA3VHc//fU37VrbmzU/SgNjcJzdKFB9d3JZZAAe2wZ1tSQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@antoniomuso/lz4-napi-linux-arm64-musl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@antoniomuso/lz4-napi-linux-arm64-musl/-/lz4-napi-linux-arm64-musl-2.10.0.tgz",
+      "integrity": "sha512-LNUlCFiTfYUstWcpNP2op9tf6RfxWlB1LmkdGfUvt/L4xgagktDnDy6Bii+ErZfocQ/M8hUDJnA57c4a/uax4A==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@antoniomuso/lz4-napi-linux-ppc64-gnu": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@antoniomuso/lz4-napi-linux-ppc64-gnu/-/lz4-napi-linux-ppc64-gnu-2.10.0.tgz",
+      "integrity": "sha512-gNTGuwI2aYp+yNvFZe60iKVv/whfhTK3d3n8kbP0WG8nLvfka+wIch67aQM3G4eqB/KlS7fLAJdCvVC5x4CQWw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@antoniomuso/lz4-napi-linux-riscv64-gnu": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@antoniomuso/lz4-napi-linux-riscv64-gnu/-/lz4-napi-linux-riscv64-gnu-2.10.0.tgz",
+      "integrity": "sha512-mHh5I55EtfFxS82Cm+HyGt6XezvBVDZV406qvS80FxEhHP4yNititbaGd/uGJ8Hr0+Fh4TDKPyiDZps19FJEoQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@antoniomuso/lz4-napi-linux-s390x-gnu": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@antoniomuso/lz4-napi-linux-s390x-gnu/-/lz4-napi-linux-s390x-gnu-2.10.0.tgz",
+      "integrity": "sha512-CVR4x8W5EqypGKsK2ffGxvtDz5NCUN6fx4jQPEMhL6LR66uc8TxKtYzlF+hvQnuVkN3Va+NwTGCurJS9CVPGFA==",
+      "cpu": [
+        "s390x"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@antoniomuso/lz4-napi-linux-x64-gnu": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@antoniomuso/lz4-napi-linux-x64-gnu/-/lz4-napi-linux-x64-gnu-2.10.0.tgz",
+      "integrity": "sha512-UQQZephsIQrEbMM+Wp7SKYUqVR9DJLCMkZkOoLU9DDf2Ctvy6jXuqQoFF3ajh/mPh8gFp/s1WEcnUO8IRBiDpw==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@antoniomuso/lz4-napi-linux-x64-musl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@antoniomuso/lz4-napi-linux-x64-musl/-/lz4-napi-linux-x64-musl-2.10.0.tgz",
+      "integrity": "sha512-f30AGLcOsyiQU0EuWYmCZGID/6vcr/1scKaQ2G90QBJ/8aTWTwRDZGT7NPOE6mJ71ioI/ZLJGHiytjbiPjZfng==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@antoniomuso/lz4-napi-openharmony-arm64": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@antoniomuso/lz4-napi-openharmony-arm64/-/lz4-napi-openharmony-arm64-2.10.0.tgz",
+      "integrity": "sha512-LUrHBJcnHqKsCyt0LvgsrRij5VWHXtwUQyJZT+kXSfkW+snIqKqVzucFpMHETFDKQNkMTsmHruVV/UEBbYuw/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@antoniomuso/lz4-napi-win32-arm64-msvc": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@antoniomuso/lz4-napi-win32-arm64-msvc/-/lz4-napi-win32-arm64-msvc-2.10.0.tgz",
+      "integrity": "sha512-6k8Qu3V8fq4QbHS6vPQy8fggOvTUMQsVZP+WZBUMrG6A4ZPiMmPfFF+xJfLJCnOoijkBdRSiS1Y9oEv84lFPDw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@antoniomuso/lz4-napi-win32-ia32-msvc": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@antoniomuso/lz4-napi-win32-ia32-msvc/-/lz4-napi-win32-ia32-msvc-2.10.0.tgz",
+      "integrity": "sha512-5zKO7JdZXM/GL5XuTufwtIc3OVLhbRC/5PkcY4XmpU/IjUm4P9OkBAPNqBTgFfZbDc7eCigf92UcPLEk1PIShg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@antoniomuso/lz4-napi-win32-x64-msvc": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@antoniomuso/lz4-napi-win32-x64-msvc/-/lz4-napi-win32-x64-msvc-2.10.0.tgz",
+      "integrity": "sha512-YC15uBJQdkXtPpu0JXozeEAO+b4LVjo2gOWKsPNmhNGhtkIAnKJZo+ueO6KNaFx4W6H2DQyAEiP1DsoBND26fw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/@aws-crypto/crc32": {
@@ -1130,17 +1463,46 @@
       }
     },
     "node_modules/@darabonba/typescript": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@darabonba/typescript/-/typescript-1.0.4.tgz",
-      "integrity": "sha512-icl8RGTw4DiWRpco6dVh21RS0IqrH4s/eEV36TZvz/e1+paogSZjaAgox7ByrlEuvG+bo5d8miq/dRlqiUaL/w==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@darabonba/typescript/-/typescript-1.0.5.tgz",
+      "integrity": "sha512-pfxHFVM8I3h8K2o8skpDQLMmR5iAeQ2eNpP1HrKDEm/9ZPF8aKwDKPwwEszT1NnIo0Y3++E7x1YsVkVpGjA/xw==",
       "license": "Apache License 2.0",
       "dependencies": {
         "@alicloud/tea-typescript": "^1.5.1",
+        "http-proxy-agent": "^5.0.0",
+        "https-proxy-agent": "^5.0.1",
         "httpx": "^2.3.2",
         "lodash": "^4.17.21",
         "moment": "^2.30.1",
         "moment-timezone": "^0.5.45",
+        "socks-proxy-agent": "^6.2.1",
+        "ws": "^8.18.0",
         "xml2js": "^0.6.2"
+      }
+    },
+    "node_modules/@darabonba/typescript/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/@darabonba/typescript/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/@electric-sql/pglite": {
@@ -2958,6 +3320,15 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/@tootallnate/once": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.1.tgz",
+      "integrity": "sha512-HqmEUIGRJ5fSXchkVgR5F7qn48bDBzv0kWj/Kfu5e6uci4UlEeng4331LnBkWffb++Ei3FOVLxo8JJWMFBDMeQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -4113,6 +4484,32 @@
         "node": ">=16.9.0"
       }
     },
+    "node_modules/http-proxy-agent": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
+      "license": "MIT",
+      "dependencies": {
+        "@tootallnate/once": "2",
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/http-proxy-agent/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
     "node_modules/http2-client": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/http2-client/-/http2-client-1.3.5.tgz",
@@ -4539,6 +4936,34 @@
       "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/lz4-napi": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/lz4-napi/-/lz4-napi-2.10.0.tgz",
+      "integrity": "sha512-NEW7rrcRA+6928P2X9IB4TCeHXT1VKTz63+lmiKkWBMORI2OtenveC+DsqtYfWMZZ52gULHcon5Z7QgXvDpRHg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      },
+      "optionalDependencies": {
+        "@antoniomuso/lz4-napi-android-arm-eabi": "2.10.0",
+        "@antoniomuso/lz4-napi-android-arm64": "2.10.0",
+        "@antoniomuso/lz4-napi-darwin-arm64": "2.10.0",
+        "@antoniomuso/lz4-napi-darwin-x64": "2.10.0",
+        "@antoniomuso/lz4-napi-freebsd-x64": "2.10.0",
+        "@antoniomuso/lz4-napi-linux-arm-gnueabihf": "2.10.0",
+        "@antoniomuso/lz4-napi-linux-arm64-gnu": "2.10.0",
+        "@antoniomuso/lz4-napi-linux-arm64-musl": "2.10.0",
+        "@antoniomuso/lz4-napi-linux-ppc64-gnu": "2.10.0",
+        "@antoniomuso/lz4-napi-linux-riscv64-gnu": "2.10.0",
+        "@antoniomuso/lz4-napi-linux-s390x-gnu": "2.10.0",
+        "@antoniomuso/lz4-napi-linux-x64-gnu": "2.10.0",
+        "@antoniomuso/lz4-napi-linux-x64-musl": "2.10.0",
+        "@antoniomuso/lz4-napi-openharmony-arm64": "2.10.0",
+        "@antoniomuso/lz4-napi-win32-arm64-msvc": "2.10.0",
+        "@antoniomuso/lz4-napi-win32-ia32-msvc": "2.10.0",
+        "@antoniomuso/lz4-napi-win32-x64-msvc": "2.10.0"
+      }
     },
     "node_modules/mark.js": {
       "version": "8.11.1",
@@ -5651,6 +6076,32 @@
       "engines": {
         "node": ">= 10.0.0",
         "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks-proxy-agent": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-6.2.1.tgz",
+      "integrity": "sha512-a6KW9G+6B3nWZ1yB8G7pJwL3ggLy1uTzKAgCb7ttblwqdz9fMGJUuTy3uFzEP48FAs9FLILlmzDlE2JJhVQaXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^6.0.2",
+        "debug": "^4.3.3",
+        "socks": "^2.6.2"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/socks-proxy-agent/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
       }
     },
     "node_modules/source-map": {

--- a/services/fc/package.json
+++ b/services/fc/package.json
@@ -14,6 +14,7 @@
     "@alicloud/dysmsapi20170525": "^4.5.1",
     "@alicloud/fc20230330": "^4.7.6",
     "@alicloud/openapi-client": "^0.4.12",
+    "@alicloud/sls20201230": "^5.11.0",
     "@aws-sdk/client-s3": "^3.600.0",
     "@aws-sdk/s3-request-presigner": "^3.600.0",
     "@hono/node-server": "^1.19.14",

--- a/services/fc/s.yaml
+++ b/services/fc/s.yaml
@@ -97,6 +97,10 @@ resources:
         APPS_OSS_BUCKET: ${env('APPS_OSS_BUCKET', '')}
         APPS_REGION: ${env('APPS_REGION', '')}
         APPS_OSS_ENDPOINT: ${env('APPS_OSS_ENDPOINT', '')}
+        # Log destination for deployed apps. Blank → derived from the account
+        # id (`teamclu-apps-<accountId>` / `app-logs`) and created on deploy.
+        APPS_SLS_PROJECT: ${env('APPS_SLS_PROJECT', '')}
+        APPS_SLS_LOGSTORE: ${env('APPS_SLS_LOGSTORE', '')}
         # Parent domain for per-app vanity hostnames. Only self-host has the
         # reverse proxy that terminates them, so this is normally blank here —
         # declared so the two targets stay in step (deploy-env-parity.test.ts).

--- a/services/fc/src/index.ts
+++ b/services/fc/src/index.ts
@@ -22,6 +22,8 @@ import { makeTeardownAppDeps, type TeardownAppDeps } from "./lib/provisioning/ap
 import { PutObjectCommand } from "@aws-sdk/client-s3";
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
 import { resolveAppsOss, getAppsS3Client } from "./lib/provisioning/apps-oss.js";
+import { resolveAppsSls, getSlsClient, makeSlsOps, type SlsOps } from "./lib/provisioning/sls-client.js";
+import { makeAppLogsReader } from "./lib/provisioning/app-logs.js";
 import { readGiteaConfig, makeGiteaClient } from "./lib/provisioning/gitea.js";
 import { readGotrueOAuthConfig, makeGotrueOAuthClient } from "./lib/provisioning/gotrue-oauth.js";
 import { makeVanityLookup } from "./lib/apps-vanity.js";
@@ -71,6 +73,75 @@ export function syncGetQueryToBody(event: any) {
 // The apps database is a SEPARATE, softer requirement — only `data_app` needs
 // it. Static apps deploy fine without APPS_DB_ADMIN_URL; asking for one is what
 // raises the error, not merely having the module loaded.
+/**
+ * The app-log destination, and whether it is usable yet.
+ *
+ * One object shared by the deploy path (which points functions at it) and the
+ * read path (which queries it), because those two must never disagree about
+ * which logstore an app's logs are in.
+ *
+ * `ensure` is memoized and remembers a failure: an account whose key cannot
+ * create an SLS project would otherwise retry on every deploy and — worse —
+ * keep handing the FC API a `logConfig` naming a project that does not exist,
+ * which fails the whole deploy. After a failed ensure, `config()` reads as
+ * undefined and functions are created with no log config at all.
+ */
+interface AppLogsProvisioner {
+  unavailableReason?: string;
+  ops?: SlsOps;
+  config: () => { project: string; logstore: string } | undefined;
+  ensure: () => Promise<void>;
+}
+
+function buildAppLogsProvisioner(): AppLogsProvisioner {
+  const resolvedOss = resolveAppsOss();
+  const resolvedSls = resolveAppsSls();
+  const reason = resolvedOss.error ?? resolvedSls.error;
+  if (reason || !resolvedOss.profile || !resolvedSls.config) {
+    return {
+      unavailableReason: reason ?? "app logs are not configured",
+      config: () => undefined,
+      ensure: async () => {},
+    };
+  }
+  const cfg = resolvedSls.config;
+  const ops = makeSlsOps(getSlsClient(resolvedOss.profile), cfg);
+  let state: "unknown" | "ready" | "failed" = "unknown";
+  return {
+    ops,
+    config: () =>
+      state === "failed" ? undefined : { project: cfg.project, logstore: cfg.logstore },
+    ensure: async () => {
+      if (state !== "unknown") return;
+      try {
+        await ops.ensureLogStore();
+        state = "ready";
+      } catch (e) {
+        state = "failed";
+        throw e;
+      }
+    },
+  };
+}
+
+// Built on first use, not at import: this module is imported by tooling that
+// has no environment at all, and the memo is only worth anything if the object
+// outlives one request.
+let appLogsProvisionerMemo: AppLogsProvisioner | null = null;
+function appLogsProvisioner(): AppLogsProvisioner {
+  appLogsProvisionerMemo ??= buildAppLogsProvisioner();
+  return appLogsProvisionerMemo;
+}
+
+/** Read side of the same destination — see {@link buildAppLogsProvisioner}. */
+function makeAppLogsDeps() {
+  const provisioner = appLogsProvisioner();
+  if (!provisioner.ops) {
+    return { appLogsUnavailableReason: provisioner.unavailableReason };
+  }
+  return { appLogs: makeAppLogsReader(provisioner.ops) };
+}
+
 function makeDeployDeps() {
   const resolved = resolveAppsOss();
   if (resolved.error) return { deployUnavailableReason: resolved.error };
@@ -92,6 +163,7 @@ function makeDeployDeps() {
     // from — a layer ARN is region-scoped.
     region: profile.region,
     vpc: appsFcVpc,
+    logs: () => appLogsProvisioner().config(),
   });
   const appsAdminUrl = process.env.APPS_DB_ADMIN_URL?.trim() || undefined;
   const appsAppUrl = process.env.APPS_DB_APP_URL?.trim() || undefined;
@@ -114,7 +186,11 @@ function makeDeployDeps() {
       fcFunctionName: string;
       ossObjectName: string;
       platformAuthEnv?: Record<string, string>;
-    }) => finalizeDeployImpl({ appsAdminUrl, appsAppUrl, fcOps }, a),
+    }) =>
+      finalizeDeployImpl(
+        { appsAdminUrl, appsAppUrl, fcOps, ensureLogStore: () => appLogsProvisioner().ensure() },
+        a,
+      ),
   };
 }
 
@@ -311,6 +387,7 @@ export function makeBusinessRepoFactory() {
       ...makeDeployDeps(),
       ...makeTeardownDeps(),
       ...makeAppDataDeps(),
+      ...makeAppLogsDeps(),
       ...makeGiteaDeps(),
       ...makeGotrueOAuthDeps(),
     });

--- a/services/fc/src/lib/provisioning/app-deploy.ts
+++ b/services/fc/src/lib/provisioning/app-deploy.ts
@@ -256,6 +256,14 @@ export interface FinalizeDeps {
   };
   genPassword?: () => string;
   extraEnv?: (input: FinalizeInput) => Record<string, string>;
+  /**
+   * Create the SLS project and logstore the function's `logConfig` points at.
+   *
+   * Called before the function is created, because Function Compute rejects a
+   * `logConfig` naming a project that does not exist. Best-effort by contract:
+   * see the call site.
+   */
+  ensureLogStore?: () => Promise<void>;
 }
 export interface FinalizeInput {
   appId: string;
@@ -331,6 +339,19 @@ export async function finalizeDeploy(deps: FinalizeDeps, input: FinalizeInput): 
 
   if (input.platformAuthEnv) Object.assign(env, input.platformAuthEnv);
   if (deps.extraEnv) Object.assign(env, deps.extraEnv(input));
+
+  // Best-effort, and deliberately not fatal. An app deployed without logs is
+  // worse off than one with them; an app that cannot deploy at all because the
+  // deployment's key lacks an SLS permission is worse off than both. The
+  // provisioner remembers the failure and stops offering the log config, so the
+  // function is created without one rather than with a dangling project.
+  if (deps.ensureLogStore) {
+    try {
+      await deps.ensureLogStore();
+    } catch (e) {
+      console.warn(`[apps] deploying without logs — log store not ready: ${e}`);
+    }
+  }
 
   await deps.fcOps.ensureFunction(input.fcFunctionName, {
     ossObjectName: input.ossObjectName,

--- a/services/fc/src/lib/provisioning/app-logs.ts
+++ b/services/fc/src/lib/provisioning/app-logs.ts
@@ -1,0 +1,300 @@
+/**
+ * Turn raw SLS rows into the log entries `GET /v1/apps/:appId/logs` returns.
+ *
+ * Function Compute delivers four different things into one logstore, told apart
+ * by `__topic__`:
+ *
+ * - `FCLogs:<functionName>`          — what the app itself printed (`message`)
+ * - `FCRequestMetrics:/<fn>`         — one row per HTTP request: status, duration
+ * - `FCInstanceEvents:/<fn>`         — instance created / destroyed
+ * - `FCInstanceMetrics:/<fn>`        — CPU / memory samples
+ *
+ * Only the first two are worth an agent's context window, and only the first
+ * two are returned.
+ *
+ * ## Why the filtering happens here and not in the SLS query
+ *
+ * `contains` and `requestId` are applied to normalized entries rather than
+ * pushed into the query string. Three reasons, all learned the hard way:
+ * SLS tokenizes on punctuation, so a term with an underscore (a table name, a
+ * env var) simply does not match; interpolating caller text into a query
+ * language that has `or` is an injection surface on a filter whose whole job is
+ * to keep one app inside its own logs; and an app's own output carries no
+ * `requestId` field at all — the id only appears in FC's framing lines, so
+ * correlating it is something only this module can do.
+ *
+ * The cost is that both filters search the fetched window, not all of history.
+ * That is stated in the API description rather than hidden.
+ */
+
+import type { SlsRow } from "./sls-client.js";
+
+/** Which of the two useful topics a caller wants. */
+export type AppLogKind = "app" | "request" | "all";
+
+export interface AppLogEntry {
+  /** ISO-8601, UTC. SLS stores whole seconds. */
+  ts: string;
+  kind: "app" | "request";
+  level: "info" | "warn" | "error";
+  message: string;
+  /** FC request id, when it is known — see {@link attachRequestIds}. */
+  requestId?: string;
+  instanceId?: string;
+  statusCode?: number;
+  durationMs?: number;
+  method?: string;
+  path?: string;
+  coldStart?: boolean;
+}
+
+/** `FCLogs:<fn>` is what the app printed; `FCRequestMetrics:/<fn>` is FC's own
+ *  per-request row. The slash is FC's, not a typo — the two topics are shaped
+ *  differently and a reader that assumes one shape finds nothing. */
+export function appLogTopic(functionName: string): string {
+  return `FCLogs:${functionName}`;
+}
+
+export function requestLogTopic(functionName: string): string {
+  return `FCRequestMetrics:/${functionName}`;
+}
+
+/**
+ * FC's own framing around each invocation. Dropped from the output — it is two
+ * lines of noise per request — but read first: these lines are the only place
+ * an app log line's request id appears.
+ */
+const FC_FRAMING = /^\s*FC Invoke (Start|End) RequestId:\s*(\S+)\s*$/;
+
+const ERROR_WORDS = /\b(error|err|exception|fatal|unhandled|rejection|traceback|panic)\b/i;
+/**
+ * `TypeError`, `ReferenceError`, `PostgresError` — the words that actually
+ * appear when a Node app falls over, and none of which the rule above catches:
+ * there is no word boundary inside `TypeError`.
+ *
+ * Case-SENSITIVE on purpose. Case-insensitively this also matches `terror`,
+ * `mirror` and every other word that happens to end in those five letters.
+ */
+const ERROR_CLASS = /[A-Za-z_]\w*Error\b/;
+const WARN_WORDS = /\b(warn|warning|deprecated)\b/i;
+
+function topicKind(topic: string): "app" | "request" | null {
+  if (topic.startsWith("FCLogs:")) return "app";
+  if (topic.startsWith("FCRequestMetrics:")) return "request";
+  return null;
+}
+
+function isoFromSeconds(raw: string | undefined): string {
+  const seconds = Number(raw ?? 0);
+  if (!Number.isFinite(seconds) || seconds <= 0) return new Date(0).toISOString();
+  return new Date(seconds * 1000).toISOString();
+}
+
+function num(raw: string | undefined): number | undefined {
+  if (raw === undefined || raw === "") return undefined;
+  const n = Number(raw);
+  return Number.isFinite(n) ? n : undefined;
+}
+
+/** Level for a line the app printed. FC adds no level of its own. */
+export function inferLevel(message: string): "info" | "warn" | "error" {
+  if (ERROR_WORDS.test(message) || ERROR_CLASS.test(message)) return "error";
+  if (WARN_WORDS.test(message)) return "warn";
+  return "info";
+}
+
+/**
+ * One SLS row → one entry, or null for a row that is framing, noise, or from a
+ * topic this endpoint does not serve.
+ */
+export function normalizeSlsRow(row: SlsRow): AppLogEntry | null {
+  const kind = topicKind(row.__topic__ ?? "");
+  if (!kind) return null;
+  const ts = isoFromSeconds(row.__time__);
+  const instanceId = row.instanceID || undefined;
+
+  if (kind === "app") {
+    const message = (row.message ?? "").replace(/\s+$/, "");
+    if (!message.trim()) return null;
+    if (FC_FRAMING.test(message)) return null;
+    return { ts, kind, level: inferLevel(message), message, instanceId };
+  }
+
+  const statusCode = num(row.statusCode);
+  const durationMs = num(row.durationMs);
+  const method = row.method || undefined;
+  const path = row.requestURI || undefined;
+  const failed = row.hasFunctionError === "true" || (statusCode ?? 0) >= 500;
+  const parts = [method, path].filter(Boolean).join(" ");
+  const tail = [
+    statusCode === undefined ? null : `→ ${statusCode}`,
+    durationMs === undefined ? null : `in ${durationMs}ms`,
+    row.isColdStart === "true" ? "(cold start)" : null,
+  ]
+    .filter(Boolean)
+    .join(" ");
+  return {
+    ts,
+    kind,
+    level: failed ? "error" : (statusCode ?? 0) >= 400 ? "warn" : "info",
+    message: [parts, tail].filter(Boolean).join(" ") || "request",
+    requestId: row.requestId || undefined,
+    instanceId,
+    statusCode,
+    durationMs,
+    method,
+    path,
+    coldStart: row.isColdStart === "true" ? true : undefined,
+  };
+}
+
+/**
+ * Give each app log line the request id of the invocation it was printed in.
+ *
+ * FC brackets every invocation with `FC Invoke Start/End RequestId: <id>` on the
+ * same instance, and those framing lines are the only carrier of the id — the
+ * app's own lines have no `requestId` field. Walking one instance's stream in
+ * time order is what turns "these 40 lines" into "the 6 lines from the request
+ * that 500'd", which is the question worth asking.
+ *
+ * Takes the raw rows (framing included, which {@link normalizeSlsRow} drops) and
+ * returns entries in the order given.
+ */
+export function normalizeRows(rows: SlsRow[]): AppLogEntry[] {
+  // Oldest first so a Start line is seen before the lines it brackets.
+  const chronological = [...rows].sort(
+    (a, b) => Number(a.__time__ ?? 0) - Number(b.__time__ ?? 0),
+  );
+  const openByInstance = new Map<string, string>();
+  const out: AppLogEntry[] = [];
+
+  for (const row of chronological) {
+    const instance = row.instanceID ?? "";
+    const framing = topicKind(row.__topic__ ?? "") === "app" && FC_FRAMING.exec(row.message ?? "");
+    if (framing) {
+      const [, which, requestId] = framing;
+      if (which === "Start") openByInstance.set(instance, requestId);
+      else openByInstance.delete(instance);
+      continue;
+    }
+    const entry = normalizeSlsRow(row);
+    if (!entry) continue;
+    if (entry.kind === "app" && !entry.requestId) {
+      const open = openByInstance.get(instance);
+      if (open) entry.requestId = open;
+    }
+    out.push(entry);
+  }
+  return out;
+}
+
+export interface AppLogFilter {
+  contains?: string | null;
+  requestId?: string | null;
+  kind?: AppLogKind;
+}
+
+/** Case-insensitive substring on the message; exact match on the request id. */
+export function filterEntries(entries: AppLogEntry[], filter: AppLogFilter): AppLogEntry[] {
+  const contains = filter.contains?.trim().toLowerCase() || null;
+  const requestId = filter.requestId?.trim() || null;
+  const kind = filter.kind ?? "app";
+  return entries.filter((e) => {
+    if (kind !== "all" && e.kind !== kind) return false;
+    if (requestId && e.requestId !== requestId) return false;
+    if (contains && !e.message.toLowerCase().includes(contains)) return false;
+    return true;
+  });
+}
+
+/**
+ * Newest first, capped.
+ *
+ * Newest first because the question is nearly always "what just happened"; the
+ * cap because a tool result large enough to blow the caller's context is worse
+ * than a short one that says it was cut off.
+ */
+export function takeNewest(entries: AppLogEntry[], limit: number): {
+  items: AppLogEntry[];
+  truncated: boolean;
+} {
+  const sorted = [...entries].sort((a, b) => (a.ts < b.ts ? 1 : a.ts > b.ts ? -1 : 0));
+  return { items: sorted.slice(0, limit), truncated: sorted.length > limit };
+}
+
+// ─── Reader ──────────────────────────────────────────────────────────────────
+
+export interface ReadAppLogsInput {
+  /** `tc-app-<appId>` — what FC named the topic after. */
+  functionName: string;
+  sinceMinutes: number;
+  limit: number;
+  kind: AppLogKind;
+  contains?: string | null;
+  requestId?: string | null;
+  /** Injectable clock, for tests. */
+  now?: number;
+}
+
+export interface AppLogsResult {
+  items: AppLogEntry[];
+  /** More matched than `limit`, or the scan budget cut the window short. */
+  truncated: boolean;
+  /** The window actually read, as ISO strings — an empty answer is ambiguous
+   *  without it ("no errors" vs "wrong five minutes"). */
+  from: string;
+  to: string;
+}
+
+/**
+ * How many raw rows a single call may pull before giving up on finding more
+ * matches. Ten pages: enough that a `contains` over a quiet app reaches back
+ * through the whole window, bounded enough that a chatty one cannot turn one
+ * tool call into a minute of paging.
+ */
+export const SCAN_BUDGET_ROWS = 1000;
+
+export function makeAppLogsReader(ops: {
+  fetchWindow: (args: {
+    topic: string;
+    from: number;
+    to: number;
+    maxRows: number;
+  }) => Promise<SlsRow[]>;
+}) {
+  return async function readAppLogs(input: ReadAppLogsInput): Promise<AppLogsResult> {
+    const nowMs = input.now ?? Date.now();
+    const to = Math.floor(nowMs / 1000);
+    const from = to - input.sinceMinutes * 60;
+
+    const topics: string[] = [];
+    if (input.kind === "app" || input.kind === "all") topics.push(appLogTopic(input.functionName));
+    if (input.kind === "request" || input.kind === "all") {
+      topics.push(requestLogTopic(input.functionName));
+    }
+
+    const budget = Math.min(SCAN_BUDGET_ROWS, Math.max(input.limit * 10, 200));
+    const rows: SlsRow[] = [];
+    let hitBudget = false;
+    for (const topic of topics) {
+      const page = await ops.fetchWindow({ topic, from, to, maxRows: budget });
+      if (page.length >= budget) hitBudget = true;
+      rows.push(...page);
+    }
+
+    const entries = filterEntries(normalizeRows(rows), {
+      contains: input.contains,
+      requestId: input.requestId,
+      kind: input.kind,
+    });
+    const { items, truncated } = takeNewest(entries, input.limit);
+    return {
+      items,
+      truncated: truncated || hitBudget,
+      from: new Date(from * 1000).toISOString(),
+      to: new Date(to * 1000).toISOString(),
+    };
+  };
+}
+
+export type AppLogsReader = ReturnType<typeof makeAppLogsReader>;

--- a/services/fc/src/lib/provisioning/fc-client.ts
+++ b/services/fc/src/lib/provisioning/fc-client.ts
@@ -100,12 +100,51 @@ export interface FcOpsConfig {
   region: string;
   /** When set, every app function create/update joins this VPC. */
   vpc?: AppsFcVpcConfig;
+  /**
+   * Where the function's own output goes. Omitted (the state every app was in
+   * until 2026-09) means Function Compute keeps NO logs at all: not in the
+   * console, not through any API, so "why does my app 500" has no answer.
+   *
+   * A getter, not a value: the destination has to exist before a function may
+   * point at it, and the caller only learns whether it does when it tries to
+   * create it. Returning undefined after that failed is what keeps a missing
+   * SLS permission from turning every deploy into a hard failure.
+   */
+  logs?: () => { project: string; logstore: string } | undefined;
 }
 export interface EnsureFunctionArgs {
   ossObjectName: string;
   env: Record<string, string>;
   /** What the app declared about how it is started. Absent → the built-in Node contract. */
   runtime?: AppRuntimeSpec;
+}
+
+/**
+ * Log delivery for an app function.
+ *
+ * `enableRequestMetrics` is what produces the one-row-per-request stream with
+ * status code and duration — the half of "logs" that answers whether a request
+ * arrived at all, which the app's own output cannot.
+ *
+ * Delivery does NOT need the function to carry a role: the live function that
+ * had logs on before this existed has `role: ""`, and the account's
+ * `AliyunServiceRoleForFC` is what writes. So this stays safe on a deployment
+ * whose `ROLE_ARN` is empty, which is the documented shape.
+ */
+function functionLogInput(logs: { project: string; logstore: string } | undefined) {
+  if (!logs) return {};
+  return {
+    logConfig: new $fc.LogConfig({
+      project: logs.project,
+      logstore: logs.logstore,
+      enableRequestMetrics: true,
+      enableInstanceMetrics: true,
+      // How FC decides where one multi-line log entry ends. `DefaultRegex` is
+      // what the console configures; `None` makes every line its own entry and
+      // shreds stack traces.
+      logBeginRule: "DefaultRegex",
+    }),
+  };
 }
 
 function functionNetworkInput(vpc: AppsFcVpcConfig | undefined) {
@@ -212,6 +251,7 @@ export function makeFcOps(client: any, cfg: FcOpsConfig) {
             customRuntimeConfig: startCommand(args.runtime),
             code: codeLocation(args.ossObjectName),
             ...functionNetworkInput(cfg.vpc),
+            ...functionLogInput(cfg.logs?.()),
           }),
         }));
       } else {
@@ -227,7 +267,10 @@ export function makeFcOps(client: any, cfg: FcOpsConfig) {
       //
       // VPC config is re-sent for the same reason: a function created before
       // APPS_FC_VPC_* was wired would keep an empty vpcConfig through every
-      // redeploy and time out against an internal RDS host forever.
+      // redeploy and time out against an internal RDS host forever. And the log
+      // config for the same reason again — the nine functions deployed before
+      // it existed have no logs, and a code-only update would leave them with
+      // none no matter how many times their owner redeployed.
       await client.updateFunction(functionName, new $fc.UpdateFunctionRequest({
         body: new $fc.UpdateFunctionInput({
           environmentVariables: args.env,
@@ -235,6 +278,7 @@ export function makeFcOps(client: any, cfg: FcOpsConfig) {
           customRuntimeConfig: startCommand(args.runtime),
           code: codeLocation(args.ossObjectName),
           ...functionNetworkInput(cfg.vpc),
+          ...functionLogInput(cfg.logs?.()),
         }),
       }));
     },

--- a/services/fc/src/lib/provisioning/sls-client.ts
+++ b/services/fc/src/lib/provisioning/sls-client.ts
@@ -1,0 +1,231 @@
+import SlsClient, * as $sls from "@alicloud/sls20201230";
+import { Config } from "@alicloud/openapi-client";
+import { appsRegion, type AppsOssProfile } from "./apps-oss.js";
+import { accountIdFromRoleArn } from "./fc-client.js";
+
+type SlsClientInstance = InstanceType<typeof SlsClient.default>;
+
+/**
+ * Where deployed app functions send their logs.
+ *
+ * Function Compute writes nothing anywhere unless the function carries a
+ * `logConfig`, and a function created through our API never had one: of the ten
+ * `tc-app-*` functions live on 2026-09-08, nine had `{project:"", logstore:""}`
+ * and therefore no retrievable output at all — not in the console, not through
+ * any API. This module is the other half of fixing that: the destination has to
+ * exist before a function can be pointed at it.
+ *
+ * One project and one logstore for every app, filtered by `__topic__` (FC names
+ * the topic after the function, so the filter is exact). Not one logstore per
+ * app: a logstore costs at least one shard, SLS caps how many a project may
+ * hold, and the authorization that matters happens in the Cloud API against the
+ * app row — never in SLS, which sees one service account.
+ */
+export interface AppsSlsConfig {
+  project: string;
+  logstore: string;
+  region: string;
+}
+
+export type AppsSlsResolution =
+  | { config: AppsSlsConfig; error?: undefined }
+  | { config?: undefined; error: string };
+
+type Env = NodeJS.ProcessEnv;
+
+const trimmed = (v: string | undefined) => v?.trim() || "";
+
+/** Days of log retention. Long enough to debug last week's incident. */
+export const APPS_SLS_TTL_DAYS = 14;
+
+/**
+ * SLS project names are unique across ALL Alibaba Cloud accounts, so a fixed
+ * default would collide with a stranger's project (this is why the FC console
+ * generates `serverless-<region>-<uuid>`). The account id makes ours ours.
+ */
+export function defaultSlsProject(env: Env = process.env): string | null {
+  const accountId =
+    trimmed(env.ALIYUN_ACCOUNT_ID) || accountIdFromRoleArn(env.ROLE_ARN) || null;
+  return accountId ? `teamclu-apps-${accountId}` : null;
+}
+
+/**
+ * Resolve the log destination, or explain what is missing.
+ *
+ * `APPS_SLS_PROJECT` exists so a deployment can point at a project it already
+ * has — including the one the FC console auto-created the first time somebody
+ * switched logs on by hand.
+ */
+export function resolveAppsSls(env: Env = process.env): AppsSlsResolution {
+  const project = trimmed(env.APPS_SLS_PROJECT) || defaultSlsProject(env);
+  if (!project) {
+    return {
+      error:
+        "no SLS project: set APPS_SLS_PROJECT, or ALIYUN_ACCOUNT_ID / ROLE_ARN so one can be derived",
+    };
+  }
+  return {
+    config: {
+      project,
+      logstore: trimmed(env.APPS_SLS_LOGSTORE) || "app-logs",
+      region: appsRegion(env),
+    },
+  };
+}
+
+/**
+ * `profile` carries the Alibaba credentials the app functions run under. Same
+ * reasoning as {@link getFcClient}: on a deployment whose default
+ * `ACCESS_KEY_ID` is MinIO's, those credentials do not authenticate here.
+ */
+export function getSlsClient(profile?: AppsOssProfile): SlsClientInstance {
+  return new SlsClient.default(
+    new Config({
+      accessKeyId: profile?.accessKeyId ?? process.env.ACCESS_KEY_ID,
+      accessKeySecret: profile?.accessKeySecret ?? process.env.ACCESS_KEY_SECRET,
+      // The SDK maps the region to `<region>.log.aliyuncs.com` itself and adds
+      // the project as a host prefix per call, so no endpoint is set here.
+      regionId: profile?.region ?? appsRegion(),
+    }) as any,
+  );
+}
+
+/** SLS answers "it is already there" with a 4xx and a name, not a 200. */
+function isAlreadyExists(e: any): boolean {
+  const code = e?.code ?? e?.data?.Code ?? e?.data?.errorCode ?? "";
+  return /AlreadyExist/i.test(String(code)) || /already exist/i.test(String(e?.message ?? ""));
+}
+
+/** Log entries as SLS returns them: a flat map of string values. */
+export type SlsRow = Record<string, string>;
+
+/** `GetLogs` refuses more than this per call, so a window is paged. */
+const MAX_LINES_PER_CALL = 100;
+
+export interface FetchWindowArgs {
+  /** Exact `__topic__` to read — FC names it after the function. */
+  topic: string;
+  /** Unix seconds, inclusive. */
+  from: number;
+  /** Unix seconds, inclusive. */
+  to: number;
+  /** Stop after this many rows, however many pages that takes. */
+  maxRows: number;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function makeSlsOps(client: any, cfg: AppsSlsConfig) {
+  const ops = {
+    /**
+     * Create the project, the logstore and its index if they are not there.
+     *
+     * Idempotent and safe to call on every deploy; the calls that matter fail
+     * with `*AlreadyExist` the second time. An index is created even though the
+     * queries here filter by topic alone: `GetLogs` reads through the index
+     * engine, and a logstore without one answers every read with an error.
+     */
+    async ensureLogStore(): Promise<void> {
+      try {
+        await client.createProject(
+          new $sls.CreateProjectRequest({
+            projectName: cfg.project,
+            description: "TeamClu deployed apps — function logs",
+          }),
+        );
+      } catch (e) {
+        if (!isAlreadyExists(e)) throw e;
+      }
+      try {
+        await client.createLogStore(
+          cfg.project,
+          new $sls.CreateLogStoreRequest({
+            logstoreName: cfg.logstore,
+            ttl: APPS_SLS_TTL_DAYS,
+            shardCount: 2,
+            autoSplit: true,
+            maxSplitShard: 8,
+            telemetryType: "None",
+          }),
+        );
+      } catch (e) {
+        if (!isAlreadyExists(e)) throw e;
+      }
+      try {
+        await client.createIndex(
+          cfg.project,
+          cfg.logstore,
+          new $sls.CreateIndexRequest({
+            body: new $sls.Index({
+              // Full text over the whole line, plus the fields a human would
+              // want to filter on in the SLS console.
+              line: new $sls.IndexLine({
+                caseSensitive: false,
+                chn: true,
+                token: [",", " ", "'", '"', ";", "=", "(", ")", "[", "]", "{", "}", "?", "@", "&", "<", ">", "/", ":", "\n", "\t", "\r"],
+              }),
+              keys: {
+                functionName: new $sls.IndexKey({ type: "text", caseSensitive: false, token: ["-", ":", "/"] }),
+                requestId: new $sls.IndexKey({ type: "text", caseSensitive: false, token: ["-"] }),
+                instanceID: new $sls.IndexKey({ type: "text", caseSensitive: false, token: ["-"] }),
+                statusCode: new $sls.IndexKey({ type: "long" }),
+                durationMs: new $sls.IndexKey({ type: "double" }),
+              },
+            }),
+          }),
+        );
+      } catch (e) {
+        if (!isAlreadyExists(e)) throw e;
+      }
+    },
+
+    /** One page. `offset` walks a window that is bigger than one call. */
+    async getLogs(args: {
+      topic: string;
+      from: number;
+      to: number;
+      line: number;
+      offset: number;
+    }): Promise<SlsRow[]> {
+      const resp = await client.getLogs(
+        cfg.project,
+        cfg.logstore,
+        new $sls.GetLogsRequest({
+          from: args.from,
+          to: args.to,
+          topic: args.topic,
+          line: Math.min(args.line, MAX_LINES_PER_CALL),
+          offset: args.offset,
+          // Newest first: a window is read for what just happened, and the cap
+          // should drop the oldest rows rather than the ones being looked for.
+          reverse: true,
+        }),
+      );
+      return (resp?.body?.data ?? []) as SlsRow[];
+    },
+
+    /** Read a whole time window for one topic, up to `maxRows`. */
+    async fetchWindow(args: FetchWindowArgs): Promise<SlsRow[]> {
+      const out: SlsRow[] = [];
+      let offset = 0;
+      while (out.length < args.maxRows) {
+        const want = Math.min(MAX_LINES_PER_CALL, args.maxRows - out.length);
+        const page = await ops.getLogs({
+          topic: args.topic,
+          from: args.from,
+          to: args.to,
+          line: want,
+          offset,
+        });
+        out.push(...page);
+        // A short page is the end of the window, not a hint to try again: SLS
+        // pages by offset and returns fewer rows only when there are no more.
+        if (page.length < want) break;
+        offset += page.length;
+      }
+      return out;
+    },
+  };
+  return ops;
+}
+
+export type SlsOps = ReturnType<typeof makeSlsOps>;

--- a/services/fc/src/lib/routes/apps.ts
+++ b/services/fc/src/lib/routes/apps.ts
@@ -115,6 +115,22 @@ export function registerApps(router) {
     return { body: out };
   });
 
+  // The deployed function's own output. Read-only and scoped to one app by the
+  // repository, which names the function from the app row — the caller never
+  // gets to say which function's logs it wants.
+  router.get("/v1/apps/:appId/logs", async (ctx) => {
+    const appId = decodeURIComponent(ctx.params.appId);
+    const out = await ctx.repository.getAppLogs(appId, {
+      sinceMinutes: ctx.query.get("sinceMinutes"),
+      limit: ctx.query.get("limit"),
+      kind: ctx.query.get("kind"),
+      contains: ctx.query.get("contains"),
+      requestId: ctx.query.get("requestId"),
+    });
+    if (!out) throw new ApiError(404, "not_found", "app not found");
+    return { body: out };
+  });
+
   router.get("/v1/apps/:appId/git-head", async (ctx) => {
     const appId = decodeURIComponent(ctx.params.appId);
     const out = await ctx.repository.getAppGitHead(appId);

--- a/services/fc/src/lib/routes/apps.ts
+++ b/services/fc/src/lib/routes/apps.ts
@@ -2,12 +2,56 @@ import { ApiError } from "../http-utils.js";
 import { parseLimit, requireString } from "../routing-utils.js";
 
 /**
+ * Drop credentials out of a repo URL before it is stored.
+ *
+ * `https://x:ghp_…@github.com/owner/repo.git` is a working git address and the
+ * obvious way to import a private repo, so people paste it. What they do not
+ * expect is that it lands in `apps.git_remote_url` — a column `GET /v1/apps/:id`
+ * hands to every member who can see the app, and which nothing ever redacts.
+ * One paste turns a personal access token into team-readable data.
+ *
+ * The credential still reaches the clone: the desktop sends the address the
+ * user typed straight to its local daemon for that one call. What stops here is
+ * the copy that would outlive it.
+ *
+ * Scheme decides how much goes:
+ * - **http(s)** — the whole userinfo. Nothing there is an address; an anonymous
+ *   clone needs none of it, and every form GitHub documents (`token@`,
+ *   `user:token@`) is a secret.
+ * - **ssh / git** — the password half only. `git@` IS the address for those,
+ *   and dropping it produces a URL that cannot connect.
+ * - **scp-like `git@host:path`** — untouched, for the same reason.
+ */
+export function stripUrlCredentials(url: string): string {
+  const schemeEnd = url.indexOf("://");
+  if (schemeEnd < 0) return url;
+  const scheme = url.slice(0, schemeEnd);
+  const rest = url.slice(schemeEnd + 3);
+  const authorityEnd = rest.search(/[/?#]/);
+  const authority = authorityEnd < 0 ? rest : rest.slice(0, authorityEnd);
+  const tail = authorityEnd < 0 ? "" : rest.slice(authorityEnd);
+  // Last `@`, not the first: a password is supposed to percent-encode one, and
+  // a lenient split on the first would cut a host off a sloppy-but-working URL.
+  const at = authority.lastIndexOf("@");
+  if (at < 0) return url;
+  const userinfo = authority.slice(0, at);
+  const host = authority.slice(at + 1);
+  const lower = scheme.toLowerCase();
+  const keep = lower === "ssh" || lower === "git" ? userinfo.split(":")[0] : "";
+  return `${scheme}://${keep ? `${keep}@` : ""}${host}${tail}`;
+}
+
+/**
  * Normalize the optional repo URL an app is imported from.
  *
  * The daemon validates it again before handing it to `git clone` — that check
  * is the security boundary, since it is the one next to the process spawn. This
  * one exists so a typo is a 400 at create time instead of a row that can never
  * be seeded. Same allowlist: http(s) / ssh / git://, or scp-like `git@host:path`.
+ *
+ * Credentials are stripped here rather than rejected: refusing the paste would
+ * be a dead end for a private repo on a machine with no credential helper, and
+ * the address is still perfectly usable without them.
  */
 function normalizeGitRemoteUrl(raw: unknown): string | null {
   if (raw === undefined || raw === null) return null;
@@ -25,7 +69,7 @@ function normalizeGitRemoteUrl(raw: unknown): string | null {
       "gitRemoteUrl must be an http(s), ssh or git:// address",
     );
   }
-  return url;
+  return stripUrlCredentials(url);
 }
 
 export function registerApps(router) {

--- a/services/fc/src/lib/supabase-repo.ts
+++ b/services/fc/src/lib/supabase-repo.ts
@@ -48,6 +48,7 @@ import {
 } from "./validation/team-env-secrets.js";
 import { isLegalFcTransition } from "./provisioning/app-fc-status.js";
 import {
+  appFunctionName,
   appOssObjectName,
   assertDeployAllowed,
   checkDeployInProgress,
@@ -57,6 +58,7 @@ import {
   parseDeployToken,
   parseOptionalGitCommitSha,
 } from "./provisioning/app-deploy.js";
+import type { AppLogKind } from "./provisioning/app-logs.js";
 import { decodeRowKey, describeDbError, parsePageLimit, type AppDataTarget, type FilterOp } from "./provisioning/app-data-db.js";
 import { teardownAppResources, type TeardownAppDeps } from "./provisioning/app-delete.js";
 import { giteaUnavailable, GITEA_AUTH_KIND } from "./provisioning/gitea.js";
@@ -300,6 +302,37 @@ async function runAppData<T>(fn: () => Promise<T>): Promise<T> {
   }
 }
 
+/**
+ * Bounds for a log read, applied here rather than trusted from the caller.
+ *
+ * The window is capped at the retention period: asking for more is not an
+ * error, it is a window that is mostly empty, and clamping says so by
+ * returning what exists. The row cap is what keeps one call from returning
+ * more text than its caller can hold.
+ */
+export const APP_LOGS_MAX_MINUTES = 7 * 24 * 60;
+export const APP_LOGS_MAX_ROWS = 200;
+
+function parseLogMinutes(raw: unknown): number {
+  const n = Math.floor(Number(raw));
+  if (!Number.isFinite(n) || n <= 0) return 30;
+  return Math.min(n, APP_LOGS_MAX_MINUTES);
+}
+
+function parseLogLimit(raw: unknown): number {
+  const n = Math.floor(Number(raw));
+  if (!Number.isFinite(n) || n <= 0) return 100;
+  return Math.min(n, APP_LOGS_MAX_ROWS);
+}
+
+function parseLogKind(raw: unknown): AppLogKind {
+  return raw === "request" || raw === "all" ? raw : "app";
+}
+
+function parseLogText(raw: unknown): string | null {
+  return typeof raw === "string" && raw.trim() ? raw.trim() : null;
+}
+
 const APP_DATA_FILTER_OPS: readonly FilterOp[] = ["eq", "contains", "isNull", "notNull"];
 
 /** `filterColumn` + `filterOp` (+ `filterValue`), or nothing. */
@@ -338,6 +371,11 @@ export function createSupabaseBusinessRepository(options) {
     // reason names the variable so the 503 is actionable.
     appData,
     appDataUnavailableReason,
+    // Reads the deployed function's own logs out of SLS. Absent when the
+    // deployment has no Alibaba credentials or no SLS project to point at —
+    // the reason names what is missing, as with the two above.
+    appLogs,
+    appLogsUnavailableReason,
     trustedExternalJwtSecret = process.env.TRUSTED_EXTERNAL_JWT_SECRET,
     // Optional push hook — called after every successful message INSERT. Best-effort:
     // errors are logged and swallowed so insert outcome is never affected.
@@ -3832,6 +3870,72 @@ export function createSupabaseBusinessRepository(options) {
       const ops = this.requireAppData();
       await runAppData(() => ops.deleteRow(resolved.target, { table, key: decodeRowKey(rowKey) }));
       return { ok: true };
+    },
+
+    /**
+     * What the deployed function itself printed, plus one row per request.
+     *
+     * Authorized like the data browser and for the same reason: an app's log
+     * lines carry whatever it decided to print, which is its users' data. So
+     * `view` gets the same 404 the feature gives a non-member, and the caller's
+     * own permission on the app row is what decides — never the SLS credential,
+     * which is one service account for every app on the deployment.
+     *
+     * The function name is read off the row rather than derived, so an app
+     * deployed under an older naming scheme still finds its own logs; deriving
+     * it is only the fallback for a row that predates the column.
+     */
+    async getAppLogs(appId: string, query: any = {}) {
+      const { data: app, error } = await supabase
+        .from("apps")
+        .select("id, slug, team_id, type, fc_status, fc_function_name, created_by_actor_id")
+        .eq("id", appId)
+        .maybeSingle();
+      if (error) throw error;
+      if (!app) return null;
+
+      const permission = await this.resolveAppCallerPermissionForApp(app);
+      if (!permission || permission.level === "view") return null;
+
+      // Distinguishable from "no logs in that window", which is the answer that
+      // sends someone looking for a bug that is not there.
+      if (!app.fc_status || app.fc_status === "not_deployed") {
+        throw new ApiError(
+          409,
+          "app_not_deployed",
+          "this app has never been deployed, so it has no logs yet",
+        );
+      }
+      if (!appLogs) {
+        throw new ApiError(
+          503,
+          "app_logs_unavailable",
+          appLogsUnavailableReason
+            ? `app logs are not configured: ${appLogsUnavailableReason}`
+            : "app logs are not configured",
+        );
+      }
+
+      try {
+        return await appLogs({
+          functionName: app.fc_function_name || appFunctionName(app.id),
+          sinceMinutes: parseLogMinutes(query.sinceMinutes),
+          limit: parseLogLimit(query.limit),
+          kind: parseLogKind(query.kind),
+          contains: parseLogText(query.contains),
+          requestId: parseLogText(query.requestId),
+        });
+      } catch (e: any) {
+        if (e instanceof ApiError) throw e;
+        // A logstore that exists but has never received a row answers with a
+        // 4xx rather than an empty page. That is "nothing yet", not a failure
+        // the caller can act on.
+        if (/LogStoreNotExist|IndexConfigNotExist|ProjectNotExist/i.test(String(e?.code ?? ""))) {
+          return { items: [], truncated: false, from: null, to: null };
+        }
+        console.warn(`[apps] app log read failed: ${e?.code ?? e}`);
+        throw new ApiError(502, "app_logs_failed", "could not read this app's logs");
+      }
     },
 
     async listAppSessions(appId: string) {

--- a/services/fc/test/provisioning/app-logs.test.ts
+++ b/services/fc/test/provisioning/app-logs.test.ts
@@ -1,0 +1,235 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  appLogTopic,
+  requestLogTopic,
+  filterEntries,
+  inferLevel,
+  makeAppLogsReader,
+  normalizeRows,
+  normalizeSlsRow,
+  takeNewest,
+  SCAN_BUDGET_ROWS,
+} from "../../src/lib/provisioning/app-logs.js";
+
+const FN = "tc-app-dcb910dc-1688-44a6-814b-943a1d848d65";
+const INSTANCE = "c-6a9fbf89-173c38a5-fcb0e565fb65";
+
+/** An app-output row, shaped exactly as SLS returns one (all values strings). */
+function appRow(time: number, message: string, instance = INSTANCE) {
+  return {
+    __time__: String(time),
+    __topic__: appLogTopic(FN),
+    functionName: FN,
+    instanceID: instance,
+    message,
+    qualifier: "LATEST",
+    versionId: "",
+  };
+}
+
+function requestRow(time: number, over: Record<string, string> = {}) {
+  return {
+    __time__: String(time),
+    __topic__: requestLogTopic(FN),
+    functionName: FN,
+    instanceID: INSTANCE,
+    requestId: "1-6a9fbf92-174ae003-aa99f23c49ae",
+    method: "GET",
+    requestURI: "/?status=active",
+    statusCode: "200",
+    durationMs: "25.69",
+    isColdStart: "false",
+    hasFunctionError: "false",
+    qualifier: "LATEST",
+    ...over,
+  };
+}
+
+test("the two topics are named the way FC names them", () => {
+  // The request topic carries a slash the app topic does not. Getting it wrong
+  // is not an error — it is an empty result, which reads as "no logs".
+  assert.equal(appLogTopic(FN), `FCLogs:${FN}`);
+  assert.equal(requestLogTopic(FN), `FCRequestMetrics:/${FN}`);
+});
+
+test("instance events and metrics are not returned", () => {
+  // Same logstore, three other topics. An agent asking for logs does not want
+  // a CPU sample every ten seconds.
+  for (const topic of [`FCInstanceMetrics:/${FN}`, `FCInstanceEvents:/${FN}`]) {
+    assert.equal(normalizeSlsRow({ __time__: "1788854497", __topic__: topic }), null);
+  }
+});
+
+test("an app line keeps its text and gets a level inferred from it", () => {
+  const entry = normalizeSlsRow(appRow(1788854162, "TypeError: cannot read x"))!;
+  assert.equal(entry.kind, "app");
+  assert.equal(entry.level, "error");
+  assert.equal(entry.message, "TypeError: cannot read x");
+  assert.equal(entry.ts, new Date(1788854162_000).toISOString());
+});
+
+test("level inference does not fire on a word that merely contains one", () => {
+  assert.equal(inferLevel("terror management"), "info");
+  assert.equal(inferLevel("mirror the layout"), "info");
+  // …while the words a Node app actually crashes with do count, even though
+  // none of them has a word boundary before "Error".
+  assert.equal(inferLevel("TypeError: x is not a function"), "error");
+  assert.equal(inferLevel("PostgresError: relation does not exist"), "error");
+  assert.equal(inferLevel("listening on 9000"), "info");
+  assert.equal(inferLevel("WARN: slow query"), "warn");
+});
+
+test("a request row reads as one sentence, with the numbers kept", () => {
+  const entry = normalizeSlsRow(requestRow(1788854162))!;
+  assert.equal(entry.kind, "request");
+  assert.equal(entry.statusCode, 200);
+  assert.equal(entry.durationMs, 25.69);
+  assert.match(entry.message, /GET \/\?status=active/);
+  assert.match(entry.message, /→ 200/);
+});
+
+test("a 5xx request is an error even when FC reports no function error", () => {
+  // A framework that catches its own exception and answers 500 leaves
+  // hasFunctionError false. Reading only that flag hides exactly the requests
+  // worth looking at.
+  const entry = normalizeSlsRow(requestRow(1, { statusCode: "500", hasFunctionError: "false" }))!;
+  assert.equal(entry.level, "error");
+  const notFound = normalizeSlsRow(requestRow(1, { statusCode: "404", hasFunctionError: "false" }))!;
+  assert.equal(notFound.level, "warn");
+});
+
+test("FC's invoke framing is dropped, but its request id is kept on the lines it brackets", () => {
+  const rows = [
+    appRow(100, "\nFC Invoke Start RequestId: req-A"),
+    appRow(101, "loading config"),
+    appRow(102, "boom"),
+    appRow(103, "\nFC Invoke End RequestId: req-A"),
+    appRow(110, "outside any invocation"),
+  ];
+  const entries = normalizeRows(rows);
+  assert.deepEqual(
+    entries.map((e) => [e.message, e.requestId]),
+    [
+      ["loading config", "req-A"],
+      ["boom", "req-A"],
+      ["outside any invocation", undefined],
+    ],
+  );
+});
+
+test("request ids do not leak across instances", () => {
+  // Two instances serve two requests at the same time; attributing one's lines
+  // to the other's id would send someone reading the wrong request.
+  const other = "c-other-instance";
+  const entries = normalizeRows([
+    appRow(100, "\nFC Invoke Start RequestId: req-A"),
+    { ...appRow(101, "\nFC Invoke Start RequestId: req-B", other), instanceID: other },
+    appRow(102, "from A"),
+    { ...appRow(103, "from B", other), instanceID: other },
+  ]);
+  const byMessage = Object.fromEntries(entries.map((e) => [e.message, e.requestId]));
+  assert.equal(byMessage["from A"], "req-A");
+  assert.equal(byMessage["from B"], "req-B");
+});
+
+test("rows arriving newest-first still get their framing applied", () => {
+  // SLS is asked for `reverse: true`, so the End line arrives before the Start
+  // one. A walk that trusted arrival order would attach nothing.
+  const entries = normalizeRows([
+    appRow(103, "\nFC Invoke End RequestId: req-A"),
+    appRow(102, "boom"),
+    appRow(100, "\nFC Invoke Start RequestId: req-A"),
+  ]);
+  assert.equal(entries.length, 1);
+  assert.equal(entries[0].requestId, "req-A");
+});
+
+test("filters are substring and exact, and kind selects the stream", () => {
+  const entries = normalizeRows([
+    appRow(100, "\nFC Invoke Start RequestId: req-A"),
+    appRow(101, "Table user_sessions is empty"),
+    appRow(102, "unrelated"),
+    requestRow(103, { requestId: "req-A" }),
+  ]);
+  // Underscores survive: this is a substring match, not a tokenized query.
+  const hit = filterEntries(entries, { contains: "user_sessions" });
+  assert.deepEqual(hit.map((e) => e.message), ["Table user_sessions is empty"]);
+
+  const byRequest = filterEntries(entries, { requestId: "req-A", kind: "all" });
+  assert.equal(byRequest.length, 3);
+
+  const requestsOnly = filterEntries(entries, { kind: "request" });
+  assert.equal(requestsOnly.length, 1);
+});
+
+test("takeNewest returns newest first and reports the cut", () => {
+  const entries = normalizeRows([appRow(100, "old"), appRow(300, "new"), appRow(200, "mid")]);
+  const { items, truncated } = takeNewest(entries, 2);
+  assert.deepEqual(items.map((e) => e.message), ["new", "mid"]);
+  assert.equal(truncated, true);
+  assert.equal(takeNewest(entries, 5).truncated, false);
+});
+
+// --- the reader -------------------------------------------------------------
+
+function fakeOps(byTopic: Record<string, any[]>) {
+  const calls: any[] = [];
+  return {
+    calls,
+    fetchWindow: async (args: any) => {
+      calls.push(args);
+      return byTopic[args.topic] ?? [];
+    },
+  };
+}
+
+test("kind=app reads only the app topic; kind=all reads both", async () => {
+  const ops = fakeOps({});
+  const read = makeAppLogsReader(ops);
+  await read({ functionName: FN, sinceMinutes: 30, limit: 10, kind: "app" });
+  assert.deepEqual(ops.calls.map((c) => c.topic), [appLogTopic(FN)]);
+
+  ops.calls.length = 0;
+  await read({ functionName: FN, sinceMinutes: 30, limit: 10, kind: "all" });
+  assert.deepEqual(ops.calls.map((c) => c.topic), [appLogTopic(FN), requestLogTopic(FN)]);
+});
+
+test("the window is the one that was asked for, and is reported back", async () => {
+  // An empty answer is ambiguous without it: "no errors" and "wrong five
+  // minutes" look identical.
+  const now = 1788854162_000;
+  const read = makeAppLogsReader(fakeOps({}));
+  const out = await read({ functionName: FN, sinceMinutes: 15, limit: 10, kind: "app", now });
+  assert.equal(out.to, new Date(now).toISOString());
+  assert.equal(out.from, new Date(now - 15 * 60_000).toISOString());
+});
+
+test("a scan that fills its budget comes back truncated", async () => {
+  // The caller must be able to tell "nothing matched in the last hour" from
+  // "we stopped looking after a thousand rows".
+  const flood = Array.from({ length: SCAN_BUDGET_ROWS }, (_, i) => appRow(1000 + i, `line ${i}`));
+  const read = makeAppLogsReader(fakeOps({ [appLogTopic(FN)]: flood }));
+  const out = await read({ functionName: FN, sinceMinutes: 60, limit: 200, kind: "app" });
+  assert.equal(out.truncated, true);
+  assert.equal(out.items.length, 200);
+});
+
+test("filtering happens after the framing is read, so request_id works on app output", async () => {
+  const rows = [
+    appRow(100, "\nFC Invoke Start RequestId: req-A"),
+    appRow(101, "handling"),
+    appRow(102, "\nFC Invoke End RequestId: req-A"),
+    appRow(200, "\nFC Invoke Start RequestId: req-B"),
+    appRow(201, "other work"),
+  ];
+  const read = makeAppLogsReader(fakeOps({ [appLogTopic(FN)]: rows }));
+  const out = await read({
+    functionName: FN,
+    sinceMinutes: 60,
+    limit: 50,
+    kind: "app",
+    requestId: "req-A",
+  });
+  assert.deepEqual(out.items.map((e) => e.message), ["handling"]);
+});

--- a/services/fc/test/provisioning/fc-client.test.ts
+++ b/services/fc/test/provisioning/fc-client.test.ts
@@ -239,3 +239,44 @@ test("ensureHttpTrigger swallows 'trigger already exists' then reads the URL", a
   const url = await ops.ensureHttpTrigger("tc-app-1");
   assert.equal(url, "https://fn.example.fcapp.run");
 });
+
+// --- log delivery -----------------------------------------------------------
+
+const LOGS = { project: "teamclu-apps-1", logstore: "app-logs" };
+
+test("a new function is created with its log config", async () => {
+  const notFound = Object.assign(new Error("not found"), { statusCode: 404, code: "FunctionNotFound" });
+  const { client, calls } = fakeClient({ getFunction: async () => { throw notFound; } });
+  const ops = makeFcOps(client as any, { bucket: "b", role: undefined, region: "cn-shenzhen", logs: () => LOGS });
+  await ops.ensureFunction("tc-app-1", { ossObjectName: "apps/1/code.zip", env: {} });
+  const create = calls.find((c) => c[0] === "createFunction")[1].body;
+  assert.equal(create.logConfig.project, "teamclu-apps-1");
+  assert.equal(create.logConfig.logstore, "app-logs");
+  // Without this there is no per-request row, and "did the request even arrive"
+  // has no answer.
+  assert.equal(create.logConfig.enableRequestMetrics, true);
+});
+
+test("an existing function gets its log config re-sent on every update", async () => {
+  // The nine functions deployed before log delivery existed carry an empty log
+  // config. A code-only update would leave them with no logs forever, however
+  // many times their owner redeployed — the same trap the Node layer and the
+  // VPC config were both fixed for.
+  const { client, calls } = fakeClient();
+  const ops = makeFcOps(client as any, { bucket: "b", role: undefined, region: "cn-shenzhen", logs: () => LOGS });
+  await ops.ensureFunction("tc-app-1", { ossObjectName: "apps/1/code.zip", env: {} });
+  const update = calls.find((c) => c[0] === "updateFunction")[2].body;
+  assert.equal(update.logConfig.project, "teamclu-apps-1");
+  assert.equal(update.logConfig.logstore, "app-logs");
+});
+
+test("a deployment with no usable log store deploys without a log config", async () => {
+  // Not an empty project/logstore pair: Function Compute rejects a logConfig
+  // naming a project that does not exist, which would turn "logs are not set
+  // up" into "this app cannot deploy at all".
+  const { client, calls } = fakeClient();
+  const ops = makeFcOps(client as any, { bucket: "b", role: undefined, region: "cn-shenzhen", logs: () => undefined });
+  await ops.ensureFunction("tc-app-1", { ossObjectName: "apps/1/code.zip", env: {} });
+  const update = calls.find((c) => c[0] === "updateFunction")[2].body;
+  assert.equal(update.logConfig, undefined);
+});

--- a/services/fc/test/routes-apps.test.ts
+++ b/services/fc/test/routes-apps.test.ts
@@ -252,6 +252,47 @@ test("DELETE /v1/apps/:id 404s when repo returns false", async () => {
   );
 });
 
+// --- App logs route ---------------------------------------------------------
+
+test("GET /v1/apps/:id/logs forwards the query and 404s on null", async () => {
+  const { router, routes } = makeRouter();
+  registerApps(router);
+  const handler = routes.find((r) => r[0] === "GET" && r[1] === "/v1/apps/:appId/logs")[2];
+  let seen: any;
+  const res = await handler({
+    params: { appId: "app-1" },
+    query: new URLSearchParams(
+      "sinceMinutes=120&limit=50&kind=all&contains=user_sessions&requestId=req-A",
+    ),
+    repository: {
+      getAppLogs: async (appId: string, query: any) => {
+        seen = { appId, query };
+        return { items: [], truncated: false };
+      },
+    },
+  });
+  assert.deepEqual(res.body, { items: [], truncated: false });
+  assert.equal(seen.appId, "app-1");
+  assert.deepEqual(seen.query, {
+    sinceMinutes: "120",
+    limit: "50",
+    kind: "all",
+    contains: "user_sessions",
+    requestId: "req-A",
+  });
+
+  // Null is "you cannot see this app", which must be indistinguishable from it
+  // not existing — the same contract the data browser routes hold to.
+  await assert.rejects(
+    () => handler({
+      params: { appId: "x" },
+      query: new URLSearchParams(""),
+      repository: { getAppLogs: async () => null },
+    }),
+    (e: any) => e?.statusCode === 404,
+  );
+});
+
 // --- App data browser routes ------------------------------------------------
 
 test("GET /v1/apps/:id/data/tables forwards the app id and 404s on null", async () => {

--- a/services/fc/test/routes-apps.test.ts
+++ b/services/fc/test/routes-apps.test.ts
@@ -1,6 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { registerApps } from "../src/lib/routes/apps.js";
+import { registerApps, stripUrlCredentials } from "../src/lib/routes/apps.js";
 
 function makeRouter() {
   const routes = [];
@@ -39,6 +39,72 @@ test("POST /v1/apps passes an optional gitRemoteUrl through", async () => {
 
   await post({ json: { teamId: "t1", name: "X", type: "static_web", gitRemoteUrl: "   " }, repository });
   assert.equal(seen.gitRemoteUrl, null, "an empty field is the same as none");
+});
+
+test("a pasted token never reaches the stored repo URL", async () => {
+  // `apps.git_remote_url` is handed to every member who can see the app, and
+  // nothing redacts it. One paste of the URL GitHub shows you for a private
+  // repo would make a personal access token team-readable, permanently.
+  const { router, routes } = makeRouter();
+  registerApps(router);
+  const post = routes.find((r) => r[0] === "POST" && r[1] === "/v1/apps")[2];
+  let seen: any;
+  const repository = { createApp: async (input: any) => { seen = input; return { id: "app-1" }; } };
+
+  await post({
+    json: {
+      teamId: "t1", name: "X", type: "static_web",
+      gitRemoteUrl: "https://someone:ghp_0123456789abcdef@github.com/owner/private.git",
+    },
+    repository,
+  });
+  assert.equal(seen.gitRemoteUrl, "https://github.com/owner/private.git");
+  assert.ok(!seen.gitRemoteUrl.includes("ghp_"), "no token survives the write");
+});
+
+test("stripUrlCredentials keeps the parts of a URL that are the address", () => {
+  // http(s): all of the userinfo is a credential.
+  assert.equal(
+    stripUrlCredentials("https://ghp_secret@github.com/o/r.git"),
+    "https://github.com/o/r.git",
+  );
+  assert.equal(
+    stripUrlCredentials("http://u:p@git.internal:3000/o/r?ref=main#frag"),
+    "http://git.internal:3000/o/r?ref=main#frag",
+  );
+
+  // ssh / git: `git@` IS the address; only a password would be a secret.
+  assert.equal(
+    stripUrlCredentials("ssh://git@github.com/o/r.git"),
+    "ssh://git@github.com/o/r.git",
+  );
+  assert.equal(
+    stripUrlCredentials("ssh://git:hunter2@github.com/o/r.git"),
+    "ssh://git@github.com/o/r.git",
+  );
+
+  // scp-like has no scheme to reason about, and `git@` is load-bearing there too.
+  assert.equal(
+    stripUrlCredentials("git@github.com:owner/repo.git"),
+    "git@github.com:owner/repo.git",
+  );
+
+  // Nothing to strip is left exactly as it was.
+  for (const url of [
+    "https://github.com/owner/repo.git",
+    "git://example.com/repo.git",
+  ]) {
+    assert.equal(stripUrlCredentials(url), url);
+  }
+});
+
+test("a password containing an @ does not cut the host off", () => {
+  // Such a password should be percent-encoded, and git tolerates it when it is
+  // not; splitting on the FIRST `@` would store `p@github.com` as the host.
+  assert.equal(
+    stripUrlCredentials("https://u:p@ss@github.com/o/r.git"),
+    "https://github.com/o/r.git",
+  );
 });
 
 test("POST /v1/apps rejects a gitRemoteUrl git would not treat as an address", async () => {

--- a/services/fc/test/supabase-repo.test.ts
+++ b/services/fc/test/supabase-repo.test.ts
@@ -3039,6 +3039,92 @@ test("app data: a non-member gets nothing", async () => {
   assert.equal(await repo.listAppDataTables("app-1"), null);
 });
 
+// --- App logs ---------------------------------------------------------------
+
+function logsRepo(appRow: any, { level, actorId = "actor-app-1", appLogs, appLogsUnavailableReason }: any = {}) {
+  const access = level && actorId !== "actor-app-1"
+    ? [{ app_id: "app-1", member_id: actorId, permission_level: level, granted_by_member_id: "actor-app-1" }]
+    : [];
+  return appsRepo(
+    appsSupabase({
+      seed: { apps: [appRow], app_member_access: access, teams: [{ id: "team-1", oid: "org-derived" }] },
+      actorRow: { id: actorId },
+    }),
+    { appLogs, appLogsUnavailableReason },
+  );
+}
+
+const LIVE_APP = { ...APP_ROW, provision_status: "ready", fc_status: "live", fc_endpoint: "https://x.fcapp.run" };
+
+test("app logs: the function name comes off the row, and the query is clamped", async () => {
+  // Clamped here rather than trusted: `limit` decides how much text lands in
+  // the caller's context, and the window is bounded by what SLS still holds.
+  let seen: any;
+  const repo = logsRepo(
+    { ...LIVE_APP, fc_function_name: "tc-app-legacy-name" },
+    { appLogs: async (input: any) => { seen = input; return { items: [], truncated: false }; } },
+  );
+  await repo.getAppLogs("app-1", { sinceMinutes: "999999", limit: "5000", kind: "nonsense", contains: "  ", requestId: "req-A" });
+  assert.equal(seen.functionName, "tc-app-legacy-name");
+  assert.equal(seen.sinceMinutes, 7 * 24 * 60);
+  assert.equal(seen.limit, 200);
+  assert.equal(seen.kind, "app");
+  assert.equal(seen.contains, null, "a blank filter is no filter, not an empty match");
+  assert.equal(seen.requestId, "req-A");
+});
+
+test("app logs: a row with no recorded function name falls back to the derived one", async () => {
+  let seen: any;
+  const repo = logsRepo(LIVE_APP, {
+    appLogs: async (input: any) => { seen = input; return { items: [], truncated: false }; },
+  });
+  await repo.getAppLogs("app-1", {});
+  assert.equal(seen.functionName, "tc-app-app-1");
+  assert.equal(seen.sinceMinutes, 30, "a caller that asks for nothing gets the last half hour");
+});
+
+test("app logs: prompt can read them, view and non-members cannot", async () => {
+  // Same tier as the data browser and for the same reason: a log line carries
+  // whatever the app printed, which is its users' data.
+  const reader = async () => ({ items: [{ ts: "2026-09-08T00:00:00.000Z", kind: "app", level: "info", message: "hi" }], truncated: false });
+
+  const prompt = logsRepo(LIVE_APP, { level: "prompt", actorId: "member-other", appLogs: reader });
+  assert.equal(((await prompt.getAppLogs("app-1", {})) as any).items.length, 1);
+
+  const view = logsRepo(LIVE_APP, { level: "view", actorId: "member-other", appLogs: reader });
+  assert.equal(await view.getAppLogs("app-1", {}), null);
+
+  const stranger = logsRepo(LIVE_APP, { actorId: "member-other", appLogs: reader });
+  assert.equal(await stranger.getAppLogs("app-1", {}), null);
+});
+
+test("app logs: an app that was never deployed says so, rather than reading as empty", async () => {
+  const repo = logsRepo({ ...APP_ROW, fc_status: null }, {
+    appLogs: async () => { throw new Error("must not be called"); },
+  });
+  await assert.rejects(
+    () => repo.getAppLogs("app-1", {}),
+    (e: any) => e?.statusCode === 409 && e?.code === "app_not_deployed",
+  );
+});
+
+test("app logs: an unconfigured deployment names what is missing", async () => {
+  const repo = logsRepo(LIVE_APP, { appLogsUnavailableReason: "APPS_ACCESS_KEY_ID is not set" });
+  await assert.rejects(
+    () => repo.getAppLogs("app-1", {}),
+    (e: any) => e?.statusCode === 503 && /APPS_ACCESS_KEY_ID/.test(e?.message ?? ""),
+  );
+});
+
+test("app logs: a logstore that has never received a row reads as empty, not as a failure", async () => {
+  // The first deploy creates the destination; nothing writes to it until the
+  // app is next invoked. That window must not look like a broken feature.
+  const repo = logsRepo(LIVE_APP, {
+    appLogs: async () => { throw Object.assign(new Error("nope"), { code: "LogStoreNotExist" }); },
+  });
+  assert.deepEqual(await repo.getAppLogs("app-1", {}), { items: [], truncated: false, from: null, to: null });
+});
+
 test("app data: static and undeployed apps give distinguishable 409s", async () => {
   // The control panel shows a different sentence for each; a shared 404 would
   // make both read as "something is broken".


### PR DESCRIPTION
自建应用的两件事：**agent 能自己发布和排查它写的应用**，以及**应用终于有日志了**。

## 起点：线上根本没有日志

9/8 实测 apps 账号（`1457752404144823`）里的 10 个 `tc-app-*` 函数，**9 个 `logConfig` 是 `{project:"", logstore:""}`** —— 函数计算不配 logConfig 就什么都不留，控制台和 API 都查不到。唯一那个有日志的是有人在控制台手工点开的。

所以「让 agent 查日志」是两件事：先让日志存在，再给一条能授权的读路径。

## 四个提交

### 1. `feat(fc)` 给应用配上日志，加读取端点

- `fc-client.ts` 在 **create 和 update 两处**都发 `logConfig`。只在 create 发的话，存量那 9 个函数不管重新部署多少次都还是没日志——和 Node layer、VPC config 各踩过一次的是同一个坑。
- SLS project/logstore 按需创建（`teamclu-apps-<accountId>` / `app-logs`，14 天 TTL）。**失败不阻塞部署**：ensure 挂了就记住并不再提供 logConfig，免得把一个不存在的 project 塞给 FC 反而让部署整个失败。实测函数 `role` 为空也能投递（账号里已有 `AliyunServiceRoleForFC`），所以不需要动 `ROLE_ARN`。
- `GET /v1/apps/:appId/logs` 按 app data browser 的规矩鉴权：`prompt` 能读，`view` 和非成员 404——日志行里是应用自己 print 的东西，也就是它用户的数据。

`contains` / `requestId` 在**归一化之后**过滤，没有拼进 SLS 查询。三个原因：SLS 按标点分词，带下划线的词根本匹配不到；把调用方文本拼进一个有 `or` 的查询语言，正好是那个「把 app 关在自己日志里」的过滤器的注入面；而且应用自己的输出**没有 requestId 字段**——那个 id 只出现在 FC 的 `FC Invoke Start/End` 框架行里，归一化时读出来贴回去。这才让「那个 500 的请求打了哪几行」问得出来。

`APPS_SLS_PROJECT` / `APPS_SLS_LOGSTORE` 两个部署目标都声明了，`.env.example` 也补了（parity 测试当场抓到漏的那次）。

### 2. `feat(desktop)` introspect 加三样能力

`manage_app`（list / status / deploy / logs）+ `manage_app_data`（tables / rows / update_row / delete_row）。

- **deploy 放在桌面进程里**：中间那段构建要本地 daemon，外面两段要用户的云端 bearer，只有这个进程两样都有（daemon 是 agent actor，`apps_update_if_creator` 会挡住它）。
- `/deploy` 之后任何失败都回写 `deploy_error`——服务端看不见本地构建挂了，而卡在 `awaiting_build` 的行会把后续部署堵死 30 分钟。
- 部署报错**存进去之前先脱敏**：预签名 PUT 是应用 OSS 对象的凭证，daemon 会把失败的 URL 原样引在错误里，而 `deployError` 是所有能看到这个应用的人都读得到的。
- 写数据行只按主键定位一行，key 由工具照表的 catalog 排序编码——复合主键顺序错了不报错，只会改到**另一行**。

全程走登录用户的 bearer，权限由 Cloud API 判（部署/改行要 admin，读要 prompt），这里不提权。

### 3. `feat(app)` 控制面加入口，日志开在 tab 里

「线上」组里：登录方式 → 线上数据 → **运行日志** → 自定义域名。

入口**不发请求**（能不能有日志 `fcStatus` 上就有，而控制面每次切应用都重渲染）；没部署过给一句话不给按钮——一个永远返回空的按钮看着就像坏了；上次部署失败的**保留**按钮，那正是最该看日志的时候。

tab 里三个流（应用输出 / 请求 / 全部）、五个时间窗、子串搜索，以及 **request id 芯片**：点一下就把视图收窄到那一次请求。空状态说的是「这段时间没有」而不是「没有日志」——安静了十分钟的应用，后一句话会让人以为功能坏了。

### 4. `fix(apps)` 顺手修的两个洞

评审「输入 https 的 GitHub 私有仓库会怎样」时读出来的，不是撞出来的：

- **clone 可能永远挂着**。`GIT_TERMINAL_PROMPT=0` 拦得住 git 自己问密码，拦不住 credential helper；会弹窗的 helper（git-credential-manager）会一直等人点，而 daemon 没有那块屏幕。现在 5 分钟封顶，**杀进程组而不是进程**（git 是把 helper 当子进程起的）。抽出的 `sync/bounded_proc.rs` 和 `app_build` 共用一份循环。
- **粘贴的 token 会被永久存下来**。`https://x:ghp_…@github.com/o/r.git` 是 GitHub 给私有仓库显示的地址，粘进来就原样进了 `apps.git_remote_url`——那一列 `GET /v1/apps/:id` 会发给每个能看到这个应用的成员，且没人脱敏。现在按 scheme 剥：http(s) 丢整个 userinfo，ssh/git 只丢密码（`git@` 就是地址），scp 形式不动。**私有仓库导入照样能用**：桌面端把用户输入的地址直接给本地 daemon 做那一次 clone，凭证只活在这一次调用里。

## 验证

| | |
|---|---|
| services/fc | **1115 用例 0 失败**（新增日志归一化 15 + logConfig 3 + 路由/仓储若干） |
| 前端 | **3409 用例 0 失败**，lint 0 error，i18n parity 绿 |
| daemon | **1607 用例 0 失败**，`--all-targets --no-run` 编译通过 |
| desktop Rust | `introspect_api` 27 绿，`teamclu-introspect` 66 绿 |

## 已知遗留

- 存量 9 个应用要**各自下一次部署**才会补上 logConfig。
- agent 部署完，桌面 UI 的那一行不会自己刷新（要切一下）。
- `git clone` 仍会把带凭证的 URL 写进 checkout 自己的 `.git/config`——改写它会让用户下次 `git pull` 莫名失败，故意没动。
- cron 触发的 agent 是 full access，理论上可以无人值守直接把应用发上线。要不要给 `deploy` 单独加闸没有定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
