### PR TITLE
fix(gateway): stream agent thinking into channel-created sessions

### DIFF
--- a/apps/daemon/src/channels/agent_handle.rs
+++ b/apps/daemon/src/channels/agent_handle.rs
@@ -159,6 +159,10 @@ pub struct AmuxdAgentHandle {
     /// Read-only from a chat's point of view since #933: `/workspace` no longer
     /// rewrites it (or `daemon.toml`) — it scopes to the session instead.
     pub bot_configs: Arc<Mutex<HashMap<String, BotRuntimeConfig>>>,
+    /// Same channel cron uses: ACP frames while `event_rx` is checked out, so
+    /// `poll_events` cannot publish thinking/tools/output to `session/live`.
+    /// `None` in unit tests that never drive a live turn.
+    pub live_event_tx: Option<tokio::sync::mpsc::Sender<crate::runtime::CheckedOutTurnEvent>>,
 }
 
 /// Returned by `resolve_or_spawn`. `spawned` is true iff this call was
@@ -855,6 +859,17 @@ impl AmuxdAgentHandle {
                     break salvage_on_timeout(&segments, &live);
                 }
             };
+            // Mirror cron: the checkout owns `event_rx`, so `poll_events` never
+            // sees these frames. Forward a copy for `session/live` before we
+            // consume it — otherwise a WeCom/Feishu turn is invisible on the
+            // desktop until the final reply, with no thinking or tools.
+            crate::runtime::forward_checked_out_turn_event(
+                self.live_event_tx.as_ref(),
+                &agent_id,
+                &outcome.real_acp_sid,
+                &event,
+            );
+
             if let Some(crate::proto::amux::acp_event::Event::Error(err)) = &event.event.event {
                 let details = if err.details.is_empty() {
                     err.message.clone()
@@ -1501,6 +1516,7 @@ pub(crate) mod tests {
             workspace_resolver: Arc::new(crate::config::WorkspaceResolver::new(backend)),
             workspace_override: Arc::new(Mutex::new(HashMap::new())),
             bot_configs: Arc::new(Mutex::new(HashMap::new())),
+            live_event_tx: None,
         }
     }
 

--- a/apps/daemon/src/daemon/server.rs
+++ b/apps/daemon/src/daemon/server.rs
@@ -239,11 +239,13 @@ pub struct DaemonServer {
     cron_turn_done_tx: mpsc::Sender<cron::CronTurnDone>,
     /// Receiver half, `take()`n by whichever run loop (MQTT or NATS) is active.
     cron_turn_done_rx: Option<mpsc::Receiver<cron::CronTurnDone>>,
-    /// Sender for the ACP events of an in-flight cron turn. The turn task owns
-    /// the agent's event channel, so nothing else can publish them to
-    /// `session/live`; the loop drains this and does it (see
+    /// Sender for ACP events of a checked-out turn (cron and gateway). The
+    /// turn task owns the agent's event channel, so nothing else can publish
+    /// them to `session/live`; the loop drains this and does it (see
     /// `publish_cron_turn_event`). Bounded and `try_send`-only — the UI must
-    /// never be able to stall a model turn.
+    /// never be able to stall a model turn. Gateway sessions share this so
+    /// thinking / tools stream in the desktop thread the same way as a
+    /// regular collab turn.
     cron_turn_event_tx: mpsc::Sender<cron::CronTurnEvent>,
     /// Receiver half, `take()`n by whichever run loop is active.
     cron_turn_event_rx: Option<mpsc::Receiver<cron::CronTurnEvent>>,

--- a/apps/daemon/src/daemon/server/channels.rs
+++ b/apps/daemon/src/daemon/server/channels.rs
@@ -164,6 +164,7 @@ impl DaemonServer {
             workspace_resolver: self.workspace_resolver.clone(),
             workspace_override: Arc::new(AsyncMutex::new(HashMap::new())),
             bot_configs: Arc::new(AsyncMutex::new(bot_configs)),
+            live_event_tx: Some(self.cron_turn_event_tx.clone()),
         });
         // Everything this store writes gets announced on `session/{id}/live`.
         // Without it a gateway conversation exists only in the cloud table, and

--- a/apps/daemon/src/daemon/server/cron.rs
+++ b/apps/daemon/src/daemon/server/cron.rs
@@ -42,20 +42,14 @@ pub(crate) struct CronTurnDone {
     pub(crate) reply_tx: oneshot::Sender<String>,
 }
 
-/// One ACP event of a cron-driven turn, sent from the turn task to the active
-/// run loop so it can reach `session/live`.
+/// One ACP event of a checked-out turn (cron or gateway), sent from the
+/// turn task to the active run loop so it can reach `session/live`.
 ///
 /// The turn task owns the agent's event channel for the whole turn, so
 /// `poll_events` — and with it `forward_agent_event` — never sees these frames.
 /// Publishing is what `forward_agent_event` would have done; it has to happen
 /// on the loop because it needs `&self.teamclu`, which is not `Send`.
-pub(crate) struct CronTurnEvent {
-    /// Runtime key (8-char), not the actor id.
-    pub(crate) agent_id: String,
-    /// Set only for subagent sessions, matching `forward_agent_event`.
-    pub(crate) child_acp_session_id: Option<String>,
-    pub(crate) event: crate::proto::amux::AcpEvent,
-}
+pub(crate) type CronTurnEvent = crate::runtime::CheckedOutTurnEvent;
 
 /// Caches the `(cloud_session_id, acp_session_id)` pair for each cron logical
 /// `session_key`.
@@ -448,13 +442,14 @@ Pass it as `reply_token` to the `send_channel_message` tool, together with an ex
         let _ = reply_tx.send(result.to_string());
     }
 
-    /// Publish one event of a cron-driven turn to `session/live`.
+    /// Publish one event of a checked-out turn (cron or gateway) to
+    /// `session/live`.
     ///
     /// This is `forward_agent_event`'s publish tail and deliberately nothing
     /// else: the turn task has already fed the event to the aggregator, and
     /// ingesting it a second time here would emit the reply twice. Without it
-    /// a cron session sat frozen — "Run Now" navigates you into the thread and
-    /// nothing moves until the whole answer appears at once.
+    /// a cron or WeCom session sat frozen — the desktop thread received the
+    /// user prompt, then nothing moved until the finished reply.
     pub(super) async fn publish_cron_turn_event(&mut self, ev: CronTurnEvent) {
         use crate::proto::amux;
 
@@ -827,18 +822,12 @@ Pass it as `reply_token` to the `send_channel_message` tool, together with an ex
             // the desktop renders the turn as it happens. Best-effort: a full
             // channel drops frames rather than stalling the model turn behind
             // the UI, and the finalized reply lands regardless.
-            let forwarded = CronTurnEvent {
-                agent_id: agent_id.clone(),
-                child_acp_session_id: Some(event.acp_session_id.clone())
-                    .filter(|sid| !sid.is_empty() && sid != acp_sid),
-                event: event.event.clone(),
-            };
-            if event_tx.try_send(forwarded).is_err() {
-                tracing::debug!(
-                    agent_id = %agent_id,
-                    "cron: live event channel full; dropping one streaming frame"
-                );
-            }
+            crate::runtime::forward_checked_out_turn_event(
+                Some(&event_tx),
+                &agent_id,
+                acp_sid,
+                &event,
+            );
 
             if let Some(crate::proto::amux::acp_event::Event::Error(err)) = &event.event.event {
                 let details = if err.details.is_empty() {

--- a/apps/daemon/src/runtime/acp_event_frame.rs
+++ b/apps/daemon/src/runtime/acp_event_frame.rs
@@ -1,4 +1,5 @@
 use crate::proto::amux;
+use tokio::sync::mpsc;
 
 /// ACP event plus the originating ACP session id (root or child subagent).
 #[derive(Clone, Debug)]
@@ -23,5 +24,104 @@ impl AcpEventFrame {
     pub fn with_reply_to(mut self, reply_to_message_id: Option<String>) -> Self {
         self.turn_reply_to_message_id = reply_to_message_id.filter(|id| !id.is_empty());
         self
+    }
+}
+
+/// ACP event from a checked-out turn (gateway / cron) that still needs to
+/// reach `session/live`.
+///
+/// The turn owner takes `event_rx` for the whole turn, so `poll_events` —
+/// and with it `forward_agent_event` — never sees these frames. Cron already
+/// forwarded them; gateway turns must do the same or the desktop session
+/// sits still until the final reply (no thinking, no tools, no streaming).
+#[derive(Clone, Debug)]
+pub struct CheckedOutTurnEvent {
+    /// Runtime key. After ADR-0004 this is the cloud session id, which is
+    /// also what `target_sessions` publishes onto `session/{id}/live`.
+    pub agent_id: String,
+    /// Set only for subagent sessions, matching `forward_agent_event`.
+    pub child_acp_session_id: Option<String>,
+    pub event: amux::AcpEvent,
+}
+
+impl CheckedOutTurnEvent {
+    pub fn from_frame(agent_id: &str, root_acp_sid: &str, frame: &AcpEventFrame) -> Self {
+        Self {
+            agent_id: agent_id.to_string(),
+            child_acp_session_id: Some(frame.acp_session_id.clone())
+                .filter(|sid| !sid.is_empty() && sid != root_acp_sid),
+            event: frame.event.clone(),
+        }
+    }
+}
+
+/// Best-effort copy onto the run-loop live channel. A full channel drops
+/// the frame rather than stalling the model turn; `tx == None` is a no-op
+/// (unit tests, or a daemon that has not started its MQTT loop yet).
+pub fn forward_checked_out_turn_event(
+    tx: Option<&mpsc::Sender<CheckedOutTurnEvent>>,
+    agent_id: &str,
+    root_acp_sid: &str,
+    frame: &AcpEventFrame,
+) {
+    let Some(tx) = tx else {
+        return;
+    };
+    let forwarded = CheckedOutTurnEvent::from_frame(agent_id, root_acp_sid, frame);
+    if tx.try_send(forwarded).is_err() {
+        tracing::debug!(
+            agent_id,
+            "checked-out turn: live event channel full; dropping one streaming frame"
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn thinking_frame(acp_sid: &str, text: &str) -> AcpEventFrame {
+        AcpEventFrame::new(
+            acp_sid,
+            amux::AcpEvent {
+                event: Some(amux::acp_event::Event::Thinking(amux::AcpThinking {
+                    text: text.into(),
+                })),
+                model: String::new(),
+            },
+        )
+    }
+
+    #[test]
+    fn forwards_thinking_frames_onto_the_live_channel() {
+        let (tx, mut rx) = mpsc::channel(8);
+        let frame = thinking_frame("acp-root", "let me look that up");
+        forward_checked_out_turn_event(Some(&tx), "cloud-session", "acp-root", &frame);
+
+        let got = rx.try_recv().expect("thinking must reach session/live");
+        assert_eq!(got.agent_id, "cloud-session");
+        assert_eq!(got.child_acp_session_id, None);
+        match got.event.event {
+            Some(amux::acp_event::Event::Thinking(t)) => {
+                assert_eq!(t.text, "let me look that up");
+            }
+            other => panic!("expected thinking, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn stamps_child_acp_session_id_for_subagent_frames() {
+        let (tx, mut rx) = mpsc::channel(8);
+        let frame = thinking_frame("acp-child", "nested plan");
+        forward_checked_out_turn_event(Some(&tx), "cloud-session", "acp-root", &frame);
+
+        let got = rx.try_recv().expect("subagent thinking must be forwarded");
+        assert_eq!(got.child_acp_session_id.as_deref(), Some("acp-child"));
+    }
+
+    #[test]
+    fn missing_live_channel_is_a_noop() {
+        let frame = thinking_frame("acp-root", "unused");
+        forward_checked_out_turn_event(None, "cloud-session", "acp-root", &frame);
     }
 }

--- a/apps/daemon/src/runtime/mod.rs
+++ b/apps/daemon/src/runtime/mod.rs
@@ -41,6 +41,7 @@ pub mod turn_reply;
 pub mod well_known_bin;
 mod workspace_runtime;
 
+pub use acp_event_frame::{forward_checked_out_turn_event, CheckedOutTurnEvent};
 pub use backend::{create_backend, AcpCommand, AcpStartupMetadata, AgentBackend, ForkSpec};
 pub use context_service::RuntimeContextService;
 pub use handle::{InjectedContextItem, PendingMessage, RuntimeHandle};


### PR DESCRIPTION
## Summary
- Channel (WeCom / Feishu / Discord) turns checkout `event_rx`, so `poll_events` never publishes ACP thinking/tool/output frames to `session/live`.
- Desktop sessions and cron already stream those frames; gateway turns only persisted the final `AgentReply`, so opening the thread showed no thinking process.
- Forward each checked-out ACP frame on the same live channel cron already uses (`cron_turn_event_tx` → `publish_cron_turn_event`). The channel still composes its own reply locally; the loop does not ingest twice.

## Test plan
- [ ] Restart `amuxd`
- [ ] Send a WeCom/Feishu message that triggers thinking + tools
- [ ] Open that gateway session in the desktop app while the turn is running — thinking and tool cards should stream like a regular session
- [ ] Confirm the channel still receives the final reply
- [ ] `node scripts/daemon-cargo.js test --bin amuxd acp_event_frame`


Made with [Cursor](https://cursor.com)