### PR TITLE
fix(app): CronJobDialog 的测试看不到 cron store 的 coerceSchedule

### DIFF
--- a/packages/app/src/components/settings/cron/__tests__/CronJobDialog.test.tsx
+++ b/packages/app/src/components/settings/cron/__tests__/CronJobDialog.test.tsx
@@ -4,7 +4,13 @@ import { render } from '@testing-library/react'
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({ t: (k: string, d?: string) => d ?? k, i18n: { language: 'en', changeLanguage: vi.fn() } }),
 }))
-vi.mock('@/stores/cron', () => ({
+// Partial, not a replacement: this module also exports `coerceSchedule`, which
+// `jobToFormState` calls on every render of the dialog. A factory that returns
+// only the store hook makes that export vanish, and the dialog throws before it
+// renders anything — which is what happened when coerceSchedule was added in
+// #1339. Only the hook needs stubbing; the schedule normaliser is pure.
+vi.mock('@/stores/cron', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/stores/cron')>()),
   useCronStore: vi.fn(() => ({
     addJob: vi.fn(),
     updateJob: vi.fn(),


### PR DESCRIPTION
`Lint, Typecheck & Test` 在 main 上是红的，因此**每一个 PR 都是红的**——#1346 和 #1347 都撞在这条上。

## 根因

`vi.mock('@/stores/cron', factory)` 是**整体替换**模块，不是部分 mock。

这在 #1339 之前没问题。那个 PR 往 `@/stores/cron` 里加了 `coerceSchedule`，而 `jobToFormState`（`lib/cron/cron-utils.ts:365`）每次渲染对话框都要调它。mock 让这个导出凭空消失，组件在渲染出任何东西之前就抛了：

```
Error: [vitest] No "coerceSchedule" export is defined on the "@/stores/cron" mock.
```

## 改法

换成 `importOriginal` 的部分 mock：只桩掉 `useCronStore`，纯函数 `coerceSchedule` 保持真实。这也正是 vitest 报错信息本身建议的写法。

只桩 hook 是对的——`coerceSchedule` 没有副作用，测试没有理由替换它，替换它反而会让这个用例对未来的 schedule 归一化逻辑失去覆盖。

## 验证

改前：`Tests 1 failed | 3438 passed`（在干净的 `origin/main` worktree 上同样红，确认不是某个分支引入的）
改后：`Tests 3439 passed | 0 failed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)