### PR TITLE
fix(daemon): 修 main 上编不过的 amuxd 测试目标（#1334 起）

### DIFF
--- a/apps/daemon/src/runtime/pi_rpc/process.rs
+++ b/apps/daemon/src/runtime/pi_rpc/process.rs
@@ -1127,7 +1127,7 @@ mod tests {
         let (tx, _rx) = tokio::sync::mpsc::channel(16);
         shared.routes.lock().insert(
             "pi:/s.jsonl".into(),
-            super::Route {
+            crate::runtime::pi_rpc::Route {
                 event_tx: tx,
                 permission: crate::runtime::permission_policy::PermissionPolicy::Ask,
                 pool_key: attached_key.clone(),
@@ -1135,7 +1135,7 @@ mod tests {
                 turn_active: false,
                 turn_reply_to: None,
                 turn_requester: None,
-                translate: super::translate::TranslateState::default(),
+                translate: crate::runtime::pi_rpc::translate::TranslateState::default(),
                 last_entry_id: None,
             },
         );


### PR DESCRIPTION
`process.rs` 的 `mod tests` 里，`super::` 指的是 **process** 模块而不是 `pi_rpc`，所以 `super::Route` 和 `super::translate::TranslateState` 指向的东西在那一层根本不存在。从 #1334 (`14b78dadc`) 起，amuxd 的所有测试目标都编不过：

```
error[E0422]: cannot find struct, variant or union type `Route` in module `super`
error[E0433]: cannot find `translate` in `super`
```

这不是 flaky 也不是环境问题：`Daemon Unit Tests (Linux)` 在那之后 main 的每一个 commit 上都是红的，针对 main 开的每个 PR 也都跟着红。

改成 crate 路径而不是 `super::super::` —— 这两个东西在这个文件其它地方就是这么称呼的。

## 验证

- `cargo test -p amuxd --all-targets --no-run`（CI 那一步「Compile all amuxd test targets」）通过
- `cargo test -p amuxd --bin amuxd`：**1633 passed / 0 failed**

没跑整包 `cargo fmt` —— 这个 crate 本来就不是 fmt-clean 的（同文件 258 / 1116 行有既有差异），跑了会顺手改掉一堆无关代码。这两行本身不影响格式。

🤖 Generated with [Claude Code](https://claude.com/claude-code)