### PR TITLE
fix(channel): unattended full access and WeCom/desktop turn delivery

### DIFF
--- a/apps/daemon/src/channels/core/mod.rs
+++ b/apps/daemon/src/channels/core/mod.rs
@@ -499,6 +499,15 @@ impl Core {
             TurnEnd::Answered
         };
 
+        // Persist the session row as soon as the turn is done. WeCom's finish
+        // frame still waits on the stream ack; parking write_reply behind that
+        // left desktop without a ChatMessage until the bubble caught up.
+        if !produced_nothing {
+            self.writer
+                .write_reply(&session.session_id, &reply, attachments.clone())
+                .await?;
+        }
+
         // The streaming bubble carries the text; files cannot be edited into
         // it, so they go out as their own delivery right after — still one
         // logical reply, and one row in the session.
@@ -506,16 +515,6 @@ impl Core {
             .update(&handle, &outbound.text, Some(end))
             .await
             .map_err(|e| CoreError::Render(e.to_string()))?;
-
-        // Record before the file send. WeCom media goes out on a separate
-        // API that can fail after the text already landed in the chat
-        // (a reload clearing the process-global gateway holder); skipping
-        // write_reply then left the desktop session with no answer.
-        if !produced_nothing {
-            self.writer
-                .write_reply(&session.session_id, &reply, attachments)
-                .await?;
-        }
 
         let file_deliveries = if outbound.attachments.is_empty() {
             0

--- a/apps/daemon/src/channels/manager.rs
+++ b/apps/daemon/src/channels/manager.rs
@@ -523,9 +523,14 @@ impl ChannelManager {
             };
             gw.set_config(cfg).await;
             // One pipeline for every channel; the gateway is left with the
-            // protocol.
-            gw.use_core_pipeline(self.core_sink_for(Arc::new(gw.as_driver())))
-                .await;
+            // protocol. Keep the same Arc the sink holds so MCP sends can
+            // piggyback on an open stream bubble.
+            let driver = Arc::new(gw.as_driver());
+            gw.bind_live_driver(Arc::downgrade(&driver)).await;
+            gw.use_core_pipeline(
+                self.core_sink_for(driver as Arc<dyn teamclu_gateway::driver::ChannelDriver>),
+            )
+            .await;
             match gw.start().await {
                 Ok(()) => {
                     println!("[ChannelManager] wecom bot {} started", bot.bot_id);

--- a/apps/daemon/src/daemon/server/channels.rs
+++ b/apps/daemon/src/daemon/server/channels.rs
@@ -533,7 +533,11 @@ impl DaemonServer {
                     has_file = file_path.is_some(),
                     "mcp-send: routing"
                 );
-                if open {
+                // Files belong on the in-flight reply. Mid-turn *text* is a
+                // progress notice (scrape wait, etc.) and must go out now —
+                // swallowing it left WeCom silent while the tool still said
+                // "Message sent."
+                if mcp_send_parks_file_on_open_turn(open, file_path.is_some()) {
                     return self
                         .attach_to_running_turn(mgr, &session_id, message, file_path, binding)
                         .await;
@@ -581,15 +585,9 @@ impl DaemonServer {
         binding: &str,
     ) -> anyhow::Result<serde_json::Value> {
         let Some(path) = file_path else {
-            // Text-only, to the chat this turn already answers into: the reply
-            // is on its way there, so sending it again would duplicate it.
-            // Reported as handled so the agent does not retry.
-            return Ok(serde_json::json!({
-                "binding": binding,
-                "message_sent": false,
-                "file_sent": false,
-                "note": "text goes back as this turn's reply; `send` is for files, or for a different chat",
-            }));
+            anyhow::bail!(
+                "mcp-send: attach_to_running_turn requires a file — text-only sends go out immediately"
+            );
         };
 
         let bytes = tokio::fs::read(path)
@@ -1082,6 +1080,12 @@ mod gateway_model_tests {
     }
 }
 
+/// Files ride the in-flight reply. Mid-turn text is a progress notice and
+/// must be delivered immediately — see `handle_mcp_send`.
+fn mcp_send_parks_file_on_open_turn(turn_open: bool, has_file: bool) -> bool {
+    turn_open && has_file
+}
+
 /// The chat a `mcp-send` envelope is allowed to reach.
 ///
 /// The token is the whole authorization story, which is why an envelope
@@ -1264,5 +1268,29 @@ mod mcp_send_target_tests {
         // Wrong / missing kind.
         assert!(placeholder_target_reason("room:x").is_some());
         assert!(placeholder_target_reason("bot:botA/").is_some());
+    }
+}
+
+#[cfg(test)]
+mod mcp_send_open_turn_tests {
+    use super::mcp_send_parks_file_on_open_turn;
+
+    #[test]
+    fn text_only_during_an_open_turn_is_not_parked() {
+        assert!(
+            !mcp_send_parks_file_on_open_turn(true, false),
+            "wait notices must dispatch now, not wait for the final reply"
+        );
+    }
+
+    #[test]
+    fn a_file_during_an_open_turn_is_parked_on_the_reply() {
+        assert!(mcp_send_parks_file_on_open_turn(true, true));
+    }
+
+    #[test]
+    fn idle_turn_never_parks() {
+        assert!(!mcp_send_parks_file_on_open_turn(false, true));
+        assert!(!mcp_send_parks_file_on_open_turn(false, false));
     }
 }

--- a/apps/daemon/src/daemon/server/runtime_lifecycle.rs
+++ b/apps/daemon/src/daemon/server/runtime_lifecycle.rs
@@ -598,8 +598,36 @@ impl DaemonServer {
 
         // Refresh-watch suppression remains inside execution-context assembly,
         // after the managed-LLM lookup has completed.
+        //
+        // Channel / cron sessions are unattended: a permission card nobody can
+        // answer hangs the turn. `get_session_binding` returns the live binding
+        // or the durable `gateway_key`, so RuntimeStart from the desktop keeps
+        // the same full-access policy the gateway spawn path already uses
+        // (`is_gateway` ⇒ `PermissionPolicy::Full`).
+        let is_gateway = if session_id.is_empty() {
+            false
+        } else {
+            match self.backend.get_session_binding(session_id).await {
+                Ok(Some(_)) => true,
+                Ok(None) => false,
+                Err(e) => {
+                    warn!(
+                        session_id,
+                        error = %e,
+                        "apply_start_runtime: session binding lookup failed; defaulting to ask"
+                    );
+                    false
+                }
+            }
+        };
         let context = self
-            .assemble_execution_context(&resolved_worktree, None, Some(&ws_id), false, None)
+            .assemble_execution_context(
+                &resolved_worktree,
+                None,
+                Some(&ws_id),
+                is_gateway,
+                None,
+            )
             .await
             .map_err(|e| StartRuntimeError {
                 error_code: "ENV_ASSEMBLE_FAILED".to_string(),

--- a/apps/daemon/src/http/workspaces.rs
+++ b/apps/daemon/src/http/workspaces.rs
@@ -288,7 +288,14 @@ async fn reconcile_team_provider(state: &HttpState) {
     let after = std::fs::read(config_path).ok();
     if before != after {
         if let Some(supervisor) = state.runtime_supervisor.as_ref() {
-            supervisor.request_all_workspace_host_refreshes().await;
+            // A GET must not `kill_all()`. The desktop fetches this list on the
+            // first send after daemon start, racing the in-flight prompt — that
+            // was "pi prompt: process exited before responding". Unattached
+            // (prewarmed) hosts can still be replaced so the next spawn sees
+            // the rewritten `provider.team`.
+            supervisor
+                .request_unattached_workspace_host_refreshes()
+                .await;
         }
     }
 }

--- a/apps/daemon/src/runtime/backend.rs
+++ b/apps/daemon/src/runtime/backend.rs
@@ -178,6 +178,15 @@ pub trait AgentBackend: Send {
 
     fn invalidate_all_workspace_hosts(&mut self) -> usize;
 
+    /// Evict pooled hosts that have no attached session.
+    ///
+    /// Used by `GET /providers` after `provider.team` is rewritten. A full
+    /// `invalidate_all_workspace_hosts` races the first prompt after daemon
+    /// start. Default keeps every host; pi replaces only unattached children.
+    fn invalidate_unattached_workspace_hosts(&mut self) -> usize {
+        0
+    }
+
     /// Permanently retire backend processes and background tasks during daemon exit.
     async fn shutdown_for_exit(&mut self) -> usize;
 

--- a/apps/daemon/src/runtime/manager.rs
+++ b/apps/daemon/src/runtime/manager.rs
@@ -1139,6 +1139,15 @@ impl RuntimeManager {
             .invalidate_all_workspace_hosts()
     }
 
+    /// Refresh idle/prewarmed hosts after a GET-path `provider.team` rewrite.
+    /// Attached sessions (including the attach→prompt window) stay up.
+    pub async fn request_unattached_workspace_host_refreshes(&mut self) -> usize {
+        self.agent_backend
+            .lock()
+            .await
+            .invalidate_unattached_workspace_hosts()
+    }
+
     /// Full local-runtime teardown for daemon exit (`amuxd stop` / SIGTERM).
     /// Stops every session handle, then kills backend host processes
     /// (`opencode serve` process group including MCP children).

--- a/apps/daemon/src/runtime/pi_rpc/mod.rs
+++ b/apps/daemon/src/runtime/pi_rpc/mod.rs
@@ -1597,6 +1597,24 @@ impl AgentBackend for PiRpcBackend {
         self.shared.pool.kill_all()
     }
 
+    fn invalidate_unattached_workspace_hosts(&mut self) -> usize {
+        let attached: std::collections::HashSet<process::PoolKey> = self
+            .shared
+            .routes
+            .lock()
+            .values()
+            .map(|r| r.pool_key.clone())
+            .collect();
+        let killed = self.shared.pool.kill_except(&attached);
+        if killed > 0 {
+            info!(
+                killed,
+                "evicted unattached pi hosts after provider.team reconcile"
+            );
+        }
+        killed
+    }
+
     async fn shutdown_for_exit(&mut self) -> usize {
         self.shared.pool.kill_all()
     }

--- a/apps/daemon/src/runtime/pi_rpc/process.rs
+++ b/apps/daemon/src/runtime/pi_rpc/process.rs
@@ -20,7 +20,7 @@
 //! survives env changes and daemon restarts. Crash recovery is lazy: a dead
 //! child is respawned on the next `ensure()` (attach / prompt).
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Instant;
@@ -240,6 +240,37 @@ impl PiProcessPool {
             .filter(|p| p.is_alive())
             .map(Arc::clone)
             .collect()
+    }
+
+    /// Kill children that have no attached session.
+    ///
+    /// `GET /v1/workspaces/:id/providers` rewrites `provider.team` and used to
+    /// call [`Self::kill_all`]. The desktop fetches that list on the first send
+    /// after daemon start, so the prompt's host died mid-request and the UI
+    /// showed "pi prompt: process exited before responding". Prewarmed hosts
+    /// with no session are idle and can be replaced; anything already in
+    /// `keep` (a live attach, even before `turn_active`) must survive.
+    pub(crate) fn kill_except(&self, keep: &HashSet<PoolKey>) -> usize {
+        let victims: Vec<Arc<PiProcess>> = {
+            let mut procs = self.procs.lock();
+            let keys: Vec<PoolKey> = procs
+                .keys()
+                .filter(|k| !keep.contains(*k))
+                .cloned()
+                .collect();
+            keys.into_iter()
+                .filter_map(|k| procs.remove(&k))
+                .collect()
+        };
+        let mut killed = 0;
+        for p in victims {
+            self.clear_generation_for_process(&p);
+            if p.is_alive() {
+                p.kill();
+                killed += 1;
+            }
+        }
+        killed
     }
 
     /// Kill and drop all children. Returns the number that were alive.
@@ -1016,6 +1047,123 @@ mod tests {
         assert!(
             !in_flight.is_finished(),
             "the session's in-flight command was not killed"
+        );
+
+        in_flight.abort();
+        shared.pool.kill_all();
+    }
+
+    /// GET /providers used to `kill_all()` when `provider.team` bytes changed.
+    /// After daemon start the desktop fetches that list on the first send,
+    /// while a prompt is already on the attached host — and a prewarmed
+    /// neighbour worktree was killed with it. Keep the attached child.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn provider_reconcile_does_not_kill_an_attached_session_child() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let home = tempfile::tempdir().unwrap();
+        let _env = crate::test_brand_env::BrandEnvGuard::set_amuxd_home(home.path());
+
+        let bin_dir = tempfile::tempdir().unwrap();
+        let fake_pi = bin_dir.path().join("fake-pi");
+        std::fs::write(
+            &fake_pi,
+            "#!/bin/sh\necho 'fake-pi startup noise' >&2\ncat > /dev/null\n",
+        )
+        .unwrap();
+        std::fs::set_permissions(&fake_pi, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        let pkg = bin_dir.path().join("pkg");
+        std::fs::create_dir_all(pkg.join("dist")).unwrap();
+        std::fs::write(pkg.join("dist/cli.js"), "").unwrap();
+        let config_path = crate::config::DaemonConfig::default_path();
+        std::fs::create_dir_all(config_path.parent().unwrap()).unwrap();
+        std::fs::write(
+            &config_path,
+            format!(
+                "[actor]\nid = \"d\"\nname = \"m\"\n[mqtt]\nbroker_url = \"tcp://x:1883\"\n\
+                 [agents.pi]\nnode = {:?}\npackage_root = {:?}\nsession_host = \"rpc\"\n",
+                fake_pi.to_string_lossy(),
+                pkg.to_string_lossy()
+            ),
+        )
+        .unwrap();
+
+        let attached_dir = tempfile::tempdir().unwrap();
+        let prewarm_dir = tempfile::tempdir().unwrap();
+        let shared = super::Shared::new();
+        let attached_key = PoolKey {
+            domain: IsolationDomainKey::Workspace("ws-attached".into()),
+            env_revision: ProcessEnvRevision::from_bindings(&HashMap::new()),
+            worktree: attached_dir.path().to_string_lossy().into_owned(),
+        };
+        let prewarm_key = PoolKey {
+            domain: IsolationDomainKey::Workspace("ws-prewarm".into()),
+            env_revision: ProcessEnvRevision::from_bindings(&HashMap::new()),
+            worktree: prewarm_dir.path().to_string_lossy().into_owned(),
+        };
+
+        let attached = shared
+            .pool
+            .ensure_with_env(&shared, &attached_key, SpawnEnv::default())
+            .expect("attached spawn");
+        let prewarmed = shared
+            .pool
+            .ensure_with_env(&shared, &prewarm_key, SpawnEnv::default())
+            .expect("prewarm spawn");
+        assert!(attached.is_alive());
+        assert!(prewarmed.is_alive());
+
+        let client = attached.client.clone();
+        let in_flight = tokio::spawn(async move {
+            client.request(serde_json::json!({"type": "prompt"})).await
+        });
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(20);
+        while attached.stderr_tail().is_empty() && std::time::Instant::now() < deadline {
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        }
+
+        let (tx, _rx) = tokio::sync::mpsc::channel(16);
+        shared.routes.lock().insert(
+            "pi:/s.jsonl".into(),
+            super::Route {
+                event_tx: tx,
+                permission: crate::runtime::permission_policy::PermissionPolicy::Ask,
+                pool_key: attached_key.clone(),
+                session_path: "/s.jsonl".into(),
+                turn_active: false,
+                turn_reply_to: None,
+                turn_requester: None,
+                translate: super::translate::TranslateState::default(),
+                last_entry_id: None,
+            },
+        );
+
+        let keep: HashSet<PoolKey> = shared
+            .routes
+            .lock()
+            .values()
+            .map(|r| r.pool_key.clone())
+            .collect();
+        let killed = shared.pool.kill_except(&keep);
+        assert_eq!(killed, 1, "only the unattached prewarm host is replaced");
+        assert!(
+            attached.is_alive(),
+            "the session's child must survive a provider-list reconcile"
+        );
+        let dead_by = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        while prewarmed.is_alive() && std::time::Instant::now() < dead_by {
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        }
+        assert!(
+            !prewarmed.is_alive(),
+            "a host with no session is idle and can be replaced"
+        );
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+        assert!(
+            !in_flight.is_finished(),
+            "the in-flight prompt must not see process-exited"
         );
 
         in_flight.abort();

--- a/apps/daemon/src/runtime/supervisor.rs
+++ b/apps/daemon/src/runtime/supervisor.rs
@@ -978,6 +978,11 @@ impl RuntimeSupervisor {
         agents.request_all_workspace_host_refreshes().await
     }
 
+    pub async fn request_unattached_workspace_host_refreshes(&self) -> usize {
+        let mut agents = self.agents.lock().await;
+        agents.request_unattached_workspace_host_refreshes().await
+    }
+
     /// Install the channel that receives `(workspace_id, path)` whenever a
     /// reload evicted the pooled provider hosts (see `prewarm_notify`).
     pub fn set_prewarm_notifier(&self, tx: tokio::sync::mpsc::Sender<(String, String)>) {

--- a/apps/desktop/crates/teamclu-introspect/src/send.rs
+++ b/apps/desktop/crates/teamclu-introspect/src/send.rs
@@ -40,7 +40,7 @@ pub async fn handle(
                 .map(str::to_string),
         )
         .await
-        .map(|_| json!({ "content": [{ "type": "text", "text": "Message sent." }] }));
+        .map(|v| tool_result_from_daemon_send(&v));
     }
 
     let channel = arguments
@@ -571,6 +571,27 @@ async fn send_wecom(
     }))
 }
 
+/// Map amuxd's `{ ok, result }` into the MCP tool payload.
+///
+/// The daemon used to swallow mid-turn text (`message_sent: false`) while this
+/// wrapper still told the model "Message sent." — so scrape wait notices never
+/// reached WeCom and the agent did not retry.
+fn tool_result_from_daemon_send(v: &Value) -> Value {
+    let result = v.get("result").unwrap_or(v);
+    let sent = result.get("message_sent").and_then(|x| x.as_bool());
+    let note = result
+        .get("note")
+        .and_then(|x| x.as_str())
+        .unwrap_or("")
+        .trim();
+    let text = match sent {
+        Some(false) if !note.is_empty() => note.to_string(),
+        Some(false) => "Message was not delivered to the chat.".to_string(),
+        _ => "Message sent.".to_string(),
+    };
+    json!({ "content": [{ "type": "text", "text": text }] })
+}
+
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
 /// Split `text` into chunks of at most `max_len` bytes, preferring newline
@@ -611,4 +632,44 @@ pub fn split_message(text: &str, max_len: usize) -> Vec<String> {
     }
 
     chunks
+}
+
+#[cfg(test)]
+mod daemon_send_result_tests {
+    use super::tool_result_from_daemon_send;
+    use serde_json::json;
+
+    fn text_of(v: &serde_json::Value) -> &str {
+        v["content"][0]["text"].as_str().unwrap()
+    }
+
+    #[test]
+    fn a_delivered_send_still_reads_as_message_sent() {
+        let reply = json!({ "ok": true, "result": { "message_sent": true } });
+        assert_eq!(text_of(&tool_result_from_daemon_send(&reply)), "Message sent.");
+    }
+
+    #[test]
+    fn a_swallowed_send_surfaces_the_daemon_note() {
+        let reply = json!({
+            "ok": true,
+            "result": {
+                "message_sent": false,
+                "note": "text goes back as this turn's reply"
+            }
+        });
+        assert_eq!(
+            text_of(&tool_result_from_daemon_send(&reply)),
+            "text goes back as this turn's reply"
+        );
+    }
+
+    #[test]
+    fn a_failed_delivery_without_a_note_is_not_reported_as_sent() {
+        let reply = json!({ "ok": true, "result": { "message_sent": false } });
+        assert_eq!(
+            text_of(&tool_result_from_daemon_send(&reply)),
+            "Message was not delivered to the chat."
+        );
+    }
 }

--- a/crates/teamclu-gateway/src/wecom.rs
+++ b/crates/teamclu-gateway/src/wecom.rs
@@ -10,8 +10,7 @@ use futures_util::stream::SplitSink;
 #[allow(unused_imports)]
 use futures_util::StreamExt;
 use serde::Deserialize;
-use std::sync::Arc;
-use std::sync::OnceLock;
+use std::sync::{Arc, OnceLock, Weak};
 use std::time::{Duration, Instant};
 use tokio::sync::{mpsc, oneshot, RwLock};
 
@@ -617,6 +616,11 @@ pub struct WeComGateway {
     /// the next successful subscribe. Process crash is not covered — the
     /// session already has the reply.
     outbox: WeComOutbox,
+    /// The core-pipeline driver that owns in-flight stream pacers. MCP
+    /// `send_to_user` has no `reply_context`, so it cannot `deliver()`; it
+    /// upgrades this weak ref to piggyback onto an open stream instead of
+    /// firing `aibot_send_msg` that WeCom drops while the bubble is live.
+    live_driver: Arc<RwLock<Weak<WeComDriver>>>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -1157,7 +1161,7 @@ impl driver::ChannelDriver for WeComDriver {
         let pacer = StreamPacer::new(req_id, &stream_id, &sink, self.gateway.clone(), min_gap);
         pacer
             .send(
-                &progress_frame_with_notice(Duration::ZERO, None, None),
+                &progress_frame_with_notice(Duration::ZERO, None),
                 false,
             )
             .await
@@ -1180,11 +1184,11 @@ impl driver::ChannelDriver for WeComDriver {
 
     /// Progress while the turn runs; the answer itself at the end.
     ///
-    /// The intermediate text is deliberately NOT streamed. `stream` carries
-    /// plain text, so a markdown answer would arrive with its fences, tables
-    /// and lists as literal characters, and every frame spends one of the 30
-    /// messages a minute this conversation is allowed. A progress line costs
-    /// the same per frame but does not need to be complete or pretty.
+    /// Intermediate agent text is not written into the stream card — only the
+    /// elapsed timer (and an optional queue notice). `stream` is plain text, so
+    /// a markdown draft would show fences and tables as literals, and every
+    /// frame spends one of the 30 messages a minute this conversation is
+    /// allowed. The finish frame / follow-up markdown carries the real answer.
     ///
     /// Past `stream_max_secs` this driver closes the bubble itself and later
     /// `update(..., Some(end))` pushes markdown on a new req_id. Core keeps
@@ -1229,8 +1233,7 @@ impl driver::ChannelDriver for WeComDriver {
             match decide_progress(phase, Instant::now() >= snapshot.deadline) {
                 ProgressDecision::Swallow => return Ok(()),
                 ProgressDecision::SendProgress => {
-                    let line = newest_line(text);
-                    let frame = progress_frame_with_notice(elapsed, line.as_deref(), notice);
+                    let frame = progress_frame_with_notice(elapsed, notice);
                     if let Err(e) = snapshot.pacer.send(&frame, false).await {
                         // A missed progress ack must not abort the turn.
                         eprintln!("[WeCom] progress frame failed: {e}");
@@ -1308,7 +1311,7 @@ impl WeComDriver {
     /// If this chat still has an open stream, rewrite the queue notice into
     /// the progress bubble and remember it for later frames. Returns whether
     /// the notice was piggybacked (so the caller must not also send markdown).
-    async fn piggyback_notice(
+    pub(crate) async fn piggyback_notice(
         &self,
         chatid: &str,
         text: &str,
@@ -1325,7 +1328,7 @@ impl WeComDriver {
         let elapsed = inflight.opened_at.elapsed();
         let notice = inflight.pending_notice.clone();
         drop(pacers);
-        let frame = progress_frame_with_notice(elapsed, None, notice.as_deref());
+        let frame = progress_frame_with_notice(elapsed, notice.as_deref());
         if let Err(e) = pacer.send(&frame, false).await {
             eprintln!("[WeCom] queue notice piggyback failed: {e}");
         }
@@ -1394,35 +1397,6 @@ fn truncate_wecom_content(text: &str) -> String {
         end -= 1;
     }
     text[..end].to_string()
-}
-
-/// How much of the newest line rides along in the progress frame.
-const PROGRESS_LINE_CHARS: usize = 40;
-
-/// The tail of what the agent has written so far, for the progress bubble.
-///
-/// The turn reports **cumulative** text, so "newest" means the last non-empty
-/// line. Fence markers and heading hashes are dropped: `stream` is plain text,
-/// so they would show up as literal characters in the one place we cannot
-/// render them.
-///
-/// Truncation counts characters, not bytes — a byte slice through a Chinese
-/// reply panics, and this runs on every frame of every turn.
-fn newest_line(text: &str) -> Option<String> {
-    let line = text
-        .lines()
-        .rev()
-        .map(str::trim)
-        .find(|l| !l.is_empty() && !l.starts_with("```"))?;
-    let line = line.trim_start_matches(['#', '*', '-', '>', ' ']);
-    if line.is_empty() {
-        return None;
-    }
-    let mut out: String = line.chars().take(PROGRESS_LINE_CHARS).collect();
-    if line.chars().count() > PROGRESS_LINE_CHARS {
-        out.push('…');
-    }
-    Some(out)
 }
 
 /// WeCom's media API takes its own type word, not a mime.
@@ -1529,7 +1503,15 @@ impl WeComGateway {
             inbound_sink: Arc::new(RwLock::new(None)),
             pending_responses: Arc::new(tokio::sync::Mutex::new(std::collections::HashMap::new())),
             outbox: WeComOutbox::new(),
+            live_driver: Arc::new(RwLock::new(Weak::new())),
         }
+    }
+
+    /// Remember the driver the core pipeline is using so proactive MCP sends
+    /// can piggyback on its open stream. Pass a downgrade of the same `Arc`
+    /// handed to `use_core_pipeline`.
+    pub async fn bind_live_driver(&self, driver: Weak<WeComDriver>) {
+        *self.live_driver.write().await = driver;
     }
 
     pub async fn set_config(&self, config: WeComConfig) {
@@ -2210,6 +2192,18 @@ impl WeComGateway {
         chat_type: u32,
         text: &str,
     ) -> Result<(), String> {
+        if !text.trim().is_empty() {
+            let driver = self.live_driver.read().await.upgrade();
+            if let Some(driver) = driver {
+                match driver.piggyback_notice(chatid, text).await {
+                    Ok(true) => return Ok(()),
+                    Ok(false) => {}
+                    Err(e) => {
+                        eprintln!("[WeCom] mid-turn piggyback failed: {e}");
+                    }
+                }
+            }
+        }
         match self
             .send_chat_message_attempt(chatid, chat_type, text)
             .await
@@ -3071,33 +3065,6 @@ mod progress_line_tests {
     use super::*;
 
     #[test]
-    fn the_progress_line_is_the_newest_line_not_the_first() {
-        // The turn reports cumulative text; the reader wants to see where the
-        // agent is now, not where it started.
-        let text = "第一行\n第二行\n第三行";
-        assert_eq!(newest_line(text).unwrap(), "第三行");
-    }
-
-    #[test]
-    fn a_long_line_is_truncated_by_characters_not_bytes() {
-        // Slicing bytes through a Chinese reply panics, and this runs on every
-        // frame of every turn.
-        let line = "中".repeat(100);
-        let out = newest_line(&line).unwrap();
-        assert_eq!(out.chars().count(), PROGRESS_LINE_CHARS + 1, "40 chars + …");
-        assert!(out.ends_with('…'));
-    }
-
-    #[test]
-    fn fence_and_heading_markers_do_not_leak_into_the_bubble() {
-        // `stream` is plain text, so markdown syntax shows up as characters in
-        // exactly the place it cannot be rendered.
-        assert_eq!(newest_line("答案\n```python").unwrap(), "答案");
-        assert_eq!(newest_line("## 标题").unwrap(), "标题");
-        assert_eq!(newest_line("- 列表项").unwrap(), "列表项");
-    }
-
-    #[test]
     fn a_stopped_turn_and_a_finished_one_close_differently() {
         // WeCom cannot delete this bubble, so whatever it says is what the
         // chat keeps. "Done" above a turn the user cancelled is a lie it keeps
@@ -3150,13 +3117,6 @@ mod progress_line_tests {
         assert!(closing.len() <= WECOM_CONTENT_MAX_BYTES);
         assert!(closing.is_char_boundary(closing.len()));
         assert!(!closing.is_empty());
-    }
-
-    #[test]
-    fn text_with_nothing_showable_falls_back_to_no_line() {
-        assert!(newest_line("").is_none());
-        assert!(newest_line("   \n\n  ").is_none());
-        assert!(newest_line("###").is_none());
     }
 }
 

--- a/crates/teamclu-gateway/src/wecom.rs
+++ b/crates/teamclu-gateway/src/wecom.rs
@@ -1,8 +1,9 @@
 use crate::i18n;
 use crate::wecom_config::{WeComConfig, WeComGatewayStatus, WeComGatewayStatusResponse};
 use crate::wecom_delivery::{
-    self, decide_finish, decide_progress, progress_frame_with_notice, should_requeue,
-    still_running_close_with_notice, FinishDecision, ProgressDecision, SendError, StreamPhase,
+    self, decide_finish, decide_progress, progress_frame_with_notice, progress_rewrite_due,
+    should_requeue, still_running_close_with_notice, FinishDecision, ProgressDecision, SendError,
+    StreamPhase,
 };
 use crate::wecom_outbox::{PendingSend, WeComOutbox};
 use base64::Engine as _;
@@ -521,13 +522,11 @@ const STREAM_FRAME_MIN_GAP: Duration =
 ///
 /// Every frame of a turn rewrites the *same* bubble, and WeCom applies those
 /// rewrites under optimistic concurrency: two landing close together come back
-/// as errcode 6000 (数据版本冲突, "possible simultaneous modification by
-/// multiple callers, retry later") and the losing rewrite is dropped. The agent
-/// side sends an update the moment a segment flushes — deliberately, so text
-/// appears promptly — which on a long answer means several frames within
-/// milliseconds. Spacing them here keeps that behaviour for every other channel
-/// while staying inside what WeCom will accept. Each frame waits for the WS
-/// ack so a 6000 is retried instead of silently dropped.
+/// as errcode 6000 (数据版本冲突) and the losing rewrite is dropped. Progress
+/// frames that arrive inside `min_gap` are **dropped**, not slept — sleeping
+/// serialized leftover progress after the turn had already finished, so WeCom
+/// kept ticking and desktop `write_reply` waited on it. Finish and wait-notice
+/// frames send immediately; a 6000 is retried in `send_stream_chunk_acked`.
 #[derive(Clone)]
 struct StreamPacer {
     req_id: String,
@@ -556,15 +555,28 @@ impl StreamPacer {
         }
     }
 
-    /// Send one frame, waiting out the remainder of the gap since the previous
-    /// one. The lock is deliberately held across the wait: it is what serializes
-    /// the progressive-update task against the terminal frame.
+    /// Send one frame. Progress inside `min_gap` is skipped; finish always
+    /// sends. The lock serializes progress against the terminal frame.
     async fn send(&self, content: &str, finish: bool) -> Result<(), SendError> {
+        self.send_impl(content, finish, finish).await
+    }
+
+    /// Wait-notice / queue rewrite: send now even inside the progress gap.
+    async fn send_now(&self, content: &str) -> Result<(), SendError> {
+        self.send_impl(content, false, true).await
+    }
+
+    async fn send_impl(
+        &self,
+        content: &str,
+        finish: bool,
+        must_send: bool,
+    ) -> Result<(), SendError> {
         let mut last = self.last_frame_at.lock().await;
-        if let Some(prev) = *last {
-            let since = prev.elapsed();
-            if since < self.min_gap {
-                tokio::time::sleep(self.min_gap - since).await;
+        if !must_send {
+            let since = (*last).map(|prev| prev.elapsed());
+            if !progress_rewrite_due(since, self.min_gap) {
+                return Ok(());
             }
         }
         let timeout = if finish {
@@ -1329,7 +1341,7 @@ impl WeComDriver {
         let notice = inflight.pending_notice.clone();
         drop(pacers);
         let frame = progress_frame_with_notice(elapsed, notice.as_deref());
-        if let Err(e) = pacer.send(&frame, false).await {
+        if let Err(e) = pacer.send_now(&frame).await {
             eprintln!("[WeCom] queue notice piggyback failed: {e}");
         }
         Ok(true)

--- a/crates/teamclu-gateway/src/wecom_delivery.rs
+++ b/crates/teamclu-gateway/src/wecom_delivery.rs
@@ -169,23 +169,16 @@ pub fn format_elapsed(d: Duration) -> String {
     }
 }
 
-/// Progress bubble: elapsed time plus the newest agent line.
-pub fn progress_frame(elapsed: Duration, line: Option<&str>) -> String {
-    let head = format!("{PROGRESS_HEAD} · {}", format_elapsed(elapsed));
-    match line {
-        Some(l) if !l.is_empty() => format!("{head}\n{l}"),
-        _ => head,
-    }
+/// Progress bubble: elapsed time only. Intermediate agent text stays off the
+/// stream card; the answer is the finish frame / follow-up markdown.
+pub fn progress_frame(elapsed: Duration) -> String {
+    format!("{PROGRESS_HEAD} · {}", format_elapsed(elapsed))
 }
 
 /// Append a queue notice so it is visible while the stream bubble is the only
 /// thing WeCom will reliably rewrite.
-pub fn progress_frame_with_notice(
-    elapsed: Duration,
-    line: Option<&str>,
-    notice: Option<&str>,
-) -> String {
-    let base = progress_frame(elapsed, line);
+pub fn progress_frame_with_notice(elapsed: Duration, notice: Option<&str>) -> String {
+    let base = progress_frame(elapsed);
     match notice {
         Some(n) if !n.trim().is_empty() => format!("{base}\n\n{n}"),
         _ => base,
@@ -379,22 +372,18 @@ mod tests {
     }
 
     #[test]
-    fn progress_frame_carries_elapsed_and_newest_line() {
-        let frame = progress_frame(Duration::from_secs(192), Some("正在查询订单数据…"));
-        assert!(frame.starts_with("💭 执行中 · 3分12秒"));
-        assert!(frame.contains("正在查询订单数据…"));
+    fn progress_frame_is_elapsed_only() {
+        let frame = progress_frame(Duration::from_secs(192));
+        assert_eq!(frame, "💭 执行中 · 3分12秒");
     }
 
     #[test]
     fn progress_notice_is_appended_not_inline() {
-        let frame = progress_frame_with_notice(
-            Duration::from_secs(5),
-            Some("工具中"),
-            Some("上一条还在处理"),
-        );
-        assert!(frame.contains("工具中"));
+        let frame = progress_frame_with_notice(Duration::from_secs(5), Some("上一条还在处理"));
+        assert!(frame.starts_with("💭 执行中 · 5秒"));
         assert!(frame.contains("上一条还在处理"));
         assert!(frame.contains("\n\n"));
+        assert!(!frame.contains("工具中"));
     }
 
     #[test]

--- a/crates/teamclu-gateway/src/wecom_delivery.rs
+++ b/crates/teamclu-gateway/src/wecom_delivery.rs
@@ -112,6 +112,17 @@ pub fn decide_finish(phase: StreamPhase) -> FinishDecision {
     }
 }
 
+/// Whether a *progress* rewrite should go out, given time since the last
+/// stream frame. Extra progress is dropped, not delayed — sleeping the gap
+/// stalled the finish frame (and `write_reply`) after the turn was already
+/// done. Finish / wait-notice frames always send.
+pub fn progress_rewrite_due(since_last: Option<Duration>, min_gap: Duration) -> bool {
+    match since_last {
+        None => true,
+        Some(elapsed) => elapsed >= min_gap,
+    }
+}
+
 /// Pull errcode/errmsg from either the top level or `body` (WeCom uses both).
 pub fn errcode_and_msg(v: &Value) -> (i64, String) {
     let code = v
@@ -391,6 +402,14 @@ mod tests {
         let text = still_running_close_text(Duration::from_secs(240));
         assert!(text.contains("4 分钟"));
         assert!(text.contains("完成后将单独推送结果"));
+    }
+
+    #[test]
+    fn extra_progress_is_dropped_when_the_gap_has_not_elapsed() {
+        let gap = Duration::from_secs(10);
+        assert!(progress_rewrite_due(None, gap));
+        assert!(progress_rewrite_due(Some(Duration::from_secs(10)), gap));
+        assert!(!progress_rewrite_due(Some(Duration::from_millis(9999)), gap));
     }
 
     #[test]

--- a/packages/app/src/components/MqttLiveWiring.tsx
+++ b/packages/app/src/components/MqttLiveWiring.tsx
@@ -165,6 +165,8 @@ export function MqttLiveWiring({ userId, teamId, onMyActorId }: MqttLiveWiringPr
     const streamKey = agentStreamKey(sessionId, actorId);
     clearTerminalAwaitTimeout(streamKey);
     // MQTT QoS0 / stalled daemon must not leave the live dock spinning forever.
+    // Gateway WeCom `write_reply` is after the stream finish-ack (up to 15s),
+    // so this has to outlast that wait or the dock closes before the bubble.
     terminalAwaitTimeoutRef.current[streamKey] = setTimeout(() => {
       delete terminalAwaitTimeoutRef.current[streamKey];
       if (!terminalFlushPendingRef.current[streamKey]) return;
@@ -183,16 +185,15 @@ export function MqttLiveWiring({ userId, teamId, onMyActorId }: MqttLiveWiringPr
         clearTerminalFlushPending(streamKey);
         return;
       }
-      // No daemon reply arrived — release the live dock; stream parts stay in
-      // archive via finishSessionActor so Process cards are not lost.
-      clearTerminalFlushPending(streamKey);
+      // Keep terminalFlushPending: a late write_reply must still flush. Closing
+      // the dock here used to drop that flag and the ChatMessage never landed.
       useV2StreamingStore.getState().finishSessionActor(sessionId, actorId, {
         reason: "statusChange.terminal.timeout",
       });
       useV2StreamingStore
         .getState()
         .clearInterruptedFlushPending(sessionId, actorId);
-    }, 8_000);
+    }, 20_000);
   }
 
   const flushTurnAgentReplyInFlightRef = useRef<Record<string, boolean>>({});
@@ -456,6 +457,12 @@ export function MqttLiveWiring({ userId, teamId, onMyActorId }: MqttLiveWiringPr
     });
     for (const { sessionId, actorId, reason } of stale) {
       const streamKey = agentStreamKey(sessionId, actorId);
+      if (terminalFlushPendingRef.current[streamKey]) {
+        // ACP Idle already armed the daemon write_reply wait. Gateway turns
+        // persist that row after the channel finish-ack; stealing the dock
+        // here dropped the ChatMessage.
+        continue;
+      }
       const flushed = flushTurnAgentReply(sessionId, actorId, trigger);
       logInterruptMsgDiag(trigger, {
         sessionId,

--- a/packages/app/src/components/mqtt-live-wiring/__tests__/handle-live-message.test.ts
+++ b/packages/app/src/components/mqtt-live-wiring/__tests__/handle-live-message.test.ts
@@ -1,0 +1,125 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { create } from "@bufbuild/protobuf";
+import { handleLiveMessage } from "../handle-live-message";
+import type { LiveWiringContext } from "../context";
+import {
+  LiveEventEnvelopeSchema,
+  MessageKind,
+  MessageSchema,
+} from "@/lib/proto/teamclu_pb";
+import {
+  flushPendingSessionRevisionsForTests,
+  useV2StreamingStore,
+} from "@/stores/v2-streaming-store";
+import { useSessionMessageStore } from "@/stores/session-message-store";
+
+vi.mock("@/lib/cache/local-cache", () => ({
+  upsertMessagesBatch: vi.fn().mockResolvedValue(undefined),
+}));
+
+const SESSION_ID = "sess-wecom";
+const ACTOR_ID = "actor-1";
+const STREAM_KEY = `${SESSION_ID}::${ACTOR_ID}`;
+
+function resetStores() {
+  flushPendingSessionRevisionsForTests();
+  useV2StreamingStore.setState({
+    byKey: {},
+    archived: [],
+    persistedPlansBySession: {},
+    interruptedFlushPending: {},
+    revisionBySession: {},
+  });
+  useSessionMessageStore.setState({ messages: {} });
+}
+
+function mockCtx(overrides: Partial<LiveWiringContext> = {}): LiveWiringContext {
+  const flushTurnAgentReply = vi.fn().mockReturnValue(true);
+  return {
+    pendingStreamRepliesRef: { current: {} },
+    terminalFlushPendingRef: { current: {} },
+    followUpActiveRef: { current: {} },
+    clearTerminalFlushPending: vi.fn(),
+    clearFollowUpActive: vi.fn(),
+    flushTurnAgentReply,
+    scheduleTerminalDaemonReplyTimeout: vi.fn(),
+    removeInterruptedStreamPlaceholderForRealReply: vi.fn(),
+    ...overrides,
+  };
+}
+
+function agentReplyEvent(content: string) {
+  const message = create(MessageSchema, {
+    messageId: "reply-1",
+    sessionId: SESSION_ID,
+    senderActorId: ACTOR_ID,
+    kind: MessageKind.AGENT_REPLY,
+    content,
+    turnId: "turn-1",
+  });
+  return {
+    envelope: create(LiveEventEnvelopeSchema, {
+      eventId: "evt-1",
+      eventType: "message.created",
+      sessionId: SESSION_ID,
+      actorId: ACTOR_ID,
+    }),
+    message,
+  };
+}
+
+describe("handleLiveMessage parked AGENT_REPLY", () => {
+  beforeEach(() => {
+    resetStores();
+  });
+
+  it("parks a mid-turn AGENT_REPLY while the live stream is still active", () => {
+    const store = useV2StreamingStore.getState();
+    store.appendThinking(SESSION_ID, ACTOR_ID, "先想一下");
+    store.appendOutput(SESSION_ID, ACTOR_ID, "还没说完");
+
+    const ctx = mockCtx();
+    handleLiveMessage(ctx, agentReplyEvent("还没说完"), SESSION_ID);
+
+    expect(ctx.flushTurnAgentReply).not.toHaveBeenCalled();
+    expect(ctx.pendingStreamRepliesRef.current[STREAM_KEY]).toHaveLength(1);
+    expect(useSessionMessageStore.getState().messages[SESSION_ID]).toBeUndefined();
+  });
+
+  it("flushes write_reply after Idle timeout closed the dock (stream inactive, terminalPending cleared)", () => {
+    const store = useV2StreamingStore.getState();
+    store.appendThinking(SESSION_ID, ACTOR_ID, "先刷新再回答");
+    store.appendOutput(SESSION_ID, ACTOR_ID, "今天的情况是…");
+    store.finishSessionActor(SESSION_ID, ACTOR_ID, {
+      reason: "statusChange.terminal.timeout",
+    });
+    expect(useV2StreamingStore.getState().byKey[STREAM_KEY]?.active).toBe(false);
+
+    const ctx = mockCtx();
+    handleLiveMessage(ctx, agentReplyEvent("今天的情况是…"), SESSION_ID);
+
+    expect(ctx.flushTurnAgentReply).toHaveBeenCalledWith(
+      SESSION_ID,
+      ACTOR_ID,
+      "mqtt.message.created.streamInactive",
+    );
+    expect(ctx.pendingStreamRepliesRef.current[STREAM_KEY]).toHaveLength(1);
+  });
+
+  it("still flushes when terminal Idle is waiting for daemon write_reply", () => {
+    const store = useV2StreamingStore.getState();
+    store.appendThinking(SESSION_ID, ACTOR_ID, "思考");
+    store.appendOutput(SESSION_ID, ACTOR_ID, "答案");
+
+    const ctx = mockCtx({
+      terminalFlushPendingRef: { current: { [STREAM_KEY]: true } },
+    });
+    handleLiveMessage(ctx, agentReplyEvent("答案"), SESSION_ID);
+
+    expect(ctx.flushTurnAgentReply).toHaveBeenCalledWith(
+      SESSION_ID,
+      ACTOR_ID,
+      "mqtt.message.created.terminalPending",
+    );
+  });
+});

--- a/packages/app/src/components/mqtt-live-wiring/handle-live-message.ts
+++ b/packages/app/src/components/mqtt-live-wiring/handle-live-message.ts
@@ -2,7 +2,7 @@ import {
   scheduleSessionListRefresh,
 } from "@/lib/messages/inbox-handler";
 import { MessageKind} from "@/lib/proto/teamclu_pb";
-import { agentStreamKey, isToolOnlyTurnAnchor} from "@/lib/stream/live-agent-stream";
+import { agentStreamKey, isToolOnlyTurnAnchor, shouldFlushParkedAgentReply } from "@/lib/stream/live-agent-stream";
 import { flushAllStreamDeltas } from "@/lib/stream/stream-delta-buffer";
 import { bumpSessionListLastMessage, messageKindUpdatesSessionPreview } from "@/lib/session/session-list-preview";
 import { resolveStreamEntryForPersist} from "@/lib/stream/streaming-persist";
@@ -82,8 +82,12 @@ export function handleLiveMessage(
                 nextPendingReplies,
                 resolvedStreamEntry,
               );
-              const shouldFlush =
-                terminalPending || toolOnlyAnchor;
+              const streamInactive = !streamEntry.active;
+              const shouldFlush = shouldFlushParkedAgentReply({
+                terminalPending,
+                toolOnlyAnchor,
+                streamActive: streamEntry.active,
+              });
               logInterruptMsgDiag("mqtt.agentReply.parked", {
                 sessionId: sid,
                 actorId: senderActorId,
@@ -92,6 +96,7 @@ export function handleLiveMessage(
                 contentLength: (msg.content ?? "").trim().length,
                 terminalPending,
                 toolOnlyAnchor,
+                streamInactive,
                 shouldFlush,
                 ...summarizeFlushDecision({
                   pending: nextPendingReplies,
@@ -105,9 +110,11 @@ export function handleLiveMessage(
                   senderActorId,
                   terminalPending
                     ? "mqtt.message.created.terminalPending"
-                    : "mqtt.message.created.toolOnlyAnchor",
+                    : toolOnlyAnchor
+                      ? "mqtt.message.created.toolOnlyAnchor"
+                      : "mqtt.message.created.streamInactive",
                 );
-                if (flushed && terminalPending) {
+                if (flushed && (terminalPending || streamInactive)) {
                   clearTerminalFlushPending(streamKey);
                 }
               }

--- a/packages/app/src/lib/session/__tests__/session-permission-mode.test.ts
+++ b/packages/app/src/lib/session/__tests__/session-permission-mode.test.ts
@@ -21,8 +21,21 @@ Object.defineProperty(globalThis, "localStorage", {
   writable: true,
 });
 
+const listRows: { id: string; source?: string | null }[] = [];
+
+vi.mock("@/stores/session-list-store", () => ({
+  useSessionListStore: Object.assign(
+    (selector: (s: { rows: typeof listRows }) => unknown) =>
+      selector({ rows: listRows }),
+    {
+      getState: () => ({ rows: listRows }),
+    },
+  ),
+}));
+
 import {
   getSessionPermissionMode,
+  isUnattendedSessionSource,
   resetSessionPermissionModesForTests,
   setSessionPermissionMode,
   shouldAutoAllowSessionPermissions,
@@ -33,12 +46,27 @@ describe("session-permission-mode", () => {
   beforeEach(() => {
     mockLocalStorage.clear();
     vi.clearAllMocks();
+    listRows.length = 0;
     resetSessionPermissionModesForTests();
   });
 
   it("defaults to default for unknown session", () => {
     expect(getSessionPermissionMode("sess-1")).toBe("default");
     expect(shouldAutoAllowSessionPermissions("sess-1")).toBe(false);
+  });
+
+  it("defaults gateway and cron sessions to fullAccess", () => {
+    expect(isUnattendedSessionSource("gateway")).toBe(true);
+    expect(isUnattendedSessionSource("cron")).toBe(true);
+    expect(isUnattendedSessionSource("user")).toBe(false);
+
+    expect(getSessionPermissionMode("gw-1", "gateway")).toBe("fullAccess");
+    expect(getSessionPermissionMode("cron-1", "cron")).toBe("fullAccess");
+    expect(shouldAutoAllowSessionPermissions("gw-1")).toBe(false);
+
+    listRows.push({ id: "gw-1", source: "gateway" });
+    expect(getSessionPermissionMode("gw-1")).toBe("fullAccess");
+    expect(shouldAutoAllowSessionPermissions("gw-1")).toBe(true);
   });
 
   it("persists fullAccess per session", () => {
@@ -57,6 +85,18 @@ describe("session-permission-mode", () => {
     expect(mockLocalStorage.setItem).toHaveBeenCalled();
     const last = mockLocalStorage.setItem.mock.calls.at(-1)?.[1] as string;
     expect(last).not.toContain("sess-a");
+  });
+
+  it("keeps explicit default on a gateway session", () => {
+    listRows.push({ id: "gw-1", source: "gateway" });
+    expect(getSessionPermissionMode("gw-1")).toBe("fullAccess");
+
+    setSessionPermissionMode("gw-1", "default");
+    expect(getSessionPermissionMode("gw-1")).toBe("default");
+    expect(shouldAutoAllowSessionPermissions("gw-1")).toBe(false);
+
+    setSessionPermissionMode("gw-1", "fullAccess");
+    expect(getSessionPermissionMode("gw-1")).toBe("fullAccess");
   });
 
   it("LRU evicts oldest when exceeding 200 fullAccess sessions", () => {

--- a/packages/app/src/lib/session/session-permission-mode.ts
+++ b/packages/app/src/lib/session/session-permission-mode.ts
@@ -1,5 +1,6 @@
 import { useSyncExternalStore } from "react";
 import { appStoragePrefix } from "@/lib/config/build-config";
+import { useSessionListStore } from "@/stores/session-list-store";
 
 export type SessionPermissionMode = "default" | "fullAccess";
 
@@ -7,20 +8,36 @@ const STORAGE_KEY = `${appStoragePrefix}-session-permission-modes`;
 const CHANGE_EVENT = `${appStoragePrefix}-session-permission-modes-changed`;
 const MAX_ENTRIES = 200;
 
+/**
+ * Unattended origins have nobody to answer permission cards. Channel
+ * (gateway) and cron sessions therefore default to full access — same policy
+ * the daemon applies via `PermissionPolicy::Full`.
+ */
+export function isUnattendedSessionSource(source?: string | null): boolean {
+  return source === "gateway" || source === "cron";
+}
+
 type StoredPayload = {
   order: string[];
+  /** Explicit fullAccess choices (and legacy seeded entries). */
   fullAccess: Record<string, true>;
+  /**
+   * Explicit "ask" overrides for unattended sessions. Without this, switching
+   * a gateway session back to 默认权限 would immediately flip to fullAccess
+   * again via the source default.
+   */
+  forceDefault: Record<string, true>;
 };
 
 function emptyPayload(): StoredPayload {
-  return { order: [], fullAccess: {} };
+  return { order: [], fullAccess: {}, forceDefault: {} };
 }
 
 function readPayload(): StoredPayload {
   try {
     const raw = localStorage.getItem(STORAGE_KEY);
     if (!raw) return emptyPayload();
-    const parsed = JSON.parse(raw) as StoredPayload;
+    const parsed = JSON.parse(raw) as Partial<StoredPayload>;
     if (!parsed || typeof parsed !== "object") return emptyPayload();
     return {
       order: Array.isArray(parsed.order)
@@ -29,6 +46,10 @@ function readPayload(): StoredPayload {
       fullAccess:
         parsed.fullAccess && typeof parsed.fullAccess === "object"
           ? parsed.fullAccess
+          : {},
+      forceDefault:
+        parsed.forceDefault && typeof parsed.forceDefault === "object"
+          ? parsed.forceDefault
           : {},
     };
   } catch {
@@ -47,6 +68,24 @@ function writePayload(payload: StoredPayload): void {
   }
 }
 
+function touchOrder(payload: StoredPayload, id: string): void {
+  payload.order = payload.order.filter((s) => s !== id);
+  payload.order.push(id);
+  while (payload.order.length > MAX_ENTRIES) {
+    const oldest = payload.order.shift();
+    if (!oldest) continue;
+    delete payload.fullAccess[oldest];
+    delete payload.forceDefault[oldest];
+  }
+}
+
+function lookupSessionSource(sessionId: string): string | null {
+  return (
+    useSessionListStore.getState().rows.find((r) => r.id === sessionId)?.source ??
+    null
+  );
+}
+
 export function subscribeSessionPermissionModes(cb: () => void): () => void {
   if (typeof window === "undefined") {
     return () => {};
@@ -56,11 +95,18 @@ export function subscribeSessionPermissionModes(cb: () => void): () => void {
   return () => window.removeEventListener(CHANGE_EVENT, handler);
 }
 
-export function getSessionPermissionMode(sessionId: string): SessionPermissionMode {
+export function getSessionPermissionMode(
+  sessionId: string,
+  sourceHint?: string | null,
+): SessionPermissionMode {
   const id = sessionId.trim();
   if (!id) return "default";
-  const { fullAccess } = readPayload();
-  return fullAccess[id] ? "fullAccess" : "default";
+  const { fullAccess, forceDefault } = readPayload();
+  if (forceDefault[id]) return "default";
+  if (fullAccess[id]) return "fullAccess";
+  const source = sourceHint ?? lookupSessionSource(id);
+  if (isUnattendedSessionSource(source)) return "fullAccess";
+  return "default";
 }
 
 export function setSessionPermissionMode(
@@ -71,18 +117,21 @@ export function setSessionPermissionMode(
   if (!id) return;
 
   const payload = readPayload();
+  const source = lookupSessionSource(id);
 
   if (mode === "default") {
     delete payload.fullAccess[id];
-    payload.order = payload.order.filter((s) => s !== id);
-  } else {
-    payload.fullAccess[id] = true;
-    payload.order = payload.order.filter((s) => s !== id);
-    payload.order.push(id);
-    while (payload.order.length > MAX_ENTRIES) {
-      const oldest = payload.order.shift();
-      if (oldest) delete payload.fullAccess[oldest];
+    if (isUnattendedSessionSource(source)) {
+      payload.forceDefault[id] = true;
+      touchOrder(payload, id);
+    } else {
+      delete payload.forceDefault[id];
+      payload.order = payload.order.filter((s) => s !== id);
     }
+  } else {
+    delete payload.forceDefault[id];
+    payload.fullAccess[id] = true;
+    touchOrder(payload, id);
   }
 
   writePayload(payload);
@@ -95,9 +144,14 @@ export function shouldAutoAllowSessionPermissions(sessionId: string): boolean {
 export function useSessionPermissionMode(
   sessionId: string | null,
 ): SessionPermissionMode {
+  const source = useSessionListStore((s) =>
+    sessionId
+      ? (s.rows.find((r) => r.id === sessionId)?.source ?? null)
+      : null,
+  );
   return useSyncExternalStore(
     subscribeSessionPermissionModes,
-    () => (sessionId ? getSessionPermissionMode(sessionId) : "default"),
+    () => (sessionId ? getSessionPermissionMode(sessionId, source) : "default"),
     () => "default",
   );
 }

--- a/packages/app/src/lib/stream/__tests__/live-agent-stream.test.ts
+++ b/packages/app/src/lib/stream/__tests__/live-agent-stream.test.ts
@@ -13,6 +13,7 @@ import {
   isTerminalAgentStatus,
   joinDistinctPendingReplyChunks,
   isToolOnlyTurnAnchor,
+  shouldFlushParkedAgentReply,
   mergePendingAgentReplies,
   normalizeToolResultEvent,
   normalizeToolUseEvent,
@@ -220,6 +221,37 @@ describe("live agent stream event helpers", () => {
       content: "",
     });
     expect(isToolOnlyTurnAnchor(pending, streamEntry)).toBe(true);
+  });
+
+  it("keeps mid-turn slices parked, and flushes once Idle or the live stream ends", () => {
+    expect(
+      shouldFlushParkedAgentReply({
+        terminalPending: false,
+        toolOnlyAnchor: false,
+        streamActive: true,
+      }),
+    ).toBe(false);
+    expect(
+      shouldFlushParkedAgentReply({
+        terminalPending: true,
+        toolOnlyAnchor: false,
+        streamActive: true,
+      }),
+    ).toBe(true);
+    expect(
+      shouldFlushParkedAgentReply({
+        terminalPending: false,
+        toolOnlyAnchor: true,
+        streamActive: true,
+      }),
+    ).toBe(true);
+    expect(
+      shouldFlushParkedAgentReply({
+        terminalPending: false,
+        toolOnlyAnchor: false,
+        streamActive: false,
+      }),
+    ).toBe(true);
   });
 
   it("detects when a stream ended without any visible content", () => {

--- a/packages/app/src/lib/stream/live-agent-stream.ts
+++ b/packages/app/src/lib/stream/live-agent-stream.ts
@@ -122,6 +122,22 @@ export function isToolOnlyTurnAnchor(
   return !merged.content.trim() && streamEntryHasVisibleContent(streamEntry);
 }
 
+/**
+ * Mid-turn AgentReply slices stay parked until the turn ends.
+ *
+ * Gateway checkout forwards ACP Idle *during* `run_turn`, then `write_reply`
+ * only after the channel finish frame (WeCom ack can take 15s). Desktop Idle
+ * starts an 8s wait and may `finishSessionActor` before that row arrives —
+ * an inactive live stream is already past terminal, so flush the parked reply.
+ */
+export function shouldFlushParkedAgentReply(args: {
+  terminalPending: boolean;
+  toolOnlyAnchor: boolean;
+  streamActive: boolean;
+}): boolean {
+  return args.terminalPending || args.toolOnlyAnchor || !args.streamActive;
+}
+
 type StreamVisibilityEntry = {
   outputText?: string;
   thinkingText?: string;

--- a/services/supabase/migrations/20260909180000_gateway_session_source_and_full_access.sql
+++ b/services/supabase/migrations/20260909180000_gateway_session_source_and_full_access.sql
@@ -1,0 +1,95 @@
+-- Channel (gateway) sessions should be marked source='gateway', not the
+-- default 'user'. Desktop permission UI and RuntimeStart treat unattended
+-- origins as full access; without the stamp those sessions looked like
+-- ordinary chats and stayed on "ask" / 默认权限.
+--
+-- Cron rows that reach ensure_gateway_session with a `cron/<job>/<run>`
+-- binding keep source='cron'. createCronSession already inserts that value;
+-- the CASE below only matters for the rare path that creates via this RPC.
+
+-- Backfill existing channel sessions. Leave cron bindings alone.
+UPDATE amux.sessions
+   SET source = 'gateway'
+ WHERE source = 'user'
+   AND gateway_key IS NOT NULL
+   AND gateway_key NOT LIKE 'cron/%';
+
+create or replace function amux.ensure_gateway_session(
+  p_team_id uuid,
+  p_binding text,
+  p_title text,
+  p_primary_agent_actor_id uuid,
+  p_owner_member_actor_ids uuid[],
+  p_participant_actor_ids uuid[]
+)
+returns table(session_id uuid, acp_session_id text, created boolean)
+language plpgsql
+security definer
+set search_path to 'amux', 'public', 'extensions'
+as $function$
+declare
+  v_session uuid;
+  v_acp     text;
+  v_created boolean := false;
+  v_source  text := case
+    when p_binding like 'cron/%' then 'cron'
+    else 'gateway'
+  end;
+begin
+  select s.id, s.acp_session_id
+    into v_session, v_acp
+    from amux.sessions as s
+   where s.team_id = p_team_id
+     and s.binding = p_binding;
+
+  if v_session is null then
+    insert into amux.sessions
+      (team_id, idea_id, created_by_actor_id, primary_agent_id,
+       mode, title, binding, gateway_key, acp_session_id, source)
+    values
+      (p_team_id,
+       null,
+       p_primary_agent_actor_id,
+       p_primary_agent_actor_id,
+       'collab',
+       p_title,
+       p_binding,
+       p_binding,
+       encode(extensions.gen_random_bytes(16), 'hex'),
+       v_source)
+    returning amux.sessions.id, amux.sessions.acp_session_id
+      into v_session, v_acp;
+    v_created := true;
+  else
+    -- Un-archive on inbound traffic, backfill gateway_key, and stamp source
+    -- when the row still carries the historical default 'user'. Do not clobber
+    -- an explicit cron/thread/user rewrite.
+    update amux.sessions
+       set archived_at = null,
+           gateway_key = coalesce(gateway_key, p_binding),
+           source = case
+             when source = 'user' then v_source
+             else source
+           end
+     where id = v_session
+       and (
+         archived_at is not null
+         or gateway_key is null
+         or source = 'user'
+       );
+  end if;
+
+  insert into amux.session_participants (session_id, actor_id)
+    select v_session, participant_actor_id
+      from unnest(
+        array[p_primary_agent_actor_id]
+          || coalesce(p_owner_member_actor_ids, '{}'::uuid[])
+          || coalesce(p_participant_actor_ids,  '{}'::uuid[])
+      ) as participant_actor_id
+     where participant_actor_id is not null
+  on conflict on constraint session_participants_session_id_actor_id_key
+  do nothing;
+
+  return query select v_session, v_acp, v_created;
+end;
+$function$;


### PR DESCRIPTION
## Summary
- Stamp gateway/cron sessions as unattended (`source`) and default them to full access so a permission card cannot hang a WeCom/cron turn; `RuntimeStart` uses the same `PermissionPolicy::Full` path as gateway spawn.
- Deliver mid-turn WeCom text (wait notices) via stream piggyback instead of swallowing `send_channel_message`; progress bubble only updates `执行中 · N秒`. Desktop flushes a late `AGENT_REPLY` after ACP Idle so thinking no longer leaves the final reply missing.
- Do not sleep leftover WeCom progress frames after the turn is done — drop extras, send the finish frame immediately, and `write_reply` before the stream ack so desktop is not blocked on the bubble catching up.
- `GET /providers` after a `provider.team` rewrite only replaces unattached pi hosts, so the first prompt after daemon start does not die with `pi prompt: process exited before responding`.

## Test plan
- [ ] WeCom DM: send a long scrape/refresh turn — bubble shows only `执行中 · N秒`, wait notice (if any) appears in the live stream, final answer lands on both WeCom and desktop.
- [ ] After thinking finishes on desktop, the ChatMessage should appear without waiting for WeCom to finish rewriting the progress bubble.
- [ ] Channel session permission UI defaults to full access; switching to 默认权限 sticks.
- [ ] After daemon start, first desktop send into a workspace does not fail with `pi prompt: process exited before responding`.
- [ ] Frontend: `pnpm --filter @teamclu/app exec vitest run src/components/mqtt-live-wiring/__tests__/handle-live-message.test.ts src/lib/session/__tests__/session-permission-mode.test.ts src/lib/stream/__tests__/live-agent-stream.test.ts`