### PR TITLE
fix(wecom): ack stream frames and redeliver long-turn answers

### DIFF
--- a/apps/daemon/src/channels/manager.rs
+++ b/apps/daemon/src/channels/manager.rs
@@ -517,6 +517,9 @@ impl ChannelManager {
                 encoding_aes_key: bot.encoding_aes_key.clone(),
                 owner_id: None,
                 bot_name: bot.bot_name.clone(),
+                stream_max_secs: c.stream_max_secs,
+                progress_frame_gap_secs: c.progress_frame_gap_secs,
+                final_max_retries: c.final_max_retries,
             };
             gw.set_config(cfg).await;
             // One pipeline for every channel; the gateway is left with the

--- a/apps/daemon/src/cli/channel.rs
+++ b/apps/daemon/src/cli/channel.rs
@@ -93,6 +93,9 @@ fn bind(cfg: &mut DaemonConfig, b: ChannelBindArgs) -> anyhow::Result<()> {
                 secret,
                 encoding_aes_key,
                 bots: vec![],
+                stream_max_secs: 240,
+                progress_frame_gap_secs: 10,
+                final_max_retries: 3,
             });
         }
         ChannelBindPlatform::Feishu { app_id, app_secret } => {

--- a/apps/daemon/src/config/daemon_config.rs
+++ b/apps/daemon/src/config/daemon_config.rs
@@ -549,6 +549,18 @@ pub struct WeComBot {
     pub bot_name: Option<String>,
 }
 
+fn default_wecom_stream_max_secs() -> u64 {
+    240
+}
+
+fn default_wecom_progress_gap_secs() -> u64 {
+    10
+}
+
+fn default_wecom_final_max_retries() -> u32 {
+    3
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct WeComChannel {
     pub enabled: bool,
@@ -562,6 +574,16 @@ pub struct WeComChannel {
     // ----- new multi-bot list -----
     #[serde(default)]
     pub bots: Vec<WeComBot>,
+    /// Seconds a WeCom stream bubble may stay open before the driver closes
+    /// it and later pushes the answer as markdown. `0` disables the early close.
+    #[serde(default = "default_wecom_stream_max_secs")]
+    pub stream_max_secs: u64,
+    /// Minimum gap between two frames of the same stream, in seconds.
+    #[serde(default = "default_wecom_progress_gap_secs")]
+    pub progress_frame_gap_secs: u64,
+    /// How many times a failed proactive send is retried from the outbox.
+    #[serde(default = "default_wecom_final_max_retries")]
+    pub final_max_retries: u32,
 }
 
 impl WeComChannel {
@@ -1005,6 +1027,9 @@ encoding_aes_key = "k"
     fn wecom_empty_yields_no_bots() {
         let wecom: WeComChannel = toml::from_str("enabled = false\n").unwrap();
         assert!(wecom.resolved_bots().is_empty());
+        assert_eq!(wecom.stream_max_secs, 240);
+        assert_eq!(wecom.progress_frame_gap_secs, 10);
+        assert_eq!(wecom.final_max_retries, 3);
     }
 
     #[test]

--- a/crates/teamclu-gateway/src/lib.rs
+++ b/crates/teamclu-gateway/src/lib.rs
@@ -29,6 +29,8 @@ pub mod wechat;
 pub mod wechat_config;
 pub mod wecom;
 pub mod wecom_config;
+mod wecom_delivery;
+mod wecom_outbox;
 
 pub use config::*;
 pub use discord::DiscordGateway;

--- a/crates/teamclu-gateway/src/wecom.rs
+++ b/crates/teamclu-gateway/src/wecom.rs
@@ -1,5 +1,10 @@
 use crate::i18n;
 use crate::wecom_config::{WeComConfig, WeComGatewayStatus, WeComGatewayStatusResponse};
+use crate::wecom_delivery::{
+    self, decide_finish, decide_progress, progress_frame_with_notice, should_requeue,
+    still_running_close_with_notice, FinishDecision, ProgressDecision, SendError, StreamPhase,
+};
+use crate::wecom_outbox::{PendingSend, WeComOutbox};
 use base64::Engine as _;
 use futures_util::stream::SplitSink;
 #[allow(unused_imports)]
@@ -7,6 +12,7 @@ use futures_util::StreamExt;
 use serde::Deserialize;
 use std::sync::Arc;
 use std::sync::OnceLock;
+use std::time::{Duration, Instant};
 use tokio::sync::{mpsc, oneshot, RwLock};
 
 use crate::{driver, AgentHandle, ChannelStore};
@@ -506,22 +512,11 @@ const HEARTBEAT_TIMEOUT_SECS: u64 = 6;
 type PendingResponses =
     Arc<tokio::sync::Mutex<std::collections::HashMap<String, oneshot::Sender<serde_json::Value>>>>;
 
-/// Minimum spacing between two frames of the same streamed reply. See
-/// [`StreamPacer`] for why frames cannot simply be fired as fast as the agent
-/// produces text.
-/// Minimum gap between two frames of one streaming reply.
-///
-/// WeCom counts **every** frame against "30 messages/minute, 1000/hour per
-/// conversation" — replies and proactive pushes share that budget, and a stream
-/// is not consolidated into one message
-/// (<https://developer.work.weixin.qq.com/document/path/101463>). At the old
-/// 900ms this burned 66 frames a minute, more than twice the allowance, so a
-/// long answer would start losing frames part-way through and read as a reply
-/// that froze. 2.1s keeps it at ~28/minute with room for the final message.
-const STREAM_FRAME_MIN_GAP: std::time::Duration = std::time::Duration::from_millis(2100);
-
-#[allow(dead_code)]
-const TERMINAL_FRAME_ACK_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+/// Default gap when config is missing or zero. 10s keeps a long turn at
+/// ~6 frames/minute against WeCom's 30/minute conversation quota
+/// (<https://developer.work.weixin.qq.com/document/path/101463>).
+const STREAM_FRAME_MIN_GAP: Duration =
+    Duration::from_secs(wecom_delivery::DEFAULT_PROGRESS_FRAME_GAP_SECS);
 
 /// Paces the frames of one streamed reply.
 ///
@@ -532,21 +527,32 @@ const TERMINAL_FRAME_ACK_TIMEOUT: std::time::Duration = std::time::Duration::fro
 /// side sends an update the moment a segment flushes — deliberately, so text
 /// appears promptly — which on a long answer means several frames within
 /// milliseconds. Spacing them here keeps that behaviour for every other channel
-/// while staying inside what WeCom will accept.
+/// while staying inside what WeCom will accept. Each frame waits for the WS
+/// ack so a 6000 is retried instead of silently dropped.
 #[derive(Clone)]
 struct StreamPacer {
     req_id: String,
     stream_id: String,
     ws_sink: WsSink,
-    last_frame_at: Arc<tokio::sync::Mutex<Option<std::time::Instant>>>,
+    gateway: WeComGateway,
+    min_gap: Duration,
+    last_frame_at: Arc<tokio::sync::Mutex<Option<Instant>>>,
 }
 
 impl StreamPacer {
-    fn new(req_id: &str, stream_id: &str, ws_sink: &WsSink) -> Self {
+    fn new(
+        req_id: &str,
+        stream_id: &str,
+        ws_sink: &WsSink,
+        gateway: WeComGateway,
+        min_gap: Duration,
+    ) -> Self {
         Self {
             req_id: req_id.to_string(),
             stream_id: stream_id.to_string(),
             ws_sink: ws_sink.clone(),
+            gateway,
+            min_gap,
             last_frame_at: Arc::new(tokio::sync::Mutex::new(None)),
         }
     }
@@ -554,23 +560,31 @@ impl StreamPacer {
     /// Send one frame, waiting out the remainder of the gap since the previous
     /// one. The lock is deliberately held across the wait: it is what serializes
     /// the progressive-update task against the terminal frame.
-    async fn send(&self, content: &str, finish: bool) -> Result<(), String> {
+    async fn send(&self, content: &str, finish: bool) -> Result<(), SendError> {
         let mut last = self.last_frame_at.lock().await;
         if let Some(prev) = *last {
             let since = prev.elapsed();
-            if since < STREAM_FRAME_MIN_GAP {
-                tokio::time::sleep(STREAM_FRAME_MIN_GAP - since).await;
+            if since < self.min_gap {
+                tokio::time::sleep(self.min_gap - since).await;
             }
         }
-        let result = WeComGateway::send_stream_chunk_static(
-            &self.req_id,
-            &self.stream_id,
-            content,
-            finish,
-            &self.ws_sink,
-        )
-        .await;
-        *last = Some(std::time::Instant::now());
+        let timeout = if finish {
+            wecom_delivery::PROACTIVE_ACK_TIMEOUT
+        } else {
+            wecom_delivery::STREAM_FRAME_ACK_TIMEOUT
+        };
+        let result = self
+            .gateway
+            .send_stream_chunk_acked(
+                &self.req_id,
+                &self.stream_id,
+                content,
+                finish,
+                &self.ws_sink,
+                timeout,
+            )
+            .await;
+        *last = Some(Instant::now());
         result
     }
 }
@@ -599,6 +613,10 @@ pub struct WeComGateway {
     /// be switched back without a rebuild. It goes away once the new path has
     /// been through a real WeCom round trip.
     inbound_sink: Arc<RwLock<Option<Arc<dyn driver::InboundSink>>>>,
+    /// Proactive sends that failed while the socket was down. Flushed after
+    /// the next successful subscribe. Process crash is not covered — the
+    /// session already has the reply.
+    outbox: WeComOutbox,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -946,17 +964,23 @@ pub struct WeComDriver {
     pacers: tokio::sync::Mutex<std::collections::HashMap<String, InFlightReply>>,
 }
 
-/// A streaming reply being written, and where its finished text has to go.
+/// A streaming reply being written.
 ///
-/// The conversation is kept because the final answer does NOT go out through
-/// the stream: `stream` carries plain text, so a markdown answer arrives with
-/// its fences and lists as literal characters. The stream shows progress, and
-/// the finished answer is sent once as a `markdown` message, which WeCom
-/// renders.
+/// Short turns still finish inside the stream bubble (that content is what
+/// WeCom keeps). Turns that outlive [`WeComConfig::stream_max_secs`] close the
+/// stream with a "still running" frame and push the answer afterwards via
+/// `aibot_send_msg` on a new req_id.
 struct InFlightReply {
     pacer: StreamPacer,
     chatid: String,
     chat_type: u32,
+    opened_at: Instant,
+    deadline: Instant,
+    stream_closed: bool,
+    /// Queue notice to keep rewriting into the bubble while the stream is the
+    /// only rewrite WeCom will reliably accept (proactive send during an open
+    /// stream is often dropped).
+    pending_notice: Option<String>,
 }
 
 impl WeComDriver {
@@ -1086,8 +1110,17 @@ impl driver::ChannelDriver for WeComDriver {
 
         let Some(req_id) = reply_context else {
             // Nothing to answer: this is proactive, which WeCom does through a
-            // different command entirely.
+            // different command entirely. If a stream bubble is still open on
+            // this chat, piggyback the text there — aibot_send_msg during an
+            // open stream is often dropped.
             let (chatid, chat_type) = Self::chat_target(to);
+            if self
+                .piggyback_notice(chatid, &msg.text)
+                .await
+                .unwrap_or(false)
+            {
+                return Ok(driver::DeliveryId(format!("notice-on-stream:{chatid}")));
+            }
             self.gateway
                 .send_chat_message(chatid, chat_type, &msg.text)
                 .await
@@ -1107,12 +1140,28 @@ impl driver::ChannelDriver for WeComDriver {
             return Ok(driver::DeliveryId(format!("markdown:{chatid}")));
         }
 
+        let cfg = self.gateway.config.read().await.clone();
+        let min_gap = if cfg.progress_frame_gap_secs == 0 {
+            STREAM_FRAME_MIN_GAP
+        } else {
+            Duration::from_secs(cfg.progress_frame_gap_secs)
+        };
+        let opened_at = Instant::now();
+        let deadline = if cfg.stream_max_secs == 0 {
+            opened_at + Duration::from_secs(365 * 24 * 3600)
+        } else {
+            opened_at + Duration::from_secs(cfg.stream_max_secs)
+        };
+
         let stream_id = uuid::Uuid::new_v4().to_string();
-        let pacer = StreamPacer::new(req_id, &stream_id, &sink);
+        let pacer = StreamPacer::new(req_id, &stream_id, &sink, self.gateway.clone(), min_gap);
         pacer
-            .send(PROGRESS_OPENING, false)
+            .send(
+                &progress_frame_with_notice(Duration::ZERO, None, None),
+                false,
+            )
             .await
-            .map_err(driver::DriverError::Transport)?;
+            .map_err(|e| driver::DriverError::Transport(e.to_string()))?;
 
         self.pacers.lock().await.insert(
             stream_id.clone(),
@@ -1120,6 +1169,10 @@ impl driver::ChannelDriver for WeComDriver {
                 pacer,
                 chatid: chatid.to_string(),
                 chat_type,
+                opened_at,
+                deadline,
+                stream_closed: false,
+                pending_notice: None,
             },
         );
         Ok(driver::DeliveryId(stream_id))
@@ -1132,16 +1185,29 @@ impl driver::ChannelDriver for WeComDriver {
     /// and lists as literal characters, and every frame spends one of the 30
     /// messages a minute this conversation is allowed. A progress line costs
     /// the same per frame but does not need to be complete or pretty.
+    ///
+    /// Past `stream_max_secs` this driver closes the bubble itself and later
+    /// `update(..., Some(end))` pushes markdown on a new req_id. Core keeps
+    /// calling; closed progress is swallowed so a long turn is not a render
+    /// error.
     async fn update(
         &self,
         id: &driver::DeliveryId,
         text: &str,
         end: Option<driver::TurnEnd>,
     ) -> Result<(), driver::DriverError> {
-        let (pacer, chatid, chat_type) = {
+        let snapshot = {
             let pacers = self.pacers.lock().await;
             match pacers.get(&id.0) {
-                Some(r) => (r.pacer.clone(), r.chatid.clone(), r.chat_type),
+                Some(r) => InFlightSnapshot {
+                    pacer: r.pacer.clone(),
+                    chatid: r.chatid.clone(),
+                    chat_type: r.chat_type,
+                    opened_at: r.opened_at,
+                    deadline: r.deadline,
+                    stream_closed: r.stream_closed,
+                    pending_notice: r.pending_notice.clone(),
+                },
                 None => {
                     return Err(driver::DriverError::Transport(format!(
                         "no streaming reply {} to update — it was already finished",
@@ -1151,55 +1217,158 @@ impl driver::ChannelDriver for WeComDriver {
             }
         };
 
+        let phase = if snapshot.stream_closed {
+            StreamPhase::ClosedForFollowup
+        } else {
+            StreamPhase::Open
+        };
+        let elapsed = snapshot.opened_at.elapsed();
+        let notice = snapshot.pending_notice.as_deref();
+
         let Some(end) = end else {
-            let frame = match newest_line(text) {
-                Some(line) => format!("{PROGRESS_OPENING} {line}"),
-                None => PROGRESS_OPENING.to_string(),
-            };
-            return pacer
-                .send(&frame, false)
-                .await
-                .map_err(driver::DriverError::Transport);
+            match decide_progress(phase, Instant::now() >= snapshot.deadline) {
+                ProgressDecision::Swallow => return Ok(()),
+                ProgressDecision::SendProgress => {
+                    let line = newest_line(text);
+                    let frame = progress_frame_with_notice(elapsed, line.as_deref(), notice);
+                    if let Err(e) = snapshot.pacer.send(&frame, false).await {
+                        // A missed progress ack must not abort the turn.
+                        eprintln!("[WeCom] progress frame failed: {e}");
+                    }
+                    return Ok(());
+                }
+                ProgressDecision::CloseEarly => {
+                    let closing = still_running_close_with_notice(elapsed, notice);
+                    if let Err(e) = snapshot.pacer.send(&closing, true).await {
+                        eprintln!("[WeCom] early stream close failed: {e}");
+                    }
+                    if let Some(r) = self.pacers.lock().await.get_mut(&id.0) {
+                        r.stream_closed = true;
+                    }
+                    return Ok(());
+                }
+            }
         };
 
-        // WeCom has no delete/recall API, so this bubble is permanent once
-        // opened. The finish=true `content` *is* what the user keeps — official
-        // docs put the answer there. Closing on "✅ 已完成" and sending the
-        // body via `aibot_send_msg` left only the marker: WeCom often drops a
-        // proactive send that follows a stream on the same callback (already
-        // observed for template_card).
-        //
-        // A turn that ended with nothing to show closes on "cancelled": saying
-        // "done" after the user typed `/stop` reports that the thing they
-        // stopped finished anyway.
-        let closing = stream_finish_content(end, text);
-        if let Err(e) = pacer.send(&closing, true).await {
-            // Last resort: the stream frame did not leave. A proactive
-            // markdown may still land — it is how commands reply without a
-            // stream — but it is the path that was failing in the common case.
-            if text.trim().is_empty() {
+        match decide_finish(phase) {
+            FinishDecision::Swallow => {
                 self.pacers.lock().await.remove(&id.0);
-                return Err(driver::DriverError::Transport(e));
+                Ok(())
             }
-            eprintln!("[WeCom] stream finish failed ({e}); falling back to markdown send");
-            self.gateway
-                .send_chat_message(&chatid, chat_type, text)
-                .await
-                .map_err(driver::DriverError::Transport)?;
+            FinishDecision::FollowupMarkdown => {
+                self.pacers.lock().await.remove(&id.0);
+                if matches!(end, driver::TurnEnd::NoAnswer) {
+                    let _ = self
+                        .gateway
+                        .send_chat_message(&snapshot.chatid, snapshot.chat_type, PROGRESS_CANCELLED)
+                        .await;
+                    return Ok(());
+                }
+                if text.trim().is_empty() {
+                    return Ok(());
+                }
+                self.send_answer_followup(&snapshot.chatid, snapshot.chat_type, text)
+                    .await
+            }
+            FinishDecision::FinishInStream => {
+                // WeCom has no delete/recall API, so this bubble is permanent
+                // once opened. For a short turn the finish=true content *is*
+                // what the user keeps. A turn that ended with nothing to show
+                // closes on "cancelled".
+                let closing = stream_finish_content(end, text);
+                if let Err(e) = snapshot.pacer.send(&closing, true).await {
+                    if text.trim().is_empty() {
+                        self.pacers.lock().await.remove(&id.0);
+                        return Err(driver::DriverError::Transport(e.to_string()));
+                    }
+                    eprintln!("[WeCom] stream finish failed ({e}); falling back to markdown send");
+                    self.pacers.lock().await.remove(&id.0);
+                    return self
+                        .send_answer_followup(&snapshot.chatid, snapshot.chat_type, text)
+                        .await;
+                }
+                self.pacers.lock().await.remove(&id.0);
+                Ok(())
+            }
         }
-        self.pacers.lock().await.remove(&id.0);
-        Ok(())
     }
 }
 
-/// What the progress bubble says while a turn runs.
-const PROGRESS_OPENING: &str = "💭 正在思考…";
+struct InFlightSnapshot {
+    pacer: StreamPacer,
+    chatid: String,
+    chat_type: u32,
+    opened_at: Instant,
+    deadline: Instant,
+    stream_closed: bool,
+    pending_notice: Option<String>,
+}
+
+impl WeComDriver {
+    /// If this chat still has an open stream, rewrite the queue notice into
+    /// the progress bubble and remember it for later frames. Returns whether
+    /// the notice was piggybacked (so the caller must not also send markdown).
+    async fn piggyback_notice(
+        &self,
+        chatid: &str,
+        text: &str,
+    ) -> Result<bool, driver::DriverError> {
+        let mut pacers = self.pacers.lock().await;
+        let Some((_, inflight)) = pacers
+            .iter_mut()
+            .find(|(_, r)| r.chatid == chatid && !r.stream_closed)
+        else {
+            return Ok(false);
+        };
+        inflight.pending_notice = Some(text.to_string());
+        let pacer = inflight.pacer.clone();
+        let elapsed = inflight.opened_at.elapsed();
+        let notice = inflight.pending_notice.clone();
+        drop(pacers);
+        let frame = progress_frame_with_notice(elapsed, None, notice.as_deref());
+        if let Err(e) = pacer.send(&frame, false).await {
+            eprintln!("[WeCom] queue notice piggyback failed: {e}");
+        }
+        Ok(true)
+    }
+
+    async fn send_answer_followup(
+        &self,
+        chatid: &str,
+        chat_type: u32,
+        text: &str,
+    ) -> Result<(), driver::DriverError> {
+        match self
+            .gateway
+            .send_markdown_segments(chatid, chat_type, text)
+            .await
+        {
+            Ok(()) => Ok(()),
+            Err(e) => {
+                eprintln!("[WeCom] follow-up markdown failed ({e}); sending fallback");
+                match self
+                    .gateway
+                    .send_chat_message(chatid, chat_type, wecom_delivery::FALLBACK_SEE_SESSION)
+                    .await
+                {
+                    Ok(()) => Ok(()),
+                    Err(fb) => {
+                        eprintln!("[WeCom] fallback notice also failed: {fb}");
+                        // Session already has the reply; do not fail the turn.
+                        Ok(())
+                    }
+                }
+            }
+        }
+    }
+}
+
 /// Fallback when an answered turn produced nothing showable.
 const PROGRESS_DONE: &str = "✅ 已完成";
 /// …or once it was stopped, which is a different thing from finishing.
 const PROGRESS_CANCELLED: &str = "⏹️ 已取消";
 /// WeCom `stream.content` / markdown cap, in UTF-8 bytes.
-const WECOM_CONTENT_MAX_BYTES: usize = 20480;
+const WECOM_CONTENT_MAX_BYTES: usize = wecom_delivery::WECOM_CONTENT_MAX_BYTES;
 
 /// The `finish=true` stream body. This is the bubble WeCom keeps.
 fn stream_finish_content(end: driver::TurnEnd, text: &str) -> String {
@@ -1359,6 +1528,7 @@ impl WeComGateway {
             card_metadata: Arc::new(RwLock::new(std::collections::HashMap::new())),
             inbound_sink: Arc::new(RwLock::new(None)),
             pending_responses: Arc::new(tokio::sync::Mutex::new(std::collections::HashMap::new())),
+            outbox: WeComOutbox::new(),
         }
     }
 
@@ -1560,6 +1730,10 @@ impl WeComGateway {
         // Heartbeat task
         let ws_sink = Arc::new(tokio::sync::Mutex::new(ws_sink));
         *self.shared_ws_sink.write().await = Some(Arc::clone(&ws_sink));
+        let flusher = self.clone();
+        tokio::spawn(async move {
+            flusher.flush_outbox().await;
+        });
         let ws_sink_hb = Arc::clone(&ws_sink);
         let (hb_shutdown_tx, mut hb_shutdown_rx) = mpsc::channel::<()>(1);
 
@@ -1997,16 +2171,17 @@ impl WeComGateway {
         Ok(())
     }
 
-    /// Static version of send_stream_chunk for use in spawned tasks (no &self needed)
-    async fn send_stream_chunk_static(
+    /// Send one stream frame and wait for the WS ack (same callback req_id,
+    /// serialized by the pacer so waiters do not collide).
+    async fn send_stream_chunk_acked(
+        &self,
         req_id: &str,
         stream_id: &str,
         content: &str,
         finish: bool,
         ws_sink: &WsSink,
-    ) -> Result<(), String> {
-        use futures_util::SinkExt;
-
+        timeout: Duration,
+    ) -> Result<(), SendError> {
         let reply = serde_json::json!({
             "cmd": "aibot_respond_msg",
             "headers": { "req_id": req_id },
@@ -2019,35 +2194,57 @@ impl WeComGateway {
                 },
             }
         });
-
-        ws_sink
-            .lock()
+        self.send_json_acked_retry(reply, req_id, ws_sink, timeout)
             .await
-            .send(tokio_tungstenite::tungstenite::Message::Text(
-                reply.to_string().into(),
-            ))
-            .await
-            .map_err(|e| format!("Failed to send reply: {}", e))
     }
 
     /// Send a proactive message to a WeCom conversation via aibot_send_msg.
     /// Requires the gateway to be connected and the target user to have
     /// previously messaged the bot in that conversation.
+    ///
+    /// Transport / timeout failures are queued and flushed after the next
+    /// subscribe so a disconnect during a long turn does not drop the answer.
     pub async fn send_chat_message(
         &self,
         chatid: &str,
         chat_type: u32,
         text: &str,
     ) -> Result<(), String> {
-        use futures_util::SinkExt;
+        match self
+            .send_chat_message_attempt(chatid, chat_type, text)
+            .await
+        {
+            Ok(()) => Ok(()),
+            Err(e @ (SendError::Transport(_) | SendError::Timeout | SendError::Conflict)) => {
+                self.outbox.enqueue(PendingSend {
+                    chatid: chatid.to_string(),
+                    chat_type,
+                    text: text.to_string(),
+                    retry_count: 0,
+                });
+                eprintln!("[WeCom] queued proactive send to {chatid} after {e}");
+                Ok(())
+            }
+            Err(e) => Err(e.to_string()),
+        }
+    }
 
+    async fn send_chat_message_attempt(
+        &self,
+        chatid: &str,
+        chat_type: u32,
+        text: &str,
+    ) -> Result<(), SendError> {
         let ws_sink = self.shared_ws_sink.read().await.clone().ok_or_else(|| {
-            "WeCom gateway is not connected. Cannot send proactive message.".to_string()
+            SendError::Transport(
+                "WeCom gateway is not connected. Cannot send proactive message.".into(),
+            )
         })?;
 
+        let req_id = uuid::Uuid::new_v4().to_string();
         let msg = serde_json::json!({
             "cmd": "aibot_send_msg",
-            "headers": { "req_id": uuid::Uuid::new_v4().to_string() },
+            "headers": { "req_id": req_id },
             "body": {
                 "chatid": chatid,
                 "chat_type": chat_type,
@@ -2056,20 +2253,73 @@ impl WeComGateway {
             }
         });
 
-        ws_sink
-            .lock()
-            .await
-            .send(tokio_tungstenite::tungstenite::Message::Text(
-                msg.to_string().into(),
-            ))
-            .await
-            .map_err(|e| format!("Failed to send proactive message: {}", e))?;
+        self.send_json_acked_retry(
+            msg,
+            &req_id,
+            &ws_sink,
+            wecom_delivery::PROACTIVE_ACK_TIMEOUT,
+        )
+        .await?;
 
         println!(
             "[WeCom] Proactive message sent to chatid={}, chat_type={}",
             chatid, chat_type
         );
         Ok(())
+    }
+
+    /// Split a long answer and send each piece with quota-safe spacing.
+    async fn send_markdown_segments(
+        &self,
+        chatid: &str,
+        chat_type: u32,
+        text: &str,
+    ) -> Result<(), String> {
+        let segments = wecom_delivery::split_markdown_segments(
+            text,
+            wecom_delivery::MARKDOWN_SEGMENT_MAX_BYTES,
+        );
+        if segments.is_empty() {
+            return Ok(());
+        }
+        for (i, seg) in segments.iter().enumerate() {
+            if i > 0 {
+                tokio::time::sleep(wecom_delivery::QUOTA_SAFE_GAP).await;
+            }
+            self.send_chat_message(chatid, chat_type, seg).await?;
+        }
+        Ok(())
+    }
+
+    async fn flush_outbox(&self) {
+        let items = self.outbox.drain();
+        if items.is_empty() {
+            return;
+        }
+        println!("[WeCom] flushing {} pending send(s)", items.len());
+        let max_retries = self.config.read().await.final_max_retries.max(1);
+        for (i, mut item) in items.into_iter().enumerate() {
+            if i > 0 {
+                tokio::time::sleep(wecom_delivery::QUOTA_SAFE_GAP).await;
+            }
+            match self
+                .send_chat_message_attempt(&item.chatid, item.chat_type, &item.text)
+                .await
+            {
+                Ok(()) => {}
+                Err(e) => {
+                    if should_requeue(item.retry_count, max_retries, &e) {
+                        item.retry_count += 1;
+                        self.outbox.enqueue(item);
+                    } else {
+                        eprintln!(
+                            "[WeCom] dropping pending send to {} after {}: {e}",
+                            item.chatid, max_retries
+                        );
+                    }
+                }
+            }
+        }
     }
 
     /// Send a WS command and wait for the response (matched by req_id).
@@ -2079,6 +2329,18 @@ impl WeComGateway {
         req_id: &str,
         ws_sink: &WsSink,
     ) -> Result<serde_json::Value, String> {
+        self.ws_request_timeout(msg, req_id, ws_sink, Duration::from_secs(30))
+            .await
+            .map_err(|e| e.to_string())
+    }
+
+    async fn ws_request_timeout(
+        &self,
+        msg: serde_json::Value,
+        req_id: &str,
+        ws_sink: &WsSink,
+        timeout: Duration,
+    ) -> Result<serde_json::Value, SendError> {
         use futures_util::SinkExt;
 
         let (tx, rx) = oneshot::channel();
@@ -2087,27 +2349,84 @@ impl WeComGateway {
             .await
             .insert(req_id.to_string(), tx);
 
-        ws_sink
+        if let Err(e) = ws_sink
             .lock()
             .await
             .send(tokio_tungstenite::tungstenite::Message::Text(
                 msg.to_string().into(),
             ))
             .await
-            .map_err(|e| {
-                // Clean up on send failure
-                let pending = self.pending_responses.clone();
-                let rid = req_id.to_string();
-                tokio::spawn(async move {
-                    pending.lock().await.remove(&rid);
-                });
-                format!("Failed to send WS request: {}", e)
-            })?;
+        {
+            self.pending_responses.lock().await.remove(req_id);
+            return Err(SendError::Transport(format!(
+                "Failed to send WS request: {e}"
+            )));
+        }
 
-        tokio::time::timeout(std::time::Duration::from_secs(30), rx)
+        match tokio::time::timeout(timeout, rx).await {
+            Ok(Ok(value)) => Ok(value),
+            Ok(Err(_)) => {
+                self.pending_responses.lock().await.remove(req_id);
+                Err(SendError::Transport(
+                    "WS response channel closed".to_string(),
+                ))
+            }
+            Err(_) => {
+                self.pending_responses.lock().await.remove(req_id);
+                Err(SendError::Timeout)
+            }
+        }
+    }
+
+    async fn send_json_acked(
+        &self,
+        msg: serde_json::Value,
+        req_id: &str,
+        ws_sink: &WsSink,
+        timeout: Duration,
+    ) -> Result<(), SendError> {
+        let resp = self
+            .ws_request_timeout(msg, req_id, ws_sink, timeout)
+            .await?;
+        wecom_delivery::classify_response(&resp)
+    }
+
+    async fn send_json_acked_retry(
+        &self,
+        msg: serde_json::Value,
+        req_id: &str,
+        ws_sink: &WsSink,
+        timeout: Duration,
+    ) -> Result<(), SendError> {
+        match self
+            .send_json_acked(msg.clone(), req_id, ws_sink, timeout)
             .await
-            .map_err(|_| "WS request timed out".to_string())?
-            .map_err(|_| "WS response channel closed".to_string())
+        {
+            Ok(()) => Ok(()),
+            Err(SendError::Conflict) => {
+                for backoff_ms in wecom_delivery::CONFLICT_BACKOFF_MS {
+                    tokio::time::sleep(Duration::from_millis(*backoff_ms)).await;
+                    match self
+                        .send_json_acked(msg.clone(), req_id, ws_sink, timeout)
+                        .await
+                    {
+                        Ok(()) => return Ok(()),
+                        Err(SendError::Conflict) => continue,
+                        Err(e) => return Err(e),
+                    }
+                }
+                Err(SendError::Conflict)
+            }
+            Err(SendError::RateLimited { retry_after_ms }) => {
+                tokio::time::sleep(Duration::from_millis(
+                    retry_after_ms.unwrap_or(wecom_delivery::RATE_LIMIT_RETRY_MS),
+                ))
+                .await;
+                self.send_json_acked(msg, req_id, ws_sink, timeout).await
+            }
+            Err(SendError::Timeout) => self.send_json_acked(msg, req_id, ws_sink, timeout).await,
+            Err(e) => Err(e),
+        }
     }
 
     /// Upload media data to WeCom via the 3-step WebSocket upload protocol.
@@ -2740,7 +3059,11 @@ mod message_parts_tests {
 #[cfg(test)]
 mod stream_frame_tests {
     use super::*;
-    use serde_json::json;
+
+    #[test]
+    fn progress_frames_are_spaced_ten_seconds_apart() {
+        assert_eq!(STREAM_FRAME_MIN_GAP, Duration::from_secs(10));
+    }
 }
 
 #[cfg(test)]

--- a/crates/teamclu-gateway/src/wecom_config.rs
+++ b/crates/teamclu-gateway/src/wecom_config.rs
@@ -1,7 +1,11 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
-#[serde(rename_all = "camelCase")]
+use crate::wecom_delivery::{
+    DEFAULT_FINAL_MAX_RETRIES, DEFAULT_PROGRESS_FRAME_GAP_SECS, DEFAULT_STREAM_MAX_SECS,
+};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", default)]
 pub struct WeComConfig {
     #[serde(default)]
     pub enabled: bool,
@@ -23,6 +27,30 @@ pub struct WeComConfig {
     /// cannot tell where a multi-word name ends.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub bot_name: Option<String>,
+    /// Seconds a stream bubble may stay open. Past this the driver finishes
+    /// it with a "still running" frame and later pushes the answer as
+    /// markdown. `0` disables the early close (tests / emergency).
+    pub stream_max_secs: u64,
+    /// Minimum gap between two frames of the same stream, in seconds.
+    pub progress_frame_gap_secs: u64,
+    /// How many times a failed proactive send is retried from the outbox.
+    pub final_max_retries: u32,
+}
+
+impl Default for WeComConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            bot_id: String::new(),
+            secret: String::new(),
+            encoding_aes_key: None,
+            owner_id: None,
+            bot_name: None,
+            stream_max_secs: DEFAULT_STREAM_MAX_SECS,
+            progress_frame_gap_secs: DEFAULT_PROGRESS_FRAME_GAP_SECS,
+            final_max_retries: DEFAULT_FINAL_MAX_RETRIES,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -100,4 +128,18 @@ pub struct WeComQrAuthPollResult {
     pub status: String, // "waiting" | "success" | "expired"
     pub bot_id: Option<String>,
     pub secret: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn missing_delivery_fields_take_the_new_defaults() {
+        let cfg: WeComConfig = serde_json::from_str(r#"{"enabled":true,"botId":"b"}"#).unwrap();
+        assert_eq!(cfg.bot_id, "b");
+        assert_eq!(cfg.stream_max_secs, DEFAULT_STREAM_MAX_SECS);
+        assert_eq!(cfg.progress_frame_gap_secs, DEFAULT_PROGRESS_FRAME_GAP_SECS);
+        assert_eq!(cfg.final_max_retries, DEFAULT_FINAL_MAX_RETRIES);
+    }
 }

--- a/crates/teamclu-gateway/src/wecom_delivery.rs
+++ b/crates/teamclu-gateway/src/wecom_delivery.rs
@@ -1,0 +1,493 @@
+//! Pure helpers for WeCom long-turn delivery: ack classification, progress
+//! copy, stream-window decisions, and markdown chunking.
+//!
+//! The websocket I/O stays in `wecom.rs`; this module exists so the retry
+//! policy and the 240s early-close state machine can be unit-tested without
+//! a live bot.
+
+use serde_json::Value;
+use std::time::Duration;
+
+/// Default stream bubble lifetime before WeComDriver closes it and switches
+/// the final answer onto `aibot_send_msg`. Kept on the driver, not ChannelCaps.
+pub const DEFAULT_STREAM_MAX_SECS: u64 = 240;
+/// Progress frames share the 30/minute conversation quota with everything
+/// else. 10s → 6 frames/minute, leaving room for the answer.
+pub const DEFAULT_PROGRESS_FRAME_GAP_SECS: u64 = 10;
+pub const DEFAULT_FINAL_MAX_RETRIES: u32 = 3;
+
+/// WeCom `stream.content` / markdown hard cap, UTF-8 bytes.
+pub const WECOM_CONTENT_MAX_BYTES: usize = 20480;
+/// Segment size for follow-up markdown. Far below the 20KB cap so a `(n/m)`
+/// prefix still fits, and a long answer stays readable.
+pub const MARKDOWN_SEGMENT_MAX_BYTES: usize = 8192;
+
+/// Quota-safe gap between two independent sends (outbox flush, multi-segment
+/// markdown). Matches WeCom's 30/minute conversation budget.
+pub const QUOTA_SAFE_GAP: Duration = Duration::from_millis(2100);
+
+/// Progress / stream-finish ack wait.
+pub const STREAM_FRAME_ACK_TIMEOUT: Duration = Duration::from_secs(5);
+/// Proactive `aibot_send_msg` and the stream's terminal frame.
+pub const PROACTIVE_ACK_TIMEOUT: Duration = Duration::from_secs(15);
+
+/// errcode 6000 retry delays, in order.
+pub const CONFLICT_BACKOFF_MS: &[u64] = &[100, 300, 1000];
+pub const RATE_LIMIT_RETRY_MS: u64 = 2000;
+
+/// Fallback when every delivery path failed. The session already has the
+/// reply (`write_reply` runs before the final `update`).
+pub const FALLBACK_SEE_SESSION: &str = "答案生成完毕但推送失败，请在会话中查看";
+
+const PROGRESS_HEAD: &str = "💭 执行中";
+
+/// How a WS ack (or the lack of one) is classified.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SendError {
+    /// errcode 6000 — concurrent rewrite; retry with backoff.
+    Conflict,
+    RateLimited {
+        retry_after_ms: Option<u64>,
+    },
+    Rejected(String),
+    Transport(String),
+    Timeout,
+}
+
+impl std::fmt::Display for SendError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Conflict => write!(f, "wecom errcode 6000 (conflict)"),
+            Self::RateLimited { retry_after_ms } => {
+                write!(f, "wecom rate limited (retry_after_ms={retry_after_ms:?})")
+            }
+            Self::Rejected(s) => write!(f, "wecom rejected: {s}"),
+            Self::Transport(s) => write!(f, "wecom transport: {s}"),
+            Self::Timeout => write!(f, "wecom ack timeout"),
+        }
+    }
+}
+
+impl std::error::Error for SendError {}
+
+/// Lifecycle of one WeCom stream bubble.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StreamPhase {
+    /// `aibot_respond_msg` is still accepted on this callback.
+    Open,
+    /// Early `finish=true` already sent; later progress is swallowed and the
+    /// answer goes out as markdown.
+    ClosedForFollowup,
+    /// Terminal finish (answer or cancelled) already sent.
+    Finished,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProgressDecision {
+    SendProgress,
+    CloseEarly,
+    Swallow,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FinishDecision {
+    FinishInStream,
+    FollowupMarkdown,
+    Swallow,
+}
+
+pub fn decide_progress(phase: StreamPhase, past_deadline: bool) -> ProgressDecision {
+    match phase {
+        StreamPhase::ClosedForFollowup | StreamPhase::Finished => ProgressDecision::Swallow,
+        StreamPhase::Open if past_deadline => ProgressDecision::CloseEarly,
+        StreamPhase::Open => ProgressDecision::SendProgress,
+    }
+}
+
+pub fn decide_finish(phase: StreamPhase) -> FinishDecision {
+    match phase {
+        StreamPhase::Open => FinishDecision::FinishInStream,
+        StreamPhase::ClosedForFollowup => FinishDecision::FollowupMarkdown,
+        StreamPhase::Finished => FinishDecision::Swallow,
+    }
+}
+
+/// Pull errcode/errmsg from either the top level or `body` (WeCom uses both).
+pub fn errcode_and_msg(v: &Value) -> (i64, String) {
+    let code = v
+        .get("body")
+        .and_then(|b| b.get("errcode"))
+        .and_then(|c| c.as_i64())
+        .or_else(|| v.get("errcode").and_then(|c| c.as_i64()))
+        .unwrap_or(0);
+    let msg = v
+        .get("body")
+        .and_then(|b| b.get("errmsg"))
+        .and_then(|m| m.as_str())
+        .or_else(|| v.get("errmsg").and_then(|m| m.as_str()))
+        .unwrap_or("")
+        .to_string();
+    (code, msg)
+}
+
+pub fn classify_errcode(code: i64, errmsg: &str) -> Result<(), SendError> {
+    if code == 0 {
+        return Ok(());
+    }
+    if code == 6000 {
+        return Err(SendError::Conflict);
+    }
+    if is_rate_limited(code, errmsg) {
+        return Err(SendError::RateLimited {
+            retry_after_ms: None,
+        });
+    }
+    Err(SendError::Rejected(format!("errcode={code} {errmsg}")))
+}
+
+pub fn classify_response(v: &Value) -> Result<(), SendError> {
+    let (code, msg) = errcode_and_msg(v);
+    classify_errcode(code, &msg)
+}
+
+fn is_rate_limited(code: i64, errmsg: &str) -> bool {
+    matches!(code, 45009 | 45011 | 45033)
+        || errmsg.contains("freq")
+        || errmsg.contains("limit")
+        || errmsg.contains("busy")
+        || errmsg.contains("频")
+}
+
+pub fn format_elapsed(d: Duration) -> String {
+    let secs = d.as_secs();
+    let m = secs / 60;
+    let s = secs % 60;
+    if m == 0 {
+        format!("{s}秒")
+    } else {
+        format!("{m}分{s}秒")
+    }
+}
+
+/// Progress bubble: elapsed time plus the newest agent line.
+pub fn progress_frame(elapsed: Duration, line: Option<&str>) -> String {
+    let head = format!("{PROGRESS_HEAD} · {}", format_elapsed(elapsed));
+    match line {
+        Some(l) if !l.is_empty() => format!("{head}\n{l}"),
+        _ => head,
+    }
+}
+
+/// Append a queue notice so it is visible while the stream bubble is the only
+/// thing WeCom will reliably rewrite.
+pub fn progress_frame_with_notice(
+    elapsed: Duration,
+    line: Option<&str>,
+    notice: Option<&str>,
+) -> String {
+    let base = progress_frame(elapsed, line);
+    match notice {
+        Some(n) if !n.trim().is_empty() => format!("{base}\n\n{n}"),
+        _ => base,
+    }
+}
+
+/// `finish=true` body used when the stream window is exhausted but the turn
+/// is still running.
+pub fn still_running_close_text(elapsed: Duration) -> String {
+    let mins = elapsed.as_secs().div_ceil(60).max(1);
+    format!("⏳ 任务仍在执行（已 {mins} 分钟），完成后将单独推送结果")
+}
+
+pub fn still_running_close_with_notice(elapsed: Duration, notice: Option<&str>) -> String {
+    let base = still_running_close_text(elapsed);
+    match notice {
+        Some(n) if !n.trim().is_empty() => format!("{base}\n\n{n}"),
+        _ => base,
+    }
+}
+
+/// Split a markdown answer on blank lines, then lines, then char boundaries,
+/// so each piece stays under `max_bytes`. Multi-part replies get `（n/m）`.
+pub fn split_markdown_segments(text: &str, max_bytes: usize) -> Vec<String> {
+    if text.is_empty() {
+        return Vec::new();
+    }
+    if max_bytes == 0 {
+        return vec![text.to_string()];
+    }
+    if text.len() <= max_bytes {
+        return vec![text.to_string()];
+    }
+
+    let mut raw = Vec::new();
+    for para in text.split("\n\n") {
+        if para.is_empty() {
+            continue;
+        }
+        if para.len() <= max_bytes {
+            raw.push(para.to_string());
+            continue;
+        }
+        for line in para.split('\n') {
+            if line.len() <= max_bytes {
+                raw.push(line.to_string());
+                continue;
+            }
+            raw.extend(split_char_boundary(line, max_bytes));
+        }
+    }
+    if raw.is_empty() {
+        raw.extend(split_char_boundary(text, max_bytes));
+    }
+
+    let packed = pack_segments(raw, max_bytes);
+    let total = packed.len();
+    if total <= 1 {
+        return packed;
+    }
+    packed
+        .into_iter()
+        .enumerate()
+        .map(|(i, body)| format!("（{}/{}）\n{body}", i + 1, total))
+        .collect()
+}
+
+fn split_char_boundary(text: &str, max_bytes: usize) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut rest = text;
+    while !rest.is_empty() {
+        if rest.len() <= max_bytes {
+            out.push(rest.to_string());
+            break;
+        }
+        let mut end = max_bytes;
+        while end > 0 && !rest.is_char_boundary(end) {
+            end -= 1;
+        }
+        if end == 0 {
+            end = rest.chars().next().map(|c| c.len_utf8()).unwrap_or(1);
+        }
+        out.push(rest[..end].to_string());
+        rest = &rest[end..];
+    }
+    out
+}
+
+fn pack_segments(parts: Vec<String>, max_bytes: usize) -> Vec<String> {
+    let mut packed = Vec::new();
+    let mut current = String::new();
+    for part in parts {
+        if current.is_empty() {
+            current = part;
+            continue;
+        }
+        let join_len = current.len() + 1 + part.len(); // newline
+        if join_len <= max_bytes {
+            current.push('\n');
+            current.push_str(&part);
+        } else {
+            packed.push(std::mem::take(&mut current));
+            current = part;
+        }
+    }
+    if !current.is_empty() {
+        packed.push(current);
+    }
+    packed
+}
+
+/// After an acked send has already applied in-flight retries, decide whether
+/// a failed proactive message belongs back on the outbox.
+pub fn should_requeue(retry_count: u32, max_retries: u32, err: &SendError) -> bool {
+    if retry_count + 1 >= max_retries {
+        return false;
+    }
+    matches!(
+        err,
+        SendError::Transport(_) | SendError::Timeout | SendError::Conflict
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn success_is_zero_or_missing_errcode() {
+        assert!(classify_response(&json!({})).is_ok());
+        assert!(classify_response(&json!({"errcode": 0})).is_ok());
+        assert!(classify_response(&json!({"body": {"errcode": 0}})).is_ok());
+    }
+
+    #[test]
+    fn errcode_6000_is_conflict() {
+        assert_eq!(
+            classify_response(&json!({"body": {"errcode": 6000, "errmsg": "conflict"}})),
+            Err(SendError::Conflict)
+        );
+        assert_eq!(
+            classify_errcode(6000, "数据版本冲突"),
+            Err(SendError::Conflict)
+        );
+    }
+
+    #[test]
+    fn known_freq_codes_are_rate_limited() {
+        assert!(matches!(
+            classify_errcode(45009, ""),
+            Err(SendError::RateLimited { .. })
+        ));
+        assert!(matches!(
+            classify_errcode(1, "api freq out of limit"),
+            Err(SendError::RateLimited { .. })
+        ));
+        assert!(matches!(
+            classify_errcode(1, "超过频率限制"),
+            Err(SendError::RateLimited { .. })
+        ));
+    }
+
+    #[test]
+    fn other_nonzero_is_rejected() {
+        match classify_errcode(40013, "invalid appid") {
+            Err(SendError::Rejected(s)) => {
+                assert!(s.contains("40013"));
+                assert!(s.contains("invalid appid"));
+            }
+            other => panic!("expected Rejected, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn body_errcode_wins_over_missing_top_level() {
+        let (code, msg) = errcode_and_msg(&json!({
+            "headers": {"req_id": "x"},
+            "body": {"errcode": 6000, "errmsg": "conflict"}
+        }));
+        assert_eq!(code, 6000);
+        assert_eq!(msg, "conflict");
+    }
+
+    #[test]
+    fn elapsed_format_matches_the_progress_copy() {
+        assert_eq!(format_elapsed(Duration::from_secs(0)), "0秒");
+        assert_eq!(format_elapsed(Duration::from_secs(12)), "12秒");
+        assert_eq!(format_elapsed(Duration::from_secs(192)), "3分12秒");
+        assert_eq!(format_elapsed(Duration::from_secs(60)), "1分0秒");
+    }
+
+    #[test]
+    fn progress_frame_carries_elapsed_and_newest_line() {
+        let frame = progress_frame(Duration::from_secs(192), Some("正在查询订单数据…"));
+        assert!(frame.starts_with("💭 执行中 · 3分12秒"));
+        assert!(frame.contains("正在查询订单数据…"));
+    }
+
+    #[test]
+    fn progress_notice_is_appended_not_inline() {
+        let frame = progress_frame_with_notice(
+            Duration::from_secs(5),
+            Some("工具中"),
+            Some("上一条还在处理"),
+        );
+        assert!(frame.contains("工具中"));
+        assert!(frame.contains("上一条还在处理"));
+        assert!(frame.contains("\n\n"));
+    }
+
+    #[test]
+    fn still_running_copy_rounds_up_to_a_minute() {
+        let text = still_running_close_text(Duration::from_secs(240));
+        assert!(text.contains("4 分钟"));
+        assert!(text.contains("完成后将单独推送结果"));
+    }
+
+    #[test]
+    fn progress_state_machine() {
+        assert_eq!(
+            decide_progress(StreamPhase::Open, false),
+            ProgressDecision::SendProgress
+        );
+        assert_eq!(
+            decide_progress(StreamPhase::Open, true),
+            ProgressDecision::CloseEarly
+        );
+        assert_eq!(
+            decide_progress(StreamPhase::ClosedForFollowup, true),
+            ProgressDecision::Swallow
+        );
+        assert_eq!(
+            decide_progress(StreamPhase::Finished, false),
+            ProgressDecision::Swallow
+        );
+    }
+
+    #[test]
+    fn finish_state_machine() {
+        assert_eq!(
+            decide_finish(StreamPhase::Open),
+            FinishDecision::FinishInStream
+        );
+        assert_eq!(
+            decide_finish(StreamPhase::ClosedForFollowup),
+            FinishDecision::FollowupMarkdown
+        );
+        assert_eq!(
+            decide_finish(StreamPhase::Finished),
+            FinishDecision::Swallow
+        );
+    }
+
+    #[test]
+    fn short_markdown_is_one_segment_without_index() {
+        let parts = split_markdown_segments("广州今日多云。", 8192);
+        assert_eq!(parts, vec!["广州今日多云。".to_string()]);
+    }
+
+    #[test]
+    fn long_markdown_splits_on_blank_lines_and_indexes() {
+        let a = "甲".repeat(2000);
+        let b = "乙".repeat(2000);
+        let text = format!("{a}\n\n{b}");
+        let parts = split_markdown_segments(&text, 8192);
+        assert_eq!(parts.len(), 2);
+        assert!(parts[0].starts_with("（1/2）\n"));
+        assert!(parts[1].starts_with("（2/2）\n"));
+        assert!(parts[0].contains("甲"));
+        assert!(parts[1].contains("乙"));
+    }
+
+    #[test]
+    fn oversized_line_splits_on_char_boundary() {
+        let text = "中".repeat(100);
+        let parts = split_markdown_segments(&text, 10);
+        assert!(parts.len() > 1);
+        for p in &parts {
+            let body = p.split_once('\n').map(|(_, b)| b).unwrap_or(p);
+            assert!(body.len() <= 10 || p.starts_with('（'));
+            assert!(p.is_char_boundary(p.len()));
+        }
+        let joined: String = parts
+            .iter()
+            .map(|p| p.split_once('\n').map(|(_, b)| b).unwrap_or(p.as_str()))
+            .collect();
+        assert_eq!(joined, text);
+    }
+
+    #[test]
+    fn empty_markdown_yields_no_segments() {
+        assert!(split_markdown_segments("", 8192).is_empty());
+    }
+
+    #[test]
+    fn outbox_requeue_stops_at_the_retry_cap() {
+        let err = SendError::Timeout;
+        assert!(should_requeue(0, 3, &err));
+        assert!(should_requeue(1, 3, &err));
+        assert!(!should_requeue(2, 3, &err));
+        assert!(!should_requeue(0, 3, &SendError::Rejected("no".into())));
+        assert!(should_requeue(0, 3, &SendError::Transport("down".into())));
+    }
+}

--- a/crates/teamclu-gateway/src/wecom_outbox.rs
+++ b/crates/teamclu-gateway/src/wecom_outbox.rs
@@ -1,0 +1,83 @@
+//! In-memory outbox for WeCom proactive sends that failed while the
+//! websocket was down. Flushed after a successful subscribe.
+//!
+//! Process crash is intentionally not covered: `write_reply` already
+//! persisted the session, so the user can read the answer in the app.
+
+use std::collections::VecDeque;
+use std::sync::{Arc, Mutex};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PendingSend {
+    pub chatid: String,
+    pub chat_type: u32,
+    pub text: String,
+    pub retry_count: u32,
+}
+
+#[derive(Clone, Default)]
+pub struct WeComOutbox {
+    inner: Arc<Mutex<VecDeque<PendingSend>>>,
+}
+
+impl WeComOutbox {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn enqueue(&self, item: PendingSend) {
+        self.inner
+            .lock()
+            .expect("wecom outbox mutex")
+            .push_back(item);
+    }
+
+    pub fn drain(&self) -> Vec<PendingSend> {
+        self.inner
+            .lock()
+            .expect("wecom outbox mutex")
+            .drain(..)
+            .collect()
+    }
+
+    pub fn len(&self) -> usize {
+        self.inner.lock().expect("wecom outbox mutex").len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn enqueue_preserves_order_and_drain_clears() {
+        let box_ = WeComOutbox::new();
+        box_.enqueue(PendingSend {
+            chatid: "a".into(),
+            chat_type: 1,
+            text: "one".into(),
+            retry_count: 0,
+        });
+        box_.enqueue(PendingSend {
+            chatid: "b".into(),
+            chat_type: 2,
+            text: "two".into(),
+            retry_count: 1,
+        });
+        assert_eq!(box_.len(), 2);
+        let items = box_.drain();
+        assert_eq!(items[0].chatid, "a");
+        assert_eq!(items[1].text, "two");
+        assert!(box_.is_empty());
+    }
+
+    #[test]
+    fn drain_of_empty_is_empty() {
+        let box_ = WeComOutbox::new();
+        assert!(box_.drain().is_empty());
+    }
+}


### PR DESCRIPTION
## Summary
- Long WeCom turns were losing the final answer because it only lived in the `finish=true` stream frame, which is fire-and-forget, quota-heavy (2.1s/frame), and bound to a short callback window.
- Stream and `aibot_send_msg` now wait on the existing `ws_request` ack path: errcode 6000 retries, 10s progress frames, and a 240s driver-local stream close (not `ChannelCaps`) followed by markdown on a new req_id.
- Failed proactive sends go to an in-memory outbox flushed after subscribe. Queue notices piggyback on an open stream so they are not dropped. Feishu/email unchanged.

Occupancy / stuck-tool release stays in #1325. Desktop thinking for channel sessions stays on `fix/gateway-session-thinking`.

## Test plan
- [ ] `cargo test -p teamclu-gateway` (ack classify, stream state machine, markdown split, outbox)
- [ ] Short WeCom turn (<4 min): still finishes inside the stream bubble with the full answer
- [ ] Long WeCom turn (>4 min): progress at ~10s, early close copy, then markdown answer after the turn
- [ ] Answer >8KB: segmented `（n/m）` markdown
- [ ] Disconnect during follow-up send, reconnect: outbox flushes
- [ ] Send a second WeCom message while a turn is running: queue notice appears in the progress bubble
- [ ] R1: after stream close, wait 30s / 5min then confirm a proactive markdown still lands


Made with [Cursor](https://cursor.com)