### PR TITLE
fix(cron): MCP one-time jobs show as one-time, not cron JSON

### DIFF
--- a/apps/desktop/crates/teamclu-introspect/src/cron.rs
+++ b/apps/desktop/crates/teamclu-introspect/src/cron.rs
@@ -74,10 +74,16 @@ fn job_action_body(workspace: &str, args: &Value, action: &str) -> Result<Value,
 }
 
 fn parse_scope(args: &Value) -> Result<&'static str, String> {
-    match args.get("scope").and_then(|v| v.as_str()).unwrap_or("global") {
+    match args
+        .get("scope")
+        .and_then(|v| v.as_str())
+        .unwrap_or("global")
+    {
         "global" => Ok("global"),
         "workspace" => Ok("workspace"),
-        other => Err(format!("scope must be 'global' or 'workspace', got {other}")),
+        other => Err(format!(
+            "scope must be 'global' or 'workspace', got {other}"
+        )),
     }
 }
 
@@ -125,26 +131,101 @@ fn sanitize_manage_response(mut resp: Value) -> Value {
 }
 
 fn normalize_schedule(schedule: &Value) -> Result<Value, String> {
-    if let Some(expr) = schedule.as_str() {
-        let expr = expr.trim();
-        if expr.is_empty() {
-            return Err("schedule cron expression cannot be empty".to_string());
-        }
-        return Ok(json!({ "kind": "cron", "expr": expr }));
+    if let Some(raw) = schedule.as_str() {
+        return normalize_schedule_string(raw);
     }
 
     let Some(schedule_obj) = schedule.as_object() else {
-        return Err("schedule must be a cron expression string or schedule object".to_string());
+        return Err(
+            "schedule must be a cron expression string, ISO-8601 timestamp, or schedule object"
+                .to_string(),
+        );
     };
 
-    if !matches!(
-        schedule_obj.get("kind").and_then(|v| v.as_str()),
-        Some("at" | "every" | "cron")
-    ) {
-        return Err("schedule.kind must be one of: at, every, cron".to_string());
+    normalize_schedule_object(schedule_obj)
+}
+
+fn normalize_schedule_string(raw: &str) -> Result<Value, String> {
+    let raw = raw.trim();
+    if raw.is_empty() {
+        return Err("schedule cannot be empty".to_string());
     }
 
-    Ok(Value::Object(schedule_obj.clone()))
+    // Tool schema is string | object, so models often stringify the object.
+    // Parse that JSON instead of stuffing it into `expr` as a cron string.
+    if raw.starts_with('{') {
+        if let Ok(parsed) = serde_json::from_str::<Value>(raw) {
+            if parsed.is_object() {
+                return normalize_schedule(&parsed);
+            }
+        }
+    }
+
+    if chrono::DateTime::parse_from_rfc3339(raw).is_ok() {
+        return Ok(json!({ "kind": "at", "at": raw }));
+    }
+
+    Ok(json!({ "kind": "cron", "expr": raw }))
+}
+
+fn normalize_schedule_object(
+    schedule_obj: &serde_json::Map<String, Value>,
+) -> Result<Value, String> {
+    let mut out = schedule_obj.clone();
+    if let Some(every_ms) = out.remove("every_ms") {
+        out.entry("everyMs".to_string()).or_insert(every_ms);
+    }
+
+    let kind = out
+        .get("kind")
+        .and_then(|v| v.as_str())
+        .map(normalize_schedule_kind);
+
+    match kind.as_deref() {
+        Some(k @ ("at" | "every" | "cron")) => {
+            // `{kind:"cron", expr:"{\"kind\":\"at\",...}"}` is the same LLM
+            // mix-up one layer deeper — unwrap instead of storing JSON as expr.
+            if k == "cron" {
+                if let Some(expr) = out.get("expr").and_then(|v| v.as_str()) {
+                    let expr = expr.trim();
+                    if expr.starts_with('{') {
+                        if let Ok(parsed) = serde_json::from_str::<Value>(expr) {
+                            if parsed.is_object() {
+                                return normalize_schedule(&parsed);
+                            }
+                        }
+                    }
+                }
+            }
+            out.insert("kind".into(), json!(k));
+            Ok(Value::Object(out))
+        }
+        Some(other) => Err(format!(
+            "schedule.kind must be one of: at, every, cron, got {other}"
+        )),
+        None => {
+            if out.get("at").and_then(|v| v.as_str()).is_some() {
+                out.insert("kind".into(), json!("at"));
+                return Ok(Value::Object(out));
+            }
+            if out.get("everyMs").is_some() {
+                out.insert("kind".into(), json!("every"));
+                return Ok(Value::Object(out));
+            }
+            if out.get("expr").and_then(|v| v.as_str()).is_some() {
+                out.insert("kind".into(), json!("cron"));
+                return Ok(Value::Object(out));
+            }
+            Err("schedule.kind must be one of: at, every, cron".to_string())
+        }
+    }
+}
+
+fn normalize_schedule_kind(kind: &str) -> String {
+    match kind.trim().to_ascii_lowercase().as_str() {
+        "once" | "one-time" | "onetime" | "at" => "at".to_string(),
+        other => other.to_string(),
+    }
 }
 
 fn require_job_id<'a>(args: &'a Value) -> Result<&'a str, String> {
@@ -215,6 +296,97 @@ mod tests {
         assert_eq!(body["payload"]["message"], "Summarize yesterday's work");
         assert_eq!(body["enabled"], true);
         assert!(body.get("workspace_path").is_none());
+    }
+
+    /// Models often stringify the schedule object because the tool schema
+    /// allows string | object. That JSON must become a one-time job, not a
+    /// cron expression whose `expr` is the raw JSON (which is what the
+    /// settings dialog then shows as "Cron 表达式").
+    #[test]
+    fn stringified_at_schedule_becomes_one_time_not_cron_expr() {
+        let body = create_request_body(
+            "/tmp/ws",
+            &json!({
+                "name": "One-shot ping",
+                "schedule": "{\"kind\": \"at\", \"at\": \"2026-09-09T20:10:30+08:00\"}",
+                "message": "ping"
+            }),
+        )
+        .unwrap();
+
+        assert_eq!(body["schedule"]["kind"], "at");
+        assert_eq!(body["schedule"]["at"], "2026-09-09T20:10:30+08:00");
+        assert!(body["schedule"].get("expr").is_none());
+    }
+
+    #[test]
+    fn iso_timestamp_schedule_becomes_one_time() {
+        let body = create_request_body(
+            "/tmp/ws",
+            &json!({
+                "name": "One-shot ping",
+                "schedule": "2026-09-09T20:10:30+08:00",
+                "message": "ping"
+            }),
+        )
+        .unwrap();
+
+        assert_eq!(
+            body["schedule"],
+            json!({ "kind": "at", "at": "2026-09-09T20:10:30+08:00" })
+        );
+    }
+
+    #[test]
+    fn at_object_schedule_is_preserved() {
+        let body = create_request_body(
+            "/tmp/ws",
+            &json!({
+                "name": "One-shot ping",
+                "schedule": { "kind": "at", "at": "2026-09-09T20:10:30+08:00" },
+                "message": "ping"
+            }),
+        )
+        .unwrap();
+
+        assert_eq!(body["schedule"]["kind"], "at");
+        assert_eq!(body["schedule"]["at"], "2026-09-09T20:10:30+08:00");
+    }
+
+    #[test]
+    fn once_kind_alias_becomes_at() {
+        let body = create_request_body(
+            "/tmp/ws",
+            &json!({
+                "name": "One-shot ping",
+                "schedule": { "kind": "once", "at": "2026-09-09T20:10:30+08:00" },
+                "message": "ping"
+            }),
+        )
+        .unwrap();
+
+        assert_eq!(body["schedule"]["kind"], "at");
+        assert_eq!(body["schedule"]["at"], "2026-09-09T20:10:30+08:00");
+    }
+
+    #[test]
+    fn cron_object_whose_expr_is_stringified_at_becomes_one_time() {
+        let body = create_request_body(
+            "/tmp/ws",
+            &json!({
+                "name": "One-shot ping",
+                "schedule": {
+                    "kind": "cron",
+                    "expr": "{\"kind\": \"at\", \"at\": \"2026-09-09T20:10:30+08:00\"}"
+                },
+                "message": "ping"
+            }),
+        )
+        .unwrap();
+
+        assert_eq!(body["schedule"]["kind"], "at");
+        assert_eq!(body["schedule"]["at"], "2026-09-09T20:10:30+08:00");
+        assert!(body["schedule"].get("expr").is_none());
     }
 
     #[test]

--- a/apps/desktop/crates/teamclu-introspect/src/main.rs
+++ b/apps/desktop/crates/teamclu-introspect/src/main.rs
@@ -133,7 +133,7 @@ fn tool_definitions() -> Value {
                         "description": "Human-readable description of what the job does."
                     },
                     "schedule": {
-                        "description": "Schedule for the job (required for create). A plain string is treated as a 5-field cron expression, e.g. '0 9 * * 1-5'. For one-time or interval jobs, pass an object such as {\"kind\":\"at\",\"at\":\"2026-05-07T09:00:00Z\"}, {\"kind\":\"every\",\"everyMs\":3600000}, or {\"kind\":\"cron\",\"expr\":\"0 9 * * 1-5\",\"tz\":\"Asia/Shanghai\"}.",
+                        "description": "Schedule for the job (required for create). Pass an object, do not stringify it. One-time: {\"kind\":\"at\",\"at\":\"2026-09-09T20:10:30+08:00\"} (ISO-8601). Interval: {\"kind\":\"every\",\"everyMs\":3600000}. Recurring cron: {\"kind\":\"cron\",\"expr\":\"0 9 * * 1-5\",\"tz\":\"Asia/Shanghai\"}. A plain string is only a 5-field cron expression (e.g. '0 9 * * 1-5') or an ISO-8601 timestamp.",
                         "anyOf": [
                             { "type": "string" },
                             {

--- a/apps/desktop/src/commands/cron/mod.rs
+++ b/apps/desktop/src/commands/cron/mod.rs
@@ -336,8 +336,36 @@ fn parse_create_request(body: &serde_json::Value) -> Result<CreateCronJobRequest
     obj.remove("scope");
     obj.remove("workspace_path");
     obj.remove("job_id");
+    if let Some(schedule) = obj.get("schedule").cloned() {
+        obj.insert("schedule".into(), unwrap_stringified_schedule(schedule));
+    }
     serde_json::from_value(serde_json::Value::Object(obj))
         .map_err(|e| format!("invalid create request: {e}"))
+}
+
+/// Recover when a sidecar stuffed a one-time/interval object into `expr`
+/// because the model stringified `{kind:"at",...}` as a cron expression.
+fn unwrap_stringified_schedule(schedule: serde_json::Value) -> serde_json::Value {
+    let Some(obj) = schedule.as_object() else {
+        return schedule;
+    };
+    if obj.get("kind").and_then(|v| v.as_str()) != Some("cron") {
+        return schedule;
+    }
+    let Some(expr) = obj.get("expr").and_then(|v| v.as_str()) else {
+        return schedule;
+    };
+    let expr = expr.trim();
+    if !expr.starts_with('{') {
+        return schedule;
+    }
+    let Ok(inner) = serde_json::from_str::<serde_json::Value>(expr) else {
+        return schedule;
+    };
+    match inner.get("kind").and_then(|v| v.as_str()) {
+        Some("at" | "every" | "cron") => inner,
+        _ => schedule,
+    }
 }
 
 pub(crate) async fn ensure_instance(
@@ -621,5 +649,27 @@ mod mcp_create_tests {
         assert_eq!(request.name, "Morning summary");
         assert_eq!(request.payload.message, "hello");
         assert_eq!(request.schedule.expr.as_deref(), Some("0 9 * * *"));
+    }
+
+    #[test]
+    fn parse_create_request_unwraps_stringified_at_schedule_stuffed_in_cron_expr() {
+        let body = serde_json::json!({
+            "action": "create",
+            "scope": "global",
+            "name": "One-shot ping",
+            "enabled": true,
+            "schedule": {
+                "kind": "cron",
+                "expr": "{\"kind\": \"at\", \"at\": \"2026-09-09T20:10:30+08:00\"}"
+            },
+            "payload": { "message": "ping" }
+        });
+        let request = parse_create_request(&body).unwrap();
+        assert_eq!(request.schedule.kind, ScheduleKind::At);
+        assert_eq!(
+            request.schedule.at.as_deref(),
+            Some("2026-09-09T20:10:30+08:00")
+        );
+        assert!(request.schedule.expr.is_none());
     }
 }

--- a/packages/app/src/lib/cron/__tests__/cron-utils.test.ts
+++ b/packages/app/src/lib/cron/__tests__/cron-utils.test.ts
@@ -74,6 +74,27 @@ describe('cron-utils permission mode', () => {
     expect(form.permissionMode).toBe('default')
     expect(formStateToPayload(form).permissionMode).toBe('default')
   })
+
+  it('treats a stringified at-schedule stuffed in cron expr as one-time', () => {
+    const now = new Date().toISOString()
+    const form = jobToFormState({
+      id: 'job-1',
+      name: 'One-shot ping',
+      enabled: true,
+      schedule: {
+        kind: 'cron',
+        expr: '{"kind":"at","at":"2026-09-09T20:10:30+08:00"}',
+      },
+      payload: { message: 'ping' },
+      deleteAfterRun: false,
+      createdAt: now,
+      updatedAt: now,
+    })
+
+    expect(form.scheduleKind).toBe('at')
+    expect(form.at).toBe('2026-09-09T20:10:30+08:00')
+    expect(form.cronExpr).toBe('')
+  })
 })
 
 describe('cron-utils seatalk delivery registry', () => {

--- a/packages/app/src/lib/cron/cron-utils.ts
+++ b/packages/app/src/lib/cron/cron-utils.ts
@@ -4,6 +4,7 @@
  */
 
 import {
+  coerceSchedule,
   type CronSchedule,
   type CronPayload,
   type CronDelivery,
@@ -361,11 +362,13 @@ export const defaultFormState: JobFormState = {
 }
 
 export function jobToFormState(job: CronJob): JobFormState {
+  const schedule = coerceSchedule(job.schedule)
+
   // Parse interval from everyMs
   let everyValue = 30
   let everyUnit: 'minutes' | 'hours' | 'days' = 'minutes'
-  if (job.schedule.everyMs) {
-    const ms = job.schedule.everyMs
+  if (schedule.everyMs) {
+    const ms = schedule.everyMs
     if (ms >= 86400000) {
       everyValue = Math.round(ms / 86400000)
       everyUnit = 'days'
@@ -387,12 +390,12 @@ export function jobToFormState(job: CronJob): JobFormState {
   return {
     name: job.name,
     enabled: job.enabled,
-    scheduleKind: job.schedule.kind,
-    at: job.schedule.at || '',
+    scheduleKind: schedule.kind,
+    at: schedule.at || '',
     everyValue,
     everyUnit,
-    cronExpr: job.schedule.expr || '',
-    cronTz: job.schedule.tz || '',
+    cronExpr: schedule.expr || '',
+    cronTz: schedule.tz || '',
     message: job.payload.message,
     model: job.payload.model || '',
     backend: job.payload.backend || '',

--- a/packages/app/src/stores/__tests__/cron.test.ts
+++ b/packages/app/src/stores/__tests__/cron.test.ts
@@ -147,6 +147,15 @@ describe('cron helpers', () => {
     expect(formatSchedule({ kind: 'cron', expr: '0 9 * * *', tz: 'UTC' })).toBe('Cron: 0 9 * * * (UTC)')
   })
 
+  it('formatSchedule unwraps a one-time job stuffed into cron expr', () => {
+    expect(
+      formatSchedule({
+        kind: 'cron',
+        expr: '{"kind":"at","at":"2026-09-09T20:10:30+08:00"}',
+      }),
+    ).toMatch(/^One-time:/)
+  })
+
   it('getRunStatusColor returns correct colors', () => {
     expect(getRunStatusColor('success')).toBe('text-green-500')
     expect(getRunStatusColor('failed')).toBe('text-red-500')

--- a/packages/app/src/stores/cron.ts
+++ b/packages/app/src/stores/cron.ts
@@ -533,6 +533,29 @@ export function normalizeCronRunRecord(record: CronRunRecord): CronRunRecord {
 
 /** Convert schedule to human-readable string */
 export function formatSchedule(schedule: CronSchedule): string {
+  return formatCoercedSchedule(coerceSchedule(schedule))
+}
+
+/**
+ * Recover when MCP stuffed a stringified `{kind:"at",...}` into `expr`
+ * because the model serialized the schedule object as a cron string.
+ */
+export function coerceSchedule(schedule: CronSchedule): CronSchedule {
+  if (schedule.kind !== 'cron') return schedule
+  const expr = schedule.expr?.trim()
+  if (!expr?.startsWith('{')) return schedule
+  try {
+    const inner = JSON.parse(expr) as Partial<CronSchedule>
+    if (inner && (inner.kind === 'at' || inner.kind === 'every' || inner.kind === 'cron')) {
+      return inner as CronSchedule
+    }
+  } catch {
+    // keep the original cron row
+  }
+  return schedule
+}
+
+function formatCoercedSchedule(schedule: CronSchedule): string {
   switch (schedule.kind) {
     case 'at':
       if (schedule.at) {


### PR DESCRIPTION
## Description

`manage_cron_job` one-time creates were stored as cron expressions whose `expr` was the raw JSON (`{"kind":"at","at":"..."}`). The settings dialog then showed **Cron 表达式** instead of **一次性**.

Models stringify the schedule object because the tool schema allows `string | object`. A plain string was always treated as a 5-field cron expression.

This PR:
- Parses a stringified schedule object (and ISO-8601 timestamps) as `kind: at`
- Unwraps the same mix-up on the desktop create path
- Coerces already-saved rows in the automation list and edit dialog

Follow-up to #1337 (MCP jobs now land in the global store).

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Test plan

- [ ] Rebuild desktop (sidecar included) from this branch and restart the app
- [ ] Ask the agent to create a **one-time** job via MCP (`manage_cron_job`)
- [ ] Open the job: schedule type is **一次性**, datetime is the requested time, not JSON in the cron field
- [ ] Recurring cron strings such as `0 9 * * 1-5` still create cron-expression jobs
- [ ] Open a previously mis-saved job (JSON in the cron field): the dialog shows one-time; saving writes the correct schedule

## Additional Notes

Desktop must be rebuilt for new MCP creates. Frontend coerce is enough to display/edit jobs that were already saved wrong.

Rust desktop-crate tests were not run locally (memory constraint). Introspect crate tests and the related Vitest files were run.

Made with [Cursor](https://cursor.com)