### PR TITLE
feat(apps): belayo 的镜像仓库 —— 跑在它自己的 Dokploy 上

### DIFF
--- a/deploy/belayo/registry/README.md
+++ b/deploy/belayo/registry/README.md
@@ -1,0 +1,84 @@
+# belayo 的镜像仓库
+
+belayo 上的容器应用（`teamclu.app.json` 里 `runtime: "container"`）要有个地方放镜像。
+ACR 个人版已经无法新建、企业版按实例收费，所以跟 self-host 一样自建一个。
+
+区别只在托管方式：self-host 那份跑在盒子的 docker compose 里、由 Caddy 挡在前面
+（`deploy/self-host/docker-compose.yml` 的 `registry` profile），belayo 这份跑在
+Dokploy 上、由它的 Traefik 挡在前面。**FC 侧的代码完全一样**，两边都只是给
+`APPS_REGISTRY_*` 填不同的值。
+
+## 部署位置
+
+Dokploy（`https://service.ucar.cc`，47.107.171.43）→ 项目 **infra** → 新建一个
+**Compose** 类型的服务，名字 `teamclu-registry`，把 `docker-compose.yml` 贴进去。
+
+主机名用 `registry.service.ucar.cc`：`*.service.ucar.cc` 已经有泛解析 A 记录指向
+这台机器，**不需要加 DNS**。Traefik 会自己去 Let's Encrypt 申请证书。
+
+## 需要填的环境变量（在 Dokploy 那个栈的 Environment 里，不要进仓库）
+
+| 变量 | 值 |
+|---|---|
+| `REGISTRY_HOST` | `registry.service.ucar.cc` |
+| `REGISTRY_OSS_BUCKET` | `belayo-teamclu-apps`（跟 belayo 的 `APPS_OSS_BUCKET` 同一个） |
+| `REGISTRY_OSS_REGION` | `cn-shenzhen` |
+| `REGISTRY_OSS_ENDPOINT` | `https://oss-cn-shenzhen.aliyuncs.com` |
+| `REGISTRY_OSS_ACCESS_KEY` / `REGISTRY_OSS_SECRET_KEY` | belayo FC 用的那对 `ACCESS_KEY_ID` / `ACCESS_KEY_SECRET` |
+| `REGISTRY_PUSH_AUTH` | 写权限账号的 htpasswd 行 |
+| `REGISTRY_PULL_AUTH` | 只读账号的 htpasswd 行 |
+
+两个 htpasswd 行这样生成：
+
+```bash
+htpasswd -nbB teamclu-push '<push 密码>'
+htpasswd -nbB teamclu-pull '<pull 密码>'
+```
+
+**在 Dokploy 里粘贴时把每个 `$` 写成 `$$`** —— compose 会做变量插值，单个 `$`
+会把 bcrypt 哈希吃掉一半，症状是所有请求 401 而日志里什么都看不出来。
+
+读路由上**两个账号都要收**（compose 里已经是 `${REGISTRY_PULL_AUTH},${REGISTRY_PUSH_AUTH}`）：
+`docker login` 第一件事是打 `GET /v2/`，只认 pull 账号的读路由会把 push 账号
+在它推任何东西之前就挡掉，报的还是 `login attempt ... 401 Unauthorized`。
+
+## 然后配 FC
+
+belayo 的 FC 是手工部署的（`services/fc/deploy-aliyun-fc.sh` + `.env.belayo.local`），
+在那个 env 文件里加：
+
+```
+APPS_REGISTRY_HOST=registry.service.ucar.cc
+APPS_REGISTRY_NAMESPACE=apps
+APPS_REGISTRY_USERNAME=teamclu-push
+APPS_REGISTRY_PASSWORD=<push 密码明文>
+APPS_REGISTRY_PULL_USERNAME=teamclu-pull
+APPS_REGISTRY_PULL_PASSWORD=<pull 密码明文>
+APPS_REGISTRY_PULL_HOST=
+```
+
+明文密码给 FC 是必须的：它要把 push 那对发给开发者的机器去推镜像，把 pull 那对
+烘进函数配置让 FC 去拉。Traefik 那边存的是同样两个密码的 bcrypt 哈希。
+
+`APPS_REGISTRY_PULL_HOST` 留空 —— FC 从公网按同一个名字拉。
+
+## 验证
+
+```bash
+# 只读账号推不上去（应当 401）
+echo FROM scratch | docker build -t registry.service.ucar.cc/apps/probe:v1 -
+docker login registry.service.ucar.cc -u teamclu-pull   # 输 pull 密码
+docker push registry.service.ucar.cc/apps/probe:v1      # 期望 401
+
+# 写账号推得上去、两个账号都拉得下来
+docker login registry.service.ucar.cc -u teamclu-push
+docker push registry.service.ucar.cc/apps/probe:v1
+docker pull registry.service.ucar.cc/apps/probe:v1
+```
+
+## 已知代价
+
+镜像字节是**穿过这个容器**流的，不是重定向到 OSS（驱动拼出来的 OSS URL 没有给
+客户端签名，重定向会让 pull 在 manifest 成功之后 403 在 blob 上）。所以推拉都吃
+Dokploy 那台机器的带宽。这个 Swarm 资源本来就不宽裕，内存限了 512M —— 它只是转发
+字节，自己不做缓存。

--- a/deploy/belayo/registry/docker-compose.yml
+++ b/deploy/belayo/registry/docker-compose.yml
@@ -1,0 +1,103 @@
+# Private image registry for belayo's container apps.
+#
+# Deployed as a Dokploy compose stack in the `infra` project, beside gitea and
+# the AI gateway. Dokploy's Traefik terminates TLS on `*.service.ucar.cc`,
+# which already has a wildcard A record — this needs no DNS change of its own.
+#
+# The registry stores images; it does not run them. So an ARM64 Swarm node
+# serving `linux/amd64` images (the only architecture Function Compute runs) is
+# not a contradiction — nothing here executes what it holds.
+#
+# Blobs go to belayo's own OSS bucket, not to a node volume: this Swarm is
+# resource-tight and image layers are the least bounded thing that could land
+# on it. `registry:3`, not `:2` — the 2.x S3 driver addresses the bucket
+# path-style and OSS answers `SecondLevelDomainForbidden: Please use virtual
+# hosted style` to the very first blob upload.
+#
+# Env comes from the Dokploy stack's own environment tab (never this file):
+#   REGISTRY_HOST                  registry.service.ucar.cc
+#   REGISTRY_OSS_BUCKET            belayo-teamclu-apps
+#   REGISTRY_OSS_REGION            cn-shenzhen
+#   REGISTRY_OSS_ENDPOINT          https://oss-cn-shenzhen.aliyuncs.com
+#   REGISTRY_OSS_ACCESS_KEY        belayo's ACCESS_KEY_ID
+#   REGISTRY_OSS_SECRET_KEY        belayo's ACCESS_KEY_SECRET
+#   REGISTRY_PUSH_AUTH             htpasswd line, bcrypt, `$` doubled (see README)
+#   REGISTRY_PULL_AUTH             htpasswd line for the read-only user, same form
+services:
+  registry:
+    image: registry:3
+    restart: unless-stopped
+    environment:
+      REGISTRY_HTTP_ADDR: "0.0.0.0:5000"
+      REGISTRY_STORAGE: "s3"
+      REGISTRY_STORAGE_S3_REGION: "${REGISTRY_OSS_REGION}"
+      REGISTRY_STORAGE_S3_REGIONENDPOINT: "${REGISTRY_OSS_ENDPOINT}"
+      REGISTRY_STORAGE_S3_BUCKET: "${REGISTRY_OSS_BUCKET}"
+      REGISTRY_STORAGE_S3_ACCESSKEY: "${REGISTRY_OSS_ACCESS_KEY}"
+      REGISTRY_STORAGE_S3_SECRETKEY: "${REGISTRY_OSS_SECRET_KEY}"
+      REGISTRY_STORAGE_S3_ROOTDIRECTORY: "/registry"
+      # OSS answers on the bucket's own hostname, like S3. Path style is what
+      # MinIO needs and what OSS rejects.
+      REGISTRY_STORAGE_S3_FORCEPATHSTYLE: "false"
+      REGISTRY_STORAGE_S3_V4AUTH: "true"
+      # Bytes stream through this container rather than via a redirect: the OSS
+      # URLs the driver composes are not signed for the client, so a pull would
+      # 403 on the blob right after a successful manifest.
+      REGISTRY_STORAGE_REDIRECT_DISABLE: "true"
+      # Deleting a tag is how an app's images are reclaimed on teardown.
+      REGISTRY_STORAGE_DELETE_ENABLED: "true"
+    networks:
+      - dokploy-network
+    # Container labels, not `deploy.labels`: Dokploy runs compose stacks with
+    # plain `docker compose`, and Traefik reads labels off the container there.
+    # Under `deploy:` they become swarm service labels, which nothing on this
+    # box looks at — the router simply never appears and the host 404s.
+    labels:
+    - traefik.enable=true
+    - traefik.docker.network=dokploy-network
+    - traefik.http.services.teamclu-registry.loadbalancer.server.port=5000
+
+    # Two logins, split by method. The deployed function keeps its pull
+    # credential in its own configuration, where anyone who can read the
+    # function can read it — and a credential that can also push there
+    # means replacing the image every instance of that app executes.
+    #
+    # A pull is GET/HEAD; everything that writes a blob, a manifest or a
+    # tag is POST/PUT/PATCH/DELETE. The write router carries the higher
+    # priority so it wins over the catch-all for those methods.
+    - traefik.http.middlewares.teamclu-registry-push.basicauth.users=${REGISTRY_PUSH_AUTH}
+    # BOTH accounts on the read side: `docker login` starts with a GET, so a
+    # read router that only knows the pull account rejects the push account
+    # before it ever gets to push anything.
+    - traefik.http.middlewares.teamclu-registry-pull.basicauth.users=${REGISTRY_PULL_AUTH},${REGISTRY_PUSH_AUTH}
+
+    - traefik.http.routers.teamclu-registry-write.rule=Host(`${REGISTRY_HOST}`) && (Method(`POST`) || Method(`PUT`) || Method(`PATCH`) || Method(`DELETE`))
+    - traefik.http.routers.teamclu-registry-write.priority=100
+    - traefik.http.routers.teamclu-registry-write.entrypoints=websecure
+    - traefik.http.routers.teamclu-registry-write.tls.certresolver=letsencrypt
+    - traefik.http.routers.teamclu-registry-write.middlewares=teamclu-registry-push
+    - traefik.http.routers.teamclu-registry-write.service=teamclu-registry
+
+    - traefik.http.routers.teamclu-registry-read.rule=Host(`${REGISTRY_HOST}`)
+    - traefik.http.routers.teamclu-registry-read.priority=10
+    - traefik.http.routers.teamclu-registry-read.entrypoints=websecure
+    - traefik.http.routers.teamclu-registry-read.tls.certresolver=letsencrypt
+    - traefik.http.routers.teamclu-registry-read.middlewares=teamclu-registry-pull
+    - traefik.http.routers.teamclu-registry-read.service=teamclu-registry
+
+    # Plain HTTP exists only to redirect: `docker push` to an http:// host
+    # would otherwise send the credential in the clear.
+    - traefik.http.routers.teamclu-registry-web.rule=Host(`${REGISTRY_HOST}`)
+    - traefik.http.routers.teamclu-registry-web.priority=5
+    - traefik.http.routers.teamclu-registry-web.entrypoints=web
+    - traefik.http.routers.teamclu-registry-web.middlewares=redirect-to-https@file
+    - traefik.http.routers.teamclu-registry-web.service=teamclu-registry
+    deploy:
+      resources:
+        limits:
+          # It proxies bytes to OSS and holds no cache of its own.
+          memory: 512M
+
+networks:
+  dokploy-network:
+    external: true


### PR DESCRIPTION
#1342 让容器应用能部署了，但只给 self-host 配了仓库。这个 PR 补上 belayo 那一半。

同一个仓库，不同的门：self-host 跑在盒子的 compose profile 里、Caddy 挡前面；belayo 跑成 Dokploy 的 compose 栈、那台机器的 Traefik 挡前面。**FC 侧代码一行都不用动** —— 两个环境的差别只在 `APPS_REGISTRY_*` 填什么。

读写分权也照搬，只是换成 Traefik 表达：一个匹配 POST/PUT/PATCH/DELETE 的写路由（优先级更高）用 push 账号，兜底路由两个账号都收。理由和之前一样 —— pull 凭证是烘在函数配置里的，谁能读函数就能读到它，那把凭证要是还能 push，就等于谁都能替换这个应用执行的镜像。

主机名 `registry.service.ucar.cc`，**不用加 DNS**：`*.service.ucar.cc` 本来就解析到那台机器。

镜像存在 ARM64 节点上而镜像本身全是 `linux/amd64`，这不矛盾 —— 仓库只存字节，不执行它们。blob 进 belayo 自己的 OSS bucket 而不是节点卷（那个 Swarm 资源紧），并且字节是穿过容器流而不是重定向到 OSS：驱动拼出来的 OSS URL 没给客户端签名，重定向会让 pull 在 manifest 成功之后 403 在 blob 上。

## 两个坑，是真部署上去推了一次镜像才发现的

都已经连原因写进文件里了：

1. **标签要打在容器上，不能放 `deploy:` 底下。** Dokploy 跑 compose 栈用的是普通 `docker compose`，`deploy.labels` 是 swarm service 标签、那台机器上没人读 —— 结果路由压根没出现，HTTP 404、HTTPS 拿到 Traefik 的默认自签证书。
2. **读路由必须两个账号都认。** `docker login` 第一件事是打 `GET /v2/`，只认 pull 账号的读路由会在 push 账号推任何东西之前就把它挡掉，报 `login attempt … 401`。

## 验证（对着线上那个栈跑的）

- 未认证 → 401
- 只读账号 `GET /v2/` → 200，`docker pull` 成功
- 写账号 `docker login` + `docker push` 成功
- **只读账号 `docker push` → 401**
- 探针镜像事后删掉了，`_catalog` 现在是空的

Dokploy 那个栈已经建好并部署（infra 项目 / `teamclu-registry`），两组凭证也已经写进 `.env.belayo.local`，belayo 下次手工发 FC 就会带上。

🤖 Generated with [Claude Code](https://claude.com/claude-code)