### PR TITLE
fix(cron): let scheduled jobs mcp-send to WeCom with explicit channel/target

### DIFF
--- a/apps/daemon/src/daemon/binding_target.rs
+++ b/apps/daemon/src/daemon/binding_target.rs
@@ -42,8 +42,62 @@ pub(crate) fn parse_binding_to_target(
         "kook" => Ok(("kook", None)),
         "wechat" => Ok(("wechat", None)),
         "email" => Ok(("email", None)),
+        "cron" => Ok(("cron", None)),
         other => anyhow::bail!("unknown binding scheme: {other}"),
     }
+}
+
+/// Turn an mcp-send binding plus optional overrides into a dispatch route.
+///
+/// A `cron://` token authorizes the send but names no chat — the caller must
+/// pass both `channel` and `target`. WeCom MCP targets (`single:` / `group:`)
+/// are translated to the daemon shape (`user:` / `chat:`).
+pub(crate) fn resolve_mcp_send_route(
+    binding: &str,
+    channel_override: Option<&str>,
+    target_override: Option<&str>,
+) -> anyhow::Result<(String, String)> {
+    let (default_channel, default_target) = parse_binding_to_target(binding)?;
+    let channel = channel_override
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .unwrap_or(default_channel);
+
+    if channel == "cron" {
+        anyhow::bail!(
+            "mcp-send: cron runs have no default chat — pass `channel` and `target` with the reply_token"
+        );
+    }
+
+    let raw_target = match target_override.map(str::trim).filter(|s| !s.is_empty()) {
+        Some(t) => t.to_string(),
+        None => default_target.ok_or_else(|| {
+            anyhow::anyhow!(
+                "mcp-send: binding '{binding}' has no default target — pass an explicit 'target' override"
+            )
+        })?,
+    };
+
+    Ok((
+        channel.to_string(),
+        normalize_dispatch_target(channel, &raw_target),
+    ))
+}
+
+fn normalize_dispatch_target(channel: &str, target: &str) -> String {
+    let target = target.trim();
+    if target.starts_with("user:") || target.starts_with("chat:") || target.starts_with("bot:") {
+        return target.to_string();
+    }
+    if matches!(channel, "wecom" | "seatalk") {
+        if let Some(id) = target.strip_prefix("single:") {
+            return format!("user:{id}");
+        }
+        if let Some(id) = target.strip_prefix("group:") {
+            return format!("chat:{id}");
+        }
+    }
+    target.to_string()
 }
 
 #[cfg(test)]
@@ -108,5 +162,29 @@ mod tests {
             err.to_string().contains("unknown binding scheme"),
             "got: {err}"
         );
+    }
+
+    #[test]
+    fn cron_binding_has_no_default_chat() {
+        let (channel, target) = parse_binding_to_target("cron://job-key/run-1").unwrap();
+        assert_eq!(channel, "cron");
+        assert!(target.is_none());
+    }
+
+    #[test]
+    fn cron_send_requires_explicit_channel_and_target() {
+        let err = resolve_mcp_send_route("cron://job-key", None, Some("single:HuangWeiGan"))
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("no default chat"), "got: {err}");
+    }
+
+    #[test]
+    fn cron_send_with_wecom_overrides_reaches_dispatch_shape() {
+        let (channel, target) =
+            resolve_mcp_send_route("cron://job-key", Some("wecom"), Some("single:HuangWeiGan"))
+                .unwrap();
+        assert_eq!(channel, "wecom");
+        assert_eq!(target, "user:HuangWeiGan");
     }
 }

--- a/apps/daemon/src/daemon/server.rs
+++ b/apps/daemon/src/daemon/server.rs
@@ -21,7 +21,7 @@ use crate::config::{DaemonConfig, SessionStore};
 // the bin build, which does not compile them.
 #[cfg(test)]
 use crate::config::SessionBinding;
-use crate::daemon::binding_target::parse_binding_to_target;
+use crate::daemon::binding_target::{parse_binding_to_target, resolve_mcp_send_route};
 use crate::daemon::runtime_cursor::{
     compute_effective_cursor_from_messages, last_unanswered_mention_idx,
     messages_strictly_after_cursor, slice_has_actionable_inbound,

--- a/apps/daemon/src/daemon/server/channels.rs
+++ b/apps/daemon/src/daemon/server/channels.rs
@@ -459,6 +459,11 @@ impl DaemonServer {
     /// have no token, so they resolve to no target and cannot send, and an
     /// explicit `target` does not rescue them: overrides are only honoured
     /// once a token has established which chat the caller belongs to.
+    ///
+    /// Cron turns are the exception that still has a token: `cron://…` names
+    /// no chat, so the caller must pass `channel` and `target` with it. That
+    /// is how a scheduled job delivers to WeCom without a workspace
+    /// `teamclu.json` binding.
     pub(crate) async fn handle_mcp_send(
         &self,
         payload: &serde_json::Value,
@@ -474,21 +479,10 @@ impl DaemonServer {
             anyhow::bail!("mcp-send: at least one of 'message' or 'file_path' is required");
         }
 
-        let (default_channel, default_target) = parse_binding_to_target(binding)?;
-        let channel = channel_override.unwrap_or(default_channel);
-        let target_owned: String;
-        let target = match target_override {
-            Some(t) => t,
-            None => match default_target {
-                Some(t) => {
-                    target_owned = t;
-                    target_owned.as_str()
-                }
-                None => anyhow::bail!(
-                    "mcp-send: binding '{binding}' has no default target — pass an explicit 'target' override"
-                ),
-            },
-        };
+        let (channel_owned, target_owned) =
+            resolve_mcp_send_route(binding, channel_override, target_override)?;
+        let channel = channel_owned.as_str();
+        let target = target_owned.as_str();
 
         // Fail closed on placeholder / half-resolved routes (issue #549). A
         // target like `current`, `chat:current`, or `chat:` (empty id) means

--- a/apps/daemon/src/runtime/pi_rpc/process.rs
+++ b/apps/daemon/src/runtime/pi_rpc/process.rs
@@ -1127,7 +1127,7 @@ mod tests {
         let (tx, _rx) = tokio::sync::mpsc::channel(16);
         shared.routes.lock().insert(
             "pi:/s.jsonl".into(),
-            super::Route {
+            crate::runtime::pi_rpc::Route {
                 event_tx: tx,
                 permission: crate::runtime::permission_policy::PermissionPolicy::Ask,
                 pool_key: attached_key.clone(),
@@ -1135,7 +1135,7 @@ mod tests {
                 turn_active: false,
                 turn_reply_to: None,
                 turn_requester: None,
-                translate: super::translate::TranslateState::default(),
+                translate: crate::runtime::pi_rpc::translate::TranslateState::default(),
                 last_entry_id: None,
             },
         );


### PR DESCRIPTION
## Summary

- Add `cron://` as an mcp-send binding scheme: it authorizes the send but carries no default chat.
- Introduce `resolve_mcp_send_route` so cron turns must pass explicit `channel` and `target`, and WeCom MCP targets (`single:` / `group:`) are normalized to daemon dispatch shape (`user:` / `chat:`).
- Refactor `handle_mcp_send` to use the shared resolver, enabling scheduled jobs to deliver replies to WeCom without a workspace `teamclu.json` binding.

## Test plan

- [x] `cargo test -p amuxd binding_target` — cron binding, explicit override, and WeCom target normalization
- [x] `pnpm rust:check`
- [ ] Manually trigger a cron job that calls mcp-send with `{ "channel": "wecom", "target": "single:<userId>" }` and confirm delivery


Made with [Cursor](https://cursor.com)