### PR TITLE
fix(daemon): fail stuck tool turns fast and release occupancy

### DIFF
--- a/apps/daemon/src/channels/agent_handle.rs
+++ b/apps/daemon/src/channels/agent_handle.rs
@@ -800,6 +800,7 @@ impl AmuxdAgentHandle {
         // runtime kept going and wrote the real answer 15s later — desktop
         // saw it, WeCom did not.
         let mut last_activity = std::time::Instant::now();
+        let mut tool_deadline: Option<std::time::Instant> = None;
         // On a turn-level timeout, salvage any reply text the agent already
         // produced instead of failing the whole turn (issue #555): OpenCode can
         // finish and persist its final assistant text while the ACP adapter
@@ -817,9 +818,10 @@ impl AmuxdAgentHandle {
         };
         let mut timed_out = false;
         let result: Result<String, AgentError> = loop {
-            let remaining = crate::runtime::turn_reply::idle_remaining_at(
+            let remaining = crate::runtime::turn_reply::wait_remaining_at(
                 last_activity,
                 turn_timeout,
+                tool_deadline,
                 std::time::Instant::now(),
             );
             if remaining.is_zero() {
@@ -830,6 +832,11 @@ impl AmuxdAgentHandle {
             let event = match next {
                 Ok(Some(ev)) => {
                     last_activity = std::time::Instant::now();
+                    crate::runtime::turn_reply::apply_tool_deadline_from_event(
+                        &ev.event,
+                        &mut tool_deadline,
+                        last_activity,
+                    );
                     ev
                 }
                 Ok(None) => {
@@ -909,7 +916,10 @@ impl AmuxdAgentHandle {
 
         {
             let mut mgr = self.manager.lock().await;
-            mgr.checkin_turn(crate::runtime::CheckedOutTurn { agent_id, event_rx });
+            mgr.checkin_turn(crate::runtime::CheckedOutTurn {
+                agent_id: agent_id.clone(),
+                event_rx,
+            });
         }
 
         // The gateway has stopped waiting; the runtime has not. A turn left
@@ -918,11 +928,15 @@ impl AmuxdAgentHandle {
         // one slow question used to take the chat down until the daemon was
         // restarted.
         if timed_out {
-            if let Err(e) = self.cancel(session).await {
-                tracing::warn!(session = %session, error = %e, "gateway turn timed out; cancel failed");
-            } else {
-                tracing::warn!(session = %session, "gateway turn timed out; runtime cancelled");
+            {
+                let mut mgr = self.manager.lock().await;
+                mgr.release_after_abandoned_turn(&agent_id).await;
             }
+            self.logical_to_acp.lock().await.remove(session);
+            tracing::warn!(
+                session = %session,
+                "gateway turn timed out; runtime released"
+            );
         }
 
         let reply_text = result?;

--- a/apps/daemon/src/daemon/server.rs
+++ b/apps/daemon/src/daemon/server.rs
@@ -1423,6 +1423,7 @@ impl DaemonServer {
                 loop {
                     tick.tick().await;
                     let mut guard = mgr.lock().await;
+                    let _stuck = guard.release_stuck_tool_turns().await;
                     let _idle = guard.evict_idle(threshold).await;
                     let _over = guard.evict_over_capacity(max_attachments).await;
                     // No publish here — main loop drains mgr.evicted_pending_publish.

--- a/apps/daemon/src/daemon/server/cron.rs
+++ b/apps/daemon/src/daemon/server/cron.rs
@@ -778,15 +778,20 @@ Pass it as `reply_token` to the `send_channel_message` tool, together with an ex
         //    wall-clock (whole turn) and idle (silence since last ACP event).
         let wall_deadline = std::time::Instant::now() + wall_timeout;
         let mut last_activity = std::time::Instant::now();
+        let mut tool_deadline: Option<std::time::Instant> = None;
         let mut segments: Vec<String> = Vec::new();
         let mut live = String::new();
         let mut timed_out = false;
         let result: anyhow::Result<CronTurnOutcome> = loop {
             let now = std::time::Instant::now();
             let wall_remaining = wall_deadline.saturating_duration_since(now);
-            let idle_remaining =
-                crate::runtime::turn_reply::idle_remaining_at(last_activity, idle_timeout, now);
-            let remaining = wall_remaining.min(idle_remaining);
+            let wait_remaining = crate::runtime::turn_reply::wait_remaining_at(
+                last_activity,
+                idle_timeout,
+                tool_deadline,
+                now,
+            );
+            let remaining = wall_remaining.min(wait_remaining);
             if remaining.is_zero() {
                 timed_out = true;
                 break crate::runtime::turn_reply::salvage_timeout_emitted(&segments, &live)
@@ -799,6 +804,11 @@ Pass it as `reply_token` to the `send_channel_message` tool, together with an ex
             let event = match tokio::time::timeout(remaining, event_rx.recv()).await {
                 Ok(Some(ev)) => {
                     last_activity = std::time::Instant::now();
+                    crate::runtime::turn_reply::apply_tool_deadline_from_event(
+                        &ev.event,
+                        &mut tool_deadline,
+                        last_activity,
+                    );
                     ev
                 }
                 Ok(None) => {
@@ -882,23 +892,13 @@ Pass it as `reply_token` to the `send_channel_message` tool, together with an ex
             crate::runtime::turn_reply::absorb_emitted(emitted, &mut segments, &mut live);
         };
 
-        // 4. Stop the runtime when the budget expired but the model is still
-        //    going — mirrors `AmuxdAgentHandle::run_turn` so poll_events does
-        //    not keep writing into the session after cron has moved on.
-        if timed_out {
-            let mut mgr = agents.lock().await;
-            if let Err(e) = mgr.cancel_by_acp_session(acp_sid).await {
-                tracing::warn!(
-                    acp_session_id = %acp_sid,
-                    error = %e,
-                    "cron: cancel after turn timeout failed"
-                );
-            }
-        }
-
-        // 5. Always check the receiver back in.
+        // 4. Stop occupying the workspace when the budget expired but the
+        //    model is still going. ACP cancel alone leaves status Active.
         {
             let mut mgr = agents.lock().await;
+            if timed_out {
+                mgr.release_after_abandoned_turn(&agent_id).await;
+            }
             mgr.checkin_turn(crate::runtime::CheckedOutTurn { agent_id, event_rx });
         }
 

--- a/apps/daemon/src/runtime/handle.rs
+++ b/apps/daemon/src/runtime/handle.rs
@@ -55,6 +55,10 @@ pub struct RuntimeHandle {
     /// the runtime. Stored as a plain `i64` because the field lives behind
     /// the manager's `AsyncMutex` — no separate locking needed.
     pub last_active_at: i64,
+    /// Unix epoch when an in-flight tool's declared timeout (+ grace) elapses.
+    /// Set from ToolUse in `poll_events`; cleared on ToolResult. Gateway
+    /// checkout skips poll_events and tracks the same deadline on its wait loop.
+    pub in_flight_tool_deadline: Option<i64>,
     pub sequence: u64,
     /// Receiver half of the per-agent event channel. Wrapped in `Option` so
     /// the gateway turn-await loop can `.take()` it for the duration of a
@@ -146,6 +150,7 @@ impl RuntimeHandle {
             tool_use_count: 0,
             started_at: now,
             last_active_at: now,
+            in_flight_tool_deadline: None,
             sequence: 0,
             event_rx: Some(event_rx),
             event_tx,
@@ -425,6 +430,7 @@ impl RuntimeHandle {
             tool_use_count: 0,
             started_at: 0,
             last_active_at: 0,
+            in_flight_tool_deadline: None,
             sequence: 0,
             event_rx: Some(event_rx),
             event_tx,

--- a/apps/daemon/src/runtime/manager.rs
+++ b/apps/daemon/src/runtime/manager.rs
@@ -3183,6 +3183,66 @@ mod tests {
     }
 
     #[test]
+    fn poll_events_stamps_declared_tool_deadline() {
+        let mut mgr = RuntimeManager::test_dummy_with_runtime("rt1");
+        let tx = mgr.get_handle_mut("rt1").unwrap().event_tx.clone();
+        tx.try_send(AcpEventFrame::new(
+            "acp-test",
+            amux::AcpEvent {
+                model: String::new(),
+                event: Some(amux::acp_event::Event::ToolUse(amux::AcpToolUse {
+                    tool_id: "1".into(),
+                    tool_name: "bash".into(),
+                    description: String::new(),
+                    params: Default::default(),
+                    tool_kind: "execute".into(),
+                    raw_input_json: r#"{"timeout":60}"#.into(),
+                    raw_output_json: String::new(),
+                    content: vec![],
+                    locations: vec![],
+                    status: "in_progress".into(),
+                })),
+            },
+        ))
+        .expect("event channel ready");
+        mgr.poll_events();
+        let deadline = mgr
+            .get_handle("rt1")
+            .unwrap()
+            .in_flight_tool_deadline
+            .expect("tool use with timeout stamps a deadline");
+        let now = chrono::Utc::now().timestamp();
+        assert!(deadline >= now + 60);
+        assert!(deadline <= now + 60 + 15 + 2);
+    }
+
+    #[tokio::test]
+    async fn release_stuck_tool_turns_stops_active_runtime_past_deadline() {
+        let mut mgr = RuntimeManager::test_dummy_with_runtime("rt-stuck");
+        {
+            let h = mgr.get_handle_mut("rt-stuck").unwrap();
+            h.status = amux::AgentStatus::Active;
+            h.in_flight_tool_deadline = Some(1);
+        }
+        let released = mgr.release_stuck_tool_turns().await;
+        assert_eq!(released, vec!["rt-stuck".to_string()]);
+        assert!(mgr.get_handle("rt-stuck").is_none());
+    }
+
+    #[tokio::test]
+    async fn release_stuck_tool_turns_skips_checked_out_gateway_turns() {
+        let mut mgr = RuntimeManager::test_dummy_with_runtime("rt-gw");
+        {
+            let h = mgr.get_handle_mut("rt-gw").unwrap();
+            h.status = amux::AgentStatus::Active;
+            h.in_flight_tool_deadline = Some(1);
+            h.event_rx = None;
+        }
+        assert!(mgr.release_stuck_tool_turns().await.is_empty());
+        assert!(mgr.get_handle("rt-gw").is_some());
+    }
+
+    #[test]
     fn poll_events_for_only_drains_allowlisted_runtimes() {
         // Regression: the HTTP/SSE adapter's event pump shares the single
         // RuntimeManager with the MQTT main loop. It used to call the global

--- a/apps/daemon/src/runtime/manager/cancel.rs
+++ b/apps/daemon/src/runtime/manager/cancel.rs
@@ -41,6 +41,30 @@ impl RuntimeManager {
         handle.cancel().await
     }
 
+    /// ACP cancel does not flip occupancy. A hung bash stays `Active`, so
+    /// `workspace_has_active_turn` keeps refusing reload / the next prompt.
+    /// After a driver has given up, cancel first; if the handle is still a
+    /// mid-turn occupant, stop it so the next message can spawn fresh.
+    pub async fn release_after_abandoned_turn(&mut self, agent_id: &str) {
+        if let Err(e) = self.cancel_agent(agent_id).await {
+            tracing::warn!(
+                agent_id,
+                error = %e,
+                "cancel after abandoned turn failed"
+            );
+        }
+        let still_occupying = self.agents.get(agent_id).is_some_and(|h| {
+            matches!(h.status, crate::proto::amux::AgentStatus::Active) || h.event_rx.is_none()
+        });
+        if still_occupying {
+            tracing::warn!(
+                agent_id,
+                "abandoned turn still occupying workspace; stopping runtime"
+            );
+            let _ = self.stop_runtime(agent_id).await;
+        }
+    }
+
     pub async fn restart_session(&mut self, agent_id: &str) -> crate::error::Result<()> {
         if self.stop_runtime(agent_id).await.is_some() {
             Ok(())

--- a/apps/daemon/src/runtime/manager/eviction.rs
+++ b/apps/daemon/src/runtime/manager/eviction.rs
@@ -43,6 +43,36 @@ impl RuntimeManager {
         evicted
     }
 
+    /// Desktop turns are driven by `poll_events`, which has no wait loop.
+    /// A bash that declared `timeout: 60` and then went silent would otherwise
+    /// sit Active until the 30-minute idle sweep. Skip checked-out receivers —
+    /// gateway/cron already enforce the same deadline on their wait loop.
+    pub async fn release_stuck_tool_turns(&mut self) -> Vec<String> {
+        let now = chrono::Utc::now().timestamp();
+        let stuck: Vec<String> = self
+            .agents
+            .iter()
+            .filter(|(_, h)| {
+                h.event_rx.is_some()
+                    && matches!(h.status, crate::proto::amux::AgentStatus::Active)
+                    && h.in_flight_tool_deadline
+                        .is_some_and(|deadline| now >= deadline)
+            })
+            .map(|(id, _)| id.clone())
+            .collect();
+        let mut released = Vec::with_capacity(stuck.len());
+        for id in stuck {
+            info!(agent_id = %id, "stuck-tool sweeper: releasing abandoned turn");
+            self.release_after_abandoned_turn(&id).await;
+            if self.agents.get(&id).is_none() {
+                released.push(id);
+            }
+        }
+        self.evicted_pending_publish
+            .extend(released.iter().cloned());
+        released
+    }
+
     /// Detach least-recently-used attachments until at most `max` remain.
     ///
     /// The idle sweep alone bounds the set only by user behaviour — how many

--- a/apps/daemon/src/runtime/manager/poll.rs
+++ b/apps/daemon/src/runtime/manager/poll.rs
@@ -36,6 +36,7 @@ impl RuntimeManager {
                 continue;
             }
             let mut got_any = false;
+            let drained_at = events.len();
             if let Some(rx) = handle.event_rx.as_mut() {
                 while let Ok(event) = rx.try_recv() {
                     events.push((agent_id.clone(), event));
@@ -44,6 +45,14 @@ impl RuntimeManager {
             }
             if got_any {
                 handle.bump_activity();
+                let now = chrono::Utc::now().timestamp();
+                for (_, frame) in &events[drained_at..] {
+                    crate::runtime::turn_reply::apply_tool_deadline_unix(
+                        &frame.event,
+                        &mut handle.in_flight_tool_deadline,
+                        now,
+                    );
+                }
             }
         }
         events

--- a/apps/daemon/src/runtime/manager/workspace_query.rs
+++ b/apps/daemon/src/runtime/manager/workspace_query.rs
@@ -233,4 +233,26 @@ mod tests {
             WorkspaceOccupancy::Cold
         );
     }
+
+    #[tokio::test]
+    async fn release_after_abandoned_turn_stops_runtime_still_marked_active() {
+        let mut manager = RuntimeManager::new(RuntimeManager::test_launch_configs(), None);
+        manager.add_test_workspace_runtime("rt1", "/tmp/ws", "ws1", amux::AgentStatus::Active);
+        assert!(manager.workspace_has_active_turn("/tmp/ws", "ws1"));
+        manager.release_after_abandoned_turn("rt1").await;
+        assert!(
+            !manager.workspace_has_active_turn("/tmp/ws", "ws1"),
+            "occupancy must clear even when ACP cancel cannot flip Idle"
+        );
+        assert!(manager.get_handle("rt1").is_none());
+    }
+
+    #[tokio::test]
+    async fn release_after_abandoned_turn_leaves_idle_runtime() {
+        let mut manager = RuntimeManager::new(RuntimeManager::test_launch_configs(), None);
+        manager.add_test_workspace_runtime("rt1", "/tmp/ws", "ws1", amux::AgentStatus::Idle);
+        manager.release_after_abandoned_turn("rt1").await;
+        assert!(manager.get_handle("rt1").is_some());
+        assert!(!manager.workspace_has_active_turn("/tmp/ws", "ws1"));
+    }
 }

--- a/apps/daemon/src/runtime/turn_reply.rs
+++ b/apps/daemon/src/runtime/turn_reply.rs
@@ -2,15 +2,104 @@
 //! one ACP turn. Shared by the gateway (`agent_handle::run_turn`) and cron
 //! (`drive_cron_turn`).
 
+use std::collections::HashMap;
 use std::time::{Duration, Instant};
 
+use crate::proto::amux;
 use crate::proto::teamclu::MessageKind;
 use crate::runtime::turn_aggregator::{EmittedMessage, TurnAggregator};
+
+/// Extra wait after a tool's own `timeout` before the daemon treats it as stuck.
+/// Pi may still be killing the process tree when the declared second elapses.
+pub const TOOL_TIMEOUT_GRACE: Duration = Duration::from_secs(15);
+const MAX_DECLARED_TOOL_TIMEOUT_SECS: u64 = 24 * 3600;
 
 /// Silence is measured from the last ACP event, not from the prompt. An idle
 /// budget resets on every event and only fires after actual quiet.
 pub fn idle_remaining_at(last_activity: Instant, idle: Duration, now: Instant) -> Duration {
     idle.saturating_sub(now.saturating_duration_since(last_activity))
+}
+
+/// How long this wait loop may sleep, combining channel idle with an optional
+/// in-flight tool deadline. A bash that declared `timeout: 60` must not sit on
+/// WeCom's 600s silence budget; a scrape that declared nothing keeps it.
+pub fn wait_remaining_at(
+    last_activity: Instant,
+    channel_idle: Duration,
+    tool_deadline: Option<Instant>,
+    now: Instant,
+) -> Duration {
+    let idle = idle_remaining_at(last_activity, channel_idle, now);
+    match tool_deadline {
+        Some(deadline) => idle.min(deadline.saturating_duration_since(now)),
+        None => idle,
+    }
+}
+
+/// Seconds the tool asked to live, from ACP `rawInput` or the string params map.
+pub fn declared_tool_timeout_secs(
+    raw_input_json: &str,
+    params: &HashMap<String, String>,
+) -> Option<u64> {
+    parse_timeout_json(raw_input_json)
+        .or_else(|| params.get("timeout").and_then(|s| parse_timeout_str(s)))
+        .filter(|&secs| secs > 0 && secs <= MAX_DECLARED_TOOL_TIMEOUT_SECS)
+}
+
+fn parse_timeout_json(raw: &str) -> Option<u64> {
+    let v: serde_json::Value = serde_json::from_str(raw).ok()?;
+    parse_timeout_value(v.get("timeout")?)
+}
+
+fn parse_timeout_value(v: &serde_json::Value) -> Option<u64> {
+    match v {
+        serde_json::Value::Number(n) => n.as_u64().or_else(|| {
+            n.as_f64()
+                .filter(|f| *f > 0.0 && f.is_finite())
+                .map(|f| f as u64)
+        }),
+        serde_json::Value::String(s) => parse_timeout_str(s),
+        _ => None,
+    }
+}
+
+fn parse_timeout_str(s: &str) -> Option<u64> {
+    s.trim().parse().ok()
+}
+
+/// ToolUse with a declared timeout starts a deadline from `now`; ToolResult clears it.
+pub fn apply_tool_deadline_from_event(
+    event: &amux::AcpEvent,
+    deadline: &mut Option<Instant>,
+    now: Instant,
+) {
+    match &event.event {
+        Some(amux::acp_event::Event::ToolUse(tu)) => {
+            *deadline = declared_tool_timeout_secs(&tu.raw_input_json, &tu.params)
+                .map(|secs| now + Duration::from_secs(secs) + TOOL_TIMEOUT_GRACE);
+        }
+        Some(amux::acp_event::Event::ToolResult(_)) => {
+            *deadline = None;
+        }
+        _ => {}
+    }
+}
+
+/// Same as [`apply_tool_deadline_from_event`] for the poll_events / sweeper path.
+pub fn apply_tool_deadline_unix(event: &amux::AcpEvent, deadline: &mut Option<i64>, now_unix: i64) {
+    match &event.event {
+        Some(amux::acp_event::Event::ToolUse(tu)) => {
+            *deadline = declared_tool_timeout_secs(&tu.raw_input_json, &tu.params).map(|secs| {
+                now_unix
+                    + i64::try_from(secs).unwrap_or(i64::MAX)
+                    + TOOL_TIMEOUT_GRACE.as_secs() as i64
+            });
+        }
+        Some(amux::acp_event::Event::ToolResult(_)) => {
+            *deadline = None;
+        }
+        _ => {}
+    }
 }
 
 /// Join the reply segments a turn has produced so far into the text a
@@ -171,6 +260,102 @@ mod tests {
         assert!(out.content.is_empty());
         assert_eq!(out.turn_id, "turn-tool");
         assert!(out.metadata_json.contains("no_final_reply"));
+    }
+
+    #[test]
+    fn declared_tool_timeout_reads_json_number_or_params() {
+        let empty = std::collections::HashMap::new();
+        let mut params = std::collections::HashMap::new();
+        params.insert("timeout".into(), "60".into());
+        assert_eq!(
+            declared_tool_timeout_secs(r#"{"command":"sleep 999","timeout":60}"#, &params),
+            Some(60)
+        );
+        assert_eq!(
+            declared_tool_timeout_secs(r#"{"timeout":"90"}"#, &empty),
+            Some(90)
+        );
+        assert_eq!(
+            declared_tool_timeout_secs("{}", &params),
+            Some(60),
+            "params fallback when JSON has no timeout"
+        );
+        assert_eq!(
+            declared_tool_timeout_secs(r#"{"command":"ls"}"#, &empty),
+            None
+        );
+        assert_eq!(
+            declared_tool_timeout_secs(r#"{"timeout":0}"#, &empty),
+            None,
+            "zero is not a declared budget"
+        );
+    }
+
+    #[test]
+    fn wait_remaining_honors_tool_deadline_without_killing_undeclared_scrapes() {
+        let idle = Duration::from_secs(600);
+        let t0 = Instant::now();
+        let after_75s = t0 + Duration::from_secs(75);
+        let tool_deadline = Some(t0 + Duration::from_secs(60) + TOOL_TIMEOUT_GRACE);
+        assert_eq!(
+            wait_remaining_at(t0, idle, tool_deadline, after_75s),
+            Duration::ZERO,
+            "bash timeout=60 plus grace must expire well before the 600s channel idle"
+        );
+        assert_eq!(
+            wait_remaining_at(t0, idle, None, after_75s),
+            Duration::from_secs(525),
+            "a scrape that never declared timeout keeps the channel idle budget"
+        );
+        let just_started = t0 + Duration::from_secs(1);
+        assert_eq!(
+            wait_remaining_at(t0, idle, tool_deadline, just_started),
+            Duration::from_secs(74),
+            "tool deadline is measured from tool start, not reset by the idle clock"
+        );
+    }
+
+    #[test]
+    fn tool_use_with_timeout_sets_deadline_and_result_clears_it() {
+        let now = Instant::now();
+        let mut deadline: Option<Instant> = None;
+        let tool_use = crate::proto::amux::AcpEvent {
+            event: Some(crate::proto::amux::acp_event::Event::ToolUse(
+                crate::proto::amux::AcpToolUse {
+                    tool_id: "1".into(),
+                    tool_name: "bash".into(),
+                    description: String::new(),
+                    params: Default::default(),
+                    tool_kind: "execute".into(),
+                    raw_input_json: r#"{"timeout":60}"#.into(),
+                    raw_output_json: String::new(),
+                    content: vec![],
+                    locations: vec![],
+                    status: "in_progress".into(),
+                },
+            )),
+            model: String::new(),
+        };
+        apply_tool_deadline_from_event(&tool_use, &mut deadline, now);
+        assert_eq!(
+            deadline,
+            Some(now + Duration::from_secs(60) + TOOL_TIMEOUT_GRACE)
+        );
+
+        let result = crate::proto::amux::AcpEvent {
+            event: Some(crate::proto::amux::acp_event::Event::ToolResult(
+                crate::proto::amux::AcpToolResult {
+                    tool_id: "1".into(),
+                    success: true,
+                    summary: String::new(),
+                    raw_output_json: String::new(),
+                    content: vec![],
+                },
+            )),
+            model: String::new(),
+        };
+        apply_tool_deadline_from_event(&result, &mut deadline, now + Duration::from_secs(2));
+        assert_eq!(deadline, None);
     }
 
     #[test]

--- a/packages/app/src/lib/diagnostics/__tests__/orchestrator-send.test.ts
+++ b/packages/app/src/lib/diagnostics/__tests__/orchestrator-send.test.ts
@@ -30,6 +30,28 @@ describe('diagnose send flow', () => {
     )
   })
 
+  it('reports workspace busy instead of a network outbox failure', () => {
+    const findings = diagnose(
+      emptyCtx({
+        outbox: [
+          {
+            messageId: 'm1',
+            sessionId: 's1',
+            state: 'failed',
+            lastError: 'workspace has active turn: 1b4827bf-d1d4-4746-98f1-ae54df3e7e53',
+            attemptCount: 1,
+            updatedAt: '2026-09-09T06:30:00.000Z',
+          },
+        ],
+      }),
+    )
+    const busy = findings.find((f) => f.code === 'send.workspace_busy')
+    expect(busy?.status).toBe('fail')
+    expect(busy?.nextAction).toContain('等当前回复结束后重试')
+    expect(busy?.nextAction).not.toBe('检查网络后重试该消息')
+    expect(findings.find((f) => f.code === 'send.outbox_failed')).toBeUndefined()
+  })
+
   it('treats remote MQTT publish failure as fail and local_fast as warn', () => {
     const remote = diagnose(
       emptyCtx({

--- a/packages/app/src/lib/diagnostics/orchestrator.ts
+++ b/packages/app/src/lib/diagnostics/orchestrator.ts
@@ -1,3 +1,4 @@
+import { isActiveTurnRefusal } from '@/lib/telemetry/runtime-error-report'
 import type {
   DiagnosticCauseCode,
   DiagnosticContext,
@@ -190,29 +191,57 @@ function diagnoseSend(ctx: DiagnosticContext): DiagnosticFinding[] {
     .slice(0, 20)
   const failed = recentOutbox.find((entry) => entry.state === 'failed')
   if (failed) {
-    out.push(
-      finding({
-        code: 'send.outbox_failed',
-        symptom: 'send',
-        status: 'fail',
-        confidence: 'high',
-        title: '消息发送',
-        message: failed.lastError ? `outbox 发送失败：${failed.lastError}` : 'outbox 发送失败',
-        nextAction: '检查网络后重试该消息',
-        evidence: [
-          {
-            source: 'outbox',
-            summary: `${failed.messageId} failed`,
-            at: failed.updatedAt,
-            data: {
-              lastError: failed.lastError,
-              attemptCount: failed.attemptCount,
-              sessionId: failed.sessionId,
+    if (isActiveTurnRefusal(failed.lastError ?? undefined)) {
+      out.push(
+        finding({
+          code: 'send.workspace_busy',
+          symptom: 'send',
+          status: 'fail',
+          confidence: 'high',
+          title: '工作区正忙',
+          message: failed.lastError
+            ? `工作区有进行中的 turn：${failed.lastError}`
+            : '工作区有进行中的 turn',
+          nextAction: '等当前回复结束后重试，不要当成网络故障',
+          evidence: [
+            {
+              source: 'outbox',
+              summary: `${failed.messageId} failed`,
+              at: failed.updatedAt,
+              data: {
+                lastError: failed.lastError,
+                attemptCount: failed.attemptCount,
+                sessionId: failed.sessionId,
+              },
             },
-          },
-        ],
-      }),
-    )
+          ],
+        }),
+      )
+    } else {
+      out.push(
+        finding({
+          code: 'send.outbox_failed',
+          symptom: 'send',
+          status: 'fail',
+          confidence: 'high',
+          title: '消息发送',
+          message: failed.lastError ? `outbox 发送失败：${failed.lastError}` : 'outbox 发送失败',
+          nextAction: '检查网络后重试该消息',
+          evidence: [
+            {
+              source: 'outbox',
+              summary: `${failed.messageId} failed`,
+              at: failed.updatedAt,
+              data: {
+                lastError: failed.lastError,
+                attemptCount: failed.attemptCount,
+                sessionId: failed.sessionId,
+              },
+            },
+          ],
+        }),
+      )
+    }
   }
 
   const cloudFail = lastErrorOf(sendTraces, 'cloud.insert')

--- a/packages/app/src/lib/diagnostics/remediations.ts
+++ b/packages/app/src/lib/diagnostics/remediations.ts
@@ -54,6 +54,7 @@ const PRIMARY: Partial<Record<DiagnosticCauseCode, RemediationId[]>> = {
   'model.catalog_unknown': ['retry_diagnose'],
   'send.cloud_insert_failed': ['retry_diagnose'],
   'send.outbox_failed': ['retry_diagnose'],
+  'send.workspace_busy': ['retry_diagnose'],
 }
 
 export function remediationsForFinding(

--- a/packages/app/src/lib/diagnostics/types.ts
+++ b/packages/app/src/lib/diagnostics/types.ts
@@ -57,6 +57,7 @@ export type DiagnosticCauseCode =
   | 'model.catalog_unknown'
   | 'model.team_gateway_unconfigured'
   | 'send.outbox_failed'
+  | 'send.workspace_busy'
   | 'send.cloud_insert_failed'
   | 'send.mqtt_publish_failed'
   | 'send.runtime_ensure_failed'


### PR DESCRIPTION
## Summary
- Honor a tool's declared timeout (plus 15s grace) so a hung `bash timeout:60` no longer sits on WeCom's 600s idle budget. Scrapes that never declare a timeout keep the channel idle cap.
- After a gateway/cron timeout, ACP cancel is not enough: if the runtime is still `Active`, stop it and drop the gateway session map so the next message can spawn fresh instead of blocking the workspace with `workspace has active turn`.
- Desktop turns get the same tool deadline via `poll_events` plus a one-minute sweeper. Diagnostics now classify that occupancy refusal as `send.workspace_busy`, not a network outbox failure.

## Test plan
- [ ] Send a WeCom message that runs `bash` with `timeout: 60` against a command that never returns — turn should fail around 75s, not 10 minutes, and a follow-up message should not hit `workspace has active turn`.
- [ ] Run a long scrape **without** a declared tool timeout and confirm it can still run up to the channel idle budget.
- [ ] After a stuck timeout, env/skills refresh should no longer loop on `deferred_active_turn` for that workspace.
- [ ] Outbox diagnostic for `workspace has active turn: <id>` should say the workspace is busy, not "检查网络后重试".
- [ ] `pnpm daemon:test -- declared_tool` and `pnpm test:unit -- src/lib/diagnostics/__tests__/orchestrator-send.test.ts` when a machine can compile.


Made with [Cursor](https://cursor.com)