### PR TITLE
fix(db): 选团队时列出了别的租户的团队 —— 手机号身份键把「会员」当成了「同事」

### DIFF
--- a/services/fc/deploy-aliyun-fc.sh
+++ b/services/fc/deploy-aliyun-fc.sh
@@ -230,6 +230,30 @@ npm install
 echo "==> Building TypeScript (-> dist/)"
 npm run build
 
+# The FC runtime is linux-x64; the machine running this script may not be.
+# Native modules ship their binding as an optionalDependency keyed on os/cpu, so
+# npm installs only the HOST's — and `s deploy` uploads node_modules exactly as
+# it stands. A deploy from macOS therefore ships a bundle whose native modules
+# cannot load, and the failure is not a degraded feature: the runtime exits 128
+# on the first request and EVERY route 502s with "Cannot find native binding".
+# That took the live API down for five minutes on 2026-09-09, and it will happen
+# again on the next deploy from a Mac if this step is removed.
+#
+# @alicloud/sls20201230 (the app-logs client) pulls in lz4-napi, the only such
+# module here today. npm refuses a foreign-platform package on principle, hence
+# --force. Version comes from the installed copy so the two cannot drift.
+echo "==> Adding linux-x64 native bindings (FC runtime is not this machine)"
+_lz4_ver="$(node -p "require('./node_modules/lz4-napi/package.json').version" 2>/dev/null || true)"
+if [ -n "$_lz4_ver" ]; then
+  npm install --no-save --no-audit --no-fund --force \
+    "@antoniomuso/lz4-napi-linux-x64-gnu@$_lz4_ver" >/dev/null
+  if [ ! -f node_modules/@antoniomuso/lz4-napi-linux-x64-gnu/lz4-napi.linux-x64-gnu.node ]; then
+    echo "ERROR: the linux-x64 lz4-napi binding is missing after install." >&2
+    echo "       Deploying now would 502 on every request. Fix the install and retry." >&2
+    exit 1
+  fi
+fi
+
 # NOTE: the GitHub Action additionally runs `npm prune --omit=dev` to shrink the
 # package. Skipped here so your local node_modules stays intact for dev. The
 # extra dev deps in the package are harmless for a test deploy.

--- a/services/fc/src/lib/supabase-repo.ts
+++ b/services/fc/src/lib/supabase-repo.ts
@@ -618,10 +618,13 @@ export function createSupabaseBusinessRepository(options) {
     // here is `amux`, so it resolves via a plain `.rpc(...)` like create_team etc.
     async listAllMyTeams() {
       // Cross-org team picker source: member teams plus every public team the
-      // caller may join. `p_default_org_id` survives only in the RPC signature
-      // — the function body has never read it, and FC no longer supplies it.
+      // caller may join. `p_default_org_id` names the shared tenant — the org
+      // phone sign-up stamps every account with, which therefore says nothing
+      // about belonging and must not contribute its public teams. Same value
+      // bootstrapTeam passes as `p_shared_org`; null on a deployment without
+      // phone login, where the picker's own-org arm behaves as it always has.
       const { data, error } = await supabase.rpc("list_teams_for_picker", {
-        p_default_org_id: null,
+        p_default_org_id: process.env.DEFAULT_ORG_ID || null,
         p_include_empty_orgs: false,
       });
       if (error) throw error;
@@ -661,11 +664,12 @@ export function createSupabaseBusinessRepository(options) {
     // plain 'member' actor (idempotent if already joined) and rejects anything
     // that is not public.
     async joinPublicTeam(teamId) {
-      // `p_default_org_id` is vestigial (the function body never read it). The
-      // org check now happens inside the RPC against amux.current_org_id().
+      // `p_default_org_id` names the shared tenant, as in listAllMyTeams: the
+      // RPC's own-org check (CS-4) passes for every phone sign-up there, so the
+      // shared org needs the extra employee test the picker now applies.
       const { data, error } = await supabase.rpc("join_public_team", {
         p_team_id: teamId,
-        p_default_org_id: null,
+        p_default_org_id: process.env.DEFAULT_ORG_ID || null,
       });
       if (error) {
         const code = error?.code || "";

--- a/services/supabase/migrations/20260909000000_picker_employee_identities_only.sql
+++ b/services/supabase/migrations/20260909000000_picker_employee_identities_only.sql
@@ -1,0 +1,183 @@
+-- The picker's cross-tenant phone key answers two different questions, and only
+-- one of them may be answered phone-wide.
+--
+-- 20260801060000_phone_linked_org_team_picker.sql stated the rule as "the
+-- current employee user's mobile is the cross-tenant key for all employee
+-- identities" and then matched on the mobile alone, using that one set both to
+-- find the caller's memberships AND to decide which orgs are theirs. On a
+-- deployment that shares `public.users` with the partner SaaS, that table is the
+-- CUSTOMER register (599k rows at admin_type = 1 on the live box, alongside
+-- height / birthday / membership-card columns), so "same mobile" resolves to
+-- every gym the person has ever bought a membership at — not to the tenants
+-- they work for.
+--
+-- What that produced: someone who is staff at three orgs saw eight, the five
+-- extras being gyms they hold a membership card at. Every extra org contributed
+-- its org-named default team — public since #959 — rendered as a joinable row
+-- carrying that tenant's team name, member count and owner's real name.
+-- Clicking one is a dead end (join_public_team's org guard from CS-4 rejects
+-- it), so this is disclosure rather than an access path; but what it discloses
+-- is one tenant's roster metadata to another tenant. On the live deployment 50
+-- of the 54 phone-carrying users saw at least one org that was not theirs, and
+-- the worst case saw 20 where 6 were real.
+--
+-- So split the two questions:
+--
+--   related_users  — WHO AM I. Stays phone-wide, and must: a phone sign-up
+--                    mints its `public.users` row in DEFAULT_ORG at the default
+--                    admin_type 1, and the teams that identity created are held
+--                    by exactly that customer-grade row. Narrowing this set is
+--                    what an earlier draft of this migration did, and it drops
+--                    five live memberships — e.g. a person signed in through
+--                    their 香蕉攀岩 staff account loses the teams their own
+--                    phone-signup identity owns. It also stays consistent with
+--                    switch_active_team, which accepts any same-phone actor.
+--
+--   employee_orgs  — WHOSE TENANT AM I IN. Employee identities only, resolved
+--                    the way the partner SaaS resolves them in its own account
+--                    picker (apps/api/src/routes/api/admin/auth/admin-accounts.ts):
+--
+--                        .eq('mobile', mobile)
+--                        .in('admin_type', [ADMIN, SUPER_ADMIN, SYSTEM_ADMIN])
+--                        .is('deleted_at', null)
+--
+--                    `admin_type >= 2` is the employee test — offboarding resets
+--                    it to 1 (NORMAL), which is why leaving a company also drops
+--                    its teams from the picker.
+--
+-- Only `public_teams` and `empty_orgs` read the org set, so this narrows exactly
+-- the is_member = false rows — the ones that were leaking — and leaves every
+-- actual membership alone. The caller's own org stays in the set unconditionally,
+-- as it is today: a phone sign-up landing in DEFAULT_ORG still sees that org's
+-- public default team, which is a separate question from this one.
+--
+-- Everything else is carried forward verbatim from
+-- 20260817010000_picker_disambiguation_fields.sql. The signature and return
+-- type are unchanged, so CREATE OR REPLACE keeps the grants this time.
+
+-- `deleted_at` is on the partner's table but not on the subset mirror the
+-- self-host baseline creates, and the predicate below has to resolve on both.
+--
+-- Guarded by a lookup rather than written as ADD COLUMN IF NOT EXISTS, because
+-- that form still demands ownership of the table before it notices there is
+-- nothing to do: as the self-host `migrate` service's role, `alter table
+-- public.users add column if not exists deleted_at` fails with "must be owner of
+-- table users" on a database where the column is already there. Where the column
+-- exists — every deployment sharing the partner's table — this issues no DDL at
+-- all and needs no privilege on it.
+do $$
+begin
+  if not exists (
+    select 1 from information_schema.columns
+     where table_schema = 'public' and table_name = 'users' and column_name = 'deleted_at'
+  ) then
+    alter table public.users add column deleted_at timestamptz;
+  end if;
+end $$;
+
+create or replace function amux.list_teams_for_picker(
+  p_default_org_id uuid default null,
+  p_include_empty_orgs boolean default false
+)
+returns table(team_id uuid, team_name text, team_slug text, org_id uuid, org_name text,
+              visibility text, is_member boolean, item_type text,
+              created_at timestamptz, member_count integer, owner_name text)
+language sql
+stable security definer
+set search_path to 'amux', 'public', 'auth'
+as $function$
+  with current_identity as (
+    select u.id, nullif(btrim(u.mobile), '') as mobile
+      from public.users u
+     where u.id = auth.uid()
+     limit 1
+  ), related_users as (
+    -- WHO AM I: every identity this person signs in as. Phone-wide on purpose —
+    -- see the header. Retain the caller even when a legacy record has no phone.
+    select auth.uid() as id
+     where auth.uid() is not null
+    union
+    select u.id
+      from public.users u
+      join current_identity c on c.mobile is not null and u.mobile = c.mobile
+  ), employee_orgs as (
+    -- WHOSE TENANT AM I IN: the caller's own org, plus the orgs they hold an
+    -- EMPLOYEE record in. A customer record sharing the phone does not count.
+    select u.org_id
+      from public.users u
+     where u.id = auth.uid()
+       and u.org_id is not null
+    union
+    select u.org_id
+      from public.users u
+      join current_identity c on c.mobile is not null and u.mobile = c.mobile
+     where u.admin_type >= 2
+       and u.deleted_at is null
+       and u.org_id is not null
+  ), member_teams as (
+    -- No org filter: an actor in the team is the membership.
+    select t.id, t.name, t.slug, t.oid, t.visibility, true as is_member, 'team'::text as item_type,
+           t.created_at
+      from amux.teams t
+     where exists (
+         select 1
+           from amux.actors a
+           join related_users ru on ru.id = a.user_id
+          where a.team_id = t.id
+       )
+  ), public_teams as (
+    select t.id, t.name, t.slug, t.oid, t.visibility, false as is_member, 'team'::text as item_type,
+           t.created_at
+      from amux.teams t
+     where t.oid in (select org_id from employee_orgs)
+       and t.visibility = 'public'
+       and not exists (
+         select 1
+           from amux.actors a
+           join related_users ru on ru.id = a.user_id
+          where a.team_id = t.id
+       )
+  ), empty_orgs as (
+    select null::uuid as id, null::text as name, null::text as slug, o.id as oid,
+           'private'::text as visibility, true as is_member, 'org'::text as item_type,
+           null::timestamptz as created_at
+      from public.orgs o
+      join employee_orgs eo on eo.org_id = o.id
+     where p_include_empty_orgs
+       and not exists (select 1 from amux.teams t where t.oid = o.id)
+  )
+  select * from (
+    select t.id as team_id, t.name as team_name, t.slug as team_slug, t.oid as org_id,
+           o.name as org_name, t.visibility, t.is_member, t.item_type,
+           t.created_at,
+           -- Counted here rather than client-side: the picker runs before the
+           -- caller has switched into the team, so a per-team member listing
+           -- would be blocked by RLS for exactly the rows worth disambiguating.
+           -- This function is SECURITY DEFINER, so the count is accurate even
+           -- for a public team the caller has not joined.
+           (select count(*)::int
+              from amux.actors a
+             where a.team_id = t.id and a.actor_type = 'member') as member_count,
+           (select a.display_name
+              from amux.team_members tm
+              join amux.actors a on a.id = tm.member_id
+             where tm.team_id = t.id and tm.role = 'owner'
+             order by a.created_at asc, a.id asc
+             limit 1) as owner_name
+      from (
+        select * from member_teams
+        union all
+        select * from public_teams
+      ) t
+      join public.orgs o on o.id = t.oid
+    union all
+    select e.id, e.name, e.slug, e.oid, o.name, e.visibility, e.is_member, e.item_type,
+           e.created_at, null::int, null::text
+      from empty_orgs e
+      join public.orgs o on o.id = e.oid
+  ) picker_items
+  order by org_name nulls last, item_type, team_name, created_at nulls last, team_id;
+$function$;
+
+comment on function amux.list_teams_for_picker(uuid, boolean) is
+  'Cross-org team picker source: teams the caller holds an actor in, plus public teams they could join in their own org and the orgs they hold an EMPLOYEE record in. Membership is resolved phone-wide (any same-phone identity''s actor counts, as in switch_active_team); the ORG set is not, and follows the partner SaaS rule — same mobile, admin_type >= 2, not soft-deleted — so a customer record sharing the caller''s phone number does not pull its tenant into the picker. Also returns created_at / member_count / owner_name so the client can disambiguate teams that share a name (an org''s teams are all named after the org).';

--- a/services/supabase/migrations/20260909010000_shared_org_not_self_joinable.sql
+++ b/services/supabase/migrations/20260909010000_shared_org_not_self_joinable.sql
@@ -1,0 +1,246 @@
+-- The shared tenant is an account namespace, not an org you belong to.
+--
+-- Phone sign-up stamps every account it mints with DEFAULT_ORG_ID: the login
+-- lookup itself is `(org_id = DEFAULT_ORG_ID, mobile = phone)`, so a teamclu
+-- phone account IS a `public.users` row in that one org. On belayo that org is
+-- also a real tenant with a real team, and the two roles collide — every person
+-- who has ever signed up reads as "in this company's org", which is how a random
+-- sign-up (user_ra3n_0232, 2026-09-01) ended up sitting in the company's own
+-- team alongside its staff.
+--
+-- The database already knows this org is special. bootstrap_login_team takes
+-- `p_shared_org` and routes it down a separate branch — a private team of your
+-- own instead of the org's default team — precisely so phone users are not all
+-- funnelled into one team. The picker and join_public_team simply never learned
+-- the same thing, so what bootstrap refuses to do automatically, the picker
+-- offered as a button.
+--
+-- Teach them, with one exception that has to survive: an EMPLOYEE of that org
+-- still belongs to it. Under the shared-org branch bootstrap gives staff a
+-- private team rather than joining them to the company team, so the picker's
+-- public row is their only self-serve way in — it is how the org's own admin
+-- joined on 2026-08-22. Blocking everyone would take that path with it.
+--
+-- Employee-ness is the same test both functions have to apply, and the failure
+-- mode of them disagreeing is the dead-end row this whole area keeps producing:
+-- the picker offers a team join_public_team then refuses. So it lives in one
+-- place, amux.caller_employee_orgs(), and both read it.
+--
+-- `p_default_org_id` is revived rather than renamed to `p_shared_org` (which is
+-- what bootstrap_login_team calls the same value). PostgREST binds RPC arguments
+-- by NAME, so renaming would break every call from an FC container that has not
+-- been redeployed yet, in both directions across the rollout window. The
+-- parameter has carried this deployment's DEFAULT_ORG_ID all along; only the use
+-- it is put to is new.
+
+-- One definition of "employee of this org", read by both functions below.
+-- SECURITY DEFINER because it reads public.users, and its callers are definers
+-- themselves; it only ever discloses the caller's own tenancy.
+create or replace function amux.caller_employee_orgs()
+returns setof uuid
+language sql
+stable security definer
+set search_path to 'amux', 'public', 'auth'
+as $function$
+  -- Same rule the partner SaaS applies in its own account picker
+  -- (apps/api/src/routes/api/admin/auth/admin-accounts.ts): the caller's own
+  -- record, plus every same-phone record, kept only where it is a live employee.
+  select distinct u.org_id
+    from public.users u
+   where u.org_id is not null
+     and u.admin_type >= 2
+     and u.deleted_at is null
+     and (
+       u.id = auth.uid()
+       or u.mobile = (select nullif(btrim(x.mobile), '') from public.users x where x.id = auth.uid() limit 1)
+     );
+$function$;
+
+comment on function amux.caller_employee_orgs() is
+  'The orgs the caller holds a live employee record in (own record or any record sharing their phone; admin_type >= 2, not soft-deleted). The single definition of employee-ness for list_teams_for_picker and join_public_team — they must not drift, or the picker offers teams the join refuses.';
+
+grant execute on function amux.caller_employee_orgs() to authenticated, service_role;
+
+-- Picker: the caller's own org no longer counts when it is the shared tenant.
+-- Body otherwise verbatim from 20260909000000_picker_employee_identities_only.sql.
+create or replace function amux.list_teams_for_picker(
+  p_default_org_id uuid default null,
+  p_include_empty_orgs boolean default false
+)
+returns table(team_id uuid, team_name text, team_slug text, org_id uuid, org_name text,
+              visibility text, is_member boolean, item_type text,
+              created_at timestamptz, member_count integer, owner_name text)
+language sql
+stable security definer
+set search_path to 'amux', 'public', 'auth'
+as $function$
+  with current_identity as (
+    select u.id, nullif(btrim(u.mobile), '') as mobile
+      from public.users u
+     where u.id = auth.uid()
+     limit 1
+  ), related_users as (
+    -- WHO AM I: every identity this person signs in as. Phone-wide on purpose —
+    -- a phone sign-up's own record is customer-grade, and the teams it created
+    -- hang off exactly that record. Retain the caller even with no phone.
+    select auth.uid() as id
+     where auth.uid() is not null
+    union
+    select u.id
+      from public.users u
+      join current_identity c on c.mobile is not null and u.mobile = c.mobile
+  ), employee_orgs as (
+    -- WHOSE TENANT AM I IN: the orgs I hold an employee record in, plus my own
+    -- org — unless my own org is the shared tenant, which every phone sign-up
+    -- is stamped with and which therefore says nothing about belonging. Being
+    -- an employee of the shared tenant still counts: that arrives through
+    -- caller_employee_orgs() above.
+    select eo.org_id from amux.caller_employee_orgs() as eo(org_id)
+    union
+    select u.org_id
+      from public.users u
+     where u.id = auth.uid()
+       and u.org_id is not null
+       and (p_default_org_id is null or u.org_id is distinct from p_default_org_id)
+  ), member_teams as (
+    -- No org filter: an actor in the team is the membership.
+    select t.id, t.name, t.slug, t.oid, t.visibility, true as is_member, 'team'::text as item_type,
+           t.created_at
+      from amux.teams t
+     where exists (
+         select 1
+           from amux.actors a
+           join related_users ru on ru.id = a.user_id
+          where a.team_id = t.id
+       )
+  ), public_teams as (
+    select t.id, t.name, t.slug, t.oid, t.visibility, false as is_member, 'team'::text as item_type,
+           t.created_at
+      from amux.teams t
+     where t.oid in (select org_id from employee_orgs)
+       and t.visibility = 'public'
+       and not exists (
+         select 1
+           from amux.actors a
+           join related_users ru on ru.id = a.user_id
+          where a.team_id = t.id
+       )
+  ), empty_orgs as (
+    select null::uuid as id, null::text as name, null::text as slug, o.id as oid,
+           'private'::text as visibility, true as is_member, 'org'::text as item_type,
+           null::timestamptz as created_at
+      from public.orgs o
+      join employee_orgs eo on eo.org_id = o.id
+     where p_include_empty_orgs
+       and not exists (select 1 from amux.teams t where t.oid = o.id)
+  )
+  select * from (
+    select t.id as team_id, t.name as team_name, t.slug as team_slug, t.oid as org_id,
+           o.name as org_name, t.visibility, t.is_member, t.item_type,
+           t.created_at,
+           -- Counted here rather than client-side: the picker runs before the
+           -- caller has switched into the team, so a per-team member listing
+           -- would be blocked by RLS for exactly the rows worth disambiguating.
+           (select count(*)::int
+              from amux.actors a
+             where a.team_id = t.id and a.actor_type = 'member') as member_count,
+           (select a.display_name
+              from amux.team_members tm
+              join amux.actors a on a.id = tm.member_id
+             where tm.team_id = t.id and tm.role = 'owner'
+             order by a.created_at asc, a.id asc
+             limit 1) as owner_name
+      from (
+        select * from member_teams
+        union all
+        select * from public_teams
+      ) t
+      join public.orgs o on o.id = t.oid
+    union all
+    select e.id, e.name, e.slug, e.oid, o.name, e.visibility, e.is_member, e.item_type,
+           e.created_at, null::int, null::text
+      from empty_orgs e
+      join public.orgs o on o.id = e.oid
+  ) picker_items
+  order by org_name nulls last, item_type, team_name, created_at nulls last, team_id;
+$function$;
+
+comment on function amux.list_teams_for_picker(uuid, boolean) is
+  'Cross-org team picker source: teams the caller holds an actor in, plus public teams they could join in the orgs they belong to. Membership is resolved phone-wide (any same-phone identity''s actor counts, as in switch_active_team); the ORG set is not — it is caller_employee_orgs() plus the caller''s own org, and the own-org arm drops out when that org is p_default_org_id, the shared tenant every phone sign-up is stamped with. Also returns created_at / member_count / owner_name so the client can disambiguate teams that share a name.';
+
+-- Join: the interface-layer half of the same rule. The picker will no longer
+-- offer these rows, but CS-4 established that the org check belongs here too —
+-- a stale client still holds the team ids it was offered yesterday.
+-- Body otherwise verbatim from 20260817040000_join_public_team_org_scope.sql.
+create or replace function amux.join_public_team(
+  p_team_id uuid,
+  p_default_org_id uuid default null
+)
+returns table(team_id uuid, team_name text, team_slug text, member_id uuid, role text, workspace_id uuid, workspace_name text)
+language plpgsql
+security definer
+set search_path to 'amux', 'public', 'auth', 'extensions'
+as $function$
+declare
+  v_user_id uuid := auth.uid();
+  v_team amux.teams%rowtype;
+  v_member_id uuid;
+  v_workspace_id uuid;
+  v_workspace_name text;
+  v_nickname text;
+  v_display_name text;
+  v_is_anonymous boolean;
+  v_caller_org uuid;
+begin
+  if v_user_id is null then
+    raise exception 'join_public_team requires an authenticated user' using errcode = '42501';
+  end if;
+  select coalesce(is_anonymous, false) into v_is_anonymous from auth.users where id = v_user_id;
+  if coalesce(v_is_anonymous, false) then
+    raise exception 'anonymous users cannot join a team' using errcode = '42501';
+  end if;
+  select * into v_team from amux.teams where id = p_team_id;
+  if not found then raise exception 'team not found' using errcode = 'P0002'; end if;
+  if v_team.visibility is distinct from 'public' then
+    raise exception 'team is not a joinable public team' using errcode = '42501';
+  end if;
+
+  -- 已经是成员就放行（幂等），否则必须同 org。
+  select a.id into v_member_id from amux.actors a where a.user_id = v_user_id and a.team_id = p_team_id limit 1;
+  if v_member_id is null then
+    v_caller_org := amux.current_org_id();
+    if v_team.oid is null or v_caller_org is null or v_team.oid is distinct from v_caller_org then
+      raise exception 'team belongs to another organization' using errcode = '42501';
+    end if;
+
+    -- 共享租户：所有手机号注册的账号都落在这个 org，"同 org" 因此不构成归属。
+    -- 只有它的员工才能自助入队；其他人走邀请。
+    if p_default_org_id is not null
+       and v_team.oid = p_default_org_id
+       and not exists (select 1 from amux.caller_employee_orgs() as eo(org_id) where eo.org_id = v_team.oid)
+    then
+      raise exception 'the shared tenant''s teams are not self-joinable' using errcode = '42501';
+    end if;
+
+    select nickname into v_nickname from public.users where id = v_user_id limit 1;
+    v_member_id := gen_random_uuid();
+    v_display_name := coalesce(
+      nullif(btrim(v_nickname), ''),
+      amux.resolve_caller_display_name(v_member_id)
+    );
+    insert into amux.actors (id, team_id, actor_type, user_id, display_name, last_active_at)
+      values (v_member_id, p_team_id, 'member', v_user_id, v_display_name, now());
+    insert into amux.members (id, status) values (v_member_id, 'active');
+    insert into amux.team_members (team_id, member_id, role) values (p_team_id, v_member_id, 'member');
+  end if;
+
+  select w.id, w.name into v_workspace_id, v_workspace_name from amux.workspaces w
+    where w.team_id = p_team_id order by w.created_at asc, w.id asc limit 1;
+  return query select v_team.id, v_team.name, v_team.slug, v_member_id,
+    case when exists (select 1 from amux.team_members tm where tm.team_id = p_team_id and tm.member_id = v_member_id and tm.role = 'owner') then 'owner' else 'member' end,
+    v_workspace_id, v_workspace_name;
+end;
+$function$;
+
+comment on function amux.join_public_team(uuid, uuid) is
+  'Self-service join of a PUBLIC team in the caller''s own org. p_default_org_id names the shared tenant (this deployment''s DEFAULT_ORG_ID): every phone sign-up is stamped with that org, so same-org is not belonging there — only an employee of it, per caller_employee_orgs(), may self-join its teams.';

--- a/services/supabase/tests/028_phone_linked_org_picker.sql
+++ b/services/supabase/tests/028_phone_linked_org_picker.sql
@@ -1,6 +1,6 @@
 begin;
 
-select plan(6);
+select plan(9);
 
 create temporary table phone_picker_fixture (
   caller_id uuid not null,
@@ -23,20 +23,36 @@ declare
   v_org_a uuid := gen_random_uuid();
   v_org_b uuid := gen_random_uuid();
   v_org_other uuid := gen_random_uuid();
+  -- Same phone as the caller, but NOT an employee identity: a customer record
+  -- (admin_type 1, what the partner's member register is full of) and a
+  -- soft-deleted employee record. Neither may pull its org into the picker.
+  v_customer uuid := gen_random_uuid();
+  v_ex_staff uuid := gen_random_uuid();
+  v_org_customer uuid := gen_random_uuid();
+  v_org_ex_staff uuid := gen_random_uuid();
   v_team_linked uuid := gen_random_uuid();
+  v_team_customer uuid := gen_random_uuid();
 begin
   insert into auth.users (id, aud, role, created_at, updated_at, instance_id)
   values
     (v_caller, 'authenticated', 'authenticated', now(), now(), '00000000-0000-0000-0000-000000000000'),
     (v_linked, 'authenticated', 'authenticated', now(), now(), '00000000-0000-0000-0000-000000000000'),
-    (v_other, 'authenticated', 'authenticated', now(), now(), '00000000-0000-0000-0000-000000000000');
+    (v_other, 'authenticated', 'authenticated', now(), now(), '00000000-0000-0000-0000-000000000000'),
+    (v_customer, 'authenticated', 'authenticated', now(), now(), '00000000-0000-0000-0000-000000000000'),
+    (v_ex_staff, 'authenticated', 'authenticated', now(), now(), '00000000-0000-0000-0000-000000000000');
   insert into public.orgs (id, name)
-  values (v_org_a, 'Phone Org A'), (v_org_b, 'Phone Org B'), (v_org_other, 'Other Org');
-  insert into public.users (id, auth_user_id, org_id, mobile)
+  values (v_org_a, 'Phone Org A'), (v_org_b, 'Phone Org B'), (v_org_other, 'Other Org'),
+         (v_org_customer, 'Customer Org'), (v_org_ex_staff, 'Ex Staff Org');
+  -- admin_type is spelled out: the caller keeps the customer-grade default a
+  -- phone sign-up gets (their own row is retained unconditionally), while the
+  -- linked identity has to be an EMPLOYEE for its org to join the picker.
+  insert into public.users (id, auth_user_id, org_id, mobile, admin_type, deleted_at)
   values
-    (v_caller, v_caller, v_org_a, '13800009991'),
-    (v_linked, v_linked, v_org_b, '13800009991'),
-    (v_other, v_other, v_org_other, '13800009992');
+    (v_caller, v_caller, v_org_a, '13800009991', 1, null),
+    (v_linked, v_linked, v_org_b, '13800009991', 3, null),
+    (v_other, v_other, v_org_other, '13800009992', 3, null),
+    (v_customer, v_customer, v_org_customer, '13800009991', 1, null),
+    (v_ex_staff, v_ex_staff, v_org_ex_staff, '13800009991', 3, now());
   insert into amux.teams (id, name, slug, oid, visibility)
   values
     (gen_random_uuid(), 'Caller private', 'phone-caller-private', v_org_a, 'private'),
@@ -44,12 +60,21 @@ begin
     (gen_random_uuid(), 'A public', 'phone-a-public', v_org_a, 'public'),
     (gen_random_uuid(), 'B public', 'phone-b-public', v_org_b, 'public'),
     (gen_random_uuid(), 'Hidden private', 'phone-hidden-private', v_org_b, 'private'),
-    (gen_random_uuid(), 'Other public', 'phone-other-public', v_org_other, 'public');
+    (gen_random_uuid(), 'Other public', 'phone-other-public', v_org_other, 'public'),
+    (gen_random_uuid(), 'Customer public', 'phone-customer-public', v_org_customer, 'public'),
+    (v_team_customer, 'Customer private', 'phone-customer-private', v_org_customer, 'private'),
+    (gen_random_uuid(), 'Ex staff public', 'phone-ex-staff-public', v_org_ex_staff, 'public');
   insert into amux.actors (id, team_id, actor_type, user_id, display_name)
   select gen_random_uuid(), t.id, 'member', v_caller, 'Caller'
     from amux.teams t where t.slug = 'phone-caller-private';
   insert into amux.actors (id, team_id, actor_type, user_id, display_name)
   values (gen_random_uuid(), v_team_linked, 'member', v_linked, 'Linked');
+  -- The customer-grade identity holds a membership of its own. This is what a
+  -- phone sign-up looks like (DEFAULT_ORG, admin_type 1, a team it created), and
+  -- it has to survive: membership is resolved phone-wide even though the ORG set
+  -- is employees-only.
+  insert into amux.actors (id, team_id, actor_type, user_id, display_name)
+  values (gen_random_uuid(), v_team_customer, 'member', v_customer, 'Customer');
   perform set_config('request.jwt.claims',
     json_build_object('sub', v_caller, 'role', 'authenticated')::text, true);
   perform set_config('role', 'authenticated', true);
@@ -62,8 +87,8 @@ end $$;
 
 select is(
   (select count(*)::int from amux.list_teams_for_picker(null, true)),
-  4,
-  'picker returns only member and public teams in phone-linked orgs'
+  5,
+  'picker returns only member teams and public teams in employee orgs'
 );
 select ok(
   exists(select 1 from amux.list_teams_for_picker(null, true) where team_slug = 'phone-linked-private' and is_member),
@@ -80,6 +105,18 @@ select ok(
 select ok(
   not exists(select 1 from amux.list_teams_for_picker(null, true) where team_slug = 'phone-other-public'),
   'picker excludes teams outside phone-linked orgs'
+);
+select ok(
+  exists(select 1 from amux.list_teams_for_picker(null, true) where team_slug = 'phone-customer-private' and is_member),
+  'a team joined by a same-phone CUSTOMER identity stays visible'
+);
+select ok(
+  not exists(select 1 from amux.list_teams_for_picker(null, true) where team_slug = 'phone-customer-public'),
+  'a customer record sharing the phone does not pull its org into the picker'
+);
+select ok(
+  not exists(select 1 from amux.list_teams_for_picker(null, true) where team_slug = 'phone-ex-staff-public'),
+  'a soft-deleted employee record does not pull its org into the picker'
 );
 select ok(
   (select refresh_token is not null from amux.switch_active_team(linked_private_team) limit 1),

--- a/services/supabase/tests/036_shared_org_not_self_joinable.sql
+++ b/services/supabase/tests/036_shared_org_not_self_joinable.sql
@@ -1,0 +1,138 @@
+-- 20260909010000_shared_org_not_self_joinable.sql
+--
+-- The shared tenant (this deployment's DEFAULT_ORG_ID, passed in as
+-- p_default_org_id) is the org phone sign-up stamps every account with. Being
+-- "in" it therefore says nothing about belonging, and its public teams must not
+-- be offered to — or joinable by — everyone who has ever signed up.
+--
+-- The exception that has to survive: an EMPLOYEE of that org still belongs to
+-- it, and the picker's public row is their only self-serve way into the org's
+-- team (bootstrap_login_team's shared-org branch deliberately gives them a
+-- private team instead of joining them).
+--
+-- Both halves are asserted, on both functions, because the failure mode when
+-- they disagree is a row the picker offers and the join refuses.
+
+begin;
+
+select plan(9);
+
+create or replace function pg_temp.as_user(p_user uuid)
+returns void language plpgsql as $$
+begin
+  perform set_config('request.jwt.claims',
+    json_build_object('sub', p_user::text, 'role', 'authenticated')::text, true);
+  perform set_config('role', 'authenticated', true);
+end;
+$$;
+
+create temporary table shared_org_fixture (
+  shared_org uuid not null,
+  signup_id uuid not null,
+  staff_id uuid not null,
+  shared_public_team uuid not null,
+  signup_private_team uuid not null
+);
+grant select on shared_org_fixture to anon, authenticated;
+
+do $$
+declare
+  v_shared_org uuid := gen_random_uuid();
+  v_signup uuid := gen_random_uuid();
+  v_staff  uuid := gen_random_uuid();
+  v_public_team uuid := gen_random_uuid();
+  v_private_team uuid := gen_random_uuid();
+begin
+  insert into auth.users (id, aud, role, created_at, updated_at, instance_id)
+  values
+    (v_signup, 'authenticated', 'authenticated', now(), now(), '00000000-0000-0000-0000-000000000000'),
+    (v_staff,  'authenticated', 'authenticated', now(), now(), '00000000-0000-0000-0000-000000000000');
+  insert into public.orgs (id, name) values (v_shared_org, 'Shared Tenant');
+  -- Both live in the shared org, which is exactly the point: same org, and only
+  -- one of them an employee of it.
+  insert into public.users (id, auth_user_id, org_id, mobile, admin_type)
+  values
+    (v_signup, v_signup, v_shared_org, '13800007771', 1),
+    (v_staff,  v_staff,  v_shared_org, '13800007772', 3);
+  insert into amux.teams (id, name, slug, oid, visibility)
+  values
+    (v_public_team,  'Shared Tenant', 'shared-tenant-public',  v_shared_org, 'public'),
+    (v_private_team, 'Signup own',    'shared-signup-private', v_shared_org, 'private');
+  -- What bootstrap_login_team's shared-org branch gives a phone sign-up.
+  insert into amux.actors (id, team_id, actor_type, user_id, display_name)
+  values (gen_random_uuid(), v_private_team, 'member', v_signup, 'Signup');
+  insert into shared_org_fixture
+  values (v_shared_org, v_signup, v_staff, v_public_team, v_private_team);
+end $$;
+
+-- ── The sign-up: in the org, not of it ──────────────────────────────────────
+select pg_temp.as_user((select signup_id from shared_org_fixture));
+
+select ok(
+  not exists(
+    select 1 from amux.list_teams_for_picker((select shared_org from shared_org_fixture), false)
+     where team_slug = 'shared-tenant-public'),
+  'a phone sign-up is not offered the shared tenant''s public team'
+);
+
+select ok(
+  exists(
+    select 1 from amux.list_teams_for_picker((select shared_org from shared_org_fixture), false)
+     where team_slug = 'shared-signup-private' and is_member),
+  'the sign-up still sees the private team bootstrap gave them'
+);
+
+select is(
+  (select count(*)::int from amux.caller_employee_orgs()),
+  0,
+  'a customer-grade record is an employee of nothing'
+);
+
+-- Same call with no shared tenant configured: the own-org arm is back, which is
+-- what a deployment without phone login gets. Proves the exclusion is the
+-- parameter and not some other filter.
+select ok(
+  exists(select 1 from amux.list_teams_for_picker(null, false) where team_slug = 'shared-tenant-public'),
+  'with no shared tenant configured the own-org public team is offered as before'
+);
+
+select throws_ok(
+  format($$ select amux.join_public_team(%L::uuid, %L::uuid) $$,
+         (select shared_public_team from shared_org_fixture),
+         (select shared_org from shared_org_fixture)),
+  '42501', 'the shared tenant''s teams are not self-joinable',
+  'a phone sign-up cannot self-join the shared tenant''s team'
+);
+
+-- ── The employee: in the org and of it ──────────────────────────────────────
+select pg_temp.as_user((select staff_id from shared_org_fixture));
+
+select is(
+  (select count(*)::int from amux.caller_employee_orgs()),
+  1,
+  'an employee record resolves to its org'
+);
+
+select ok(
+  exists(
+    select 1 from amux.list_teams_for_picker((select shared_org from shared_org_fixture), false)
+     where team_slug = 'shared-tenant-public' and not is_member),
+  'an employee of the shared tenant is still offered its public team'
+);
+
+select ok(
+  (select member_id from amux.join_public_team(
+     (select shared_public_team from shared_org_fixture),
+     (select shared_org from shared_org_fixture))) is not null,
+  'an employee of the shared tenant can still self-join it'
+);
+
+select ok(
+  exists(
+    select 1 from amux.list_teams_for_picker((select shared_org from shared_org_fixture), false)
+     where team_slug = 'shared-tenant-public' and is_member),
+  'and the row flips to a membership afterwards'
+);
+
+select * from finish();
+rollback;


### PR DESCRIPTION
登录后的团队选择器把别的租户的团队列了出来。报告来自 13723441441：他只在**香蕉攀岩**和 **Betly 倍拓**任职，选择器却给出**山阶攀岩 / 岩时攀岩 / 此山攀岩**，都带「公开」可加入。

## 为什么

`amux.list_teams_for_picker` 用手机号在 `public.users` 里做跨租户身份匹配，**不加任何身份过滤**。在与合作方共享该表的部署上，那是**会员表** —— 线上 599,243 行 `admin_type = 1`，同表还有 height / birthday / 会员卡号。于是"同手机号"解析出来的是**这个人办过卡的每一家岩馆**，不是他任职的租户。每多一个 org 就多贡献一个以 org 命名的默认团队（#959 之后都是 public），渲染成可加入的一行，带着那家租户的团队名、成员数和 owner 真名。

点进去是死路 —— `join_public_team` 的 org 守卫（CS-4）会拒 —— 所以这是**信息泄露而非越权访问**，但泄露的是一家租户的花名册元数据给另一家。线上 54 个有手机号的用户里 **50 个**至少看到一个不属于自己的 org，最严重的看到 20 个（实际只有 6 个是真的）。

合作方自己早就写对了，在它自己的账号选择器里（`apps/api/src/routes/api/admin/auth/admin-accounts.ts`）：`mobile 相同 + admin_type in (2,3,4) + deleted_at is null`。我们那条迁移的注释也写着"以员工手机号作为跨租户身份键"，只是 SQL 里从来没把"员工"这个条件写进去。

## 三个提交

**1. 选择器的 org 集合收窄到员工身份** — 手机号在这里回答的是两个不同的问题，只有一个能全量展开：

- `related_users`（**我是谁**）→ **保持全手机号展开，且必须如此**。手机注册的账号落在 DEFAULT_ORG 且 `admin_type = 1`，它创建的团队只挂在这一行上。收窄它会丢真实成员关系 —— 本 PR 的第一版就是这么写的，线上模拟当场抓到 **5 条会消失的成员记录**（例如用香蕉攀岩账号登录会看不见自己手机注册身份创建的团队）。`switch_active_team` 本来也是全手机号展开的。
- `employee_orgs`（**我属于哪些租户**）→ 只认员工身份。

只有 `public_teams` 和 `empty_orgs` 读 org 集合，所以收窄的正好是 `is_member = false` 那些行。

**2. 共享租户的团队不可自助加入** — 手机注册把每个账号都盖上 `DEFAULT_ORG_ID`（登录查询本身就是 `(org_id = DEFAULT_ORG_ID, mobile = phone)`），而在 belayo 上那个 org 同时是一家真实租户。于是"同 org"对每个注册过的人都成立，那家公司自己团队的 4 个成员里**有 2 个是这么进来的**。

DB 其实早就知道这个 org 特殊：`bootstrap_login_team(p_shared_org)` 专门给它一条分支（各自建私有团队，不并进 org 默认团队）。picker 和 join 没学到，所以 bootstrap 拒绝自动做的事，picker 做成了一个按钮。

保留了必须保留的例外：**该 org 的员工仍可自助入队** —— 共享租户分支不会把员工并进公司团队，picker 那一行是他们唯一的自助入口（该 org 的管理员 2026-08-22 就是这么进去的）。"员工"的判定收进 `amux.caller_employee_orgs()` 一处，两个函数共用：它们各写一份、然后走岔，正是这一带反复产出「picker 给按钮、join 拒绝」的根源。

`p_default_org_id` 是**复活**而不是改名成 `p_shared_org`（bootstrap 对同一个值的叫法）：PostgREST 按参数名绑定 RPC 参数，改名会让滚动发布窗口里两个方向的调用都炸。

**3. 顺带修一个部署雷（与上面无关，但今天被我踩爆了）** — `s deploy` 原样上传 `node_modules`，而 npm 只装宿主平台的原生绑定。从 Mac 部署会把 macOS 的绑定传上 linux-x64 运行时，**每个路由 502**（`Runtime.ExitError: exit status 128` + `Cannot find native binding`），包括 `/v1/config/public`。见下面的事故披露。

## 线上状态（belayo 已经是这个版本了）

| 项 | 状态 |
|---|---|
| 两条迁移 | ✅ 已进 `_selfhost.schema_migrations`（跑之前对过账，belayo 与仓库只差这两条） |
| FC | ✅ 已部署（`teamclaw-belayo-live-api`，环境变量 73 键逐值核对无漂移） |
| 临时止血 | 期间曾把该团队临时改 private，**现已改回 public**（规则接管后不再需要） |

self-host 还没有 —— 它等这个 PR 合并后自动部署。self-host 的 `DEFAULT_ORG_ID` 指向一个专用 org（`TeamClaw Public`，27 个用户全 `admin_type = 1`），它的 public 团队 `Public Playground` 目前 0 成员；合并后那个团队将不再被列出/可加入。**如果它是有意留的公共沙盒，需要另行安放。**

## ⚠️ 事故披露

修这个的过程中我把 belayo API 弄挂了约 5 分钟（13:24–13:29 UTC）。原因就是提交 3 描述的原生绑定问题：我先从一个基于旧 main 的分支部署（这本身可能已经回退了 09-08 傍晚落在 main 上的两个 fc 提交），发现后 rebase 到最新 main 重发，而那次带进了 main 新增的 `@alicloud/sls20201230` → `lz4-napi`，macOS 的绑定上了 Linux 运行时。第三次部署补上 linux 绑定后恢复。当前线上是 main + 本 PR，`/v1/apps/:id/logs`（main 新增路由）返 401 而非 404，可证 main 的代码在位。

## 验证

- **pgTAP 44/44 全绿**（本地起 `public.ecr.aws/supabase/postgres:17.6.1.106` 容器，ci-bootstrap → apply-migrations → run.sh 全流程复现 CI，rebase 后重跑）
- **新断言非空**：把改动前的函数还原再跑，`028` 红 3 条、`036` 红 2 条 —— 正好是泄露那几条；"必须继续能用"的断言（员工仍可见/仍可加入、注册者自己的私有团队还在、没配共享租户时行为不变、同手机号会员身份的团队仍可见）新旧都绿
- **FC**：1118 用例 0 失败（13 skipped 需本地 Supabase），`tsc` 干净
- **线上实测五种身份**：非员工看不到也加不进（`the shared tenant's teams are not self-joinable`）；员工看得到且加得进（事务回滚，未留痕）；报告人从 8 个 org 收敛到 3 个，与小程序的账号列表完全一致；一个随机注册号从 7 个 org 收敛到 1 个 —— 而活下来的那个正是他真任职（`admin_type = 2`）的岩馆
- **无成员流失**：对全部 54 个用户模拟前后差异 —— 泄露行 **-105**，新增 **0**，丢失的成员关系 **0**

## 复审时值得盯的地方

1. `related_users` 保持全手机号展开是刻意的，别顺手收窄 —— 会丢成员关系，第一版就是这么错的
2. `p_default_org_id` 不能改名，PostgREST 按名绑定
3. self-host 的 `Public Playground` 合并后会从选择器消失

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KvQ15uWMpdC1EkYdiDGJeG
