### PR TITLE
fix(cron): MCP-created jobs appear in the desktop list

### DIFF
--- a/apps/desktop/crates/teamclu-introspect/src/cron.rs
+++ b/apps/desktop/crates/teamclu-introspect/src/cron.rs
@@ -1,6 +1,4 @@
-use chrono::Utc;
 use serde_json::{json, Value};
-use uuid::Uuid;
 
 pub async fn handle(workspace: &str, api_port: u16, arguments: &Value) -> Result<Value, String> {
     let action = arguments
@@ -8,20 +6,21 @@ pub async fn handle(workspace: &str, api_port: u16, arguments: &Value) -> Result
         .and_then(|v| v.as_str())
         .ok_or_else(|| "Missing required parameter: action".to_string())?;
 
-    match action {
-        "create" => action_create(workspace, arguments),
-        "pause" => action_set_enabled(workspace, arguments, false),
-        "resume" => action_set_enabled(workspace, arguments, true),
-        "delete" => action_delete(workspace, arguments),
-        "run" => action_run(workspace, api_port, arguments).await,
-        "get_runs" => action_get_runs(workspace, arguments),
-        other => Err(format!("Unknown action: {other}")),
-    }
+    let body = match action {
+        "create" => create_request_body(workspace, arguments)?,
+        "list" | "pause" | "resume" | "delete" | "run" | "get_runs" => {
+            job_action_body(workspace, arguments, action)?
+        }
+        other => return Err(format!("Unknown action: {other}")),
+    };
+
+    let resp = crate::desktop_api::post(api_port, "/cron-manage", &body).await?;
+    Ok(sanitize_manage_response(resp))
 }
 
 // ─── Create ───────────────────────────────────────────────────────────────────
 
-fn action_create(workspace: &str, args: &Value) -> Result<Value, String> {
+fn create_request_body(workspace: &str, args: &Value) -> Result<Value, String> {
     let name = args
         .get("name")
         .and_then(|v| v.as_str())
@@ -37,214 +36,92 @@ fn action_create(workspace: &str, args: &Value) -> Result<Value, String> {
         .and_then(|v| v.as_str())
         .ok_or_else(|| "create requires 'message'".to_string())?;
 
-    let description = args.get("description");
-    let delivery = args.get("delivery");
+    let scope = parse_scope(args)?;
+    let mut body = json!({
+        "action": "create",
+        "scope": scope,
+        "name": name,
+        "enabled": true,
+        "schedule": schedule,
+        "payload": { "message": message },
+    });
 
-    let now = Utc::now().to_rfc3339();
-    let id = Uuid::new_v4().to_string();
-
-    let mut job = serde_json::Map::new();
-    job.insert("id".to_string(), Value::String(id.clone()));
-    job.insert("name".to_string(), Value::String(name.to_string()));
-
-    if let Some(d) = description {
+    if let Some(d) = args.get("description") {
         if !d.is_null() {
-            job.insert("description".to_string(), d.clone());
+            body["description"] = d.clone();
         }
     }
-
-    job.insert("enabled".to_string(), Value::Bool(true));
-    job.insert("schedule".to_string(), schedule);
-    job.insert("payload".to_string(), json!({ "message": message }));
-
-    if let Some(d) = delivery {
+    if let Some(d) = args.get("delivery") {
         if !d.is_null() {
-            job.insert("delivery".to_string(), d.clone());
+            body["delivery"] = d.clone();
         }
     }
-
-    job.insert("createdAt".to_string(), Value::String(now.clone()));
-    job.insert("updatedAt".to_string(), Value::String(now));
-
-    let new_job = Value::Object(job);
-
-    // Read, append, write
-    let mut jobs = read_jobs_array(workspace)?;
-    jobs.push(new_job.clone());
-    write_jobs_array(workspace, jobs)?;
-
-    Ok(json!({
-        "action": "created",
-        "job": safe_job_summary(&new_job)
-    }))
+    attach_workspace_path(&mut body, workspace, args, scope);
+    Ok(body)
 }
 
-// ─── Pause / Resume ──────────────────────────────────────────────────────────
-
-fn action_set_enabled(workspace: &str, args: &Value, enabled: bool) -> Result<Value, String> {
-    let job_id = require_job_id(args)?;
-    let now = Utc::now().to_rfc3339();
-
-    let mut jobs = read_jobs_array(workspace)?;
-    let mut found = false;
-
-    for job in jobs.iter_mut() {
-        if job_matches_id(job, job_id) {
-            if let Value::Object(ref mut map) = job {
-                map.insert("enabled".to_string(), Value::Bool(enabled));
-                map.insert("updatedAt".to_string(), Value::String(now.clone()));
-            }
-            found = true;
-            break;
-        }
-    }
-
-    if !found {
-        return Err(format!("Cron job not found: {job_id}"));
-    }
-
-    write_jobs_array(workspace, jobs)?;
-
-    let action = if enabled { "resumed" } else { "paused" };
-    Ok(json!({
+fn job_action_body(workspace: &str, args: &Value, action: &str) -> Result<Value, String> {
+    let scope = parse_scope(args)?;
+    let mut body = json!({
         "action": action,
-        "job_id": job_id
-    }))
+        "scope": scope,
+    });
+    if action != "list" {
+        body["job_id"] = json!(require_job_id(args)?);
+    }
+    attach_workspace_path(&mut body, workspace, args, scope);
+    Ok(body)
 }
 
-// ─── Delete ───────────────────────────────────────────────────────────────────
-
-fn action_delete(workspace: &str, args: &Value) -> Result<Value, String> {
-    let job_id = require_job_id(args)?;
-
-    let jobs = read_jobs_array(workspace)?;
-    let original_len = jobs.len();
-
-    let updated: Vec<Value> = jobs
-        .into_iter()
-        .filter(|job| !job_matches_id(job, job_id))
-        .collect();
-
-    if updated.len() == original_len {
-        return Err(format!("Cron job not found: {job_id}"));
+fn parse_scope(args: &Value) -> Result<&'static str, String> {
+    match args.get("scope").and_then(|v| v.as_str()).unwrap_or("global") {
+        "global" => Ok("global"),
+        "workspace" => Ok("workspace"),
+        other => Err(format!("scope must be 'global' or 'workspace', got {other}")),
     }
-
-    write_jobs_array(workspace, updated)?;
-
-    // Delete run history file if it exists
-    let runs_dir = std::path::Path::new(workspace)
-        .join(crate::config::TEAMCLU_DIR)
-        .join("cron-runs");
-    let history_file = runs_dir.join(format!("{job_id}.jsonl"));
-    if history_file.exists() {
-        let _ = std::fs::remove_file(&history_file);
-    }
-
-    Ok(json!({
-        "action": "deleted",
-        "job_id": job_id
-    }))
 }
 
-// ─── Run ──────────────────────────────────────────────────────────────────────
-
-async fn action_run(workspace: &str, api_port: u16, args: &Value) -> Result<Value, String> {
-    let job_id = require_job_id(args)?;
-
-    // Verify the job exists
-    let jobs = read_jobs_array(workspace)?;
-    let job_exists = jobs.iter().any(|j| job_matches_id(j, job_id));
-    if !job_exists {
-        return Err(format!("Cron job not found: {job_id}"));
+fn attach_workspace_path(body: &mut Value, workspace: &str, args: &Value, scope: &str) {
+    if scope != "workspace" {
+        return;
     }
-
-    let resp = crate::desktop_api::send(api_port, "/cron-run", &json!({"job_id": job_id}))
-        .await
-        .map_err(|e| format!("Cron run request failed: {e}"))?;
-
-    if !resp.status().is_success() {
-        let status = resp.status();
-        let text = resp.text().await.unwrap_or_default();
-        return Err(format!("Cron run failed ({status}): {text}"));
-    }
-
-    Ok(json!({
-        "action": "triggered",
-        "job_id": job_id
-    }))
+    let path = args
+        .get("workspace_path")
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty())
+        .unwrap_or(workspace);
+    body["workspace_path"] = json!(resolve_workspace_root(path));
 }
 
-// ─── Get runs ────────────────────────────────────────────────────────────────
-
-fn action_get_runs(workspace: &str, args: &Value) -> Result<Value, String> {
-    let job_id = require_job_id(args)?;
-
-    // Verify the job exists
-    let jobs = read_jobs_array(workspace)?;
-    let job_exists = jobs.iter().any(|j| job_matches_id(j, job_id));
-    if !job_exists {
-        return Err(format!("Cron job not found: {job_id}"));
+/// Map a runtime cwd (often `{repo}/.worktrees/<id>`) back to the workspace root
+/// the desktop cron UI actually lists.
+fn resolve_workspace_root(path: &str) -> String {
+    let path = std::path::Path::new(path);
+    let abs = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        std::env::current_dir()
+            .map(|cwd| cwd.join(path))
+            .unwrap_or_else(|_| path.to_path_buf())
+    };
+    let mut parts: Vec<_> = abs.iter().map(|s| s.to_os_string()).collect();
+    if let Some(idx) = parts.iter().position(|c| c == ".worktrees") {
+        parts.truncate(idx);
+        return std::path::PathBuf::from_iter(parts)
+            .to_string_lossy()
+            .into_owned();
     }
-
-    let raw_runs = crate::config::read_cron_runs(workspace, job_id, 10)?;
-
-    // Filter to safe fields only
-    let safe_runs: Vec<Value> = raw_runs
-        .iter()
-        .map(|run| {
-            let mut out = serde_json::Map::new();
-            for field in &[
-                "runId",
-                "run_id",
-                "jobId",
-                "job_id",
-                "startedAt",
-                "started_at",
-                "finishedAt",
-                "finished_at",
-                "status",
-                "sessionId",
-                "session_id",
-                "responseSummary",
-                "response_summary",
-                "deliveryStatus",
-                "delivery_status",
-                "error",
-            ] {
-                if let Some(v) = run.get(*field) {
-                    // Normalize to snake_case
-                    let key = match *field {
-                        "runId" => "run_id",
-                        "jobId" => "job_id",
-                        "startedAt" => "started_at",
-                        "finishedAt" => "finished_at",
-                        "sessionId" => "session_id",
-                        "responseSummary" => "response_summary",
-                        "deliveryStatus" => "delivery_status",
-                        other => other,
-                    };
-                    out.insert(key.to_string(), v.clone());
-                }
-            }
-            Value::Object(out)
-        })
-        .collect();
-
-    Ok(json!({
-        "job_id": job_id,
-        "runs": safe_runs
-    }))
+    abs.to_string_lossy().into_owned()
 }
 
-// ─── Helpers ─────────────────────────────────────────────────────────────────
-
-fn read_jobs_array(workspace: &str) -> Result<Vec<Value>, String> {
-    let data = crate::config::read_cron_jobs(workspace)?;
-    Ok(crate::config::cron_jobs_from_value(&data))
-}
-
-fn write_jobs_array(workspace: &str, jobs: Vec<Value>) -> Result<(), String> {
-    crate::config::write_cron_jobs(workspace, &json!({ "jobs": jobs }))
+fn sanitize_manage_response(mut resp: Value) -> Value {
+    if let Some(job) = resp.get("job").cloned() {
+        resp["job"] = safe_job_summary(&job);
+    }
+    if let Some(jobs) = resp.get("jobs").and_then(|v| v.as_array()).cloned() {
+        resp["jobs"] = Value::Array(jobs.into_iter().map(|j| safe_job_summary(&j)).collect());
+    }
+    resp
 }
 
 fn normalize_schedule(schedule: &Value) -> Result<Value, String> {
@@ -275,13 +152,6 @@ fn require_job_id<'a>(args: &'a Value) -> Result<&'a str, String> {
         .and_then(|v| v.as_str())
         .filter(|s| !s.is_empty())
         .ok_or_else(|| "Missing required parameter: job_id".to_string())
-}
-
-fn job_matches_id(job: &Value, id: &str) -> bool {
-    job.get("id")
-        .and_then(|v| v.as_str())
-        .map(|s| s == id)
-        .unwrap_or(false)
 }
 
 /// Return safe summary fields for a job (no payload details).
@@ -317,19 +187,57 @@ fn safe_job_summary(job: &Value) -> Value {
 mod tests {
     use super::*;
     use std::path::PathBuf;
+    use uuid::Uuid;
 
     fn temp_workspace() -> PathBuf {
         std::env::temp_dir().join(format!("teamclu-introspect-cron-{}", Uuid::new_v4()))
     }
 
+    #[test]
+    fn create_body_defaults_to_global_scope_and_normalizes_cron_expr() {
+        let body = create_request_body(
+            "/tmp/ws",
+            &json!({
+                "name": "Morning summary",
+                "schedule": "0 9 * * *",
+                "message": "Summarize yesterday's work"
+            }),
+        )
+        .unwrap();
+
+        assert_eq!(body["action"], "create");
+        assert_eq!(body["scope"], "global");
+        assert_eq!(body["name"], "Morning summary");
+        assert_eq!(
+            body["schedule"],
+            json!({ "kind": "cron", "expr": "0 9 * * *" })
+        );
+        assert_eq!(body["payload"]["message"], "Summarize yesterday's work");
+        assert_eq!(body["enabled"], true);
+        assert!(body.get("workspace_path").is_none());
+    }
+
+    #[test]
+    fn resolve_workspace_root_strips_git_worktree() {
+        let input = std::path::PathBuf::from("/repo")
+            .join(".worktrees")
+            .join("cron-j1-r1");
+        let got = std::path::PathBuf::from(resolve_workspace_root(&input.to_string_lossy()));
+        assert_eq!(got, std::path::PathBuf::from("/repo"));
+    }
+
+    /// Regression: MCP used to write `{cwd}/.teamclu/cron-jobs.json` and report
+    /// success. The settings list reads the desktop cron store (global by
+    /// default), so those jobs never appeared. Create must go through the
+    /// desktop API instead of a sidecar-local file.
     #[tokio::test]
-    async fn create_writes_native_cron_jobs_wrapper_for_cron_expression() {
+    async fn create_does_not_write_a_workspace_file_the_ui_never_reads() {
         let workspace = temp_workspace();
         std::fs::create_dir_all(&workspace).unwrap();
 
         let result = handle(
             workspace.to_str().unwrap(),
-            1420,
+            9, // nothing listens here; the point is we must not succeed locally
             &json!({
                 "action": "create",
                 "name": "Morning summary",
@@ -337,28 +245,15 @@ mod tests {
                 "message": "Summarize yesterday's work"
             }),
         )
-        .await
-        .unwrap();
+        .await;
 
-        assert_eq!(result["action"], "created");
-
-        let raw = std::fs::read_to_string(workspace.join(".teamclu/cron-jobs.json")).unwrap();
-        let data: Value = serde_json::from_str(&raw).unwrap();
-        let jobs = data
-            .get("jobs")
-            .and_then(|v| v.as_array())
-            .expect("cron jobs file should use the native { jobs: [...] } shape");
-
-        assert_eq!(jobs.len(), 1);
-        assert_eq!(jobs[0]["name"], "Morning summary");
-        assert_eq!(jobs[0]["enabled"], true);
-        assert_eq!(
-            jobs[0]["schedule"],
-            json!({ "kind": "cron", "expr": "0 9 * * *" })
+        assert!(
+            result.is_err(),
+            "create must go through the desktop API, got {result:?}"
         );
-        assert_eq!(
-            jobs[0]["payload"],
-            json!({ "message": "Summarize yesterday's work" })
+        assert!(
+            !workspace.join(".teamclu/cron-jobs.json").exists(),
+            "MCP must not stash jobs in the agent cwd"
         );
 
         let _ = std::fs::remove_dir_all(workspace);

--- a/apps/desktop/crates/teamclu-introspect/src/main.rs
+++ b/apps/desktop/crates/teamclu-introspect/src/main.rs
@@ -106,14 +106,19 @@ fn tool_definitions() -> Value {
         },
         {
             "name": "manage_cron_job",
-            "description": "Create, pause, resume, delete, or inspect cron jobs.",
+            "description": "Create, pause, resume, delete, list, or inspect cron jobs. New jobs are stored as Global tasks (the default settings list). The TeamClu desktop app must be running.",
             "inputSchema": {
                 "type": "object",
                 "properties": {
                     "action": {
                         "type": "string",
                         "description": "The action to perform.",
-                        "enum": ["create", "pause", "resume", "delete", "run", "get_runs"]
+                        "enum": ["create", "list", "pause", "resume", "delete", "run", "get_runs"]
+                    },
+                    "scope": {
+                        "type": "string",
+                        "description": "Where to store the job. Defaults to 'global' (the default settings list). Use 'workspace' only for jobs that must run in a specific project folder.",
+                        "enum": ["global", "workspace"]
                     },
                     "job_id": {
                         "type": "string",

--- a/apps/desktop/src/commands/cron/mod.rs
+++ b/apps/desktop/src/commands/cron/mod.rs
@@ -77,7 +77,7 @@ pub enum CronScope {
     Workspace,
 }
 
-fn global_cron_root() -> Result<String, String> {
+pub(crate) fn global_cron_root() -> Result<String, String> {
     let base = dirs::config_dir()
         .unwrap_or_else(|| PathBuf::from("/tmp"))
         .join(crate::commands::home_storage_dir_name())
@@ -204,11 +204,18 @@ pub async fn cron_add_job(
     )
     .await?;
 
-    let now = chrono::Utc::now();
-    let id = uuid::Uuid::new_v4().to_string();
+    let job = create_job_on_instance(&instance, request).await;
+    log::info!("[Cron] Job created: {} ({})", job.name, job.id);
+    Ok(job)
+}
 
+pub(crate) async fn create_job_on_instance(
+    instance: &CronInstance,
+    request: CreateCronJobRequest,
+) -> CronJob {
+    let now = chrono::Utc::now();
     let mut job = CronJob {
-        id: id.clone(),
+        id: uuid::Uuid::new_v4().to_string(),
         name: request.name,
         description: request.description,
         enabled: request.enabled,
@@ -222,13 +229,153 @@ pub async fn cron_add_job(
         next_run_at: None,
     };
 
-    let next = instance.scheduler.compute_next_run(&job, None);
-    job.next_run_at = next;
-
+    job.next_run_at = instance.scheduler.compute_next_run(&job, None);
     instance.storage.add_job(job.clone()).await;
-    log::info!("[Cron] Job created: {} ({})", job.name, job.id);
+    instance.scheduler.emit_jobs_updated();
+    job
+}
 
-    Ok(job)
+/// MCP / HTTP entry: mutate the same CronState the settings UI lists.
+/// Defaults to global scope so created jobs show up in "Global tasks".
+pub(crate) async fn mcp_manage(
+    app: &AppHandle,
+    cron_state: &CronState,
+    body: &serde_json::Value,
+) -> Result<serde_json::Value, String> {
+    let action = body
+        .get("action")
+        .and_then(|v| v.as_str())
+        .ok_or("Missing field: action")?;
+    let scope = match body.get("scope").and_then(|v| v.as_str()) {
+        Some("workspace") => CronScope::Workspace,
+        _ => CronScope::Global,
+    };
+    let workspace_path = body
+        .get("workspace_path")
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty())
+        .map(str::to_string);
+
+    let instance = ensure_instance(app, cron_state, scope, workspace_path).await?;
+
+    match action {
+        "create" => {
+            let request = parse_create_request(body)?;
+            let job = create_job_on_instance(&instance, request).await;
+            log::info!("[Cron] MCP job created: {} ({})", job.name, job.id);
+            let job = serde_json::to_value(job).map_err(|e| e.to_string())?;
+            Ok(serde_json::json!({
+                "action": "created",
+                "job": job,
+            }))
+        }
+        "list" => {
+            let jobs = instance.storage.list_jobs().await;
+            let jobs = serde_json::to_value(jobs).map_err(|e| e.to_string())?;
+            Ok(serde_json::json!({ "action": "listed", "jobs": jobs }))
+        }
+        "pause" | "resume" => {
+            let job_id = require_mcp_job_id(body)?;
+            let enabled = action == "resume";
+            instance.storage.toggle_enabled(job_id, enabled).await?;
+            if enabled {
+                if let Some(job) = instance.storage.get_job(job_id).await {
+                    let next = instance.scheduler.compute_next_run(&job, None);
+                    instance.storage.update_next_run_at(job_id, next).await;
+                }
+            }
+            instance.scheduler.emit_jobs_updated();
+            let action_name = if enabled { "resumed" } else { "paused" };
+            Ok(serde_json::json!({
+                "action": action_name,
+                "job_id": job_id,
+            }))
+        }
+        "delete" => {
+            let job_id = require_mcp_job_id(body)?;
+            instance.storage.remove_job(job_id).await?;
+            instance.scheduler.emit_jobs_updated();
+            Ok(serde_json::json!({ "action": "deleted", "job_id": job_id }))
+        }
+        "run" => {
+            let job_id = require_mcp_job_id(body)?;
+            let job = instance
+                .storage
+                .get_job(job_id)
+                .await
+                .ok_or_else(|| format!("Job not found: {job_id}"))?;
+            let scheduler = instance.scheduler.clone();
+            tokio::spawn(async move {
+                scheduler.execute_job(job).await;
+            });
+            Ok(serde_json::json!({ "action": "triggered", "job_id": job_id }))
+        }
+        "get_runs" => {
+            let job_id = require_mcp_job_id(body)?;
+            let runs = instance.storage.get_runs(job_id, Some(10)).await;
+            let runs = serde_json::to_value(runs).map_err(|e| e.to_string())?;
+            Ok(serde_json::json!({ "job_id": job_id, "runs": runs }))
+        }
+        other => Err(format!("Unknown action: {other}")),
+    }
+}
+
+fn require_mcp_job_id(body: &serde_json::Value) -> Result<&str, String> {
+    body.get("job_id")
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| "Missing field: job_id".to_string())
+}
+
+fn parse_create_request(body: &serde_json::Value) -> Result<CreateCronJobRequest, String> {
+    let mut obj = body
+        .as_object()
+        .cloned()
+        .ok_or_else(|| "create body must be an object".to_string())?;
+    obj.remove("action");
+    obj.remove("scope");
+    obj.remove("workspace_path");
+    obj.remove("job_id");
+    serde_json::from_value(serde_json::Value::Object(obj))
+        .map_err(|e| format!("invalid create request: {e}"))
+}
+
+pub(crate) async fn ensure_instance(
+    app: &AppHandle,
+    cron_state: &CronState,
+    scope: CronScope,
+    workspace_path: Option<String>,
+) -> Result<CronInstance, String> {
+    let (storage_path, execution_workspace) = match scope {
+        CronScope::Global => (global_cron_root()?, None),
+        CronScope::Workspace => {
+            let path = workspace_path
+                .filter(|p| !p.is_empty())
+                .ok_or_else(|| "workspace scope requires workspace_path".to_string())?;
+            if !std::path::Path::new(&path).is_dir() {
+                return Err(format!("Workspace not found: {path}"));
+            }
+            (path.clone(), Some(path))
+        }
+    };
+
+    let instance = cron_state.instance_for(&storage_path).await;
+    if instance.storage.is_initialized().await {
+        return Ok(instance);
+    }
+
+    instance.storage.init(&storage_path).await;
+    instance
+        .scheduler
+        .set_execution_workspace(execution_workspace)
+        .await;
+    instance.scheduler.set_app_handle(app.clone());
+
+    let delivery_mgr = DeliveryManager::new(storage_path.clone());
+    instance.scheduler.set_delivery(delivery_mgr).await;
+    instance.scheduler.reconcile_interrupted_runs().await;
+    instance.scheduler.start().await;
+    Ok(instance)
 }
 
 /// Update an existing cron job in the calling window's workspace.
@@ -409,4 +556,70 @@ pub async fn cron_get_runs(
 pub async fn cron_refresh_delivery() -> Result<(), String> {
     log::info!("[Cron] Delivery config refresh requested (no-op, config is read on demand)");
     Ok(())
+}
+
+#[cfg(test)]
+mod mcp_create_tests {
+    use super::*;
+
+    fn sample_request() -> CreateCronJobRequest {
+        CreateCronJobRequest {
+            name: "Morning summary".into(),
+            description: None,
+            enabled: true,
+            schedule: CronSchedule {
+                kind: ScheduleKind::Cron,
+                at: None,
+                every_ms: None,
+                expr: Some("0 9 * * *".into()),
+                tz: None,
+            },
+            payload: CronPayload {
+                message: "hello".into(),
+                model: None,
+                backend: None,
+                timeout_seconds: None,
+                permission_mode: None,
+            },
+            delivery: None,
+            delete_after_run: false,
+        }
+    }
+
+    #[tokio::test]
+    async fn mcp_style_create_is_visible_to_list_jobs_on_the_same_instance() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().to_str().unwrap();
+        let state = CronState::default();
+        let instance = state.instance_for(path).await;
+        instance.storage.init(path).await;
+
+        let created = create_job_on_instance(&instance, sample_request()).await;
+        let listed = state
+            .try_instance_for(path)
+            .await
+            .unwrap()
+            .storage
+            .list_jobs()
+            .await;
+        assert_eq!(listed.len(), 1);
+        assert_eq!(listed[0].id, created.id);
+        assert_eq!(listed[0].name, "Morning summary");
+    }
+
+    #[test]
+    fn parse_create_request_accepts_mcp_global_body() {
+        let body = serde_json::json!({
+            "action": "create",
+            "scope": "global",
+            "name": "Morning summary",
+            "enabled": true,
+            "schedule": { "kind": "cron", "expr": "0 9 * * *" },
+            "payload": { "message": "hello" }
+        });
+        let request = parse_create_request(&body).unwrap();
+        assert_eq!(request.name, "Morning summary");
+        assert_eq!(request.payload.message, "hello");
+        assert_eq!(request.schedule.expr.as_deref(), Some("0 9 * * *"));
+    }
 }

--- a/apps/desktop/src/commands/cron/scheduler.rs
+++ b/apps/desktop/src/commands/cron/scheduler.rs
@@ -68,6 +68,13 @@ impl CronScheduler {
         }
     }
 
+    pub(crate) fn emit_jobs_updated(&self) {
+        let app = self.app_handle.lock().ok().and_then(|g| g.clone());
+        if let Some(app) = app {
+            let _ = app.emit("cron:jobs-updated", ());
+        }
+    }
+
     async fn persist_run_and_notify_ui(&self, record: &CronRunRecord) {
         self.storage.update_last_run(record).await;
         self.emit_cron_sessions_updated();

--- a/apps/desktop/src/commands/introspect_api.rs
+++ b/apps/desktop/src/commands/introspect_api.rs
@@ -3,6 +3,7 @@
 // Listens on 127.0.0.1:13144 and handles:
 //   POST /send-wecom        — send a proactive WeCom message
 //   POST /cron-run          — manually trigger a cron job
+//   POST /cron-manage       — create/list/pause/resume/delete/run/get_runs (MCP)
 //   POST /team-sync-all     — trigger team sync
 //   POST /env-var-set       — create or update an env var (`scope`: personal | team)
 //   POST /env-var-delete    — delete an env var (`scope`: personal | team)
@@ -273,6 +274,7 @@ fn router(app: AppHandle, token: Arc<str>) -> Router {
     Router::new()
         .route("/send-wecom", post_route!(handle_send_wecom))
         .route("/cron-run", post_route!(handle_cron_run))
+        .route("/cron-manage", post_route!(handle_cron_manage))
         .route("/team-sync-all", post_route!(handle_team_sync_all))
         .route("/env-var-set", post_route!(handle_env_var_set))
         .route("/env-var-delete", post_route!(handle_env_var_delete))
@@ -463,6 +465,14 @@ async fn handle_cron_run(app: &AppHandle, body: &[u8]) -> Result<String, String>
     });
 
     Ok(format!(r#"{{"ok":true,"job_id":"{}"}}"#, job_id))
+}
+
+async fn handle_cron_manage(app: &AppHandle, body: &[u8]) -> Result<String, String> {
+    let v: serde_json::Value =
+        serde_json::from_slice(body).map_err(|e| format!("JSON parse error: {e}"))?;
+    let cron_state = app.state::<super::cron::CronState>();
+    let result = super::cron::mcp_manage(app, &*cron_state, &v).await?;
+    serde_json::to_string(&result).map_err(|e| format!("Serialization error: {e}"))
 }
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────

--- a/packages/app/src/components/settings/CronSection.tsx
+++ b/packages/app/src/components/settings/CronSection.tsx
@@ -218,8 +218,33 @@ export function CronSection() {
     loadJobs()
     const interval = setInterval(() => {
       loadJobs()
-    }, 30000)
-    return () => clearInterval(interval)
+    }, 5000)
+
+    let cancelled = false
+    let unlisten: (() => void) | undefined
+    void import('@tauri-apps/api/event')
+      .then(({ listen }) => {
+        if (cancelled) return undefined
+        return listen('cron:jobs-updated', () => {
+          void loadJobs()
+        })
+      })
+      .then((fn) => {
+        if (cancelled) {
+          fn?.()
+          return
+        }
+        unlisten = fn
+      })
+      .catch(() => {
+        // Browser / tests: no Tauri event bus.
+      })
+
+    return () => {
+      cancelled = true
+      clearInterval(interval)
+      unlisten?.()
+    }
   }, [loadJobs, activeScope])
 
   React.useEffect(() => {

--- a/packages/app/src/hooks/use-cron-init.ts
+++ b/packages/app/src/hooks/use-cron-init.ts
@@ -14,7 +14,7 @@ export function useCronInit() {
   useEffect(() => {
     if (!isTauri() || !daemonHttpReady) return;
 
-    let unlisten: (() => void) | undefined;
+    const unlistens: Array<() => void> = [];
     let cancelled = false;
 
     (async () => {
@@ -23,13 +23,20 @@ export function useCronInit() {
       // Scheduled sessions are now identified by their persisted `source ===
       // 'cron'`, so a cron-session change just needs the session list re-pulled
       // (the fresh rows carry `source`); no separate id scan.
-      unlisten = await listen("cron:cron-sessions-updated", () => {
-        void import("@/stores/session-list-store").then(({ useSessionListStore }) =>
-          useSessionListStore.getState().load(),
-        ).catch((err: unknown) => {
-          console.warn("[App] Session list refresh failed (non-critical):", err);
-        });
-      });
+      unlistens.push(
+        await listen("cron:cron-sessions-updated", () => {
+          void import("@/stores/session-list-store").then(({ useSessionListStore }) =>
+            useSessionListStore.getState().load(),
+          ).catch((err: unknown) => {
+            console.warn("[App] Session list refresh failed (non-critical):", err);
+          });
+        }),
+      );
+      unlistens.push(
+        await listen("cron:jobs-updated", () => {
+          void useCronStore.getState().loadJobs();
+        }),
+      );
 
       try {
         await useCronStore.getState().reinit();
@@ -40,7 +47,7 @@ export function useCronInit() {
 
     return () => {
       cancelled = true;
-      unlisten?.();
+      for (const unlisten of unlistens) unlisten();
     };
   }, [daemonHttpReady]);
 }


### PR DESCRIPTION
## Description

`manage_cron_job` reported success while writing `{worktree}/.teamclu/cron-jobs.json`. The settings list defaults to **Global tasks**, which reads the desktop cron store (`cron-global`). Those are different files, so a job created in chat never showed up.

This routes MCP create/list/pause/resume/delete/run through the desktop `/cron-manage` API (default scope: global), emits `cron:jobs-updated`, and reloads the automation list immediately.

The desktop app must be running. Rebuild the `teamclu-introspect` sidecar with the desktop app — frontend HMR is not enough.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Test plan

- [ ] Rebuild desktop (sidecar included) from this branch and restart the app
- [ ] In a chat session, ask the agent to create a cron job via `manage_cron_job`
- [ ] Open Settings → Automation (or the automation panel) and confirm the job appears under **Global tasks** without waiting
- [ ] Pause / resume / delete from MCP and confirm the list updates
- [ ] Confirm creating a job from the UI still works

## Additional Notes

Jobs previously “created” by MCP may still sit in a session worktree’s `.teamclu/cron-jobs.json`. They are not migrated; recreate them after this lands.

Rust tests were not run locally (memory constraint on this machine).

Made with [Cursor](https://cursor.com)