### PR TITLE
feat(onboarding): 一次只问一个问题 — 邀请链接 → 服务器 → 登录，并让未登录也能更新

### DIFF
--- a/apps/ios/Packages/AMUXCore/Sources/AMUXCore/Actors/ActorRepository.swift
+++ b/apps/ios/Packages/AMUXCore/Sources/AMUXCore/Actors/ActorRepository.swift
@@ -35,15 +35,29 @@ public struct InviteCreated: Equatable, Sendable {
     public let expiresAt: Date
     public let deeplink: String
 
-    public init(token: String, expiresAt: Date, deeplink: String) {
+    /// - Parameter cloudAPIURL: the endpoint this invite was minted against.
+    ///   It rides along in the link so the invitee's onboarding reaches the
+    ///   right backend without being told to type an address — the same
+    ///   `cloud_api_url` parameter the daemon already reads off an agent invite
+    ///   (`apps/daemon/src/onboarding/invite_url.rs`). Optional so callers with
+    ///   no endpoint resolved emit the bare link rather than a lie.
+    public init(token: String, expiresAt: Date, deeplink: String, cloudAPIURL: URL? = nil) {
         self.token = token
         self.expiresAt = expiresAt
-        self.deeplink = Self.teamcluDeeplink(from: deeplink)
+        self.deeplink = Self.appDeeplink(from: deeplink, cloudAPIURL: cloudAPIURL)
     }
 
-    private static func teamcluDeeplink(from deeplink: String) -> String {
-        guard deeplink.hasPrefix("amux://") else { return deeplink }
-        return "teamclu://" + deeplink.dropFirst("amux://".count)
+    private static func appDeeplink(from deeplink: String, cloudAPIURL: URL?) -> String {
+        // The backend mints `amux://`, a scheme no build registers with the OS.
+        var link = deeplink.hasPrefix("amux://")
+            ? "teamclu://" + deeplink.dropFirst("amux://".count)
+            : deeplink
+        guard let cloudAPIURL, !link.isEmpty, !link.contains("cloud_api_url=") else { return link }
+        let base = cloudAPIURL.absoluteString.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+        guard let encoded = base.addingPercentEncoding(withAllowedCharacters: .alphanumerics)
+        else { return link }
+        link += link.contains("?") ? "&" : "?"
+        return link + "cloud_api_url=" + encoded
     }
 }
 

--- a/apps/ios/Packages/AMUXCore/Sources/AMUXCore/CloudAPI/CloudAPIRepositories.swift
+++ b/apps/ios/Packages/AMUXCore/Sources/AMUXCore/CloudAPI/CloudAPIRepositories.swift
@@ -480,7 +480,8 @@ public actor CloudAPIActorRepository: ActorRepository {
         guard let expiresAt = parseCloudDate(row.expiresAt) else {
             throw ActorRepositoryError.emptyResponse("create_team_invite")
         }
-        return InviteCreated(token: row.token, expiresAt: expiresAt, deeplink: row.deeplink ?? "")
+        return InviteCreated(token: row.token, expiresAt: expiresAt, deeplink: row.deeplink ?? "",
+                             cloudAPIURL: client.baseURL)
     }
 
     public func upgradeAccount(teamID: String, orgName: String, contact: String?) async throws -> OrgUpgradeResult {

--- a/apps/ios/Packages/AMUXCore/Tests/AMUXCoreTests/InviteDeeplinkTests.swift
+++ b/apps/ios/Packages/AMUXCore/Tests/AMUXCoreTests/InviteDeeplinkTests.swift
@@ -1,0 +1,48 @@
+import XCTest
+@testable import AMUXCore
+
+/// The invite link has to name the backend it belongs to: onboarding reads the
+/// address straight off it, so an invitee is never asked to type one.
+final class InviteDeeplinkTests: XCTestCase {
+
+    private let expiry = Date(timeIntervalSince1970: 1_800_000_000)
+
+    private func deeplink(_ raw: String, cloudAPIURL: URL? = nil) -> String {
+        InviteCreated(token: "tok", expiresAt: expiry, deeplink: raw, cloudAPIURL: cloudAPIURL).deeplink
+    }
+
+    func testRewritesTheBackendSchemeToOneTheOSRegisters() {
+        XCTAssertEqual(deeplink("amux://invite?token=tok"), "teamclu://invite?token=tok")
+    }
+
+    func testCarriesTheEndpointTheInviteWasMintedAgainst() {
+        XCTAssertEqual(
+            deeplink("amux://invite?token=tok", cloudAPIURL: URL(string: "https://api.acme.test")!),
+            "teamclu://invite?token=tok&cloud_api_url=https%3A%2F%2Fapi%2Eacme%2Etest"
+        )
+    }
+
+    /// A trailing slash would survive percent-encoding and reach the invitee as
+    /// part of the address; the client string-concatenates paths onto it.
+    func testTrimsATrailingSlashOffTheEndpoint() {
+        XCTAssertEqual(
+            deeplink("amux://invite?token=tok", cloudAPIURL: URL(string: "https://api.acme.test/")!),
+            "teamclu://invite?token=tok&cloud_api_url=https%3A%2F%2Fapi%2Eacme%2Etest"
+        )
+    }
+
+    func testOmitsTheEndpointWhenNoneIsResolved() {
+        XCTAssertEqual(deeplink("amux://invite?token=tok"), "teamclu://invite?token=tok")
+    }
+
+    /// An empty deeplink means the backend returned none; appending a bare
+    /// query to it would produce a link that goes nowhere.
+    func testLeavesAnEmptyDeeplinkEmpty() {
+        XCTAssertEqual(deeplink("", cloudAPIURL: URL(string: "https://api.acme.test")!), "")
+    }
+
+    func testDoesNotAppendTwiceToALinkThatAlreadyNamesAnEndpoint() {
+        let already = "teamclu://invite?token=tok&cloud_api_url=https%3A%2F%2Fapi.old.test"
+        XCTAssertEqual(deeplink(already, cloudAPIURL: URL(string: "https://api.acme.test")!), already)
+    }
+}

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -36,7 +36,6 @@ import { MqttLiveWiring } from "@/components/MqttLiveWiring";
 import { TeamSkillAutoFollow } from "@/components/TeamSkillAutoFollow";
 import { SessionHistoryLoader } from "@/components/SessionHistoryLoader";
 import { ThreadHistoryLoader } from "@/components/ThreadHistoryLoader";
-import { UpdateDialogContainer } from "@/components/updater/UpdateDialog";
 import { AppDeployConfirmDialog } from "@/components/apps/AppDeployConfirmDialog";
 import { resolveControlPanelAppId } from "@/lib/apps/app-control-panel";
 import { lazyNamed } from "@/lib/lazy-component";
@@ -919,7 +918,6 @@ function App() {
           descriptionClassName: '!text-muted-foreground !text-[11px]',
         }}
       />
-      <UpdateDialogContainer />
       <CloseToTrayHost />
       <AppDeployConfirmDialog />
       <NewSessionDialog />

--- a/packages/app/src/components/auth/DesktopOnboarding.tsx
+++ b/packages/app/src/components/auth/DesktopOnboarding.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { AlertCircle, ArrowLeft, Link2, RotateCcw, Server } from "lucide-react";
 import { useTranslation } from "react-i18next";
 
@@ -18,6 +18,7 @@ import {
 import { useAppVersion } from "@/lib/config/version";
 import { useAuthStore } from "@/stores/auth-store";
 import { useOnboardingStore } from "@/stores/onboarding";
+import { useUpdaterStore } from "@/stores/updater";
 import { LoginScreen } from "./LoginScreen";
 import { useShallow } from "zustand/react/shallow";
 
@@ -35,9 +36,88 @@ type Step = "invite" | "server" | "login";
 /** Where the server address came from, once the wizard has settled it. */
 type ServerOutcome = "invite" | "official" | "custom";
 
-function Shell({ children }: { children: React.ReactNode }) {
+/**
+ * The version line, which doubles as the way to update from here.
+ *
+ * Being able to update while signed out is the point: the updater used to be
+ * mounted inside `App`, so it only ever ran for someone who had already got
+ * past this screen — and a release that strands people here is exactly the one
+ * they need to leave.
+ */
+function VersionFooter() {
   const { t } = useTranslation();
   const appVersion = useAppVersion();
+  const { state, progress, checkForUpdates } = useUpdaterStore(
+    useShallow((s) => ({
+      state: s.update.state,
+      progress: s.update.progress,
+      checkForUpdates: s.checkForUpdates,
+    })),
+  );
+
+  const status = () => {
+    switch (state) {
+      case "checking":
+        return t("updater.checking", "Checking for updates…");
+      case "downloading":
+        return t("updater.downloading", "Downloading {{percent}}%", {
+          percent: Math.round(progress ?? 0),
+        });
+      case "ready":
+        return t("updater.restartToUpdate", "Restart to update");
+      case "up-to-date":
+        return t("updater.upToDate", "Up to date");
+      // `error` reaches the dialog, which says more than a footer can. A silent
+      // check never lands here — it resets to idle — so this is only ever the
+      // result of a click.
+      case "error":
+        return t("updater.checkFailed", "Update check failed");
+      default:
+        return t("updater.check", "Check for updates");
+    }
+  };
+
+  const busy = state === "checking" || state === "downloading";
+
+  return (
+    <button
+      type="button"
+      disabled={busy}
+      onClick={() => void checkForUpdates()}
+      className="mt-6 self-center rounded-[6px] px-2 py-1 font-mono text-[11px] text-faint transition-colors hover:text-foreground disabled:cursor-default disabled:hover:text-faint"
+    >
+      v{appVersion} · {status()}
+    </button>
+  );
+}
+
+/**
+ * Look for an update once per app run, while the user is still signed out.
+ *
+ * Deliberately NOT gated on the Settings → General opt-in the background
+ * checker honours. That preference keeps a working install from downloading
+ * things unasked; this call is for the install that cannot get past this
+ * screen, where updating is the only way out. It costs one request for the
+ * release manifest, and anything it finds still ends at a dismissable
+ * "restart to apply" prompt.
+ *
+ * Runs at most once per mount of the wizard, and never on top of a check that
+ * is already in flight or has already found something — `checkForUpdates`
+ * restarts the download from scratch.
+ */
+function useOnboardingUpdateCheck() {
+  const asked = useRef(false);
+  useEffect(() => {
+    if (asked.current) return;
+    asked.current = true;
+    const updater = useUpdaterStore.getState();
+    if (updater.update.state !== "idle") return;
+    void updater.checkForUpdates(true);
+  }, []);
+}
+
+function Shell({ children }: { children: React.ReactNode }) {
+  const { t } = useTranslation();
   const cloudApiUrl = getEffectiveServerConfigSync().cloudApiUrl;
   const override = getCloudApiUrlOverride();
   return (
@@ -45,7 +125,7 @@ function Shell({ children }: { children: React.ReactNode }) {
       <div className="absolute inset-x-0 top-0 h-12" data-tauri-drag-region />
       <div className="mx-auto flex w-full max-w-[760px] flex-1 flex-col">
         {children}
-        <p className="mt-6 text-center font-mono text-[11px] text-faint">v{appVersion}</p>
+        <VersionFooter />
         {/* An absent URL used to render nothing at all, so a build with no
             backend baked in looked exactly like a working one. */}
         <p
@@ -503,6 +583,7 @@ function ServerStep({ onBack, onDone }: { onBack: () => void; onDone: () => void
 }
 
 export function DesktopOnboarding() {
+  useOnboardingUpdateCheck();
   const { serverAck, markServerAck } = useOnboardingStore(
     useShallow((s) => ({ serverAck: s.serverAck, markServerAck: s.markServerAck })),
   );

--- a/packages/app/src/components/auth/DesktopOnboarding.tsx
+++ b/packages/app/src/components/auth/DesktopOnboarding.tsx
@@ -1,11 +1,11 @@
 import { useState } from "react";
-import { AlertCircle, ArrowLeft, Link2, LogIn, RotateCcw, Server } from "lucide-react";
+import { AlertCircle, ArrowLeft, Link2, RotateCcw, Server } from "lucide-react";
 import { useTranslation } from "react-i18next";
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { probeCloudApi } from "@/lib/config/bootstrap";
-import { parseInviteTokenInput } from "@/lib/team/invite-deeplink";
+import { parseInviteInput } from "@/lib/team/invite-deeplink";
 import { confirmInviteLinkToken } from "@/lib/team/invite-link-confirmation";
 import {
   displayHost,
@@ -21,28 +21,25 @@ import { useOnboardingStore } from "@/stores/onboarding";
 import { LoginScreen } from "./LoginScreen";
 import { useShallow } from "zustand/react/shallow";
 
-type Step = "choose" | "login" | "invite" | "server";
-
 /**
- * Everything this screen needs to know about the backend, read once.
+ * First-run setup, as a straight line: invite link → server → sign in.
  *
- * `hasBackendConfig()` answers the same question as `!cloudApiUrl` — both reduce
- * to `Boolean(getCloudApiUrlOverride() ?? env.cloudApiUrl)` — but reaching for
- * it here meant resolving the whole server config twice per render.
+ * It replaced a three-way menu (sign in / join a team / custom server) that
+ * asked the user to classify themselves before they had been told what the
+ * options meant. The line asks one answerable question at a time, and the first
+ * one — "do you have an invite link?" — answers the second for most people,
+ * because the link names the server it belongs to.
  */
-function readServerSummary(): {
-  cloudApiUrl: string | undefined;
-  override: string | null;
-  unconfigured: boolean;
-} {
-  const cloudApiUrl = getEffectiveServerConfigSync().cloudApiUrl;
-  return { cloudApiUrl, override: getCloudApiUrlOverride(), unconfigured: !cloudApiUrl };
-}
+type Step = "invite" | "server" | "login";
+
+/** Where the server address came from, once the wizard has settled it. */
+type ServerOutcome = "invite" | "official" | "custom";
 
 function Shell({ children }: { children: React.ReactNode }) {
   const { t } = useTranslation();
   const appVersion = useAppVersion();
-  const { cloudApiUrl, override } = readServerSummary();
+  const cloudApiUrl = getEffectiveServerConfigSync().cloudApiUrl;
+  const override = getCloudApiUrlOverride();
   return (
     <div className="relative flex min-h-screen flex-col bg-background px-6 py-8 text-foreground">
       <div className="absolute inset-x-0 top-0 h-12" data-tauri-drag-region />
@@ -71,31 +68,63 @@ function Shell({ children }: { children: React.ReactNode }) {
   );
 }
 
-function BackButton({ onClick }: { onClick: () => void }) {
+/**
+ * Re-run the wizard from the top — the language step included; the runtime
+ * install lives in the post-login daemon wizard and re-checks itself every
+ * launch.
+ *
+ * Reload rather than flipping state in place: half the wizard's inputs (the
+ * daemon store) were seeded on the way here, and a reload re-derives all of it,
+ * which is what makes the re-run identical to a first run.
+ */
+function rerunSetup() {
+  useOnboardingStore.getState().reset();
+  window.location.reload();
+}
+
+function RerunButton() {
   const { t } = useTranslation();
   return (
+    // Sits inside the drag strip, opposite the traffic lights. Painted after
+    // the drag region, so it stays clickable.
     <button
       type="button"
-      onClick={onClick}
-      className="mb-5 inline-flex w-fit items-center gap-1.5 rounded-[8px] px-2 py-1 text-[12px] text-muted-foreground transition-colors hover:bg-panel hover:text-foreground"
+      onClick={rerunSetup}
+      className="absolute right-6 top-6 inline-flex items-center gap-1.5 rounded-[8px] px-2 py-1 text-[12px] text-faint transition-colors hover:bg-panel hover:text-foreground"
     >
-      <ArrowLeft className="h-3.5 w-3.5" />
-      {t("onboarding.common.back", "Back")}
+      <RotateCcw className="h-3.5 w-3.5" />
+      {t("auth.onboarding.rerunSetup", "Run setup again")}
     </button>
   );
 }
 
-function DetailFrame({
+function StepFrame({
   children,
   onBack,
+  rerun,
 }: {
   children: React.ReactNode;
-  onBack: () => void;
+  onBack?: () => void;
+  rerun?: boolean;
 }) {
+  const { t } = useTranslation();
   return (
     <Shell>
+      {rerun && <RerunButton />}
       <div className="mx-auto flex w-full max-w-md flex-1 flex-col justify-center">
-        <BackButton onClick={onBack} />
+        {onBack ? (
+          <button
+            type="button"
+            onClick={onBack}
+            className="mb-5 inline-flex w-fit items-center gap-1.5 rounded-[8px] px-2 py-1 text-[12px] text-muted-foreground transition-colors hover:bg-panel hover:text-foreground"
+          >
+            <ArrowLeft className="h-3.5 w-3.5" />
+            {t("onboarding.common.back", "Back")}
+          </button>
+        ) : (
+          // Reserve the row so the card does not jump between steps.
+          <div className="mb-5 h-[26px]" />
+        )}
         {children}
       </div>
     </Shell>
@@ -107,32 +136,19 @@ function ChoiceRow({
   title,
   caption,
   primary,
-  active,
-  badge,
-  disabled,
   onClick,
 }: {
   icon: React.ReactNode;
   title: string;
   caption: React.ReactNode;
   primary?: boolean;
-  /** This row describes the state the app is already in. Drawn in `--selected`
-   *  ("selected row in panel sections"), not coral: AGENTS.md caps a frame at
-   *  two coral spots, and the sign-in chip and the footer already spend both. */
-  active?: boolean;
-  badge?: string;
-  disabled?: boolean;
   onClick: () => void;
 }) {
   return (
     <button
       type="button"
-      disabled={disabled}
       onClick={onClick}
-      className={[
-        "flex w-full items-center gap-3 rounded-[14px] border border-border p-3 text-left transition-colors disabled:cursor-not-allowed disabled:opacity-60",
-        active ? "bg-selected/70" : "bg-paper hover:bg-selected/45",
-      ].join(" ")}
+      className="flex w-full items-center gap-3 rounded-[14px] border border-border bg-paper p-3 text-left transition-colors hover:bg-selected/45"
     >
       <span
         className={[
@@ -146,245 +162,67 @@ function ChoiceRow({
         <span className="block text-[13px] font-semibold text-foreground">{title}</span>
         <span className="mt-0.5 block text-[12px] leading-5 text-muted-foreground">{caption}</span>
       </span>
-      {badge && (
-        <span className="shrink-0 rounded-[6px] bg-panel px-2 py-0.5 text-[11px] font-medium text-ink-2">
-          {badge}
-        </span>
-      )}
     </button>
   );
 }
 
-function ChooseStep({
-  onLogin,
-  onInvite,
-  onServer,
-}: {
-  onLogin: () => void;
-  onInvite: () => void;
-  onServer: () => void;
-}) {
-  const { t } = useTranslation();
-  const { loading, errorMessage } = useAuthStore(
-    useShallow((s) => ({ loading: s.loading, errorMessage: s.errorMessage })),
-  );
-  // The footer already prints the effective URL in coral, but it is 10px type
-  // at the bottom of the window — easy to miss, and it says nothing about which
-  // of these three entries put the app there. Mark the entry itself too.
-  //
-  // `unconfigured` means no Cloud API at all: none baked into the build, none
-  // set by hand. Signing in and joining a team both dead-end in that state (the
-  // login screen refuses to send a code), so say it once up top and point
-  // everything at the one entry that can fix it.
-  const { override, unconfigured } = readServerSummary();
-
-  /**
-   * Run the first-run wizard again — the language step; the runtime install
-   * lives in the post-login daemon wizard and re-checks itself every launch.
-   *
-   * Reload rather than flipping state in place: half the wizard's inputs (the
-   * daemon store) were seeded on the way here, and a reload re-derives all of
-   * it, which is what makes the re-run identical to a first run.
-   */
-  const rerunSetup = () => {
-    useOnboardingStore.getState().reset();
-    window.location.reload();
-  };
-
-  return (
-    <Shell>
-      {/* Sits inside the drag strip, opposite the traffic lights. Painted after
-          the drag region, so it stays clickable. */}
-      <button
-        type="button"
-        onClick={rerunSetup}
-        className="absolute right-6 top-6 inline-flex items-center gap-1.5 rounded-[8px] px-2 py-1 text-[12px] text-faint transition-colors hover:bg-panel hover:text-foreground"
-      >
-        <RotateCcw className="h-3.5 w-3.5" />
-        {t("auth.onboarding.rerunSetup", "Run setup again")}
-      </button>
-      <div className="mx-auto flex w-full max-w-md flex-1 flex-col justify-center">
-        <div className="mb-5">
-          <h1 className="text-[24px] font-semibold text-foreground">
-            {t("auth.onboarding.setupTitle", "Choose setup")}
-          </h1>
-          <p className="mt-2 text-[13px] leading-6 text-muted-foreground">
-            {t(
-              "auth.onboarding.setupDesc",
-              "Sign in, join a team, or connect a self-hosted server.",
-            )}
-          </p>
-        </div>
-        {unconfigured && (
-          <div className="mb-4 flex items-start gap-2 rounded-[12px] border border-border bg-panel px-3.5 py-3 text-[12px] leading-5 text-ink-2">
-            <AlertCircle className="mt-0.5 h-3.5 w-3.5 shrink-0 text-coral" />
-            <span>
-              {t(
-                "auth.onboarding.noServerNotice",
-                "No server address is configured yet. Set your company's Cloud API below — signing in and joining a team both need one.",
-              )}
-            </span>
-          </div>
-        )}
-        <div className="space-y-3">
-          <ChoiceRow
-            primary={!unconfigured}
-            icon={<LogIn className="h-4 w-4" />}
-            title={t("auth.onboarding.signInOrRegister", "Sign in or register")}
-            caption={t(
-              "auth.onboarding.signInOrRegisterDesc",
-              "Sign in directly with a verification code and bind a valid contact method.",
-            )}
-            disabled={loading || unconfigured}
-            onClick={onLogin}
-          />
-          <ChoiceRow
-            icon={<Link2 className="h-4 w-4" />}
-            title={t("auth.onboarding.joinTeam", "Join the team")}
-            caption={t("auth.onboarding.joinTeamDesc", "Paste an invite link or token to join an existing team.")}
-            disabled={loading || unconfigured}
-            onClick={onInvite}
-          />
-          {/* Not disabled while auth is in flight, unlike the two above: this is
-              the way out of a backend that is not answering, which is exactly
-              when a request is left hanging. */}
-          <ChoiceRow
-            icon={<Server className="h-4 w-4" />}
-            // With nothing configured this is the only entry that does
-            // anything, so the accent moves here from the sign-in row.
-            primary={unconfigured}
-            active={Boolean(override)}
-            badge={override ? t("auth.onboarding.serverCustomTag", "custom") : undefined}
-            title={t("auth.onboarding.customServer", "Enterprise custom server")}
-            caption={
-              override ? (
-                // Which server, not just that there is one: the address is the
-                // whole answer to "what am I about to sign in against". Kept to
-                // one line — an internal host with a port and a path wraps to
-                // three and leaves this card taller than the two above it.
-                <span
-                  className="block truncate font-mono text-[11.5px] text-ink-2"
-                  title={displayHost(override)}
-                >
-                  {displayHost(override)}
-                </span>
-              ) : unconfigured ? (
-                t(
-                  "auth.onboarding.customServerRequiredDesc",
-                  "Start here: enter the Cloud API address of your company's own server.",
-                )
-              ) : (
-                t(
-                  "auth.onboarding.customServerDesc",
-                  "Point the app at your company's self-hosted Cloud API and sign in there.",
-                )
-              )
-            }
-            onClick={onServer}
-          />
-        </div>
-        {errorMessage && (
-          <p className="mt-4 rounded-[8px] border border-destructive/20 bg-paper px-3 py-2 text-[12px] leading-5 text-destructive">
-            {errorMessage}
-          </p>
-        )}
-      </div>
-    </Shell>
-  );
+/**
+ * Applies a server address without reloading the window.
+ *
+ * The reload the "custom server" screen used to do exists to throw away a
+ * session issued by the previous backend — and this wizard only ever runs while
+ * signed out (`AuthGate` renders it under `!session`). Reloading here would
+ * also undo the wizard itself: React state is lost, the flow restarts at step
+ * one, and the invite confirmation — deliberately per-run, see
+ * `invite-link-confirmation.ts` — is gone, so a token the user just typed gets
+ * a "join this team?" dialog after sign-in.
+ *
+ * Nothing else is stale afterwards: `getBackend()` caches by
+ * `cloud_api:<url>`, remote features listen for the change event, and every
+ * other reader resolves the config at call time.
+ */
+function applyServerUrl(url: string | null): boolean {
+  try {
+    setCloudApiUrlOverride(url);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
-function InviteStep({ onBack, onNeedLogin }: { onBack: () => void; onNeedLogin: () => void }) {
+/** Shared probe + apply, used by both the invite and the custom-server steps. */
+function useServerProbe() {
   const { t } = useTranslation();
-  const { setPendingInviteToken, errorMessage } = useAuthStore(
-    useShallow((s) => ({ setPendingInviteToken: s.setPendingInviteToken, errorMessage: s.errorMessage })),
-  );
-  const [raw, setRaw] = useState("");
-  const [localError, setLocalError] = useState<string | null>(null);
-
-  const submit = (event: React.FormEvent) => {
-    event.preventDefault();
-    const token = parseInviteTokenInput(raw);
-    if (!token) {
-      setLocalError(t("auth.onboarding.inviteParseError", "Enter a valid invite token or invite link."));
-      return;
-    }
-    setLocalError(null);
-    // Member invites require a real account: stash the token and send the user
-    // to sign in. The invite is claimed automatically once they're signed in.
-    setPendingInviteToken(token);
-    // The user typed this token themselves; skip the deep-link confirmation prompt.
-    confirmInviteLinkToken(token);
-    onNeedLogin();
-  };
-
-  return (
-    <DetailFrame onBack={onBack}>
-      <form onSubmit={submit} className="rounded-[16px] border border-border bg-paper p-5">
-        <h1 className="text-[18px] font-semibold">{t("auth.onboarding.inviteTitle", "Join the team")}</h1>
-        <p className="mt-2 text-[13px] leading-6 text-muted-foreground">
-          {t("auth.onboarding.inviteDesc", "Paste an invite link or token, then sign in to join. The invite is claimed once you're signed in.")}
-        </p>
-        <label className="mt-5 block space-y-2">
-          <span className="text-[12px] font-medium text-ink-2">{t("auth.onboarding.inviteLabel", "Invite link or token")}</span>
-          <Input value={raw} onChange={(event) => setRaw(event.target.value)} className="h-10 font-mono text-[12px]" />
-        </label>
-        {(localError || errorMessage) && (
-          <p className="mt-3 text-[12px] text-destructive">{localError || errorMessage}</p>
-        )}
-        <Button type="submit" disabled={!raw.trim()} className="mt-5 h-10 w-full bg-coral text-coral-foreground">
-          {t("auth.onboarding.inviteContinueToSignIn", "Continue to sign in")}
-        </Button>
-      </form>
-    </DetailFrame>
-  );
-}
-
-function ServerStep({ onBack }: { onBack: () => void }) {
-  const { t } = useTranslation();
-  const override = getCloudApiUrlOverride();
-  const defaultUrl = getDefaultCloudApiUrl();
-  const [raw, setRaw] = useState(override ?? defaultUrl ?? "");
-  const [localError, setLocalError] = useState<string | null>(null);
   const [checking, setChecking] = useState(false);
+  const [error, setError] = useState<string | null>(null);
   // Set once a probe has failed, so the user can override a verdict that may be
-  // wrong for their situation — configuring a server that is not up yet, or one
-  // only reachable from a network they are not on right now.
+  // wrong for their situation — a server that is not up yet, or one only
+  // reachable from a network they are not on right now.
   const [allowUnverified, setAllowUnverified] = useState(false);
 
-  // A session issued by the previous backend is meaningless against the new one,
-  // so reload from scratch instead of trying to migrate state in place.
-  const applyAndReload = (value: string | null) => {
-    try {
-      setCloudApiUrlOverride(value);
-    } catch {
-      setLocalError(t("auth.onboarding.serverUrlInvalid", "Enter a valid http(s) URL, e.g. https://api.example.com"));
-      return;
-    }
-    window.location.reload();
+  const reset = () => {
+    setError(null);
+    setAllowUnverified(false);
   };
 
-  // Syntax is not enough. `https://api.example.com111` parses fine, saves fine,
-  // and reloads the app into a backend that does not exist — every subsequent
-  // failure then looks like a bug somewhere else. Ask the address whether it is
-  // a Cloud API before persisting anything.
-  const verifyAndApply = async (value: string) => {
-    setLocalError(null);
+  /** Returns true when the address was verified and applied. */
+  const verifyAndApply = async (raw: string): Promise<boolean> => {
+    setError(null);
     // Shape first. A scheme-less `api.mycorp.com` is fetched as a URL relative
     // to tauri://localhost, fails, and comes back as "could not reach that
     // address" — sending the user off to check a server that was never asked.
-    // The real problem only surfaced later, when setCloudApiUrlOverride threw.
-    if (!normalizeCloudApiUrl(value)) {
-      setLocalError(
+    if (!normalizeCloudApiUrl(raw)) {
+      setError(
         t("auth.onboarding.serverUrlInvalid", "Enter a valid http(s) URL, e.g. https://api.example.com"),
       );
-      return;
+      return false;
     }
     setChecking(true);
     try {
-      const probe = await probeCloudApi(value);
+      const probe = await probeCloudApi(raw);
       if (!probe.ok) {
         setAllowUnverified(true);
-        setLocalError(
+        setError(
           probe.reason === "unreachable"
             ? t(
                 "auth.onboarding.serverUnreachable",
@@ -396,30 +234,232 @@ function ServerStep({ onBack }: { onBack: () => void }) {
                 { status: probe.status ?? "?" },
               ),
         );
-        return;
+        return false;
       }
-      applyAndReload(value);
     } finally {
       setChecking(false);
     }
+    if (!applyServerUrl(raw)) {
+      setError(
+        t("auth.onboarding.serverUrlInvalid", "Enter a valid http(s) URL, e.g. https://api.example.com"),
+      );
+      return false;
+    }
+    return true;
+  };
+
+  return { checking, error, setError, allowUnverified, reset, verifyAndApply };
+}
+
+/**
+ * Step 1: the invite link, or an explicit "I don't have one".
+ *
+ * A link carries the inviter's Cloud API address, so answering yes settles the
+ * server question too and the next screen is sign-in. Answering no falls
+ * through to picking a server by hand.
+ */
+function InviteStep({
+  onSkip,
+  onNeedServer,
+  onDone,
+}: {
+  onSkip: () => void;
+  onNeedServer: (token: string) => void;
+  onDone: () => void;
+}) {
+  const { t } = useTranslation();
+  const setPendingInviteToken = useAuthStore((s) => s.setPendingInviteToken);
+  const [raw, setRaw] = useState("");
+  const [parseError, setParseError] = useState<string | null>(null);
+  const probe = useServerProbe();
+
+  /** Stash the token for the claim that runs right after sign-in. */
+  const acceptToken = (token: string) => {
+    setPendingInviteToken(token);
+    // The user typed this token themselves; skip the deep-link confirmation.
+    confirmInviteLinkToken(token);
+  };
+
+  const submit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    setParseError(null);
+    probe.reset();
+    const parsed = parseInviteInput(raw);
+    if (!parsed) {
+      setParseError(
+        t("auth.onboarding.inviteParseError", "Enter a valid invite token or invite link."),
+      );
+      return;
+    }
+    if (parsed.cloudApiUrl) {
+      if (!(await probe.verifyAndApply(parsed.cloudApiUrl))) return;
+      acceptToken(parsed.token);
+      onDone();
+      return;
+    }
+    // A bare token names no server. Use the one already in effect; with no
+    // effective address at all there is nothing to claim it against, so ask.
+    acceptToken(parsed.token);
+    if (getEffectiveServerConfigSync().cloudApiUrl) onDone();
+    else onNeedServer(parsed.token);
+  };
+
+  const continueUnverified = () => {
+    const parsed = parseInviteInput(raw);
+    if (!parsed?.cloudApiUrl || !applyServerUrl(parsed.cloudApiUrl)) return;
+    acceptToken(parsed.token);
+    onDone();
   };
 
   return (
-    <DetailFrame onBack={onBack}>
-      <form
-        onSubmit={(event) => {
-          event.preventDefault();
-          void verifyAndApply(raw);
-        }}
-        className="rounded-[16px] border border-border bg-paper p-5"
-      >
-        <h1 className="text-[18px] font-semibold">{t("auth.onboarding.serverTitle", "Enterprise custom server")}</h1>
+    <StepFrame rerun>
+      <form onSubmit={submit} className="rounded-[16px] border border-border bg-paper p-5">
+        <h1 className="text-[18px] font-semibold">
+          {t("auth.onboarding.inviteQuestion", "Do you have an invite link?")}
+        </h1>
         <p className="mt-2 text-[13px] leading-6 text-muted-foreground">
           {t(
-            "auth.onboarding.serverDesc",
-            "Point the app at a different TeamClu Cloud API. The app reloads and you sign in against that server.",
+            "auth.onboarding.inviteQuestionDesc",
+            "Paste it here and everything else is set up for you — including which server to sign in to. The invite is claimed right after you sign in.",
           )}
         </p>
+        <label className="mt-5 block space-y-2">
+          <span className="text-[12px] font-medium text-ink-2">
+            {t("auth.onboarding.inviteLabel", "Invite link or token")}
+          </span>
+          <Input
+            value={raw}
+            onChange={(event) => {
+              setRaw(event.target.value);
+              setParseError(null);
+              // A different link has not been rejected yet, so it does not
+              // inherit the previous one's "continue anyway".
+              probe.reset();
+            }}
+            spellCheck={false}
+            autoCapitalize="none"
+            className="h-10 font-mono text-[12px]"
+          />
+        </label>
+        {(parseError || probe.error) && (
+          <p className="mt-3 text-[12px] text-destructive">{parseError || probe.error}</p>
+        )}
+        <Button
+          type="submit"
+          disabled={probe.checking || !raw.trim()}
+          className="mt-5 h-10 w-full bg-coral text-coral-foreground"
+        >
+          {probe.checking
+            ? t("auth.onboarding.serverChecking", "Checking…")
+            : t("onboarding.common.next", "Next")}
+        </Button>
+        {probe.allowUnverified && !probe.checking && (
+          <button
+            type="button"
+            onClick={continueUnverified}
+            className="mt-3 w-full rounded-[6px] py-1 text-[12px] text-muted-foreground underline-offset-4 transition-colors hover:text-foreground hover:underline"
+          >
+            {t("auth.onboarding.inviteContinueAnyway", "Continue anyway")}
+          </button>
+        )}
+      </form>
+      <button
+        type="button"
+        onClick={onSkip}
+        className="mt-4 w-full rounded-[8px] py-2 text-[13px] text-muted-foreground underline-offset-4 transition-colors hover:text-foreground hover:underline"
+      >
+        {t("auth.onboarding.inviteNone", "I don't have an invite link")}
+      </button>
+    </StepFrame>
+  );
+}
+
+/**
+ * Step 2: which server. Only reached when no invite link named one.
+ *
+ * A build with nothing baked in has no official server to offer, so the choice
+ * collapses to the custom form rather than showing an entry that cannot work.
+ */
+function ServerStep({ onBack, onDone }: { onBack: () => void; onDone: () => void }) {
+  const { t } = useTranslation();
+  const defaultUrl = getDefaultCloudApiUrl();
+  const [custom, setCustom] = useState(!defaultUrl);
+  const [raw, setRaw] = useState(getCloudApiUrlOverride() ?? defaultUrl ?? "");
+  const probe = useServerProbe();
+
+  const chooseOfficial = () => {
+    applyServerUrl(null);
+    onDone();
+  };
+
+  const submitCustom = async (event: React.FormEvent) => {
+    event.preventDefault();
+    if (await probe.verifyAndApply(raw)) onDone();
+  };
+
+  if (!custom) {
+    return (
+      <StepFrame onBack={onBack} rerun>
+        <div className="mb-5">
+          <h1 className="text-[18px] font-semibold">
+            {t("auth.onboarding.serverChoiceTitle", "Which server do you sign in to?")}
+          </h1>
+          <p className="mt-2 text-[13px] leading-6 text-muted-foreground">
+            {t(
+              "auth.onboarding.serverChoiceDesc",
+              "Use the official server, or point the app at your company's own deployment.",
+            )}
+          </p>
+        </div>
+        <div className="space-y-3">
+          <ChoiceRow
+            primary
+            icon={<Server className="h-4 w-4" />}
+            title={t("auth.onboarding.serverOfficial", "Official server")}
+            caption={
+              <span className="block truncate font-mono text-[11.5px] text-ink-2">
+                {displayHost(defaultUrl as string)}
+              </span>
+            }
+            onClick={chooseOfficial}
+          />
+          <ChoiceRow
+            icon={<Link2 className="h-4 w-4" />}
+            title={t("auth.onboarding.serverCustom", "Custom server")}
+            caption={t(
+              "auth.onboarding.serverCustomDesc",
+              "Enter the Cloud API address of your company's own deployment.",
+            )}
+            onClick={() => setCustom(true)}
+          />
+        </div>
+      </StepFrame>
+    );
+  }
+
+  return (
+    <StepFrame onBack={defaultUrl ? () => setCustom(false) : onBack} rerun>
+      <form onSubmit={submitCustom} className="rounded-[16px] border border-border bg-paper p-5">
+        <h1 className="text-[18px] font-semibold">
+          {t("auth.onboarding.serverCustom", "Custom server")}
+        </h1>
+        <p className="mt-2 text-[13px] leading-6 text-muted-foreground">
+          {t(
+            "auth.onboarding.serverCustomFormDesc",
+            "Enter the Cloud API address of your company's own deployment. You sign in against that server.",
+          )}
+        </p>
+        {!defaultUrl && (
+          <div className="mt-4 flex items-start gap-2 rounded-[12px] border border-border bg-panel px-3.5 py-3 text-[12px] leading-5 text-ink-2">
+            <AlertCircle className="mt-0.5 h-3.5 w-3.5 shrink-0 text-coral" />
+            <span>
+              {t(
+                "auth.onboarding.noServerNotice",
+                "This build ships no server address, so there is nothing to fall back to — signing in needs one.",
+              )}
+            </span>
+          </div>
+        )}
         <label className="mt-5 block space-y-2">
           <span className="text-[12px] font-medium text-ink-2">
             {t("auth.onboarding.serverUrlLabel", "Cloud API URL")}
@@ -428,10 +468,7 @@ function ServerStep({ onBack }: { onBack: () => void }) {
             value={raw}
             onChange={(event) => {
               setRaw(event.target.value);
-              setLocalError(null);
-              // A different address has not been rejected yet, so it does not
-              // inherit the previous one's "save anyway".
-              setAllowUnverified(false);
+              probe.reset();
             }}
             placeholder="https://api.example.com"
             spellCheck={false}
@@ -439,65 +476,76 @@ function ServerStep({ onBack }: { onBack: () => void }) {
             className="h-10 font-mono text-[12px]"
           />
         </label>
-        {defaultUrl && (
-          <p className="mt-2 font-mono text-[11px] text-faint">
-            {t("auth.onboarding.serverDefaultHint", "Built-in default: {{url}}", { url: defaultUrl })}
-          </p>
-        )}
-        {localError && <p className="mt-3 text-[12px] text-destructive">{localError}</p>}
+        {probe.error && <p className="mt-3 text-[12px] text-destructive">{probe.error}</p>}
         <Button
           type="submit"
-          disabled={checking || !raw.trim() || raw.trim() === override}
+          disabled={probe.checking || !raw.trim()}
           className="mt-5 h-10 w-full bg-coral text-coral-foreground"
         >
-          {checking
+          {probe.checking
             ? t("auth.onboarding.serverChecking", "Checking…")
-            : t("auth.onboarding.serverSaveAndReload", "Save and reload")}
+            : t("onboarding.common.next", "Next")}
         </Button>
-        {allowUnverified && !checking && (
+        {probe.allowUnverified && !probe.checking && (
           <button
             type="button"
-            onClick={() => applyAndReload(raw)}
+            onClick={() => {
+              if (applyServerUrl(raw)) onDone();
+            }}
             className="mt-3 w-full rounded-[6px] py-1 text-[12px] text-muted-foreground underline-offset-4 transition-colors hover:text-foreground hover:underline"
           >
             {t("auth.onboarding.serverSaveAnyway", "Save it anyway")}
           </button>
         )}
-        {/* `defaultUrl` matters: with no baked default, "reset" would drop the
-            app back to having no backend at all — the state this screen exists
-            to get out of. Overwriting the address still works. */}
-        {override && defaultUrl && (
-          <button
-            type="button"
-            onClick={() => applyAndReload(null)}
-            className="mt-3 w-full rounded-[6px] py-1 text-[12px] text-muted-foreground underline-offset-4 transition-colors hover:text-foreground hover:underline"
-          >
-            {t("auth.onboarding.serverReset", "Reset to the built-in default")}
-          </button>
-        )}
       </form>
-    </DetailFrame>
+    </StepFrame>
   );
 }
 
 export function DesktopOnboarding() {
-  const [step, setStep] = useState<Step>("choose");
+  const { serverAck, markServerAck } = useOnboardingStore(
+    useShallow((s) => ({ serverAck: s.serverAck, markServerAck: s.markServerAck })),
+  );
+  // Someone who has been through this once — and anyone arriving on an
+  // OS-delivered invite link, whose token is already stashed — is past the
+  // questions and only has to sign in.
+  const [step, setStep] = useState<Step>(() =>
+    serverAck || useAuthStore.getState().pendingInviteToken ? "login" : "invite",
+  );
+  const [serverFrom, setServerFrom] = useState<ServerOutcome>("official");
 
-  if (step === "login") {
+  const settled = (outcome: ServerOutcome) => {
+    markServerAck();
+    setServerFrom(outcome);
+    setStep("login");
+  };
+
+  if (step === "invite") {
     return (
-      <DetailFrame onBack={() => setStep("choose")}>
-        <LoginScreen embedded />
-      </DetailFrame>
+      <InviteStep
+        onSkip={() => setStep("server")}
+        onNeedServer={() => setStep("server")}
+        onDone={() => settled("invite")}
+      />
     );
   }
-  if (step === "invite") return <InviteStep onBack={() => setStep("choose")} onNeedLogin={() => setStep("login")} />;
-  if (step === "server") return <ServerStep onBack={() => setStep("choose")} />;
-
+  if (step === "server") {
+    return (
+      <ServerStep onBack={() => setStep("invite")} onDone={() => settled("custom")} />
+    );
+  }
   return (
-    <ChooseStep
-      onLogin={() => setStep("login")}
-      onInvite={() => setStep("invite")}
-      onServer={() => setStep("server")}
-    />
+    <StepFrame
+      // No way back out of a run that never asked anything — "Run setup again"
+      // is the way to revisit those answers.
+      onBack={
+        serverAck && serverFrom === "official"
+          ? undefined
+          : () => setStep(serverFrom === "invite" ? "invite" : "server")
+      }
+      rerun
+    >
+      <LoginScreen embedded />
+    </StepFrame>
   );
 }

--- a/packages/app/src/components/auth/__tests__/DesktopOnboarding.test.tsx
+++ b/packages/app/src/components/auth/__tests__/DesktopOnboarding.test.tsx
@@ -3,31 +3,32 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 const {
   authState,
   hasConfig,
-  saveServerConfig,
   reload,
   cloudApiUrlOverride,
   setCloudApiUrlOverrideMock,
   probeCloudApi,
   effectiveCloudApiUrl,
   defaultCloudApiUrl,
+  confirmInviteLinkToken,
 } = vi.hoisted(() => ({
   authState: {
     loading: false,
     errorMessage: null as string | null,
     otpEmail: null as string | null,
+    pendingInviteToken: null as string | null,
     setPendingInviteToken: vi.fn(),
     sendOtp: vi.fn(),
     verifyOtp: vi.fn(),
     resetOtp: vi.fn(),
   },
   hasConfig: { value: true },
-  saveServerConfig: vi.fn(),
   reload: vi.fn(),
   cloudApiUrlOverride: { value: null as string | null },
   setCloudApiUrlOverrideMock: vi.fn(),
   probeCloudApi: vi.fn(),
   effectiveCloudApiUrl: { value: "https://teamclu-api.ucar.cc" as string | undefined },
   defaultCloudApiUrl: { value: "https://teamclu-api.ucar.cc" as string | undefined },
+  confirmInviteLinkToken: vi.fn(),
 }));
 
 vi.mock("@/lib/config/bootstrap", () => ({ probeCloudApi }));
@@ -38,16 +39,20 @@ vi.mock("react-i18next", () => ({
   }),
 }));
 
-vi.mock("@/stores/auth-store", () => ({
-  useAuthStore: (selector?: (state: typeof authState) => unknown) =>
-    selector ? selector(authState) : authState,
-}));
+vi.mock("@/stores/auth-store", () => {
+  const useAuthStore = (selector?: (state: typeof authState) => unknown) =>
+    selector ? selector(authState) : authState;
+  // The wizard reads the pending token imperatively to decide its first step.
+  useAuthStore.getState = () => authState;
+  return { useAuthStore };
+});
+
+vi.mock("@/lib/team/invite-link-confirmation", () => ({ confirmInviteLinkToken }));
 
 // Only the resolved values are faked; displayHost / normalizeCloudApiUrl stay
 // real so the screen formats and validates addresses the way production does.
 vi.mock("@/lib/config/server-config", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@/lib/config/server-config")>()),
-  saveServerConfig,
   // Mirrors production: `resolve()` returns the override when there is one, so
   // a test that sets an override and a different effective URL is describing a
   // state the app cannot be in.
@@ -78,23 +83,34 @@ vi.mock("@/lib/config/build-config", () => ({
 }));
 
 import { DesktopOnboarding } from "../DesktopOnboarding";
+import { useOnboardingStore } from "@/stores/onboarding";
+
+const INVITE_WITH_SERVER = "teamclu://invite?token=tok-1&cloud_api_url=https%3A%2F%2Fapi.acme.test";
+
+/** Fill the invite box and submit the step. */
+function submitInvite(value: string) {
+  fireEvent.change(screen.getByRole("textbox"), { target: { value } });
+  fireEvent.click(screen.getByRole("button", { name: /^next$/i }));
+}
 
 beforeEach(() => {
   authState.loading = false;
   authState.errorMessage = null;
   authState.otpEmail = null;
+  authState.pendingInviteToken = null;
   authState.setPendingInviteToken.mockReset();
   authState.sendOtp.mockReset();
   authState.verifyOtp.mockReset();
   authState.resetOtp.mockReset();
+  confirmInviteLinkToken.mockReset();
   hasConfig.value = true;
-  saveServerConfig.mockReset();
   cloudApiUrlOverride.value = null;
   effectiveCloudApiUrl.value = "https://teamclu-api.ucar.cc";
   defaultCloudApiUrl.value = "https://teamclu-api.ucar.cc";
   setCloudApiUrlOverrideMock.mockReset();
   probeCloudApi.mockReset();
   probeCloudApi.mockResolvedValue({ ok: true });
+  useOnboardingStore.setState({ serverAck: false });
   Object.defineProperty(window, "location", {
     value: { reload },
     writable: true,
@@ -104,245 +120,220 @@ beforeEach(() => {
 });
 
 describe("DesktopOnboarding", () => {
-  it("shows the setup choices", () => {
+  it("opens on the invite question, not on a menu of setup types", () => {
     const { container } = render(<DesktopOnboarding />);
 
     expect(container.querySelector("[data-tauri-drag-region]")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /sign in or register/i })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /join the team/i })).toBeInTheDocument();
-    // The Cloud API URL defaults to the build config, but an explicit override is
-    // reachable from here.
-    expect(screen.getByRole("button", { name: /custom server/i })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: /do you have an invite link/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /i don't have an invite link/i })).toBeInTheDocument();
+    // Nothing to sign in with yet: the server has not been settled.
+    expect(screen.queryByRole("heading", { name: /sign in/i })).not.toBeInTheDocument();
   });
 
-
-  // The wizard's gate is `!onboardingDone && (!setupAck || onboardingStarted)`,
-  // and AuthGate reads the setup-ok cache once at mount — so clearing the
-  // onboarding flags alone leaves the cache holding the door shut.
-  it("re-runs the first-run wizard from the corner entry", () => {
-    localStorage.setItem("teamclu-onboarding-done", "1");
-    localStorage.setItem("teamclu-onboarding-role", "developer");
-    localStorage.setItem("teamclu-setup-ok", "1");
+  it("rejects input that is neither a link nor a token", () => {
     render(<DesktopOnboarding />);
 
-    fireEvent.click(screen.getByRole("button", { name: /run setup again/i }));
+    submitInvite("https://example.com/invite/abc");
 
-    expect(localStorage.getItem("teamclu-onboarding-done")).toBeNull();
-    expect(localStorage.getItem("teamclu-onboarding-role")).toBeNull();
-    expect(localStorage.getItem("teamclu-setup-ok")).toBeNull();
-    expect(reload).toHaveBeenCalled();
+    expect(screen.getByText(/enter a valid invite token or invite link/i)).toBeInTheDocument();
+    expect(authState.setPendingInviteToken).not.toHaveBeenCalled();
   });
 
-  it("shows auth errors on the choices screen", () => {
-    authState.errorMessage = "Sign-in failed. Try again in a moment.";
+  // The whole point of 2.1: the link names its own backend, so the invitee is
+  // never asked to type an address.
+  it("takes the server address off the invite link, probes it, and goes to sign-in", async () => {
     render(<DesktopOnboarding />);
 
+    submitInvite(INVITE_WITH_SERVER);
 
-    expect(screen.getByText(/sign-in failed/i)).toBeInTheDocument();
+    await waitFor(() =>
+      expect(probeCloudApi).toHaveBeenCalledWith("https://api.acme.test"),
+    );
+    expect(setCloudApiUrlOverrideMock).toHaveBeenCalledWith("https://api.acme.test");
+    expect(authState.setPendingInviteToken).toHaveBeenCalledWith("tok-1");
+    // Typed by the user, so it must not raise the deep-link confirmation later.
+    expect(confirmInviteLinkToken).toHaveBeenCalledWith("tok-1");
+    await waitFor(() =>
+      expect(screen.getByRole("heading", { name: /sign in/i })).toBeInTheDocument(),
+    );
+    // A reload would restart the wizard and drop the confirmation.
+    expect(reload).not.toHaveBeenCalled();
   });
 
-  it("join team stashes a bare token and routes to sign-in", async () => {
+  it("skips the server step for a link, going straight from invite to sign-in", async () => {
     render(<DesktopOnboarding />);
 
-    fireEvent.click(screen.getByRole("button", { name: /join the team/i }));
-    fireEvent.change(screen.getByLabelText(/invite link/i), { target: { value: "tok-123" } });
-    fireEvent.click(screen.getByRole("button", { name: /continue to sign in/i }));
+    submitInvite(INVITE_WITH_SERVER);
 
-    expect(authState.setPendingInviteToken).toHaveBeenCalledWith("tok-123");
-    // Member invites can't be claimed anonymously — the user is sent to sign in.
+    await waitFor(() =>
+      expect(screen.getByRole("heading", { name: /sign in/i })).toBeInTheDocument(),
+    );
+    expect(screen.queryByRole("heading", { name: /which server/i })).not.toBeInTheDocument();
+  });
+
+  it("holds the invite when its server does not answer, then continues on demand", async () => {
+    probeCloudApi.mockResolvedValue({ ok: false, reason: "unreachable" });
+    render(<DesktopOnboarding />);
+
+    submitInvite(INVITE_WITH_SERVER);
+
+    await waitFor(() => expect(screen.getByText(/could not reach that address/i)).toBeInTheDocument());
+    expect(setCloudApiUrlOverrideMock).not.toHaveBeenCalled();
+    expect(authState.setPendingInviteToken).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole("button", { name: /continue anyway/i }));
+
+    expect(setCloudApiUrlOverrideMock).toHaveBeenCalledWith("https://api.acme.test");
+    expect(authState.setPendingInviteToken).toHaveBeenCalledWith("tok-1");
+  });
+
+  it("claims a bare token against the server already in effect", async () => {
+    render(<DesktopOnboarding />);
+
+    submitInvite("tok-bare");
+
+    await waitFor(() => expect(authState.setPendingInviteToken).toHaveBeenCalledWith("tok-bare"));
+    expect(probeCloudApi).not.toHaveBeenCalled();
+    expect(setCloudApiUrlOverrideMock).not.toHaveBeenCalled();
     await waitFor(() =>
       expect(screen.getByRole("heading", { name: /sign in/i })).toBeInTheDocument(),
     );
   });
 
-  it("login path reuses the email OTP form", () => {
-    render(<DesktopOnboarding />);
-
-    fireEvent.click(screen.getByRole("button", { name: /sign in or register/i }));
-
-    expect(screen.getByRole("heading", { name: /sign in/i })).toBeInTheDocument();
-    expect(screen.getByLabelText(/email/i)).toBeInTheDocument();
-  });
-
-  // Both of these dead-end without a backend — sign-in cannot send a code, and
-  // a claimed invite has nowhere to go — so they are closed off up front rather
-  // than letting the user walk into the failure. (The login screen keeps its own
-  // guard for the browser build; see LoginScreen.test.tsx.)
-  it("closes off sign-in and join until a server is configured", () => {
-    hasConfig.value = false;
+  // A bare token with nothing to claim it against has to ask for a server.
+  it("asks for a server when a bare token arrives on a build with none", async () => {
     effectiveCloudApiUrl.value = undefined;
-
+    defaultCloudApiUrl.value = undefined;
     render(<DesktopOnboarding />);
 
-    expect(screen.getByRole("button", { name: /sign in or register/i })).toBeDisabled();
-    expect(screen.getByRole("button", { name: /join the team/i })).toBeDisabled();
-    // The one entry that can fix it stays open.
-    expect(screen.getByRole("button", { name: /custom server/i })).toBeEnabled();
-    expect(screen.getByText(/no server address is configured yet/i)).toBeInTheDocument();
-  });
-
-  // Rendering nothing at all is how a build with no backend baked in ended up
-  // looking exactly like a working one.
-  it("says so in the footer when no server is configured", () => {
-    hasConfig.value = false;
-    effectiveCloudApiUrl.value = undefined;
-
-    render(<DesktopOnboarding />);
-
-    expect(screen.getByText("no server configured")).toBeInTheDocument();
-  });
-
-  it("custom server saves an explicit cloudApiUrl override and reloads", async () => {
-    render(<DesktopOnboarding />);
-
-    fireEvent.click(screen.getByRole("button", { name: /custom server/i }));
-    fireEvent.change(screen.getByLabelText(/cloud api url/i), {
-      target: { value: "https://self-hosted.example.com" },
-    });
-    fireEvent.click(screen.getByRole("button", { name: /save and reload/i }));
+    submitInvite("tok-bare");
 
     await waitFor(() =>
-      expect(setCloudApiUrlOverrideMock).toHaveBeenCalledWith("https://self-hosted.example.com"),
+      expect(screen.getByRole("heading", { name: /custom server/i })).toBeInTheDocument(),
     );
-    // A token from the previous backend is not valid against the new one.
-    expect(reload).toHaveBeenCalled();
+    expect(authState.setPendingInviteToken).toHaveBeenCalledWith("tok-bare");
   });
 
-  it("custom server surfaces an invalid URL instead of reloading", async () => {
-    setCloudApiUrlOverrideMock.mockImplementationOnce(() => {
-      throw new Error("Not a valid http(s) URL: nope");
-    });
+  it("offers the official server and a custom one when there is no invite", () => {
     render(<DesktopOnboarding />);
 
-    fireEvent.click(screen.getByRole("button", { name: /custom server/i }));
-    fireEvent.change(screen.getByLabelText(/cloud api url/i), { target: { value: "nope" } });
-    fireEvent.click(screen.getByRole("button", { name: /save and reload/i }));
+    fireEvent.click(screen.getByRole("button", { name: /i don't have an invite link/i }));
 
-    expect(await screen.findByText(/enter a valid http\(s\) url/i)).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: /which server do you sign in to/i })).toBeInTheDocument();
+    // The row names the address, so "official" is not a leap of faith. The
+    // footer prints it too, hence the scoped lookup.
+    const official = screen.getByRole("button", { name: /official server/i });
+    expect(official).toHaveTextContent("teamclu-api.ucar.cc");
+  });
+
+  it("clears any override when the official server is chosen", async () => {
+    cloudApiUrlOverride.value = "https://api.acme.test";
+    render(<DesktopOnboarding />);
+
+    fireEvent.click(screen.getByRole("button", { name: /i don't have an invite link/i }));
+    fireEvent.click(screen.getByRole("button", { name: /official server/i }));
+
+    expect(setCloudApiUrlOverrideMock).toHaveBeenCalledWith(null);
+    await waitFor(() =>
+      expect(screen.getByRole("heading", { name: /sign in/i })).toBeInTheDocument(),
+    );
     expect(reload).not.toHaveBeenCalled();
   });
 
-  it("custom server refuses to save an address that does not answer", async () => {
-    // The whole point: `https://api.example.com111` parses fine and used to save
-    // fine, reloading the app into a backend that does not exist.
-    probeCloudApi.mockResolvedValue({ ok: false, reason: "unreachable" });
+  it("probes a custom address before applying it", async () => {
     render(<DesktopOnboarding />);
 
+    fireEvent.click(screen.getByRole("button", { name: /i don't have an invite link/i }));
     fireEvent.click(screen.getByRole("button", { name: /custom server/i }));
-    fireEvent.change(screen.getByLabelText(/cloud api url/i), {
-      target: { value: "https://api.example.com111" },
-    });
-    fireEvent.click(screen.getByRole("button", { name: /save and reload/i }));
+    fireEvent.change(screen.getByRole("textbox"), { target: { value: "https://api.acme.test" } });
+    fireEvent.click(screen.getByRole("button", { name: /^next$/i }));
 
-    expect(await screen.findByText(/could not reach that address/i)).toBeInTheDocument();
-    expect(setCloudApiUrlOverrideMock).not.toHaveBeenCalled();
-    expect(reload).not.toHaveBeenCalled();
+    await waitFor(() => expect(probeCloudApi).toHaveBeenCalledWith("https://api.acme.test"));
+    expect(setCloudApiUrlOverrideMock).toHaveBeenCalledWith("https://api.acme.test");
+    await waitFor(() =>
+      expect(screen.getByRole("heading", { name: /sign in/i })).toBeInTheDocument(),
+    );
   });
 
-  it("custom server distinguishes 'answered but not a Cloud API' from 'unreachable'", async () => {
-    probeCloudApi.mockResolvedValue({ ok: false, reason: "not-cloud-api", status: 404 });
+  it("rejects a scheme-less address without asking the network", async () => {
     render(<DesktopOnboarding />);
 
+    fireEvent.click(screen.getByRole("button", { name: /i don't have an invite link/i }));
     fireEvent.click(screen.getByRole("button", { name: /custom server/i }));
-    fireEvent.change(screen.getByLabelText(/cloud api url/i), {
-      target: { value: "https://example.com" },
-    });
-    fireEvent.click(screen.getByRole("button", { name: /save and reload/i }));
-
-    expect(await screen.findByText(/not a teamclu cloud api/i)).toBeInTheDocument();
-    expect(setCloudApiUrlOverrideMock).not.toHaveBeenCalled();
-  });
-
-  it("custom server lets the user override a failed probe", async () => {
-    // Configuring a server that is not up yet, or one only reachable from a
-    // network the user is not on right now, is legitimate — the probe is a
-    // guard, not a verdict.
-    probeCloudApi.mockResolvedValue({ ok: false, reason: "unreachable" });
-    render(<DesktopOnboarding />);
-
-    fireEvent.click(screen.getByRole("button", { name: /custom server/i }));
-    fireEvent.change(screen.getByLabelText(/cloud api url/i), {
-      target: { value: "https://not-up-yet.example.com" },
-    });
-    fireEvent.click(screen.getByRole("button", { name: /save and reload/i }));
-
-    fireEvent.click(await screen.findByRole("button", { name: /save it anyway/i }));
-
-    expect(setCloudApiUrlOverrideMock).toHaveBeenCalledWith("https://not-up-yet.example.com");
-    expect(reload).toHaveBeenCalled();
-  });
-
-  it("custom server hides the override once the address is edited again", async () => {
-    probeCloudApi.mockResolvedValue({ ok: false, reason: "unreachable" });
-    render(<DesktopOnboarding />);
-
-    fireEvent.click(screen.getByRole("button", { name: /custom server/i }));
-    const input = screen.getByLabelText(/cloud api url/i);
-    fireEvent.change(input, { target: { value: "https://typo.example.com" } });
-    fireEvent.click(screen.getByRole("button", { name: /save and reload/i }));
-    expect(await screen.findByRole("button", { name: /save it anyway/i })).toBeInTheDocument();
-
-    // A different address has not been rejected yet.
-    fireEvent.change(input, { target: { value: "https://other.example.com" } });
-    expect(screen.queryByRole("button", { name: /save it anyway/i })).toBeNull();
-  });
-
-  // A scheme-less address is fetched relative to tauri://localhost, so probing
-  // it first reports a healthy server as unreachable.
-  it("names a malformed address as malformed instead of probing it", async () => {
-    render(<DesktopOnboarding />);
-
-    fireEvent.click(screen.getByRole("button", { name: /custom server/i }));
-    fireEvent.change(screen.getByLabelText(/cloud api url/i), {
-      target: { value: "api.mycorp.com" },
-    });
-    fireEvent.click(screen.getByRole("button", { name: /save and reload/i }));
+    fireEvent.change(screen.getByRole("textbox"), { target: { value: "api.acme.test" } });
+    fireEvent.click(screen.getByRole("button", { name: /^next$/i }));
 
     await waitFor(() => expect(screen.getByText(/enter a valid http\(s\) url/i)).toBeInTheDocument());
     expect(probeCloudApi).not.toHaveBeenCalled();
     expect(setCloudApiUrlOverrideMock).not.toHaveBeenCalled();
   });
 
-  it("custom server offers a reset only when an override is active", () => {
-    cloudApiUrlOverride.value = "https://self-hosted.example.com";
+  it("saves an unverified address once the user insists", async () => {
+    probeCloudApi.mockResolvedValue({ ok: false, reason: "not-cloud-api", status: 404 });
     render(<DesktopOnboarding />);
 
+    fireEvent.click(screen.getByRole("button", { name: /i don't have an invite link/i }));
     fireEvent.click(screen.getByRole("button", { name: /custom server/i }));
-    fireEvent.click(screen.getByRole("button", { name: /reset to the built-in default/i }));
+    fireEvent.change(screen.getByRole("textbox"), { target: { value: "https://api.acme.test" } });
+    fireEvent.click(screen.getByRole("button", { name: /^next$/i }));
 
-    // Reset goes back to the baked default, so there is nothing to probe.
-    expect(setCloudApiUrlOverrideMock).toHaveBeenCalledWith(null);
-    expect(probeCloudApi).not.toHaveBeenCalled();
-    expect(reload).toHaveBeenCalled();
+    await waitFor(() => expect(screen.getByText(/not a TeamClu Cloud API/i)).toBeInTheDocument());
+    fireEvent.click(screen.getByRole("button", { name: /save it anyway/i }));
+
+    expect(setCloudApiUrlOverrideMock).toHaveBeenCalledWith("https://api.acme.test");
   });
 
-  it("hides the reset when the build has no default to return to", () => {
-    cloudApiUrlOverride.value = "https://self-hosted.example.com";
+  // A build with nothing baked in has no official server to offer.
+  it("collapses to the custom form when the build ships no default", () => {
+    effectiveCloudApiUrl.value = undefined;
     defaultCloudApiUrl.value = undefined;
     render(<DesktopOnboarding />);
 
-    fireEvent.click(screen.getByRole("button", { name: /custom server/i }));
+    fireEvent.click(screen.getByRole("button", { name: /i don't have an invite link/i }));
 
-    // Resetting there would clear the only address the app has.
-    expect(screen.queryByRole("button", { name: /reset to the built-in default/i })).toBeNull();
+    expect(screen.queryByRole("button", { name: /official server/i })).not.toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: /custom server/i })).toBeInTheDocument();
+    expect(screen.getByText(/this build ships no server address/i)).toBeInTheDocument();
   });
 
-  it("marks the footer URL as custom when an override is active", () => {
-    cloudApiUrlOverride.value = "https://self-hosted.example.com";
+  it("goes straight to sign-in once the server question has been answered before", () => {
+    useOnboardingStore.setState({ serverAck: true });
     render(<DesktopOnboarding />);
 
-    // An override must never pass as the baked build config — so this has to
-    // anchor on the override's own host, not on the baked default.
-    expect(screen.getByText(/self-hosted\.example\.com · custom$/)).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: /sign in/i })).toBeInTheDocument();
+    expect(screen.queryByRole("heading", { name: /do you have an invite link/i })).not.toBeInTheDocument();
   });
 
-  // The footer is 10px type at the bottom of the window, and it says nothing
-  // about which of the three entries put the app on that server.
-  it("marks the custom server entry itself when an override is active", () => {
-    cloudApiUrlOverride.value = "https://self-hosted.example.com";
+  it("goes straight to sign-in when a deep link already stashed a token", () => {
+    authState.pendingInviteToken = "tok-from-deeplink";
     render(<DesktopOnboarding />);
 
-    const row = screen.getByRole("button", { name: /custom server/i });
-    expect(row).toHaveTextContent("self-hosted.example.com");
+    expect(screen.getByRole("heading", { name: /sign in/i })).toBeInTheDocument();
+  });
+
+  it("re-runs the whole wizard on demand", () => {
+    useOnboardingStore.getState().markServerAck();
+    render(<DesktopOnboarding />);
+
+    fireEvent.click(screen.getByRole("button", { name: /run setup again/i }));
+
+    expect(useOnboardingStore.getState().serverAck).toBe(false);
+    expect(reload).toHaveBeenCalled();
+  });
+
+  it("prints the effective address, marking a custom one", () => {
+    cloudApiUrlOverride.value = "https://api.acme.test";
+    render(<DesktopOnboarding />);
+
+    expect(screen.getByText(/api\.acme\.test/)).toBeInTheDocument();
+    expect(screen.getByText(/custom/)).toBeInTheDocument();
+  });
+
+  it("says so when the build has no server at all", () => {
+    effectiveCloudApiUrl.value = undefined;
+    defaultCloudApiUrl.value = undefined;
+    render(<DesktopOnboarding />);
+
+    expect(screen.getByText(/no server configured/i)).toBeInTheDocument();
   });
 });

--- a/packages/app/src/components/auth/__tests__/DesktopOnboarding.test.tsx
+++ b/packages/app/src/components/auth/__tests__/DesktopOnboarding.test.tsx
@@ -10,6 +10,8 @@ const {
   effectiveCloudApiUrl,
   defaultCloudApiUrl,
   confirmInviteLinkToken,
+  updaterState,
+  checkForUpdates,
 } = vi.hoisted(() => ({
   authState: {
     loading: false,
@@ -29,13 +31,21 @@ const {
   effectiveCloudApiUrl: { value: "https://teamclu-api.ucar.cc" as string | undefined },
   defaultCloudApiUrl: { value: "https://teamclu-api.ucar.cc" as string | undefined },
   confirmInviteLinkToken: vi.fn(),
+  updaterState: { update: { state: "idle" as string, progress: undefined as number | undefined } },
+  checkForUpdates: vi.fn(),
 }));
 
 vi.mock("@/lib/config/bootstrap", () => ({ probeCloudApi }));
 
 vi.mock("react-i18next", () => ({
   useTranslation: () => ({
-    t: (_key: string, fallback?: string) => fallback ?? _key,
+    // Interpolates like the real `t`, so a string that reaches the screen with
+    // an unfilled {{placeholder}} fails here rather than shipping.
+    t: (_key: string, fallback?: string, vars?: Record<string, unknown>) =>
+      Object.entries(vars ?? {}).reduce(
+        (out, [name, value]) => out.replaceAll(`{{${name}}}`, String(value)),
+        fallback ?? _key,
+      ),
   }),
 }));
 
@@ -48,6 +58,14 @@ vi.mock("@/stores/auth-store", () => {
 });
 
 vi.mock("@/lib/team/invite-link-confirmation", () => ({ confirmInviteLinkToken }));
+
+vi.mock("@/stores/updater", () => {
+  const state = () => ({ ...updaterState, checkForUpdates });
+  const useUpdaterStore = (selector?: (s: ReturnType<typeof state>) => unknown) =>
+    selector ? selector(state()) : state();
+  useUpdaterStore.getState = state;
+  return { useUpdaterStore };
+});
 
 // Only the resolved values are faked; displayHost / normalizeCloudApiUrl stay
 // real so the screen formats and validates addresses the way production does.
@@ -103,6 +121,8 @@ beforeEach(() => {
   authState.verifyOtp.mockReset();
   authState.resetOtp.mockReset();
   confirmInviteLinkToken.mockReset();
+  checkForUpdates.mockReset();
+  updaterState.update = { state: "idle", progress: undefined };
   hasConfig.value = true;
   cloudApiUrlOverride.value = null;
   effectiveCloudApiUrl.value = "https://teamclu-api.ucar.cc";
@@ -327,6 +347,38 @@ describe("DesktopOnboarding", () => {
 
     expect(screen.getByText(/api\.acme\.test/)).toBeInTheDocument();
     expect(screen.getByText(/custom/)).toBeInTheDocument();
+  });
+
+  // Being able to update from the login screen is the whole point: a release
+  // that strands people here is the one they need to leave.
+  it("looks for an update without waiting for anyone to sign in", () => {
+    render(<DesktopOnboarding />);
+
+    expect(checkForUpdates).toHaveBeenCalledWith(true);
+  });
+
+  it("does not restart a check that already found something", () => {
+    updaterState.update = { state: "ready", progress: undefined };
+    render(<DesktopOnboarding />);
+
+    expect(checkForUpdates).not.toHaveBeenCalled();
+  });
+
+  it("offers a manual check on the version line", () => {
+    render(<DesktopOnboarding />);
+    checkForUpdates.mockClear();
+
+    fireEvent.click(screen.getByRole("button", { name: /check for updates/i }));
+
+    // Not silent: a click deserves to be told when the check fails.
+    expect(checkForUpdates).toHaveBeenCalledWith();
+  });
+
+  it("reports update progress on the version line", () => {
+    updaterState.update = { state: "downloading", progress: 42 };
+    render(<DesktopOnboarding />);
+
+    expect(screen.getByRole("button", { name: /downloading 42%/i })).toBeDisabled();
   });
 
   it("says so when the build has no server at all", () => {

--- a/packages/app/src/components/sidebar/ActorDetailContent.tsx
+++ b/packages/app/src/components/sidebar/ActorDetailContent.tsx
@@ -16,6 +16,7 @@ import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { getBackend } from '@/lib/backend'
 import { buildInviteDeeplink } from '@/lib/team/invite-deeplink'
+import { getEffectiveServerConfigSync } from '@/lib/config/server-config'
 import { formatActorRemoveError } from '@/lib/actor/actor-remove-error'
 import type { ClientVersionEntry } from '@/lib/backend/types'
 import { actorAvatarColor } from '@/lib/actor/actor-color'
@@ -230,8 +231,10 @@ export function ActorDetailContent({ actor, teamId, onRemoved, onClose, extraSec
       }
       setReinvite({
         // Not row.deeplink: that carries the backend's `amux://` scheme, which
-        // no build registers with the OS.
-        deeplink: buildInviteDeeplink(row.token),
+        // no build registers with the OS. The endpoint rides along so the
+        // invitee's onboarding reaches this backend without being told to type
+        // an address.
+        deeplink: buildInviteDeeplink(row.token, getEffectiveServerConfigSync().cloudApiUrl),
         expiresAt: row.expiresAt ?? new Date(Date.now() + 604800 * 1000).toISOString(),
       })
     } catch (e) {

--- a/packages/app/src/components/sidebar/InviteActorDialog.tsx
+++ b/packages/app/src/components/sidebar/InviteActorDialog.tsx
@@ -15,6 +15,7 @@ import { Input } from '@/components/ui/input'
 import { UpgradeToOrgDialog } from '@/components/auth/UpgradeToOrgDialog'
 import { getBackend } from '@/lib/backend'
 import { buildInviteDeeplink } from '@/lib/team/invite-deeplink'
+import { getEffectiveServerConfigSync } from '@/lib/config/server-config'
 import { cn } from '@/lib/utils'
 import { useCurrentTeamStore } from '@/stores/current-team'
 
@@ -104,8 +105,10 @@ export function InviteActorDialog({ open, onOpenChange, teamId }: InviteActorDia
         token: row.token,
         expiresAt: row.expiresAt ?? new Date(Date.now() + 604800 * 1000).toISOString(),
         // Not row.deeplink: that carries the backend's `amux://` scheme, which
-        // no build registers with the OS.
-        deeplink: buildInviteDeeplink(row.token),
+        // no build registers with the OS. The endpoint rides along so the
+        // invitee's onboarding reaches this backend without being told to type
+        // an address.
+        deeplink: buildInviteDeeplink(row.token, getEffectiveServerConfigSync().cloudApiUrl),
       })
     } catch (e) {
       // Default-org teams are solo-only: inviting members requires upgrading the

--- a/packages/app/src/lib/team/__tests__/invite-deeplink.test.ts
+++ b/packages/app/src/lib/team/__tests__/invite-deeplink.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/lib/config/build-config', () => ({ appScheme: 'teamclu' }))
+
+import { buildInviteDeeplink, parseInviteDeeplink, parseInviteInput } from '../invite-deeplink'
+
+describe('buildInviteDeeplink', () => {
+  it('carries the inviter endpoint so the invitee never types an address', () => {
+    expect(buildInviteDeeplink('tok-1', 'https://api.acme.test')).toBe(
+      'teamclu://invite?token=tok-1&cloud_api_url=https%3A%2F%2Fapi.acme.test',
+    )
+  })
+
+  it('omits the parameter when the inviter has no endpoint resolved', () => {
+    expect(buildInviteDeeplink('tok-1')).toBe('teamclu://invite?token=tok-1')
+    expect(buildInviteDeeplink('tok-1', null)).toBe('teamclu://invite?token=tok-1')
+  })
+
+  it('round-trips a token that needs escaping', () => {
+    const link = buildInviteDeeplink('a+b/c=', 'https://api.acme.test')
+    expect(parseInviteInput(link)).toEqual({
+      token: 'a+b/c=',
+      cloudApiUrl: 'https://api.acme.test',
+    })
+  })
+})
+
+describe('parseInviteInput', () => {
+  it('reads the endpoint off a pasted link', () => {
+    expect(
+      parseInviteInput('teamclu://invite?token=tok-1&cloud_api_url=https%3A%2F%2Fapi.acme.test'),
+    ).toEqual({ token: 'tok-1', cloudApiUrl: 'https://api.acme.test' })
+  })
+
+  it('accepts the amux scheme the RPC still emits', () => {
+    expect(parseInviteInput('amux://invite?token=tok-1')).toEqual({
+      token: 'tok-1',
+      cloudApiUrl: null,
+    })
+  })
+
+  it('treats a bare token as naming no server', () => {
+    expect(parseInviteInput('  tok-1  ')).toEqual({ token: 'tok-1', cloudApiUrl: null })
+  })
+
+  it('reports an empty cloud_api_url as absent rather than as an empty address', () => {
+    expect(parseInviteInput('teamclu://invite?token=tok-1&cloud_api_url=')).toEqual({
+      token: 'tok-1',
+      cloudApiUrl: null,
+    })
+  })
+
+  it('rejects anything else carrying a scheme', () => {
+    expect(parseInviteInput('https://example.com/invite?token=tok-1')).toBeNull()
+    expect(parseInviteInput('teamclu://team?token=tok-1')).toBeNull()
+    expect(parseInviteInput('teamclu://invite?token=')).toBeNull()
+    expect(parseInviteInput('   ')).toBeNull()
+  })
+})
+
+describe('parseInviteDeeplink', () => {
+  // SEC-3: the OS hands this build links on its own scheme only.
+  it('takes the app scheme and nothing else', () => {
+    expect(parseInviteDeeplink('teamclu://invite?token=tok-1')).toBe('tok-1')
+    expect(parseInviteDeeplink('amux://invite?token=tok-1')).toBeNull()
+  })
+})

--- a/packages/app/src/lib/team/invite-deeplink.ts
+++ b/packages/app/src/lib/team/invite-deeplink.ts
@@ -11,24 +11,50 @@ const DEEPLINK_SCHEMES: ReadonlySet<string> = new Set([`${appScheme}:`])
 const PASTED_LINK_SCHEMES: ReadonlySet<string> = new Set([`${appScheme}:`, 'amux:'])
 const INVITE_HOST = 'invite'
 
+/** Query parameter carrying the inviter's Cloud API endpoint. Same name the
+ *  daemon already reads off an agent invite (`onboarding/invite_url.rs`). */
+const CLOUD_API_PARAM = 'cloud_api_url'
+
 /**
  * The invite link to hand out, always on this build's own scheme.
  *
  * Built from the token rather than passed through from the backend: the
  * `create_team_invite` RPC still returns `amux://invite?token=…`, a scheme no
  * build registers with the OS, and the pg-repo backend returns no link at all.
+ *
+ * `cloudApiUrl` is the inviter's *effective* endpoint, and carrying it is what
+ * lets an invitee reach the right backend without being told which server to
+ * type: onboarding reads it straight off the link. Omitted when the inviter has
+ * no endpoint resolved at all, which is also the only case a build can have no
+ * built-in default — there is nothing truthful to put in the link.
  */
-export function buildInviteDeeplink(token: string): string {
-  return `${appScheme}://${INVITE_HOST}?token=${encodeURIComponent(token)}`
+export function buildInviteDeeplink(token: string, cloudApiUrl?: string | null): string {
+  const base = `${appScheme}://${INVITE_HOST}?token=${encodeURIComponent(token)}`
+  if (!cloudApiUrl) return base
+  return `${base}&${CLOUD_API_PARAM}=${encodeURIComponent(cloudApiUrl)}`
 }
 
-function parseInviteUrl(raw: string, schemes: ReadonlySet<string>): string | null {
+/** What a parsed invite link carries. */
+export interface ParsedInvite {
+  token: string
+  /**
+   * The inviter's Cloud API endpoint, exactly as it appeared in the link, or
+   * null when the link carries none (a bare token, or a link minted before
+   * this parameter existed). Deliberately NOT validated here: the caller
+   * probes it before persisting anything, and this module stays out of
+   * server-config's import graph.
+   */
+  cloudApiUrl: string | null
+}
+
+function parseInviteUrl(raw: string, schemes: ReadonlySet<string>): ParsedInvite | null {
   try {
     const url = new URL(raw)
     if (!schemes.has(url.protocol)) return null
     if (url.hostname !== INVITE_HOST && url.pathname !== `//${INVITE_HOST}`) return null
     const token = url.searchParams.get('token')
-    return token && token.length > 0 ? token : null
+    if (!token) return null
+    return { token, cloudApiUrl: url.searchParams.get(CLOUD_API_PARAM) || null }
   } catch {
     return null
   }
@@ -36,15 +62,24 @@ function parseInviteUrl(raw: string, schemes: ReadonlySet<string>): string | nul
 
 /** Parse an OS-delivered deep link. Own scheme only. */
 export function parseInviteDeeplink(raw: string): string | null {
-  return parseInviteUrl(raw, DEEPLINK_SCHEMES)
+  return parseInviteUrl(raw, DEEPLINK_SCHEMES)?.token ?? null
 }
 
-/** Parse what the user typed or pasted: a bare token, or a link on an accepted scheme. */
-export function parseInviteTokenInput(raw: string): string | null {
+/**
+ * Parse what the user typed or pasted: a bare token, or a link on an accepted
+ * scheme. A bare token names no server, so it is claimed against whichever
+ * endpoint is already in effect.
+ */
+export function parseInviteInput(raw: string): ParsedInvite | null {
   const trimmed = raw.trim()
   if (!trimmed) return null
   const fromLink = parseInviteUrl(trimmed, PASTED_LINK_SCHEMES)
   if (fromLink) return fromLink
   if (trimmed.includes('://')) return null
-  return trimmed
+  return { token: trimmed, cloudApiUrl: null }
+}
+
+/** Token-only view of {@link parseInviteInput}, for callers with no server to set. */
+export function parseInviteTokenInput(raw: string): string | null {
+  return parseInviteInput(raw)?.token ?? null
 }

--- a/packages/app/src/locales/en.json
+++ b/packages/app/src/locales/en.json
@@ -463,35 +463,28 @@
     "webSsoWaiting": "Finish signing in in the window, then come back.",
     "close": "Close",
     "onboarding": {
-      "setupTitle": "Choose setup",
-      "setupDesc": "Sign in, join a team, or connect a self-hosted server.",
       "rerunSetup": "Run setup again",
-      "customServer": "Enterprise custom server",
-      "customServerDesc": "Point the app at your company's self-hosted Cloud API and sign in there.",
-      "customServerRequiredDesc": "Start here: enter the Cloud API address of your company's own server.",
-      "noServerNotice": "No server address is configured yet. Set your company's Cloud API below — signing in and joining a team both need one.",
+      "noServerNotice": "This build ships no server address, so there is nothing to fall back to — signing in needs one.",
       "serverUnset": "no server configured",
       "serverCustomTag": "custom",
-      "serverTitle": "Enterprise custom server",
-      "serverDesc": "Point the app at a different TeamClu Cloud API. The app reloads and you sign in against that server.",
+      "serverChoiceTitle": "Which server do you sign in to?",
+      "serverChoiceDesc": "Use the official server, or point the app at your company's own deployment.",
+      "serverOfficial": "Official server",
+      "serverCustom": "Custom server",
+      "serverCustomDesc": "Enter the Cloud API address of your company's own deployment.",
+      "serverCustomFormDesc": "Enter the Cloud API address of your company's own deployment. You sign in against that server.",
       "serverUrlLabel": "Cloud API URL",
       "serverUrlInvalid": "Enter a valid http(s) URL, e.g. https://api.example.com",
-      "serverDefaultHint": "Built-in default: {{url}}",
-      "serverSaveAndReload": "Save and reload",
       "serverChecking": "Checking…",
       "serverUnreachable": "Could not reach that address. Check the URL and that the server is running.",
       "serverNotCloudApi": "That address answered, but it is not a TeamClu Cloud API ({{status}}).",
       "serverSaveAnyway": "Save it anyway",
-      "serverReset": "Reset to the built-in default",
-      "signInOrRegister": "Sign in or register",
-      "signInOrRegisterDesc": "Sign in directly with a verification code and bind a valid contact method.",
-      "joinTeam": "Join the team",
-      "joinTeamDesc": "Paste an invite link or token to join an existing team.",
-      "inviteParseError": "Enter a valid invite token or invite link.",
-      "inviteTitle": "Join the team",
-      "inviteDesc": "Paste an invite link or token, then sign in to join. The invite is claimed once you're signed in.",
+      "inviteQuestion": "Do you have an invite link?",
+      "inviteQuestionDesc": "Paste it here and everything else is set up for you — including which server to sign in to. The invite is claimed right after you sign in.",
       "inviteLabel": "Invite link or token",
-      "inviteContinueToSignIn": "Continue to sign in"
+      "inviteParseError": "Enter a valid invite token or invite link.",
+      "inviteContinueAnyway": "Continue anyway",
+      "inviteNone": "I don't have an invite link"
     },
     "upgradeOrg": {
       "title": "Create your own team",
@@ -971,7 +964,8 @@
   },
   "onboarding": {
     "common": {
-      "back": "Back"
+      "back": "Back",
+      "next": "Next"
     }
   },
   "workspace": {

--- a/packages/app/src/locales/en.json
+++ b/packages/app/src/locales/en.json
@@ -1149,6 +1149,12 @@
     "loginRequired": "Please sign in before continuing."
   },
   "updater": {
+    "check": "Check for updates",
+    "checking": "Checking for updates…",
+    "downloading": "Downloading {{percent}}%",
+    "upToDate": "Up to date",
+    "restartToUpdate": "Restart to update",
+    "checkFailed": "Update check failed",
     "ready": "Update Ready",
     "failed": "Update Failed",
     "releaseNotes": "Release Notes",

--- a/packages/app/src/locales/zh-CN.json
+++ b/packages/app/src/locales/zh-CN.json
@@ -463,35 +463,28 @@
     "webSsoWaiting": "在窗口里登录完成后回到这里。",
     "close": "关闭",
     "onboarding": {
-      "setupTitle": "选择启动方式",
-      "setupDesc": "登录、加入团队，或连接企业自建服务。",
       "rerunSetup": "重新配置本机",
-      "customServer": "企业自定义服务",
-      "customServerDesc": "连接企业自建的 Cloud API，登录到公司自己的服务。",
-      "customServerRequiredDesc": "从这里开始：填入公司自建服务的 Cloud API 地址。",
-      "noServerNotice": "还没有配置服务器地址。先在下面填入企业自建的 Cloud API 地址——登录和加入团队都需要它。",
+      "noServerNotice": "这个版本没有内置服务器地址，也就没有可回退的默认值——登录必须先填一个。",
       "serverUnset": "未配置服务器",
       "serverCustomTag": "自定义",
-      "serverTitle": "企业自定义服务",
-      "serverDesc": "将应用指向另一个 TeamClu Cloud API。应用会重新加载，你需要在该服务上重新登录。",
+      "serverChoiceTitle": "登录到哪个服务器？",
+      "serverChoiceDesc": "使用官方服务器，或者把应用指向公司自建的服务。",
+      "serverOfficial": "官方服务器",
+      "serverCustom": "自定义服务器",
+      "serverCustomDesc": "填入公司自建服务的 Cloud API 地址。",
+      "serverCustomFormDesc": "填入公司自建服务的 Cloud API 地址，之后你会登录到该服务器。",
       "serverUrlLabel": "Cloud API 地址",
       "serverUrlInvalid": "请输入有效的 http(s) 地址，例如 https://api.example.com",
-      "serverDefaultHint": "内置默认：{{url}}",
-      "serverSaveAndReload": "保存并重新加载",
       "serverChecking": "检查中…",
       "serverUnreachable": "连不上这个地址。请检查 URL 是否正确、服务是否在运行。",
       "serverNotCloudApi": "这个地址有响应，但它不是 TeamClu Cloud API（{{status}}）。",
       "serverSaveAnyway": "仍然保存",
-      "serverReset": "恢复内置默认",
-      "signInOrRegister": "登录或者注册",
-      "signInOrRegisterDesc": "使用验证码直接登录，绑定个人的有效通讯方式。",
-      "joinTeam": "加入团队",
-      "joinTeamDesc": "粘贴邀请链接或邀请码，加入已有团队。",
-      "inviteParseError": "请输入有效的邀请码或邀请链接。",
-      "inviteTitle": "加入团队",
-      "inviteDesc": "粘贴邀请链接或邀请码，然后登录以加入。登录后会自动领取邀请。",
+      "inviteQuestion": "有邀请链接吗？",
+      "inviteQuestionDesc": "粘贴在这里，其余的都会自动配好——包括登录到哪个服务器。登录后会立即领取这份邀请。",
       "inviteLabel": "邀请链接或邀请码",
-      "inviteContinueToSignIn": "继续登录"
+      "inviteParseError": "请输入有效的邀请码或邀请链接。",
+      "inviteContinueAnyway": "仍然继续",
+      "inviteNone": "我没有邀请链接"
     },
     "upgradeOrg": {
       "title": "创建你自己的团队",
@@ -971,7 +964,8 @@
   },
   "onboarding": {
     "common": {
-      "back": "上一步"
+      "back": "上一步",
+      "next": "下一步"
     }
   },
   "workspace": {

--- a/packages/app/src/locales/zh-CN.json
+++ b/packages/app/src/locales/zh-CN.json
@@ -1149,6 +1149,12 @@
     "loginRequired": "请先登录后再操作。"
   },
   "updater": {
+    "check": "检查更新",
+    "checking": "检查中…",
+    "downloading": "下载中 {{percent}}%",
+    "upToDate": "已是最新版本",
+    "restartToUpdate": "重启以更新",
+    "checkFailed": "检查更新失败",
     "ready": "更新就绪",
     "failed": "更新失败",
     "releaseNotes": "更新说明",

--- a/packages/app/src/main.tsx
+++ b/packages/app/src/main.tsx
@@ -17,6 +17,7 @@ import { ensureBundledAmuxdCurrent } from '@/lib/daemon/daemon-version-upgrade'
 import { initJwtBridge } from '@/lib/daemon/jwt-bridge'
 import { installConsoleCapture, redactSentryBreadcrumb } from '@/lib/diagnostics/console-capture'
 import { InviteLinkConfirmDialog } from './components/invite/InviteLinkConfirmDialog'
+import { UpdateDialogContainer } from './components/updater/UpdateDialog'
 import { markStartup } from '@/lib/telemetry/startup-perf'
 import { removeStartupSkeleton } from './lib/utils'
 import { E2E_BUILD } from './lib/e2e/v2-control-active'
@@ -165,6 +166,15 @@ createRoot(document.getElementById('root')!).render(
             inside the shell. Only a token accepted here is ever claimed.
           */}
           <InviteLinkConfirmDialog />
+          {/*
+            Outside AuthGate for the same reason: updating needs nothing from
+            the backend — `check_update` is a plain fetch of the release
+            manifest — but mounted inside App it only ever ran for a user who
+            had already signed in AND passed team bootstrap. A build that cannot
+            get anyone past the login screen was therefore also a build nobody
+            could update out of.
+          */}
+          <UpdateDialogContainer />
           {/*
             An E2E build mounts App without AuthGate. The harness never signs
             in — it drives the app over the MCP socket and seeds sessions,

--- a/packages/app/src/stores/onboarding.ts
+++ b/packages/app/src/stores/onboarding.ts
@@ -2,13 +2,14 @@ import { create } from 'zustand'
 import { appStoragePrefix } from '@/lib/config/build-config'
 
 /**
- * First-run state that has to be answered before sign-in.
+ * First-run state that has to be answered before sign-in: the language, and
+ * which server this app talks to.
  *
- * Only the language is left (#1250). Picking a runtime and installing it used
- * to live here too; with pi the only runtime there is nothing to pick, and the
- * install moved into the post-login daemon wizard (`stores/daemon-onboarding`)
- * where the daemon's own doctor is the single source of truth — no
- * localStorage handoff, no "setup-ok" cache to go stale.
+ * Picking a runtime and installing it used to live here too; with pi the only
+ * runtime there is nothing to pick, and the install moved into the post-login
+ * daemon wizard (`stores/daemon-onboarding`) where the daemon's own doctor is
+ * the single source of truth — no localStorage handoff, no "setup-ok" cache to
+ * go stale.
  */
 
 /** The language step has been answered. Separate from the language itself:
@@ -16,6 +17,15 @@ import { appStoragePrefix } from '@/lib/config/build-config'
  *  *that* it was asked, so a user who confirms the system default is not asked
  *  again on the next launch. */
 const LANGUAGE_ACK_KEY = `${appStoragePrefix}-onboarding-language-ack`
+
+/** The server question has been answered — by an invite link that named one, by
+ *  picking the official server, or by typing a custom address.
+ *
+ *  Separate from the address itself for the same reason the language flag is:
+ *  choosing the official server writes no override, so "there is no override"
+ *  cannot distinguish "already chose the default" from "never asked". Without
+ *  this, signing out would replay the whole wizard on the way back in. */
+const SERVER_ACK_KEY = `${appStoragePrefix}-onboarding-server-ack`
 
 /** Keys the pre-#1250 wizard persisted; cleared on `reset` so a re-run starts
  *  from nothing, never read. */
@@ -48,6 +58,9 @@ type OnboardingState = {
   /** The language step has been answered at least once. */
   languageAck: boolean
   markLanguageAck: () => void
+  /** The server step has been answered at least once. */
+  serverAck: boolean
+  markServerAck: () => void
   /** Test/dev helper — forget everything and run the flow again. */
   reset: () => void
 }
@@ -60,9 +73,17 @@ export const useOnboardingStore = create<OnboardingState>((set) => ({
     set({ languageAck: true })
   },
 
+  serverAck: readFlag(SERVER_ACK_KEY),
+
+  markServerAck: () => {
+    write(SERVER_ACK_KEY, '1')
+    set({ serverAck: true })
+  },
+
   reset: () => {
     write(LANGUAGE_ACK_KEY, null)
+    write(SERVER_ACK_KEY, null)
     for (const key of LEGACY_KEYS) write(key, null)
-    set({ languageAck: false })
+    set({ languageAck: false, serverAck: false })
   },
 }))


### PR DESCRIPTION
## 为什么

首次启动原本是一个三选一的菜单（登录 / 加入团队 / 企业自定义服务），要求用户在还没被告知这些选项是什么意思之前，先给自己分类。

现在是一条直线：**选择语言 → 有邀请链接吗？→ 登录到哪个服务器 → 登录**。

被邀请的人——也就是大多数人——在第一个问题就走完了：邀请链接自己带着它所属的后端地址。

## 改了什么

### 1. 邀请链接带上 Cloud API 地址

`buildInviteDeeplink` 和 iOS 的 `InviteCreated` 都会追加 `cloud_api_url`，与 daemon 早就在读的 agent 邀请参数同名（`apps/daemon/src/onboarding/invite_url.rs`）。iOS 的链接是后端 RPC 返回的，所以补在 `ActorRepository` 那一层，带 `client.baseURL`。

从链接里来的地址在落盘前**照样探测**，和手输的一视同仁。

### 2. 落地址不再 reload 窗口

原来"企业自定义服务"那一屏保存后会 `window.location.reload()`。reload 的用途是丢掉旧后端签发的 session，而这个向导只在未登录时渲染（`AuthGate` 的 `!session` 分支）。在这里 reload 反而会：

- 把向导打回第一步（React state 全丢），用户到不了登录页；
- 丢掉那个**刻意不持久化**的邀请确认（`invite-link-confirmation.ts`），于是用户刚亲手输进去的 token，登录后还会被再问一遍"要加入这个团队吗？"

原地切是安全的，逐条核实过：`getBackend()` 按 `cloud_api:<url>` 做 cache key 会自失效；remote-features 已经在监听变更事件；其余读取方全部是调用时才解析配置。设置页里的换服务器（那里真有 session）没动。

### 3. `serverAck`

记录"服务器这个问题已经答过了"，退出登录再进不会重走一遍向导。"重新运行设置"会清掉它。

没有内置默认地址的品牌包（`getDefaultCloudApiUrl()` 为空）没有"官方服务器"可给，那一步直接塌成自定义表单。

### 4. 未登录也能更新

更新器原本挂在 `App` 里，而 `App` 在 `AuthGate` 里——只有已登录**且**团队 bootstrap 成功的用户才会挂载它。而更新本身不需要这些：`check_update` 就是一次拉 release manifest 的普通请求，不碰 Cloud API、不带 token。

结果就是：**一个没人能通过登录页的版本，同时也是没人能更新出去的版本。**

现在它和 `InviteLinkConfirmDialog` 并排挂在 gate 外面。onboarding 另外会自己找一次更新，版本号那行也变成了手动检查入口。这次检查**有意绕过** Settings → General 那个默认关闭的开关：那个开关是为了不让能正常工作的安装偷偷下东西，而这里正是走不动的那个安装。每次挂载最多一次，已在检查或已找到更新时跳过，找到了仍然是可关掉的"重启以应用"。

## 已知未做

- **agent 邀请识别不了**。token 是 `gen_random_bytes(24)`，不带 kind 标记，链接形状也一样，客户端在登录前无法判断。顺带查出来一件更值得警惕的事：真人去 claim agent 邀请**不会失败**，`claim_team_invite` 的 agent 分支只在没有调用者账号时才新建 daemon 账号，于是 agent actor 被绑到了真人账号上、邀请也被消费掉。要做提示只能服务端出手（加免鉴权的 preview 接口，或在那个分支加一条拒绝）。
- **iOS 消费端**。iOS 的生产端（邀请链接带地址）在这个 PR 里；把 `WelcomeView → ChooseAuthView` 也改成这条线性向导没做。
- **自动更新默认值**仍是关。默认关掉的自动更新实际约等于没有自动更新，但改它是产品决策，没擅自动。

## 验证

- `pnpm test:unit` — 3383 passed / 0 failed（onboarding 22 条、邀请链接解析 9 条，均为新增或重写）
- `pnpm typecheck` 干净，`pnpm lint` 0 error
- AMUXCore `swift test` — 178 XCTest + 228 swift-testing 全过（含新增 6 条链接测试）

顺手把 onboarding 测试里的 `t` mock 改成会做 `{{var}}` 插值——原来直接吐 fallback 原文，占位符没填上的文案能一路混过测试上线。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012XxpEVfZJ1R2QFQesonhM4