### PR TITLE
feat(apps): 把 belayo 的镜像仓库钉到空闲的 worker-2 上

### DIFF
--- a/deploy/belayo/registry/README.md
+++ b/deploy/belayo/registry/README.md
@@ -35,8 +35,8 @@ htpasswd -nbB teamclu-push '<push 密码>'
 htpasswd -nbB teamclu-pull '<pull 密码>'
 ```
 
-**在 Dokploy 里粘贴时把每个 `$` 写成 `$$`** —— compose 会做变量插值，单个 `$`
-会把 bcrypt 哈希吃掉一半，症状是所有请求 401 而日志里什么都看不出来。
+**stack 模式原样粘贴，单个 `$`**（上面第 3 点）。哪天改回 compose 类型跑，就要把每个
+`$` 写成 `$$` —— 两种模式的转义规则是反的，错了症状一样：全部 401，日志里什么都看不出来。
 
 读路由上**两个账号都要收**（compose 里已经是 `${REGISTRY_PULL_AUTH},${REGISTRY_PUSH_AUTH}`）：
 `docker login` 第一件事是打 `GET /v2/`，只认 pull 账号的读路由会把 push 账号

--- a/deploy/belayo/registry/docker-compose.yml
+++ b/deploy/belayo/registry/docker-compose.yml
@@ -48,55 +48,63 @@ services:
       REGISTRY_STORAGE_DELETE_ENABLED: "true"
     networks:
       - dokploy-network
-    # Container labels, not `deploy.labels`: Dokploy runs compose stacks with
-    # plain `docker compose`, and Traefik reads labels off the container there.
-    # Under `deploy:` they become swarm service labels, which nothing on this
-    # box looks at — the router simply never appears and the host 404s.
-    labels:
-    - traefik.enable=true
-    - traefik.docker.network=dokploy-network
-    - traefik.http.services.teamclu-registry.loadbalancer.server.port=5000
-
-    # Two logins, split by method. The deployed function keeps its pull
-    # credential in its own configuration, where anyone who can read the
-    # function can read it — and a credential that can also push there
-    # means replacing the image every instance of that app executes.
-    #
-    # A pull is GET/HEAD; everything that writes a blob, a manifest or a
-    # tag is POST/PUT/PATCH/DELETE. The write router carries the higher
-    # priority so it wins over the catch-all for those methods.
-    - traefik.http.middlewares.teamclu-registry-push.basicauth.users=${REGISTRY_PUSH_AUTH}
-    # BOTH accounts on the read side: `docker login` starts with a GET, so a
-    # read router that only knows the pull account rejects the push account
-    # before it ever gets to push anything.
-    - traefik.http.middlewares.teamclu-registry-pull.basicauth.users=${REGISTRY_PULL_AUTH},${REGISTRY_PUSH_AUTH}
-
-    - traefik.http.routers.teamclu-registry-write.rule=Host(`${REGISTRY_HOST}`) && (Method(`POST`) || Method(`PUT`) || Method(`PATCH`) || Method(`DELETE`))
-    - traefik.http.routers.teamclu-registry-write.priority=100
-    - traefik.http.routers.teamclu-registry-write.entrypoints=websecure
-    - traefik.http.routers.teamclu-registry-write.tls.certresolver=letsencrypt
-    - traefik.http.routers.teamclu-registry-write.middlewares=teamclu-registry-push
-    - traefik.http.routers.teamclu-registry-write.service=teamclu-registry
-
-    - traefik.http.routers.teamclu-registry-read.rule=Host(`${REGISTRY_HOST}`)
-    - traefik.http.routers.teamclu-registry-read.priority=10
-    - traefik.http.routers.teamclu-registry-read.entrypoints=websecure
-    - traefik.http.routers.teamclu-registry-read.tls.certresolver=letsencrypt
-    - traefik.http.routers.teamclu-registry-read.middlewares=teamclu-registry-pull
-    - traefik.http.routers.teamclu-registry-read.service=teamclu-registry
-
-    # Plain HTTP exists only to redirect: `docker push` to an http:// host
-    # would otherwise send the credential in the clear.
-    - traefik.http.routers.teamclu-registry-web.rule=Host(`${REGISTRY_HOST}`)
-    - traefik.http.routers.teamclu-registry-web.priority=5
-    - traefik.http.routers.teamclu-registry-web.entrypoints=web
-    - traefik.http.routers.teamclu-registry-web.middlewares=redirect-to-https@file
-    - traefik.http.routers.teamclu-registry-web.service=teamclu-registry
     deploy:
+      mode: replicated
+      replicas: 1
+      # Pinned to the idle worker: the registry streams every image byte
+      # through itself, so it is the one service here worth keeping off the
+      # manager.
+      placement:
+        constraints:
+          - node.hostname == dokploy-worker-2
       resources:
         limits:
-          # It proxies bytes to OSS and holds no cache of its own.
           memory: 512M
+      # Swarm SERVICE labels — what Traefik's swarm provider reads, and ONLY
+      # the swarm spelling of the network label: a service carrying both
+      # `traefik.docker.*` and `traefik.swarm.*` is skipped entirely, with
+      # `both Docker and Swarm labels are defined` in Traefik's log and a plain
+      # 404 at the door.
+      labels:
+        - traefik.enable=true
+        - traefik.swarm.network=dokploy-network
+        - traefik.http.services.teamclu-registry.loadbalancer.server.port=5000
+    
+        # Two logins, split by method. The deployed function keeps its pull
+        # credential in its own configuration, where anyone who can read the
+        # function can read it — and a credential that can also push there
+        # means replacing the image every instance of that app executes.
+        #
+        # A pull is GET/HEAD; everything that writes a blob, a manifest or a
+        # tag is POST/PUT/PATCH/DELETE. The write router carries the higher
+        # priority so it wins over the catch-all for those methods.
+        - traefik.http.middlewares.teamclu-registry-push.basicauth.users=${REGISTRY_PUSH_AUTH}
+        # BOTH accounts on the read side: `docker login` starts with a GET, so a
+        # read router that only knows the pull account rejects the push account
+        # before it ever gets to push anything.
+        - traefik.http.middlewares.teamclu-registry-pull.basicauth.users=${REGISTRY_PULL_AUTH},${REGISTRY_PUSH_AUTH}
+    
+        - traefik.http.routers.teamclu-registry-write.rule=Host(`${REGISTRY_HOST}`) && (Method(`POST`) || Method(`PUT`) || Method(`PATCH`) || Method(`DELETE`))
+        - traefik.http.routers.teamclu-registry-write.priority=100
+        - traefik.http.routers.teamclu-registry-write.entrypoints=websecure
+        - traefik.http.routers.teamclu-registry-write.tls.certresolver=letsencrypt
+        - traefik.http.routers.teamclu-registry-write.middlewares=teamclu-registry-push
+        - traefik.http.routers.teamclu-registry-write.service=teamclu-registry
+    
+        - traefik.http.routers.teamclu-registry-read.rule=Host(`${REGISTRY_HOST}`)
+        - traefik.http.routers.teamclu-registry-read.priority=10
+        - traefik.http.routers.teamclu-registry-read.entrypoints=websecure
+        - traefik.http.routers.teamclu-registry-read.tls.certresolver=letsencrypt
+        - traefik.http.routers.teamclu-registry-read.middlewares=teamclu-registry-pull
+        - traefik.http.routers.teamclu-registry-read.service=teamclu-registry
+    
+        # Plain HTTP exists only to redirect: `docker push` to an http:// host
+        # would otherwise send the credential in the clear.
+        - traefik.http.routers.teamclu-registry-web.rule=Host(`${REGISTRY_HOST}`)
+        - traefik.http.routers.teamclu-registry-web.priority=5
+        - traefik.http.routers.teamclu-registry-web.entrypoints=web
+        - traefik.http.routers.teamclu-registry-web.middlewares=redirect-to-https@file
+        - traefik.http.routers.teamclu-registry-web.service=teamclu-registry
 
 networks:
   dokploy-network:


### PR DESCRIPTION
#1345 把 registry 跑起来了，但它只能待在 manager 上 —— Dokploy 的 compose 栈没法指定节点。而这个服务恰恰是最该挪走的：**每一个镜像字节都要从它身上过一遍**（驱动拼出来的 OSS URL 没给客户端签名，改成重定向会让 pull 在 manifest 成功之后 403 在 blob 上）。改成 Swarm stack 就能用 placement 钉住，`dokploy-worker-2` 正好是空的。

要让它成立，有三件事当时一件都不成立：

## 1. worker 节点必须能出网

swarm 是**每个节点自己拉镜像**的，manager 拉得到不算数。任务一直卡在
`No such image: registry:3@sha256:…` 被拒、重试、再被拒。

VPC `vpc-wz96ujjns2sochtdj0rav` 的 NAT 网关上原来只有**一条按实例的 SNAT**（`172.18.29.207/32`，当初给 gitea-box 加的）。已改成 **vSwitch 粒度**（`vsw-wz9ecwto44b29foo8id9r` = 172.18.16.0/20，entry `snat-wz9tza2pxce0titpmgzcs`，EIP 不变）。阿里云不允许重叠的 SNAT 源，所以只能先删后建（脚本带回滚，没用上）。这个网段里的其它机器本来也需要出网，顺带都有了。

改完之后镜像**一次就拉下来了**。

## 2. traefik 的网络标签只能有一套

服务上同时带 `traefik.docker.network` 和 `traefik.swarm.network`，Traefik v3 会**整个跳过这个服务**：

```
ERR Skip container error="both Docker and Swarm labels are defined" providerName=swarm
```

门口返回的是干净的 **404**（不是 502），看起来就像"路由压根没建" —— 确实没建。我当初"保险起见"两个都留着，就是这么把自己坑了。stack 模式只留 swarm 那个。

## 3. 哈希里不能写 `$$`

`docker compose` 会把 `$$` 折叠成 `$`，**`docker stack deploy` 不会** —— 标签里原样留下 `$$2y$$05$$…`，任何密码都匹配不上，表现为**全部 401**。compose 模式则必须写 `$$`。两种模式的规则是反的，改类型时要一起改。这三条都连着原因写进文件了。

## 验证（对着线上，任务确认在 dokploy-worker-2 上）

| | |
|---|---|
| 未认证 | 401 |
| 只读账号 `GET /v2/` | 200 |
| 只读账号 `POST`（写） | **401** |
| 写账号 `POST` | 202 |
| 真镜像 push / 只读账号 pull | 都成功 |

探针镜像已删，`_catalog` 是空的。

🤖 Generated with [Claude Code](https://claude.com/claude-code)