### PR TITLE
fix(desktop): 修 main 上红着的 clippy —— tauri::State 上多余的 &*

### DIFF
--- a/apps/desktop/src/commands/introspect_api.rs
+++ b/apps/desktop/src/commands/introspect_api.rs
@@ -471,7 +471,7 @@ async fn handle_cron_manage(app: &AppHandle, body: &[u8]) -> Result<String, Stri
     let v: serde_json::Value =
         serde_json::from_slice(body).map_err(|e| format!("JSON parse error: {e}"))?;
     let cron_state = app.state::<super::cron::CronState>();
-    let result = super::cron::mcp_manage(app, &*cron_state, &v).await?;
+    let result = super::cron::mcp_manage(app, &cron_state, &v).await?;
     serde_json::to_string(&result).map_err(|e| format!("Serialization error: {e}"))
 }
 


### PR DESCRIPTION
`Rust Format & Clippy` 在 main 上已经红了 —— 最近三次 CI 全挂在这一条：

```
error: deref which would be done by auto-deref
   --> apps/desktop/src/commands/introspect_api.rs:474:47
474 |     let result = super::cron::mcp_manage(app, &*cron_state, &v).await?;
    |                                               ^^^^^^^^^^^^ help: try: `&cron_state`
    = note: `-D clippy::explicit-auto-deref` implied by `-D warnings`
error: could not compile `teamclu` (lib) due to 1 previous error
error: could not compile `teamclu` (lib test) due to 1 previous error
```

`cron_state` 是 `tauri::State<CronState>`，deref coercion 本来就会把 `&cron_state`
变成 `&CronState`，那个显式 `&*` 是多余的。`-D warnings` 把它升成 error，整个 crate
的 `lib` 和 `lib test` 两个 target 都编不过。

MCP cron 那批改动落地后开始红的，与本修改无关的其它两个红灯（`Daemon Unit Tests
(Linux)`、`Lint, Typecheck & Test` 里 `cron-utils` 的前端用例）不在这个 PR 范围内。

## 验证

用 CI 的原始命令跑的，不是本地那个 `pnpm rust:clippy`（它少了 `--all-targets`）：

```
cargo clippy --manifest-path apps/desktop/Cargo.toml --all-targets -- -D warnings
   Finished `dev` profile [unoptimized + debuginfo] target(s) in 8m 30s     # exit 0，零 error
cargo fmt --check --manifest-path apps/desktop/Cargo.toml                    # exit 0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KvQ15uWMpdC1EkYdiDGJeG
