### PR TITLE
fix(ci): belayo 部署把一次成功的部署判成了失败

### DIFF
--- a/.github/workflows/belayo-ai-gateway.yml
+++ b/.github/workflows/belayo-ai-gateway.yml
@@ -110,14 +110,31 @@ jobs:
             docker service update --update-order stop-first \
               --image "$IMAGE_REPO:${TAG::9}" --detach=true "$SERVICE"
 
-            # Written as explicit ifs on purpose. The compact
-            # \`[ a ] || [ b ] && { exit 1; }\` form is a trap under \`set -e\`:
-            # in the ORDINARY case, where neither test matches, the whole list
-            # exits non-zero and the script dies on the first poll.
+            # Poll on what actually matters — the target image is live and the
+            # service is at full replicas — not on UpdateStatus.
+            #
+            # UpdateStatus is NOT always there. Re-running this with a tag the
+            # service already carries changes nothing, swarm records no update,
+            # and `{{.UpdateStatus.State}}` then fails with "map has no entry for
+            # key UpdateStatus". Under `set -e` that killed the first poll
+            # iteration and failed a deploy that had actually succeeded. It is
+            # kept only as an early abort signal, read through `with` so a
+            # missing key is empty instead of fatal.
+            #
+            # Explicit ifs throughout: the compact `[ a ] || [ b ] && { exit 1; }`
+            # form is its own `set -e` trap, exiting non-zero in the ORDINARY
+            # case where neither test matches.
+            ok=""
             for i in \$(seq 1 45); do
-              state=\$(docker service inspect "$SERVICE" --format '{{.UpdateStatus.State}}')
-              reps=\$(docker service ls --format '{{.Name}} {{.Replicas}}' | awk '/$SERVICE/{print \$2}')
-              if [ "\$state" = "completed" ] && [ "\$reps" = "1/1" ]; then break; fi
+              state=\$(docker service inspect "$SERVICE" --format '{{with .UpdateStatus}}{{.State}}{{end}}' 2>/dev/null || true)
+              reps=\$(docker service ls --format '{{.Name}} {{.Replicas}}' | awk -v s="$SERVICE" '\$1==s{print \$2}')
+              # --filter status=running matters: during the swap a bare
+              # `docker ps` still lists the OLD, dying container, and reading its
+              # image reports the previous release as if it had deployed.
+              C=\$(docker ps --filter status=running --format '{{.Names}}' | grep "$SERVICE" | head -1 || true)
+              live=""
+              [ -n "\$C" ] && live=\$(docker inspect "\$C" --format '{{.Config.Image}}' 2>/dev/null || true)
+              if [ "\$reps" = "1/1" ] && [ "\$live" = "$IMAGE_REPO:${TAG::9}" ]; then ok=1; break; fi
               if [ "\$state" = "paused" ] || [ "\$state" = "rollback_completed" ]; then
                 echo "swarm gave up on the update: \$state"
                 docker service ps "$SERVICE" --no-trunc | head -5
@@ -125,19 +142,12 @@ jobs:
               fi
               sleep 4
             done
-            if [ "\$state" != "completed" ]; then
-              echo "did not converge within the window: \$state"
+            if [ -z "\$ok" ]; then
+              echo "did not converge: replicas=\$reps live=\$live want=$IMAGE_REPO:${TAG::9}"
               docker service ps "$SERVICE" --no-trunc | head -5
               exit 1
             fi
-
-            # --filter status=running matters: during the swap a bare
-            # \`docker ps\` still lists the OLD, dying container, and reading
-            # its image/env reports the previous release as if it had deployed.
-            C=\$(docker ps --filter status=running --format '{{.Names}}' | grep "$SERVICE" | head -1)
-            running=\$(docker inspect "\$C" --format '{{.Config.Image}}')
-            echo "running image: \$running"
-            [ "\$running" = "$IMAGE_REPO:${TAG::9}" ] || { echo "wrong image is live"; exit 1; }
+            echo "running image: \$live"
             docker logs --tail 3 "\$C"
           EOF
 


### PR DESCRIPTION
## 症状

`belayo-ai-gateway.yml` 合并后**自动跑了一次并成功部署**。我随后手动 dispatch 验证，第二次却红了——但 belayo 当时**完全正常**：副本 1/1、镜像正确、`healthz` 200、网关在正常服务。

**部署成功了，检查说它失败了。**

## 根因

收敛轮询读的是 `{{.UpdateStatus.State}}`，而这个字段**不总是存在**。用服务已经携带的同一个 tag 再跑一次时，spec 没有变化，swarm 根本不记录这次更新，模板于是报：

```
template: executing "" at <.UpdateStatus.State>: map has no entry for key "UpdateStatus"
```

在 `set -e` 下，第一次轮询迭代就把脚本打死了。

第一次 run 之所以通过，是因为它**真的**换了 tag（`25b4dd106` → `7fc19eac9`）；第二次走的是 no-op 路径。这个差别只有在同一个 commit 上跑第二次才暴露得出来。

## 修法

不是给模板打补丁，而是**改成断言真正要紧的性质**：跑着的容器镜像等于目标镜像，且副本数为 1/1。

这本来就是我们想确认的事——`UpdateStatus` 只是它的一个代理指标，而且是个可能缺席的代理。它保留下来只作为 `paused` / `rollback_completed` 的提前中止信号，并通过 `with` 读取，缺 key 时得到空串而不是报错。

## 验证

在网关宿主机上、**用失败那次的确切条件**（同 tag、无 UpdateStatus）跑了一遍修正后的循环：

```
第 1 次: state='(空)' reps='1/1' live='7fc19eac9'
✅ 通过 —— UpdateStatus 为空也不再致命
```

六个 run 块的 `bash -n` 也全过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L5cPobkSdBi9fJC8WMwEs8