### PR TITLE
fix(apps): 应用列表把「空」当成了答案 —— 连带清掉另两处同样的缓存，以及两处 UI

### DIFF
--- a/packages/app/src/components/apps/AppLibraryView.tsx
+++ b/packages/app/src/components/apps/AppLibraryView.tsx
@@ -34,13 +34,12 @@ function AppMeta({ app, creator }: { app: AppRow; creator: string | null }) {
   const gitMeta = appGitKind(app)
 
   return (
-    // Right-aligned, opposite the name. Left-aligned under it, the row was a
-    // short label on the far left and an action on the far right with 500px of
-    // nothing between them.
+    // A line under the name now that these are cards: the old right-aligned
+    // column existed to fill 500px of empty row, and a card has no such gap.
     //
     // Where the code lives is the load-bearing part: it is what says whether a
-    // row can be downloaded at all.
-    <span className="hidden shrink-0 items-center gap-1.5 text-[11.5px] text-faint @lg:flex">
+    // card can be downloaded at all.
+    <span className="flex min-w-0 flex-wrap items-center gap-1.5 text-[11.5px] text-faint">
       {creator && (
         <>
           <span className="max-w-[10ch] truncate">{creator}</span>
@@ -70,15 +69,21 @@ function AppName({ app }: { app: AppRow }) {
   )
 }
 
-const ROW = 'flex w-full items-center gap-3 rounded-[9px] px-3 py-2 text-left'
 /**
- * Fixed, so the meta column lands on one line across both groups.
- *
- * Sized to the download button, which is the widest thing that goes in it; a
- * row whose trailing slot is a 16px chevron would otherwise pull its meta 50px
- * further right than the row above it.
+ * One card. Bordered rather than shadowed, on paper — the palette's rule is
+ * that depth comes from a hairline and a background change, never from a drop
+ * shadow.
  */
-const TRAILING = 'flex w-[68px] shrink-0 items-center justify-end'
+const CARD =
+  'group relative flex w-full flex-col gap-2 rounded-[12px] border border-border-soft bg-paper p-3 text-left transition-colors'
+
+/** The grid the cards sit in. Container queries, not viewport ones: the width
+ *  that decides how many fit is this column's, and it changes with the right
+ *  panel while the window does not. */
+const GRID = 'grid gap-2.5 @[520px]:grid-cols-2 @[880px]:grid-cols-3'
+
+/** Top-right of the card: the download button, or the chevron on hover. */
+const TRAILING = 'flex shrink-0 items-center justify-end'
 
 /** A row for an app that is already here — clicking it opens it in column two. */
 function LocalRow({ app, creator }: { app: AppRow; creator: string | null }) {
@@ -88,13 +93,15 @@ function LocalRow({ app, creator }: { app: AppRow; creator: string | null }) {
   }, [app.id])
 
   return (
-    <button type="button" onClick={open} className={cn(ROW, 'group transition-colors hover:bg-selected/40')}>
-      <TypeMark app={app} />
-      <AppName app={app} />
-      <AppMeta app={app} creator={creator} />
-      <span className={TRAILING}>
-        <ChevronRight className="h-4 w-4 text-faint opacity-0 transition-opacity group-hover:opacity-100" />
+    <button type="button" onClick={open} className={cn(CARD, 'hover:bg-selected/30')}>
+      <span className="flex w-full items-center gap-2.5">
+        <TypeMark app={app} />
+        <AppName app={app} />
+        <span className={TRAILING}>
+          <ChevronRight className="h-4 w-4 text-faint opacity-0 transition-opacity group-hover:opacity-100" />
+        </span>
       </span>
+      <AppMeta app={app} creator={creator} />
     </button>
   )
 }
@@ -106,11 +113,12 @@ function LocalRow({ app, creator }: { app: AppRow; creator: string | null }) {
  */
 function PendingRow({ app, creator }: { app: AppRow; creator: string | null }) {
   return (
-    <div className={ROW}>
-      <TypeMark app={app} />
-      <AppName app={app} />
+    <div className={cn(CARD, 'opacity-70')}>
+      <span className="flex w-full items-center gap-2.5">
+        <TypeMark app={app} />
+        <AppName app={app} />
+      </span>
       <AppMeta app={app} creator={creator} />
-      <span className={TRAILING} />
     </div>
   )
 }
@@ -129,32 +137,34 @@ function RemoteRow({
 }) {
   const { t } = useTranslation()
   return (
-    <div className={ROW}>
-      <TypeMark app={app} />
-      <AppName app={app} />
-      <AppMeta app={app} creator={creator} />
-      <span className={TRAILING}>
-        <Button
-          variant="ghost"
-          onClick={onDownload}
-          disabled={busy}
-          className="h-7 gap-1.5 rounded-[7px] px-2 text-[12px]"
-        >
-          {busy ? (
-            <Loader2 className="h-3.5 w-3.5 animate-spin" />
-          ) : (
-            <Download className="h-3.5 w-3.5" />
-          )}
-          {t('apps.libraryDownload', '下载')}
-        </Button>
+    <div className={CARD}>
+      <span className="flex w-full items-center gap-2.5">
+        <TypeMark app={app} />
+        <AppName app={app} />
+        <span className={TRAILING}>
+          <Button
+            variant="ghost"
+            onClick={onDownload}
+            disabled={busy}
+            className="h-7 gap-1.5 rounded-[7px] px-2 text-[12px]"
+          >
+            {busy ? (
+              <Loader2 className="h-3.5 w-3.5 animate-spin" />
+            ) : (
+              <Download className="h-3.5 w-3.5" />
+            )}
+            {t('apps.libraryDownload', '下载')}
+          </Button>
+        </span>
       </span>
+      <AppMeta app={app} creator={creator} />
     </div>
   )
 }
 
 function GroupHeading({ label, count }: { label: string; count: number }) {
   return (
-    <div className="sticky top-0 z-10 flex items-center gap-1.5 bg-background px-3 pb-1.5 pt-4 text-[10.5px] font-semibold tracking-[0.08em] text-faint">
+    <div className="sticky top-0 z-10 flex items-center gap-1.5 bg-background pb-2 pt-4 text-[10.5px] font-semibold tracking-[0.08em] text-faint">
       <span>{label}</span>
       <span className="font-mono tabular-nums">· {count}</span>
     </div>
@@ -316,7 +326,7 @@ export function AppLibraryView() {
             groups.map((group) => (
               <section key={group.key}>
                 {group.label && <GroupHeading label={group.label} count={group.apps.length} />}
-                <div className={cn(!group.label && 'pt-4')}>
+                <div className={cn(GRID, !group.label && 'pt-4')}>
                   {group.apps.map((app) => {
                     if (group.key === 'here') {
                       return <LocalRow key={app.id} app={app} creator={creatorFor(app)} />

--- a/packages/app/src/components/sidebar/AppListColumn.tsx
+++ b/packages/app/src/components/sidebar/AppListColumn.tsx
@@ -86,17 +86,21 @@ export function AppListColumn() {
   const localAppIds = useAppsStore((s) => s.localAppIds)
   const loading = useAppsStore((s) => s.loading)
   const refreshLocalApps = useAppsStore((s) => s.refreshLocalApps)
+  const load = useAppsStore((s) => s.load)
   const selectApp = useAppsStore((s) => s.selectApp)
 
   const createLabel = t('apps.createTitle', '新建')
   const libraryLabel = t('apps.libraryTitle', '所有应用')
 
-  // The cloud list is loaded by the nav row (always mounted); only the local
-  // half can have changed on disk while this column was closed.
+  // Both halves. The nav row loads the cloud list too, but it is mounted once
+  // and never asks again — so an empty answer it happened to catch mid
+  // server-switch stayed on screen until the app restarted. `load` no longer
+  // caches an empty result, which makes opening this column the retry.
   React.useEffect(() => {
     if (!teamId) return
+    void load(teamId)
     void refreshLocalApps(teamId)
-  }, [teamId, refreshLocalApps])
+  }, [teamId, load, refreshLocalApps])
 
   /**
    * Only what is actually on this machine. Everything else lives in the library

--- a/packages/app/src/components/sidebar/AppListColumn.tsx
+++ b/packages/app/src/components/sidebar/AppListColumn.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import { useTranslation } from 'react-i18next'
-import { AppWindow, ChevronRight, LayoutGrid, Loader2, Plus } from 'lucide-react'
+import { AppWindow, ChevronRight, LayoutGrid, Loader2 } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { SidebarCollapseToggle } from '@/components/app-sidebar'
 import { TrafficLights } from '@/components/ui/traffic-lights'
@@ -131,17 +131,13 @@ export function AppListColumn() {
             <span className="font-mono text-[11px] font-normal text-faint"> · {items.length}</span>
           </div>
         </div>
+        {/*
+          One way in, not two. Creating lives in the library dialog, which is
+          also where you go to find an app that is not on this machine — a `+`
+          here duplicated that button one click earlier and made the header
+          read as two competing actions.
+        */}
         <div className="flex shrink-0 items-center gap-0.5">
-          <button
-            type="button"
-            onClick={() => openCreateApp(createLabel)}
-            disabled={!teamId}
-            title={t('apps.create', '新建')}
-            aria-label={t('apps.create', '新建')}
-            className="flex h-7 w-7 shrink-0 items-center justify-center rounded-[7px] text-muted-foreground transition-colors hover:bg-selected/40 hover:text-foreground disabled:opacity-40"
-          >
-            <Plus className="h-4 w-4" />
-          </button>
           <button
             type="button"
             onClick={() => openAppLibrary(libraryLabel)}

--- a/packages/app/src/components/sidebar/__tests__/AppListColumn.test.tsx
+++ b/packages/app/src/components/sidebar/__tests__/AppListColumn.test.tsx
@@ -79,12 +79,22 @@ describe('AppListColumn', () => {
     expect(useAppsStore.getState().selectedAppId).toBe('app-1')
   })
 
-  it('+ opens the create form in column three, not a modal', () => {
+  it('creating opens the form in column three, not a modal', () => {
+    // Reached from the empty state, which is now the only create affordance in
+    // this column: the header's `+` duplicated the library's own 新建 one click
+    // earlier and made the header read as two competing actions.
+    useAppsStore.setState({ items: [], localAppIds: [] })
     render(<AppListColumn />)
     fireEvent.click(screen.getByRole('button', { name: '新建' }))
     const tabs = useTabsStore.getState().tabs
     expect(tabs).toHaveLength(1)
     expect(tabs[0]).toMatchObject({ type: 'native', target: 'app-create' })
+  })
+
+  it('the header offers only the library, never a second create button', () => {
+    render(<AppListColumn />)
+    expect(screen.queryByRole('button', { name: '新建' })).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: '所有应用' })).toBeInTheDocument()
   })
 
   it('gives each app type its own glyph', () => {
@@ -120,7 +130,9 @@ describe('AppListColumn', () => {
     useAppsStore.setState({ items: [], localAppIds: [] })
     render(<AppListColumn />)
     expect(screen.getByText('还没有内容')).toBeInTheDocument()
-    expect(screen.getAllByRole('button', { name: '新建' })).toHaveLength(2)
+    // One create button (the empty state's), two ways to the library (the
+    // header icon and the empty state's own button).
+    expect(screen.getAllByRole('button', { name: '新建' })).toHaveLength(1)
     expect(screen.getAllByRole('button', { name: '所有应用' })).toHaveLength(2)
   })
 

--- a/packages/app/src/stores/apps-store.test.ts
+++ b/packages/app/src/stores/apps-store.test.ts
@@ -143,6 +143,7 @@ describe("apps-store", () => {
     useAppsStore.setState({
       items: [],
       loaded: false,
+      loadedKey: null,
       loading: false,
       error: null,
       teamId: null,
@@ -160,6 +161,34 @@ describe("apps-store", () => {
 
     await useAppsStore.getState().load("team-1"); // cached → no second call
     expect(mocks.listApps).toHaveBeenCalledTimes(1);
+  });
+
+  it("an empty answer is never cached", async () => {
+    // The failure this exists for: a list fetched a moment before the server
+    // or session finished switching comes back `[]` with a 200 — RLS filters,
+    // it does not fail — and caching that told the user their apps were gone
+    // until they restarted the app.
+    mocks.listApps.mockResolvedValueOnce([]);
+    const { useAppsStore } = await import("./apps-store");
+    await useAppsStore.getState().load("team-1");
+    expect(useAppsStore.getState().loadedKey).toBeNull();
+
+    mocks.listApps.mockResolvedValueOnce([appRow({ name: "Alpha" })]);
+    await useAppsStore.getState().load("team-1");
+    expect(mocks.listApps).toHaveBeenCalledTimes(2);
+    expect(useAppsStore.getState().items).toHaveLength(1);
+  });
+
+  it("a failed load is not cached either", async () => {
+    mocks.listApps.mockRejectedValueOnce(new Error("offline"));
+    const { useAppsStore } = await import("./apps-store");
+    await useAppsStore.getState().load("team-1");
+    expect(useAppsStore.getState().error).toBe("offline");
+    expect(useAppsStore.getState().loadedKey).toBeNull();
+
+    mocks.listApps.mockResolvedValueOnce([appRow()]);
+    await useAppsStore.getState().load("team-1");
+    expect(mocks.listApps).toHaveBeenCalledTimes(2);
   });
 
   it("force reload calls the backend again", async () => {

--- a/packages/app/src/stores/apps-store.ts
+++ b/packages/app/src/stores/apps-store.ts
@@ -18,6 +18,8 @@ import {
   type SeedAppResult,
 } from "@/lib/daemon/daemon-local-client";
 import { isTauri } from "@/lib/utils";
+import { getEffectiveServerConfigSync } from "@/lib/config/server-config";
+import { useAuthStore } from "@/stores/auth-store";
 import i18n from "@/lib/i18n";
 import type {
   AppRow,
@@ -51,6 +53,15 @@ interface AppsState {
    * empty and send the user off to download apps they already have.
    */
   localAppIds: string[] | null;
+  /**
+   * Which (server, user, team) the loaded list actually belongs to, or null
+   * when nothing authoritative is cached.
+   *
+   * Not just `teamId`: the same team id means a different set of apps on a
+   * different deployment or under a different account, and switching either
+   * one is exactly when a stale "no apps" answer used to stick.
+   */
+  loadedKey: string | null;
   recordAppSession: (appId: string, sessionId: string) => void;
   selectApp: (appId: string | null) => void;
   load: (teamId: string, opts?: { force?: boolean }) => Promise<void>;
@@ -514,6 +525,16 @@ export async function ensureAppCheckout(
   }
 }
 
+/**
+ * What a cached app list is valid for: this deployment, this account, this
+ * team. Any of the three changing makes the cached answer someone else's.
+ */
+function appsCacheKey(teamId: string): string {
+  const server = getEffectiveServerConfigSync().cloudApiUrl;
+  const user = useAuthStore.getState().session?.user?.id ?? "";
+  return `${server}|${user}|${teamId}`;
+}
+
 export const useAppsStore = create<AppsState>((set, get) => ({
   items: [],
   loaded: false,
@@ -526,6 +547,7 @@ export const useAppsStore = create<AppsState>((set, get) => ({
   appIdBySessionId: {},
   selectedAppId: null,
   localAppIds: null,
+  loadedKey: null,
   recordAppSession: (appId, sessionId) => {
     set((s) => {
       const sessionChanged = s.sessionIdByAppId[appId] !== sessionId;
@@ -545,12 +567,24 @@ export const useAppsStore = create<AppsState>((set, get) => ({
     set((s) => (s.selectedAppId === appId ? s : { selectedAppId: appId }));
   },
   load: async (teamId, opts) => {
+    const key = appsCacheKey(teamId);
     const s = get();
-    if (s.loaded && s.teamId === teamId && !opts?.force) return;
+    if (s.loadedKey === key && !opts?.force) return;
     set({ loading: true, error: null, teamId });
     try {
       const items = await getBackend().apps.listApps(teamId);
-      set({ items, loaded: true, loading: false });
+      set({
+        items,
+        loaded: true,
+        loading: false,
+        // An empty answer is never cached. RLS does not fail a request it
+        // cannot satisfy — it filters it to nothing — so a list fetched a
+        // moment before the session or the server finished switching comes
+        // back as `[]` with a 200, and caching that told the user their apps
+        // were gone until they restarted the app. Re-asking costs one request
+        // on a team that genuinely has none.
+        loadedKey: items.length > 0 ? key : null,
+      });
     } catch (e) {
       set({
         loading: false,

--- a/packages/app/src/stores/member-preferences-store.test.ts
+++ b/packages/app/src/stores/member-preferences-store.test.ts
@@ -1,0 +1,50 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getMemberDefaultAgent: vi.fn(),
+}));
+
+vi.mock("@/lib/backend", () => ({
+  getBackend: () => ({ actors: { getMemberDefaultAgent: mocks.getMemberDefaultAgent } }),
+}));
+
+describe("member-preferences-store", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+  });
+
+  it("loads once per team", async () => {
+    mocks.getMemberDefaultAgent.mockResolvedValue("agent-1");
+    const { useMemberPreferencesStore } = await import("./member-preferences-store");
+    await useMemberPreferencesStore.getState().ensureLoaded("team-1");
+    await useMemberPreferencesStore.getState().ensureLoaded("team-1");
+    expect(mocks.getMemberDefaultAgent).toHaveBeenCalledTimes(1);
+    expect(useMemberPreferencesStore.getState().defaultAgentId).toBe("agent-1");
+  });
+
+  it("a failed load is retried, not remembered as loaded", async () => {
+    // `reload` sets `teamId` before the request so it can detect a team switch
+    // racing the response. The guard used to read that same field, so a
+    // FAILURE left it set and `ensureLoaded` returned for that team forever —
+    // the member's default agent silently stayed empty until a restart.
+    mocks.getMemberDefaultAgent.mockRejectedValueOnce(new Error("offline"));
+    const { useMemberPreferencesStore } = await import("./member-preferences-store");
+    await useMemberPreferencesStore.getState().ensureLoaded("team-1");
+    expect(useMemberPreferencesStore.getState().loadedTeamId).toBeNull();
+
+    mocks.getMemberDefaultAgent.mockResolvedValueOnce("agent-1");
+    await useMemberPreferencesStore.getState().ensureLoaded("team-1");
+    expect(mocks.getMemberDefaultAgent).toHaveBeenCalledTimes(2);
+    expect(useMemberPreferencesStore.getState().defaultAgentId).toBe("agent-1");
+  });
+
+  it("switching teams loads the new one", async () => {
+    mocks.getMemberDefaultAgent.mockResolvedValue("agent-1");
+    const { useMemberPreferencesStore } = await import("./member-preferences-store");
+    await useMemberPreferencesStore.getState().ensureLoaded("team-1");
+    await useMemberPreferencesStore.getState().ensureLoaded("team-2");
+    expect(mocks.getMemberDefaultAgent).toHaveBeenCalledTimes(2);
+    expect(useMemberPreferencesStore.getState().loadedTeamId).toBe("team-2");
+  });
+});

--- a/packages/app/src/stores/member-preferences-store.ts
+++ b/packages/app/src/stores/member-preferences-store.ts
@@ -15,6 +15,9 @@ import { getBackend } from "@/lib/backend";
 interface MemberPreferencesState {
   /** Team the cached `defaultAgentId` belongs to. */
   teamId: string | null;
+  /** The team whose preferences actually loaded. Null after a failure, which
+   *  is what lets `ensureLoaded` try again. */
+  loadedTeamId: string | null;
   defaultAgentId: string | null;
   loading: boolean;
   /** Load (once per team) the caller's default agent. Cheap no-op if already loaded. */
@@ -45,12 +48,17 @@ interface MemberPreferencesState {
 
 export const useMemberPreferencesStore = create<MemberPreferencesState>((set, get) => ({
   teamId: null,
+  loadedTeamId: null,
   defaultAgentId: null,
   loading: false,
 
   ensureLoaded: async (teamId) => {
     const state = get();
-    if (state.teamId === teamId && !state.loading) return;
+    // `loadedTeamId`, not `teamId`: `reload` sets `teamId` before the request
+    // so an in-flight team switch can be detected, which meant a FAILED load
+    // left it set and this guard returned for that team forever — the default
+    // agent silently stayed empty until a restart.
+    if (state.loadedTeamId === teamId && !state.loading) return;
     await get().reload(teamId);
   },
 
@@ -60,7 +68,7 @@ export const useMemberPreferencesStore = create<MemberPreferencesState>((set, ge
       const defaultAgentId = await getBackend().actors.getMemberDefaultAgent(teamId);
       // Guard against a team switch racing an in-flight fetch.
       if (get().teamId !== teamId) return;
-      set({ defaultAgentId: defaultAgentId ?? null, loading: false });
+      set({ defaultAgentId: defaultAgentId ?? null, loading: false, loadedTeamId: teamId });
     } catch (error) {
       console.warn("[MemberPreferences] failed to load default agent", error);
       if (get().teamId === teamId) set({ loading: false });

--- a/packages/app/src/stores/thread-summaries-store.test.ts
+++ b/packages/app/src/stores/thread-summaries-store.test.ts
@@ -1,0 +1,59 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  listThreadSummaries: vi.fn(),
+}));
+
+vi.mock("@/lib/backend", () => ({
+  getBackend: () => ({ sessions: { listThreadSummaries: mocks.listThreadSummaries } }),
+}));
+
+vi.mock("@/lib/session/thread-fork-metadata", () => ({
+  rememberThreadForkMetadata: vi.fn(),
+}));
+
+describe("thread-summaries-store", () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    vi.resetModules();
+  });
+
+  it("caches a loaded list and does not ask twice", async () => {
+    mocks.listThreadSummaries.mockResolvedValue([]);
+    const { useThreadSummariesStore } = await import("./thread-summaries-store");
+    await useThreadSummariesStore.getState().load("parent-1");
+    await useThreadSummariesStore.getState().load("parent-1");
+    expect(mocks.listThreadSummaries).toHaveBeenCalledTimes(1);
+  });
+
+  it("a failure is not recorded as an empty thread list", async () => {
+    // The bug: the catch stored `{ summaries: [], loaded: true }`, so one
+    // network blip became a permanent "this session has no threads" — the
+    // guard then refused to ask again, and nothing in the UI could tell the
+    // difference between that and the truth.
+    mocks.listThreadSummaries.mockRejectedValueOnce(new Error("offline"));
+    const { useThreadSummariesStore } = await import("./thread-summaries-store");
+    await useThreadSummariesStore.getState().load("parent-1");
+    expect(useThreadSummariesStore.getState().byParent["parent-1"]?.loaded).toBe(false);
+
+    mocks.listThreadSummaries.mockResolvedValueOnce([]);
+    await useThreadSummariesStore.getState().load("parent-1");
+    expect(mocks.listThreadSummaries).toHaveBeenCalledTimes(2);
+  });
+
+  it("a failure keeps whatever was already known", async () => {
+    const summary = {
+      threadSessionId: "t-1",
+      rootMessageId: "m-1",
+      title: "Kept",
+    } as never;
+    mocks.listThreadSummaries.mockResolvedValueOnce([summary]);
+    const { useThreadSummariesStore } = await import("./thread-summaries-store");
+    await useThreadSummariesStore.getState().load("parent-1");
+    expect(useThreadSummariesStore.getState().byParent["parent-1"]?.summaries).toHaveLength(1);
+
+    mocks.listThreadSummaries.mockRejectedValueOnce(new Error("offline"));
+    await useThreadSummariesStore.getState().load("parent-1", { force: true });
+    expect(useThreadSummariesStore.getState().byParent["parent-1"]?.summaries).toHaveLength(1);
+  });
+});

--- a/packages/app/src/stores/thread-summaries-store.ts
+++ b/packages/app/src/stores/thread-summaries-store.ts
@@ -73,13 +73,18 @@ export const useThreadSummariesStore = create<ThreadSummariesStore>((set, get) =
           },
         }));
       } catch {
+        // NOT `loaded: true` with an empty list. That recorded a transient
+        // failure as "this session has no threads" — permanently, because the
+        // guard above then refused to ask again — and the UI had no way to
+        // tell the two apart. Keep whatever was known and stay unloaded so the
+        // next mount retries.
         set((state) => ({
           byParent: {
             ...state.byParent,
             [trimmed]: {
-              summaries: [],
+              summaries: state.byParent[trimmed]?.summaries ?? [],
               loading: false,
-              loaded: true,
+              loaded: state.byParent[trimmed]?.loaded ?? false,
             },
           },
         }));


### PR DESCRIPTION
起因是 belayo 上的一个现场：一个有 13 个应用的团队，界面显示 **0 个**、「还没有内容」，而新建同名应用又报 `duplicate key value violates unique constraint "apps_team_slug_uniq"` —— 行明明在，客户端就是看不见。

## 定位（每一层都实测过）

| 层 | 结果 |
|---|---|
| 数据库 | 该团队 13 行 |
| RLS（用他的 uid 模拟） | 可见 **11** 行（另 2 行是别人的 personal，本就该隐藏） |
| Cloud API（在应用内用它自己的 token 打） | **200，11 条** |
| 本地 daemon | 3 个 checkout，都在那 11 条里 |
| 客户端 | **0** ← 只有这一层是错的 |

重载 webview 立刻恢复成 4（3 个 checkout + 1 个 workdir override）。

## 根因

```ts
if (s.loaded && s.teamId === teamId && !opts?.force) return;
```

`load` 对**任何**成功响应都置 `loaded`，包括空响应。而 **RLS 不会让一个它满足不了的请求失败，它只是把结果过滤成空** —— 所以在会话或服务器切换完成前的一瞬间发出的列表请求，会拿到一个 200 + `[]`。那个答案随即变成永久：该 teamId 不会再被重新拉取，而全应用唯一带 `force` 的入口是「所有应用」那个库视图，没有任何东西提示用户去点它。

## 改动

**apps-store**
- 缓存键从 `teamId` 变成 **(server, user, team)**：同一个 team id 在不同部署、不同账号下是不同的一组应用，而切这两样正是旧答案粘住的时刻。
- **空结果不缓存**。对真的没有应用的团队代价是多一次请求；旧行为的代价是用户整份列表消失到重启为止。
- 应用栏打开时也拉云端那一半（以前只拉本地）——空结果不再缓存之后，打开这一栏本身就是重试。

**顺着这个形状扫了一遍其它 store**（守卫跳过工作 + 在「非成功/非有意义的答案」上置标志），又找到两处：

- `thread-summaries-store`：`catch` 里存 `{ summaries: [], loaded: true }` —— 一次网络抖动被永久记成「这个会话没有分支」，守卫从此拒绝再问，UI 无从分辨真假。改成保留已有内容并保持未加载。
- `member-preferences-store`：没有 loaded 标志。`reload` 为识别切团队竞态会在请求前写 `teamId`，而 `ensureLoaded` 读的是同一个字段 —— 失败也粘住，默认 Agent 静默为空直到重启。改成单独的 `loadedTeamId`，只在成功时写（`session-list-store` 早就是这个写法）。

**故意没动** `team-share-browser`：它也缓存失败，但保留并渲染 error，不会伪装成「空」。

## 顺带两处 UI

- 应用栏列头的 `+` 去掉：它和「所有应用」里的新建重复，一个点击之隔的两个按钮做同一件事。空状态那对保留 —— 那里两个按钮回答的是两个不同的问题。
- 「所有应用」改成卡片布局：原来是整行宽的行，左边一个短名字、右边一个按钮，中间 500px 空白（meta 被推到右缘正是为了填这个空）。卡片直接消掉这个空隙：名字+图标一行，`创建者 · 类型 · 代码在哪` 一行，操作在角上。纸面 + 发丝边框、不加阴影（按 AGENTS.md 的调色规则），栅格用 container query 跟着这一栏的宽度走，而不是视口。

## 测试

全量 **3448 passed**、typecheck 干净、lint 0 error。

三个 store 各补了针对性用例：空结果不缓存、失败不缓存、失败保留已有数据、失败后重试、切团队重新加载。`thread-summaries-store` 和 `member-preferences-store` 此前**一条测试都没有**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)