### PR TITLE
fix(app): vite.config 读的是 Tauri v1 环境变量名，三个开关静默失效（dev 的 tauri-mcp 监听 / debug sourcemap / Windows 构建目标）

### DIFF
--- a/packages/app/vite.config.ts
+++ b/packages/app/vite.config.ts
@@ -27,6 +27,9 @@ const isTauriMcpE2EBuild = process.env.VITE_TEAMCLU_E2E === 'true'
 // truthiness: a release build sets it to `"false"`, which is truthy.
 const isTauriDevRun =
   process.env.TAURI_ENV_DEBUG === 'true' || process.env.TAURI_DEBUG === 'true'
+// Same rename, same v1 fallback. Values are unchanged between the two
+// (`windows` / `darwin` / `linux`), so only the variable name had to move.
+const tauriTargetPlatform = process.env.TAURI_ENV_PLATFORM || process.env.TAURI_PLATFORM
 const tauriPluginMcpLinked = existsSync(path.join(tauriPluginMcpPath, 'package.json'))
 const tauriPluginMcpInstalled = (() => {
   try {
@@ -283,7 +286,15 @@ export default defineConfig({
   build: {
     // Tauri uses Chromium on Windows and WebKit on macOS and Linux
     // In web mode, target modern browsers (Chrome extension context).
-    target: process.env.VITE_APP_PLATFORM === 'web' ? 'chrome105' : (process.env.TAURI_PLATFORM === 'windows' ? 'chrome105' : 'safari13'),
+    // The Windows arm read the v1 `TAURI_PLATFORM`, which v2 never sets, so it
+    // had been permanently false: every Windows build was transpiled down to
+    // the WebKit `safari13` target even though it runs on evergreen WebView2.
+    target:
+      process.env.VITE_APP_PLATFORM === 'web'
+        ? 'chrome105'
+        : tauriTargetPlatform === 'windows'
+          ? 'chrome105'
+          : 'safari13',
     // Produce sourcemaps for error reporting. Reuses `isTauriDevRun` because
     // the bare `TAURI_DEBUG` this used to read is a Tauri v1 name that v2 never
     // sets — so this had been permanently false and no debug build has shipped

--- a/packages/app/vite.config.ts
+++ b/packages/app/vite.config.ts
@@ -12,9 +12,34 @@ const tauriPluginMcpPath = path.resolve(__dirname, '../../.tauri-plugin-mcp')
 // externalized bare specifier does not resolve inside the webview — either way
 // `execute_js` gets no answer and the whole harness times out. The npm
 // dependency provides the same listeners as the linked dev checkout.
+// A dev/debug run is driven through that same socket, and `.tauri-plugin-mcp/`
+// is a gitignored convenience link almost nobody has — so the check above used
+// to hand every `pnpm tauri:dev` the stub even though the npm dependency was
+// installed and provides the same listeners. The symptom is specific and
+// baffling: `execute_js` still answers, because `stores/dev-expose.ts` hand-
+// rolls that one listener, while every other socket command (`get_page_state`,
+// `press_key`, `type_into_focused`, `get_dom`, …) times out with no error
+// anywhere. Additive on purpose — the linked-checkout, E2E, and production
+// paths all resolve exactly as before.
 const isTauriMcpE2EBuild = process.env.VITE_TEAMCLU_E2E === 'true'
+// Tauri v2 renamed `TAURI_DEBUG` to `TAURI_ENV_DEBUG`; v1's name is kept as a
+// fallback. Compared against the literal string rather than tested for
+// truthiness: a release build sets it to `"false"`, which is truthy.
+const isTauriDevRun =
+  process.env.TAURI_ENV_DEBUG === 'true' || process.env.TAURI_DEBUG === 'true'
+const tauriPluginMcpLinked = existsSync(path.join(tauriPluginMcpPath, 'package.json'))
+const tauriPluginMcpInstalled = (() => {
+  try {
+    createRequire(import.meta.url).resolve('tauri-plugin-mcp')
+    return true
+  } catch {
+    return false
+  }
+})()
 const useTauriPluginMcpStub =
-  !isTauriMcpE2EBuild && !existsSync(path.join(tauriPluginMcpPath, 'package.json'))
+  !isTauriMcpE2EBuild &&
+  !tauriPluginMcpLinked &&
+  !(tauriPluginMcpInstalled && isTauriDevRun)
 
 // --- Build config: read build.config.json + optional environment/local overrides ---
 function readJSON(filePath: string): Record<string, unknown> | null {

--- a/packages/app/vite.config.ts
+++ b/packages/app/vite.config.ts
@@ -284,8 +284,11 @@ export default defineConfig({
     // Tauri uses Chromium on Windows and WebKit on macOS and Linux
     // In web mode, target modern browsers (Chrome extension context).
     target: process.env.VITE_APP_PLATFORM === 'web' ? 'chrome105' : (process.env.TAURI_PLATFORM === 'windows' ? 'chrome105' : 'safari13'),
-    // Produce sourcemaps for error reporting
-    sourcemap: !!process.env.TAURI_DEBUG,
+    // Produce sourcemaps for error reporting. Reuses `isTauriDevRun` because
+    // the bare `TAURI_DEBUG` this used to read is a Tauri v1 name that v2 never
+    // sets — so this had been permanently false and no debug build has shipped
+    // a sourcemap since the v2 upgrade.
+    sourcemap: isTauriDevRun,
     // Chunk splitting strategy (Vite 8 / Rolldown requires manualChunks as a function)
     rollupOptions: {
       // tauri-plugin-mcp is dev-only (linked from .tauri-plugin-mcp/, gitignored).


### PR DESCRIPTION
`packages/app/vite.config.ts` 读了三个 Tauri **v1** 环境变量。Tauri v2 把它们全改成了 `TAURI_ENV_*`，v1 的名字一个都不再设置——于是三个开关静默失效，各自坏了不同的东西，而且都不报错。

实测正在跑的 vite dev server 进程环境：**6 个 `TAURI_ENV_*`，v1 名字（`TAURI_PLATFORM` / `TAURI_DEBUG` / `TAURI_ARCH` / `TAURI_FAMILY`）一个都没有。**

| commit | 坏了什么 | 影响面 |
|---|---|---|
| `3113a4a` | dev 运行拿到 tauri-plugin-mcp 的空壳，22 个事件监听一个都没注册 | 本地开发 / 自动化 |
| `05db69f` | `tauri build --debug` 从不产出 sourcemap | debug 构建 |
| `5efaff3` | Windows 构建目标降级成 `safari13` | Windows 产物 |

## 1. dev 运行永远拿到 tauri-plugin-mcp 的空壳

`useTauriPluginMcpStub` 只检查 gitignore 的软链目录 `.tauri-plugin-mcp/`：

```ts
const useTauriPluginMcpStub =
  !isTauriMcpE2EBuild && !existsSync(path.join(tauriPluginMcpPath, 'package.json'))
```

几乎没人有那个软链，于是每次 `pnpm tauri:dev` 都把包别名成 no-op 空壳，`setupPluginListeners()` 什么都不注册——尽管 npm 依赖 `tauri-plugin-mcp@0.3.1` 装着，而且这个文件自己的注释就写着「npm 依赖提供和软链同样的监听」。

**症状极具误导性**：`execute_js` 照常工作，因为 `stores/dev-expose.ts:33` 单独手写了那一个监听；而其余每一条 socket 命令（`get_page_state` / `press_key` / `type_into_focused` / `get_dom` / `read_text` …）全部超时，任何日志里都没有任何报错。是在用 tauri-mcp 驱动 app 复现 #1331 时撞见的。

修法是纯增量的：npm 包已安装 **且** 是 dev/debug 运行时，不再用空壳。软链、E2E、生产三条路径解析结果与之前完全一致。

**已在真机验证**（把改动临时打到正在跑的 dev app，vite 自动重启后实测，测完还原）：

| 命令 | 修前 | 修后 |
|---|---|---|
| `get_page_state` | ❌ 超时 | ✅ 返回 url / title / readyState |
| `press_key` | ❌ 超时 | ✅ 返回 key / code / modifiers |
| `get_dom` | ❌ 超时 | ✅ 返回完整 DOM |

## 2. debug 构建从不产出 sourcemap

```ts
sourcemap: !!process.env.TAURI_DEBUG,   // v2 从不设置 → 恒为 false
```

自 v2 升级以来一直是 false，注释里写的「Produce sourcemaps for error reporting」从没生效过。

新的判定**与字面量字符串比较**而不是取真值——**发布版构建会把 `TAURI_ENV_DEBUG` 设成 `"false"`，而 `"false"` 是 truthy**：

```ts
const isTauriDevRun =
  process.env.TAURI_ENV_DEBUG === 'true' || process.env.TAURI_DEBUG === 'true'
```

只影响 `tauri build --debug`；dev server 的 sourcemap 本来就与这个设置无关。

## 3. Windows 构建目标一直是 safari13

```ts
process.env.TAURI_PLATFORM === 'windows' ? 'chrome105' : 'safari13'   // 恒为 false
```

Windows 跑的是常青版 WebView2，却一直按 WebKit 的 `safari13` 转译——正是这个分支存在的意义所在。v1/v2 取值相同（`windows` / `darwin` / `linux`），只是名字搬家。

取值验证，macOS / Linux / web 完全不变，只有 Windows 改变：

| 场景 | 新 | 旧 |
|---|---|---|
| **Windows (v2)** | **chrome105** | ❌ safari13 |
| macOS (v2) | safari13 | safari13 |
| Linux (v2) | safari13 | safari13 |
| web 模式 | chrome105 | chrome105 |
| Windows (v1 兜底) | chrome105 | chrome105 |

## 验证情况（据实说明）

- **① 已在真机端到端验证**（上表）。
- **②③ 只做了取值验证**（枚举各环境组合比对新旧结果）+ esbuild 语法解析。Windows 那条要真验，得有台 Windows 机器实际出包——**我没有验过 Windows 产物**。
- 三处 v1 名字都保留了 v1 兜底，所以即使某处仍以 v1 方式运行也不会回归。
- 全仓库扫过，除本文件里我刻意保留的两处兜底，没有其它 v1 `TAURI_*` 残留。

## 相关

排查 #1331（打断撞上权限确认卡死 pi host）时发现的。第 ① 条会挡住任何想用 tauri-mcp 驱动 app 做 E2E / 自动化的人。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L5cPobkSdBi9fJC8WMwEs8
