### PR TITLE
feat(daemon): amuxd manage workspace registration + agent upsert auth

### DIFF
--- a/apps/daemon/src/cli/manage.rs
+++ b/apps/daemon/src/cli/manage.rs
@@ -125,6 +125,7 @@ pub fn run() -> anyhow::Result<()> {
             .items(&[
                 "Status overview",
                 "Agent runtime (pi)",
+                "Workspaces",
                 "LLM provider",
                 "Team share secrets",
                 "Team skills",
@@ -137,10 +138,11 @@ pub fn run() -> anyhow::Result<()> {
         match choice {
             0 => show_status()?,
             1 => agent_runtime_menu(&theme)?,
-            2 => llm_menu(&theme)?,
-            3 => team_secrets_menu(&theme)?,
-            4 => team_skills_menu(&theme)?,
-            5 => sync_menu(&theme)?,
+            2 => workspaces_menu(&theme)?,
+            3 => llm_menu(&theme)?,
+            4 => team_secrets_menu(&theme)?,
+            5 => team_skills_menu(&theme)?,
+            6 => sync_menu(&theme)?,
             _ => break,
         }
     }
@@ -149,7 +151,129 @@ pub fn run() -> anyhow::Result<()> {
 
 fn print_header() {
     println!("amuxd manage — headless daemon configuration");
-    println!("Onboarding stays on `amuxd init`; use this for agent runtime, LLM + team share.");
+    println!(
+        "Onboarding stays on `amuxd init`; use this for workspaces, agent runtime, LLM + team share."
+    );
+}
+
+fn workspaces_menu(theme: &ColorfulTheme) -> anyhow::Result<()> {
+    loop {
+        let choice = Select::with_theme(theme)
+            .with_prompt("Workspaces")
+            .items(&[
+                "List registered on this machine",
+                "Register workspace",
+                "Back",
+            ])
+            .default(0)
+            .interact()?;
+
+        match choice {
+            0 => list_registered_workspaces()?,
+            1 => register_workspace_interactive(theme)?,
+            _ => break,
+        }
+    }
+    Ok(())
+}
+
+fn list_registered_workspaces() -> anyhow::Result<()> {
+    let workspaces = fetch_registered_workspaces()?;
+    if workspaces.is_empty() {
+        println!("No workspaces registered on this machine.");
+        println!("Use \"Register workspace\" to add a project directory outside ~/.amuxd.");
+        return Ok(());
+    }
+    println!("Registered workspaces:");
+    for ws in &workspaces {
+        let tag = if ws.is_default { " [default]" } else { "" };
+        println!(
+            "  - {}{}: {}",
+            ws.display_name,
+            tag,
+            ws.path.display()
+        );
+        println!("    id: {}", ws.workspace_id);
+    }
+    Ok(())
+}
+
+fn register_workspace_interactive(theme: &ColorfulTheme) -> anyhow::Result<()> {
+    if daemon_pid().is_none() {
+        anyhow::bail!("daemon is not running — start it first (`amuxd start`)");
+    }
+
+    let raw: String = Input::with_theme(theme)
+        .with_prompt("Workspace path (absolute or ~/...)")
+        .interact_text()?;
+    let path = expand_home_path(raw.trim());
+    if !path.is_dir() {
+        if Confirm::with_theme(theme)
+            .with_prompt(format!("Create directory {}?", path.display()))
+            .default(true)
+            .interact()?
+        {
+            std::fs::create_dir_all(&path)
+                .map_err(|e| anyhow::anyhow!("create {}: {e}", path.display()))?;
+        } else {
+            anyhow::bail!("not a directory: {}", path.display());
+        }
+    }
+    if !crate::config::workspace_path::is_linkable_workspace_path(&path.to_string_lossy()) {
+        anyhow::bail!(
+            "workspace path must not be under ~/.amuxd (daemon config dir): {}",
+            path.display()
+        );
+    }
+
+    let canonical = path
+        .canonicalize()
+        .map_err(|e| anyhow::anyhow!("canonicalize {}: {e}", path.display()))?;
+    let rt = tokio::runtime::Runtime::new()?;
+    let registered = rt.block_on(register_workspace_async(&canonical))?;
+    println!(
+        "✓ Registered workspace {} ({})",
+        registered.display_name, registered.workspace_id
+    );
+    println!("  path: {}", registered.path.display());
+    if registered.is_default {
+        println!("  default: yes");
+    } else {
+        println!("  default: unchanged (first registration becomes default automatically)");
+    }
+    Ok(())
+}
+
+async fn register_workspace_async(path: &Path) -> anyhow::Result<RegisteredWorkspace> {
+    #[derive(Deserialize)]
+    struct RegisterResponse {
+        workspace_id: String,
+        path: String,
+        display_name: String,
+    }
+
+    let daemon = ManageDaemonClient::connect().await?;
+    let body = daemon
+        .json::<RegisterResponse>(
+            reqwest::Method::POST,
+            "/v1/workspaces",
+            Some(serde_json::json!({ "path": path.to_string_lossy() })),
+        )
+        .await?;
+
+    let workspaces = fetch_registered_workspaces_async().await?;
+    let is_default = workspaces
+        .iter()
+        .find(|ws| ws.workspace_id == body.workspace_id)
+        .map(|ws| ws.is_default)
+        .unwrap_or(false);
+
+    Ok(RegisteredWorkspace {
+        workspace_id: body.workspace_id,
+        path: PathBuf::from(body.path),
+        display_name: body.display_name,
+        is_default,
+    })
 }
 
 fn show_status() -> anyhow::Result<()> {

--- a/crates/teamclu-gateway/src/wecom_delivery.rs
+++ b/crates/teamclu-gateway/src/wecom_delivery.rs
@@ -78,7 +78,10 @@ pub enum StreamPhase {
     /// Early `finish=true` already sent; later progress is swallowed and the
     /// answer goes out as markdown.
     ClosedForFollowup,
-    /// Terminal finish (answer or cancelled) already sent.
+    /// Terminal finish (answer or cancelled) already sent. Not assigned in the
+    /// driver today — the in-flight entry is removed instead — but kept so
+    /// `decide_*` can swallow duplicate finish calls defensively.
+    #[allow(dead_code)]
     Finished,
 }
 

--- a/crates/teamclu-gateway/src/wecom_outbox.rs
+++ b/crates/teamclu-gateway/src/wecom_outbox.rs
@@ -40,10 +40,12 @@ impl WeComOutbox {
             .collect()
     }
 
+    #[cfg(test)]
     pub fn len(&self) -> usize {
         self.inner.lock().expect("wecom outbox mutex").len()
     }
 
+    #[cfg(test)]
     pub fn is_empty(&self) -> bool {
         self.len() == 0
     }

--- a/services/fc/src/lib/supabase-repo.ts
+++ b/services/fc/src/lib/supabase-repo.ts
@@ -1342,12 +1342,27 @@ export function createSupabaseBusinessRepository(options) {
         }
       }
 
+      // Agent callers re-upserting an existing row (path/id dedup) must not
+      // wipe member attribution that Desktop registration wrote first.
+      let createdByMemberIdForRow = createdByMemberId;
+      if (targetId && createdByMemberId === null) {
+        const { data: existing, error: existingErr } = await supabase
+          .from("workspaces")
+          .select("created_by_member_id")
+          .eq("id", targetId)
+          .maybeSingle();
+        if (existingErr) throw existingErr;
+        if (existing?.created_by_member_id) {
+          createdByMemberIdForRow = existing.created_by_member_id;
+        }
+      }
+
       const row: Record<string, unknown> = {
         team_id: input.teamId,
         name: resolvedName,
         path: normalizedPath,
         agent_id: agentId,
-        created_by_member_id: createdByMemberId,
+        created_by_member_id: createdByMemberIdForRow,
         archived: input.archived ?? false,
       };
       if (targetId) row.id = targetId;

--- a/services/fc/src/lib/supabase-repo.ts
+++ b/services/fc/src/lib/supabase-repo.ts
@@ -1280,20 +1280,18 @@ export function createSupabaseBusinessRepository(options) {
     },
 
     async upsertWorkspace(input) {
-      // AUTHZ: created_by is ALWAYS resolved server-side from the authenticated
-      // caller scoped to the target team. Any client-supplied
+      // AUTHZ: created_by / agent_id are ALWAYS resolved server-side from the
+      // authenticated caller scoped to the target team. Any client-supplied
       // `input.createdByMemberId` is ignored — a multi-team user's client can
       // send the wrong team's member actor id (stale current-team value), which
       // the workspaces INSERT RLS WITH CHECK then rejects. Deriving it here
       // guarantees the row satisfies the team-scoped policy regardless of what
       // the client sends (mirrors createSession / createApp).
-      const { data: userData, error: userErr } = await supabase.auth.getUser();
-      if (userErr) throw userErr;
-      const userId = userData?.user?.id;
-      if (!userId) throw new ApiError(401, "unauthorized", "no authenticated user");
-      const resolved = await this.resolveCurrentMemberActor(input.teamId, userId);
-      if (!resolved?.id) throw new ApiError(403, "forbidden", "not a member of this team");
-      const createdByMemberId = resolved.id;
+      //
+      // Headless daemons authenticate as an agent actor. RLS allows INSERT via
+      // `workspaces_agent_write` when `agent_id = current agent`; member-only
+      // resolution used to reject every daemon `POST /v1/workspaces`.
+      const { createdByMemberId, agentId } = await this.resolveWorkspaceUpsertAuth(input);
 
       // Dedup key: explicit `id` always wins. Otherwise reuse by (team, path)
       // or by (team, agent, name) — the table's unique constraint is
@@ -1321,8 +1319,8 @@ export function createSupabaseBusinessRepository(options) {
           .select("id, path, archived")
           .eq("team_id", input.teamId)
           .eq("name", resolvedName);
-        byNameQuery = input.agentId
-          ? byNameQuery.eq("agent_id", input.agentId)
+        byNameQuery = agentId
+          ? byNameQuery.eq("agent_id", agentId)
           : byNameQuery.is("agent_id", null);
         const { data: byNameRows, error: nameErr } = await byNameQuery.limit(1);
         if (nameErr) throw nameErr;
@@ -1337,7 +1335,7 @@ export function createSupabaseBusinessRepository(options) {
             resolvedName = await findUniqueWorkspaceName(
               supabase,
               input.teamId,
-              input.agentId,
+              agentId,
               resolvedName,
             );
           }
@@ -1348,7 +1346,7 @@ export function createSupabaseBusinessRepository(options) {
         team_id: input.teamId,
         name: resolvedName,
         path: normalizedPath,
-        agent_id: input.agentId ?? null,
+        agent_id: agentId,
         created_by_member_id: createdByMemberId,
         archived: input.archived ?? false,
       };
@@ -1978,6 +1976,35 @@ export function createSupabaseBusinessRepository(options) {
         .maybeSingle();
       if (error) throw error;
       return data ? { id: data.id } : null;
+    },
+
+    async resolveWorkspaceUpsertAuth(input) {
+      const { data: userData, error: userErr } = await supabase.auth.getUser();
+      if (userErr) throw userErr;
+      const userId = userData?.user?.id;
+      if (!userId) throw new ApiError(401, "unauthorized", "no authenticated user");
+
+      const member = await this.resolveCurrentMemberActor(input.teamId, userId);
+      if (member?.id) {
+        return {
+          createdByMemberId: member.id,
+          agentId: input.agentId ?? null,
+        };
+      }
+
+      const caller = await this.resolveCurrentActor(input.teamId, userId);
+      if (!caller?.id) {
+        throw new ApiError(403, "forbidden", "not a member of this team");
+      }
+      const requestedAgentId = input.agentId ?? null;
+      if (!requestedAgentId || requestedAgentId !== caller.id) {
+        throw new ApiError(
+          403,
+          "forbidden",
+          "agent callers may only register workspaces for their own agent id",
+        );
+      }
+      return { createdByMemberId: null, agentId: caller.id };
     },
 
     async resolveFirstMemberActorForUser(userId) {

--- a/services/fc/test/supabase-repo.test.ts
+++ b/services/fc/test/supabase-repo.test.ts
@@ -2846,6 +2846,44 @@ test("upsertWorkspace returns 403 when the caller is not a member of the team", 
   );
 });
 
+test("upsertWorkspace lets an agent daemon register its own workspace", async () => {
+  const calls: any[] = [];
+  const repo = appsRepo(
+    appsSupabase({
+      calls,
+      actorRow: { id: "agent-1", actor_type: "agent" },
+    }),
+  );
+  const out = await repo.upsertWorkspace({
+    teamId: "team-b",
+    name: "Headless",
+    path: "/tmp/headless",
+    agentId: "agent-1",
+  });
+  const upsert = calls.find((c) => c.table === "workspaces" && c.op === "upsert");
+  assert.equal(upsert?.row.created_by_member_id, null);
+  assert.equal(upsert?.row.agent_id, "agent-1");
+  assert.equal(upsert?.row.team_id, "team-b");
+  assert.equal(out.teamId, "team-b");
+  assert.equal(out.name, "Headless");
+});
+
+test("upsertWorkspace rejects agent callers registering another agent's workspace", async () => {
+  const repo = appsRepo(
+    appsSupabase({ actorRow: { id: "agent-1", actor_type: "agent" } }),
+  );
+  await assert.rejects(
+    () =>
+      repo.upsertWorkspace({
+        teamId: "team-b",
+        name: "Nope",
+        path: "/tmp/x",
+        agentId: "agent-other",
+      }),
+    (err: any) => err?.statusCode === 403,
+  );
+});
+
 test("upsertWorkspace without id reuses existing row by (teamId, path)", async () => {
   // Regression: re-adding an already-synced workspace used to hit
   // workspaces_team_id_agent_id_name_key because upsert only deduped on id.

--- a/services/fc/test/supabase-repo.test.ts
+++ b/services/fc/test/supabase-repo.test.ts
@@ -2884,6 +2884,35 @@ test("upsertWorkspace rejects agent callers registering another agent's workspac
   );
 });
 
+test("upsertWorkspace agent re-register preserves member created_by on existing path", async () => {
+  const calls: any[] = [];
+  const repo = appsRepo(
+    appsSupabase({
+      calls,
+      actorRow: { id: "agent-1", actor_type: "agent" },
+      seed: {
+        workspaces: [{
+          id: "ws-existing",
+          team_id: "team-b",
+          name: "Alpha",
+          path: "/tmp/alpha",
+          agent_id: "agent-1",
+          created_by_member_id: "member-1",
+          archived: false,
+        }],
+      },
+    }),
+  );
+  await repo.upsertWorkspace({
+    teamId: "team-b",
+    name: "Alpha",
+    path: "/tmp/alpha",
+    agentId: "agent-1",
+  });
+  const upsert = calls.find((c) => c.table === "workspaces" && c.op === "upsert");
+  assert.equal(upsert?.row.created_by_member_id, "member-1");
+});
+
 test("upsertWorkspace without id reuses existing row by (teamId, path)", async () => {
   // Regression: re-adding an already-synced workspace used to hit
   // workspaces_team_id_agent_id_name_key because upsert only deduped on id.


### PR DESCRIPTION
## Summary
- Add **Workspaces** menu to `amuxd manage` (list + register via `POST /v1/workspaces`)
- Fix FC `upsertWorkspace` to allow **agent daemon** callers to register their own workspace (RLS `workspaces_agent_write` already permitted this; FC member-only auth blocked it)

## Test plan
- [x] `cargo check -p amuxd`
- [x] `services/fc` supabase-repo tests (140 pass, including new agent upsert cases)
- [ ] Deploy FC + amuxd on headless machine; `amuxd manage` → Register workspace
- [ ] Verify Desktop member workspace registration unchanged


Made with [Cursor](https://cursor.com)