### PR TITLE
fix(ci): unbreak main — fmt agents_skills, file its probe names as storage-lint debt

### DIFF
--- a/apps/desktop/src/commands/agents_skills.rs
+++ b/apps/desktop/src/commands/agents_skills.rs
@@ -76,17 +76,11 @@ fn probe_os_access(dir: &Path) -> (bool, bool, Option<(AgentsSkillsAccessKind, S
         return (
             false,
             false,
-            Some((
-                kind,
-                format!("Failed to create {}: {e}", dir.display()),
-            )),
+            Some((kind, format!("Failed to create {}: {e}", dir.display()))),
         );
     }
 
-    let probe = dir.join(format!(
-        ".teamclu-write-probe-{}",
-        std::process::id()
-    ));
+    let probe = dir.join(format!(".teamclu-write-probe-{}", std::process::id()));
     let payload = b"teamclu-agents-skills-probe\n";
 
     if let Err(e) = std::fs::write(&probe, payload) {
@@ -186,9 +180,8 @@ pub fn check_agents_skills_access(app: AppHandle) -> Result<AgentsSkillsAccess, 
         return Ok(access_result(
             skills,
             AgentsSkillsAccessKind::TauriScope,
-            scope_err.unwrap_or_else(|| {
-                "App filesystem scope does not allow ~/.agents/skills".into()
-            }),
+            scope_err
+                .unwrap_or_else(|| "App filesystem scope does not allow ~/.agents/skills".into()),
             os_readable,
             os_writable,
             false,

--- a/crates/teamclu-runtime-env/src/storage_lint.rs
+++ b/crates/teamclu-runtime-env/src/storage_lint.rs
@@ -51,6 +51,13 @@ const DEBT: &[&str] = &[
     "apps/daemon/src/workspace_meta_gate.rs",
     "apps/desktop/crates/teamclu-introspect/src/config.rs",
     "apps/desktop/crates/teamclu-introspect/src/cron.rs",
+    // Not a home directory either: probe files written INSIDE an
+    // already-resolved skills root (`.teamclu-write-probe-<n>`,
+    // `.teamclu-scope-probe`) to find out whether it is writable. Same shape as
+    // the two skill-writer entries above, and the same conclusion — clearing it
+    // means teaching the needle that a dot-name with a suffix is a file, not a
+    // home directory.
+    "apps/desktop/src/commands/agents_skills.rs",
     // Test-only: assertions that the resolver produced `.amuxd-teamclaw` /
     // `.amuxd-copilot361` for a branded build. Spelling the names is the point
     // of those assertions — this is the one entry that wants OWNERS-like


### PR DESCRIPTION
main 从 #1318 合入起就是红的，两个 job 挂在两个 guard 上。这个 PR 只做让它变绿的最小改动。

## 1. `Rust Format & Clippy` → `Check Rust formatting`

`apps/desktop/src/commands/agents_skills.rs` 三处没格式化。`cargo fmt` 的输出，没有手改。

## 2. `Daemon Unit Tests (Linux)` → `Run teamclu-runtime-env unit tests`

`storage_lint::hand_written_home_dirs_only_shrink` 报同一个文件。

**不是真的手写了 home 目录。** 路径本身解析得很对（`dirs::home_dir().join(".agents").join("skills")`）；触发 needle 的是写在**已经解析好的** skills 根目录里的探针文件名：

- `.teamclu-write-probe-<n>`（探 OS 可写性）
- `.teamclu-scope-probe`（探 Tauri fs scope）

needle 的规则是「引号后面紧跟 `.teamclu`」，它分不出这个和 `~/.teamclu` 的区别。这里没有任何东西可以改走 runtime-env 的 helper。

所以按 `DEBT` 里**已经有的两条同形态条目**（`managed_skill_writer.rs` / `roles_skills.rs`）的理由记进去了。

## 这不是最终答案

往一个「只许变短」的列表里加东西不好看。真正的修法那条注释自己就写了：**教会 needle 「带后缀的点名字是文件名，不是 home 目录」**。那是改一个公共 guard，不该塞进「main 红了」的修复里——但值得接着做，而且一次能清掉三条。

## 验证

按 CI 实际跑的命令验的：

- `cargo fmt --check --manifest-path apps/desktop/Cargo.toml` — 干净
- `cargo clippy --manifest-path apps/desktop/Cargo.toml --all-targets -- -D warnings` — 干净
- `cargo test -p teamclu-runtime-env --lib storage_lint` — 4 passed

另外核对过 main 那次失败 run 的全部 job/step，失败的就是上面这两个 step，没有第三个。

cc #1318

🤖 Generated with [Claude Code](https://claude.com/claude-code)
