### PR TITLE
fix(desktop): don't let a Rust pre-flight probe veto the Windows webview

### DIFF
--- a/apps/desktop/src/commands/webview.rs
+++ b/apps/desktop/src/commands/webview.rs
@@ -360,6 +360,47 @@ async fn ensure_http_url_reachable_async(url: &tauri::Url) -> Result<(), String>
     }
 }
 
+/// Run the pre-flight probe with the policy the platform actually needs.
+///
+/// **macOS: blocking.** The hang this gate exists to prevent is a
+/// WKWebView/AppKit behaviour (#617) — handing the platform webview an
+/// External URL it cannot open wedges the main thread, and the only fix is to
+/// never hand it one.
+///
+/// **Everywhere else: advisory.** WebView2 has no such failure mode; a URL it
+/// cannot load becomes its own error page and the process stays responsive. So
+/// off macOS a failed probe is logged and the webview opens anyway.
+///
+/// The distinction matters because the probe is not the client that will load
+/// the page, and on Windows the two disagree in ways that have nothing to do
+/// with whether the origin works:
+///
+/// - `reqwest` resolves proxies from environment variables only. It reads
+///   neither the Windows system proxy nor a PAC script, both of which WebView2
+///   honours through WinINET — so behind a corporate proxy the probe connects
+///   directly, and fails, against origins the webview loads fine.
+/// - It validates against the OS root store as `rustls` reads it, while
+///   Schannel fetches missing roots on demand and accepts chains rustls
+///   rejects.
+/// - Its budget is a flat 3s for DNS, connect, TLS and response.
+///
+/// Letting it veto there traded a macOS-only hang for a Windows-only "the
+/// button does nothing": `webview_create` returned `Err` before `add_child`,
+/// so Web SSO never opened a window at all.
+async fn preflight_url(url: &tauri::Url) -> Result<(), String> {
+    #[cfg(target_os = "macos")]
+    {
+        ensure_http_url_reachable_async(url).await
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        if let Err(err) = ensure_http_url_reachable_async(url).await {
+            log::warn!("[Webview] Pre-flight probe failed, opening anyway: {err}");
+        }
+        Ok(())
+    }
+}
+
 /// Build a documentStart script that seeds a supabase-js session into the
 /// page's localStorage so it is already authenticated when its bundle runs.
 /// `session_json` is the already-serialized supabase session object; it is
@@ -564,10 +605,11 @@ pub async fn webview_create(
         .parse::<tauri::Url>()
         .map_err(|e| format!("Invalid URL '{}': {}", url, e))?;
 
-    // Fail closed before add_child: an External URL the platform webview cannot
-    // open freezes the AppKit main thread (issue #617). Resolvable is not
-    // enough — a certificate that does not match the name wedges it too.
-    ensure_http_url_reachable_async(&parsed_url).await?;
+    // Fail closed before add_child on macOS: an External URL the platform
+    // webview cannot open freezes the AppKit main thread (issue #617), and
+    // resolvable is not enough — a certificate that does not match the name
+    // wedges it too. Advisory elsewhere; see `preflight_url`.
+    preflight_url(&parsed_url).await?;
 
     log::info!(
         "[Webview] Creating '{}' in parent '{}' url={} pos=({},{}) size={}x{}",
@@ -885,7 +927,7 @@ pub async fn webview_navigate(
             .parse::<tauri::Url>()
             .map_err(|e| format!("Invalid URL '{}': {}", url, e))?;
         // Same guard as webview_create — navigate to a bad host can freeze too.
-        ensure_http_url_reachable_async(&parsed).await?;
+        preflight_url(&parsed).await?;
         log::info!("[Webview] Navigating '{}' to {}", label, url);
         webview
             .navigate(parsed)
@@ -1259,6 +1301,30 @@ mod tests {
     async fn ensure_http_url_reachable_skips_non_http_schemes() {
         let url: tauri::Url = "about:blank".parse().expect("url");
         assert!(ensure_http_url_reachable_async(&url).await.is_ok());
+    }
+
+    /// The probe is a gate on macOS and advice everywhere else. Both arms are
+    /// pinned here because the split is the fix: letting a failed probe veto on
+    /// Windows made `webview_create` return `Err` before `add_child`, so Web
+    /// SSO never opened a window — for an origin WebView2 loads fine.
+    #[tokio::test]
+    async fn preflight_blocks_only_on_macos() {
+        // `.invalid` is reserved by RFC 2606 and must not resolve, so the probe
+        // fails at the DNS step — no network round trip, no flake.
+        let url: tauri::Url = "https://no-such-host-teamclu-617.invalid/path"
+            .parse()
+            .expect("url");
+        assert!(ensure_http_url_reachable_async(&url).await.is_err());
+
+        let gated = preflight_url(&url).await;
+        if cfg!(target_os = "macos") {
+            assert!(gated.is_err(), "macOS must fail closed (#617)");
+        } else {
+            assert!(
+                gated.is_ok(),
+                "off macOS a failed probe must not veto the webview: {gated:?}"
+            );
+        }
     }
 
     #[test]

--- a/packages/app/src/stores/auth-store.test.ts
+++ b/packages/app/src/stores/auth-store.test.ts
@@ -443,6 +443,28 @@ describe("signInWithWebSso", () => {
     expect(useAuthStore.getState().errorMessage).toBeNull();
   });
 
+  // A failing `invoke()` rejects with the command's `Err(String)` payload — a
+  // bare string, not an Error. Surfacing it is the whole point: the generic
+  // fallback is what hid a Windows webview pre-flight rejection behind
+  // "Authentication failed." with no way to tell which host or why.
+  it("surfaces a native string rejection instead of the generic fallback", async () => {
+    (runWebSso as ReturnType<typeof vi.fn>).mockRejectedValue(
+      "Host 'admin.example.com' is not reachable: error trying to connect",
+    );
+    const ok = await useAuthStore.getState().signInWithWebSso();
+    expect(ok).toBe(false);
+    expect(useAuthStore.getState().webSsoPending).toBe(false);
+    expect(useAuthStore.getState().errorMessage).toBe(
+      "Host 'admin.example.com' is not reachable: error trying to connect",
+    );
+  });
+
+  it("still falls back for a rejection that carries no message", async () => {
+    (runWebSso as ReturnType<typeof vi.fn>).mockRejectedValue("   ");
+    await useAuthStore.getState().signInWithWebSso();
+    expect(useAuthStore.getState().errorMessage).toBe("Authentication failed.");
+  });
+
   it("cancelWebSso delegates to the lib", () => {
     useAuthStore.setState({ webSsoPending: true });
     useAuthStore.getState().cancelWebSso();

--- a/packages/app/src/stores/auth-store.ts
+++ b/packages/app/src/stores/auth-store.ts
@@ -86,7 +86,15 @@ interface AuthState {
 }
 
 function errorMessageFor(error: unknown): string {
-  return error instanceof Error ? error.message : "Authentication failed.";
+  if (error instanceof Error) return error.message;
+  // A rejected `invoke()` carries whatever the command's `Err(E)` serialized
+  // to, and every native command this store calls is `Result<_, String>` — so
+  // the rejection is a bare string, never an Error. Dropping it collapsed
+  // every native failure into the same "Authentication failed.", which is how
+  // a Web SSO webview that refused to open reached users with its reason
+  // ("Host '…' is not reachable: …") discarded on the way.
+  if (typeof error === "string" && error.trim()) return error.trim();
+  return "Authentication failed.";
 }
 
 function storeSession(session: AuthSession | null): StoreAuthSession | null {


### PR DESCRIPTION
## 现象

Windows 上点「快捷登录」，遮罩和标题条画出来了，但登录页永远不出现。点 ✕、按 Esc 都没反应，几秒后面板自己关掉，表单下留下一句 `Authentication failed.`。macOS 正常。

## 定位

**webview 根本没被创建。** 对截图做像素测量：原生 webview 应占的矩形（CSS 483,108 起 480×640）与远处背景**逐字节相同**（`152,151,149`）——不是白屏，不是错误页，那里什么都没画。

**红字来自兜底分支。** `errorMessageFor` 只在抛出物**不是 `Error` 实例**时返回 `Authentication failed.`。而 `AuthError extends Error`，webSSO 自己抛的 cancelled / timeout / failed 都会显示各自的文案。所以抛出点是 `invoke("webview_create")` 本身——Rust 侧返回了 `Err(String)`，`invoke` 用一个**裸字符串** reject，真实原因被这行丢掉了。

**时序也对得上。** #1306 新加的 `ensure_http_url_reachable_async` 是 DNS 3s + HEAD 3s。这段时间里 `runWebSso` 还没进轮询循环，`cancelWebSso()` 的 `abort()` 无处可挂——所以 Esc 和 ✕ 都没反应；面板不是被点关的，是探测超时把它带下去的。

`beta.46`（`586230644`）不含 #1306，`beta.47`（`7c684bd0e`）含——是回归。

## 为什么偏偏 Windows 失败

探测用的**不是**加载页面的那个客户端，两者在 Windows 上会因为与「源站好不好」无关的原因产生分歧：

- **reqwest 0.12.28 只从环境变量取代理**（源码里 `windows-registry` / `ProxyServer` / `AutoConfigURL` 零命中；唯一的系统级代理特性 `macos-system-configuration` 还被 `default-features = false` 关掉了）。WebView2 走 WinINET，系统代理和 PAC 都认。企业网里这就是「浏览器能开、Rust 开不了」。
- 它按 rustls 读到的 OS 根存储校验，而 Schannel 会按需补根。
- 它的全部预算是 3 秒，涵盖 DNS + 连接 + TLS + 响应。

（顺带排除了一条：`admin.mx5.cn` 的链是自洽的——只信任 `ISRG Root X1` + 服务器发来的交叉签 `Root YR` 就能 verify OK，所以不是「缺新根」。）

## 改了什么

**1. `preflight_url()` —— 门禁按平台分策略。** #1306 防的是 WKWebView 卡死 AppKit 主线程（#617），那是 macOS 独有行为；WebView2 打不开的 URL 只会变成它自己的错误页，进程照样响应。于是 macOS 保持 fail-closed，其他平台探测失败只 `log::warn!` 然后照常打开。`webview_create` 和 `webview_navigate` 两个调用点都换过去了。

warn 日志特意保留：Windows 上现在会正常弹出登录页，同时日志里留下 `[Webview] Pre-flight probe failed, opening anyway: Host '…' is not reachable: …`，诊断能力不跟着门禁一起丢掉。

顺带收益：这道门禁同样卡着应用内浏览器，所以「Windows 上某些网页应用内打不开、系统浏览器能开」是同一个原因。

**2. `errorMessageFor()` —— 别再吞掉原生错误。** 这个 store 里**每一个** `invoke` 失败此前都被压成 `Authentication failed.`，不止 webSSO。

## 验证

- `pnpm test:unit`：517 文件 / **3399 通过、0 失败**
- `pnpm typecheck` 干净；`pnpm lint` **0 error**
- `cargo check --all-targets`（macOS）通过；`cargo clippy --all-targets -- -D warnings` **干净**
- `cargo fmt --check`：本 PR 触碰的文件干净

**Windows arm 怎么验的**：`--target x86_64-pc-windows-msvc` 在 macOS 上编不了（`ring` 的 C 源码需要 Windows SDK 头文件，`assert.h` 找不到）。所以改用**对调 cfg 判据**在本机编译并运行了那个分支——探测失败时 `preflight_url` 确实返回 `Ok`——然后全部还原、以最终形态重跑。新增的 `preflight_blocks_only_on_macos` 把两个 arm 都钉住，避免以后被「顺手统一」回去。

## 还没查清的

那台 Windows 的 reqwest **具体**为什么到不了 `admin.mx5.cn`——之前被 `errorMessageFor` 吞了。合入后下一个包的日志里就能直接看到。不过这不影响本 PR：门禁本来就不该在 Windows 上拦。

如果最后确认是代理，值得单独做一件事：给 Rust 侧补上 Windows 系统代理支持——目前桌面端所有 Rust 侧 HTTP 调用（`http_clients.rs::cloud_api()`、更新检查等）在 Windows 上都是代理盲的。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0154hq8qQj4G1Yab6QEpFoRW
