### PR TITLE
fix(mcp): probe tools after the subject agent is selected

### DIFF
--- a/packages/app/src/stores/__tests__/team-share-mcp-tools-refresh.test.ts
+++ b/packages/app/src/stores/__tests__/team-share-mcp-tools-refresh.test.ts
@@ -1,0 +1,44 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+vi.mock('@/lib/utils', () => ({ isTauri: () => true }))
+vi.mock('@/lib/workspace/effective-workspace', () => ({
+  effectiveWorkspacePath: async () => '/Users/me/project',
+}))
+vi.mock('@/lib/backend/provider', () => ({
+  getBackend: () => ({
+    teamMcp: { listTeamMcpServers: async () => [] },
+    teamSkills: { listTeamSkills: async () => [] },
+    actors: { createAgentManagementGrant: async () => ({ grant: 'g', nonce: 'n' }) },
+  }),
+}))
+vi.mock('@/lib/daemon/teamclu-rpc', () => ({ manageAgentCapability: vi.fn(async () => ({})) }))
+vi.mock('@/lib/agent/agent-device-reachability', () => ({
+  resolveAgentDevicePresenceSync: () => 'online',
+}))
+vi.mock('@tauri-apps/api/core', () => ({ invoke: vi.fn(async () => null) }))
+vi.mock('@/lib/daemon/local-daemon-identity', () => ({
+  getKnownLocalDaemonActorId: () => 'actor-1',
+}))
+
+import { useTeamShareBrowserStore } from '../team-share-browser'
+
+const store = () => useTeamShareBrowserStore.getState()
+
+describe('selecting an MCP subject agent', () => {
+  beforeEach(() => {
+    useTeamShareBrowserStore.setState({
+      subjectActorId: null,
+      mcp: { items: [], loading: false, loaded: false, error: null },
+    })
+  })
+
+  test('reloads MCP with tool probes so the list is not stuck at 0 tools', async () => {
+    const loadSection = vi.fn(async () => {})
+    useTeamShareBrowserStore.setState({ loadSection })
+
+    await store().setSubjectActor('actor-1')
+
+    expect(store().subjectActorId).toBe('actor-1')
+    expect(loadSection).toHaveBeenCalledWith('mcp', { force: true, withTools: true })
+  })
+})

--- a/packages/app/src/stores/team-share-browser.ts
+++ b/packages/app/src/stores/team-share-browser.ts
@@ -1305,7 +1305,10 @@ export const useTeamShareBrowserStore = create<TeamShareBrowserState>((set, get)
     set({ subjectActorId: actorId, detailTarget: null })
     await Promise.all([
       get().loadSection('skills', { force: true }),
-      get().loadSection('mcp', { force: true }),
+      // Probe after the actor is known. Opening MCP fires withTools while
+      // subjectActorId is still null, so loadMcpTools no-ops; this reload is
+      // what actually fills tool counts. Without it the list stays at "Idle · 0".
+      get().loadSection('mcp', { force: true, withTools: true }),
     ])
   },
 


### PR DESCRIPTION
## Summary
- MCP 面板打开时会在 Agent 还没选上时探测工具，`loadMcpTools` 因此直接跳过。
- 随后自动选中 Agent 会再拉一次列表，但没有带 `withTools`，四个内建服务器一直停在「空闲 · 0 个工具」。
- 选中 Agent 后改为带工具探测重载 MCP 列表。

## Test plan
- [ ] 打开 MCP 面板（冷启动、尚未选 Agent），确认自动选中本机 Agent 后内建服务器不再全是 0 个工具
- [ ] 打开某个内建服务器详情，应显示已连接和实际工具名，而不是「重新同步以加载工具」
- [ ] 手动切换 Agent 后再切回本机 Agent，工具数量应重新加载
- [ ] `pnpm --filter @teamclu/app exec vitest run src/stores/__tests__/team-share-mcp-tools-refresh.test.ts`


Made with [Cursor](https://cursor.com)