### PR TITLE
fix(self-host): 没填的 registry 密码哈希会把整个反代打挂（今天线上 40 分钟不可达的根因）

### DIFF
--- a/deploy/self-host/.env.example
+++ b/deploy/self-host/.env.example
@@ -290,6 +290,17 @@ REGISTRY_DOMAIN=
 # hands to the machine doing the build and bakes into the function.
 # Generate with:
 #   docker run --rm caddy:2 caddy hash-password --plaintext '<password>'
+#
+# ESCAPE EVERY `$` AS `$$` WHEN YOU PASTE THE HASH HERE. Compose interpolates
+# the values in this file, so a bcrypt hash pasted verbatim loses everything
+# from its second `$` onward — `$2a$14$oZK1...` becomes `$2a$14.4Ee...`, compose
+# says "The oZK1... variable is not set", and Caddy is handed a hash that can
+# never match. Check what actually arrived with
+#   docker compose exec caddy printenv REGISTRY_PUSH_PASSWORD_HASH
+#
+# Left blank, these fall back to hashes of thrown-away random passwords (see
+# docker-compose.yml), so the registry denies everyone rather than taking Caddy
+# down — an empty credential makes Caddy refuse the whole Caddyfile.
 REGISTRY_PUSH_PASSWORD_HASH=
 REGISTRY_PULL_PASSWORD_HASH=
 

--- a/deploy/self-host/docker-compose.yml
+++ b/deploy/self-host/docker-compose.yml
@@ -614,10 +614,22 @@ services:
       # plaintext in the fc service above (FC hands them out) — see the
       # Caddyfile for why a pull login is separate from a push one.
       REGISTRY_DOMAIN: "${REGISTRY_DOMAIN:-registry.localhost}"
+      # The hashes need the never-empty rule too, and more urgently than the
+      # names: Caddy's `basic_auth` rejects an empty credential by refusing to
+      # parse the WHOLE Caddyfile, so one unset hash does not disable the
+      # registry route — it stops Caddy from starting at all and takes the API,
+      # the Supabase gateway, Studio and MQTT-over-WSS down with it. That is not
+      # hypothetical: it happened on the live box on 2026-09-09, and it reaches
+      # boxes that never enabled the registry, because COMPOSE_PROFILES gates
+      # the service but not the Caddyfile block.
+      #
+      # The defaults are bcrypt hashes of passwords generated at random and
+      # thrown away, so an unconfigured registry answers "no" to everyone —
+      # which is what an unconfigured registry should do.
       REGISTRY_PUSH_USERNAME: "${APPS_REGISTRY_USERNAME:-registry-push}"
-      REGISTRY_PUSH_PASSWORD_HASH: "${REGISTRY_PUSH_PASSWORD_HASH:-}"
+      REGISTRY_PUSH_PASSWORD_HASH: "${REGISTRY_PUSH_PASSWORD_HASH:-$$2a$$14$$X7V5MuAF9idVwBSgYAJMFeHvkZSivhUHnQbGWnLmIYJigq.Pv5jGq}"
       REGISTRY_PULL_USERNAME: "${APPS_REGISTRY_PULL_USERNAME:-registry-pull}"
-      REGISTRY_PULL_PASSWORD_HASH: "${REGISTRY_PULL_PASSWORD_HASH:-}"
+      REGISTRY_PULL_PASSWORD_HASH: "${REGISTRY_PULL_PASSWORD_HASH:-$$2a$$14$$xppx2dLgnBkUKxmqcHLoCe7OIWgqOR8pupJ069c8xR/lgc/oyTB.2}"
       # Central login service for deployed apps. Same never-empty rule again.
       # Note the asymmetry with the `fc` service above, which treats blank as
       # "feature off": Caddy cannot express that, so it always has a site here.


### PR DESCRIPTION
今天 #1342 合并后，self-host **公网整个不可达约 40 分钟**（14:25–15:05 UTC）。这个 PR 修的是让它发生的那个洞。

## 发生了什么

```
Error: adapting config using caddyfile: parsing caddyfile tokens for 'handle':
parsing caddyfile tokens for 'basic_auth': username and password cannot be empty
or missing, at /etc/caddy/Caddyfile:100
```

Caddy 的 `basic_auth` 遇到空凭证，是**拒绝解析整份 Caddyfile** —— 不是把那个站点关掉。所以一个没填的哈希不会"让 registry 路由不可用"，而是**让 Caddy 起不来**，443 拒连，API / Supabase 网关 / Studio / MQTT over WSS 一起下线。

而且它够得着**从没启用过 registry 的部署**：`COMPOSE_PROFILES` 管得住 `registry` 这个 service，管不住 Caddyfile 里给它做鉴权的那段。

## 为什么会漏

旁边那两个**用户名**本来就有永不为空的处理：

```yaml
REGISTRY_PUSH_USERNAME: "${APPS_REGISTRY_USERNAME:-registry-push}"    # ✅
REGISTRY_PUSH_PASSWORD_HASH: "${REGISTRY_PUSH_PASSWORD_HASH:-}"       # ❌
REGISTRY_PULL_USERNAME: "${APPS_REGISTRY_PULL_USERNAME:-registry-pull}" # ✅
REGISTRY_PULL_PASSWORD_HASH: "${REGISTRY_PULL_PASSWORD_HASH:-}"       # ❌
```

这段正上方的注释还写着 "Same never-empty rule as S3_DOMAIN"，Caddyfile 里也专门为 `REGISTRY_DOMAIN` 写了同样的说明 —— 规则是清楚的，两个哈希单纯漏了。

## 改了什么

给两个哈希同样的待遇，默认值是**随机生成后即丢弃明文的 bcrypt 哈希**：没配置的 registry 于是对所有人回答"不行"（这本来就是它该有的行为），而不是把整个部署拽下线。

顺带在 `.env.example` 里写清 **`$$` 转义**：compose 会对 `.env` 的值做插值，bcrypt 哈希原样粘进去会从第二个 `$` 开始被吃掉 —— `$2a$14$oZK1...` 到容器里变成 `$2a$14.4Ee...`，日志只留一句 `The "oZK1..." variable is not set`。这个坑正好在运维试图从这场事故里恢复的那一刻咬人，今天就多花了一个来回。

## 验证

拿 Caddyfile 里 registry 那个 site block 直接跑 `caddy validate`：

| | 结果 |
|---|---|
| 空哈希（复现事故） | `Error: ... basic_auth: username and password cannot be empty or missing` —— 与线上报错逐字一致 |
| 新默认值 | `Valid configuration` |

另外单独确认了容器**实际收到**的是 `$2a$14$X7V5...`（跑一个探针容器 `printenv`）。注意 `docker compose config` 打印的是重新转义过的 `$$` 形式，所以渲染结果不能拿来当判据 —— 这一点也写进注释了。

## 线上现状

盒子已经手工恢复（在 `.env` 里填了两个明文无人知晓的随机口令哈希，registry 路由对所有人关闭），`/v1/config/public` 与 `/ai/healthz` 都是 200。盒子上那两个哈希与本 PR 提交的默认值**不是同一对**，所以合并不会改变线上的凭证状态。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KvQ15uWMpdC1EkYdiDGJeG
