### PR TITLE
fix(daemon): treat user interrupt as stopped, not provider error (#1331)

### DIFF
--- a/apps/daemon/assets/pi-extension/teamclu.ts
+++ b/apps/daemon/assets/pi-extension/teamclu.ts
@@ -43,7 +43,9 @@
  *
  * ## Permission flow
  *
- * `tool_call` hook: on "ask" the extension calls `ctx.ui.confirm(title, message)`.
+ * `tool_call` hook: on "ask" the extension calls `ctx.ui.confirm(title, message, { signal })`.
+ * The turn abort signal must be wired through so a user interrupt can dismiss the
+ * dialog; otherwise `session.abort()` waits forever on this await (#1331).
  * In `pi --mode rpc` that surfaces as `extension_ui_request{method:"confirm"}`
  * which amuxd translates into an AcpPermissionRequest. The message carries a
  * machine-readable trailer line `teamclu.always-pattern=<pattern>`; when the
@@ -67,18 +69,22 @@ type ToolCallEvent = {
   toolCallId: string;
   input: Record<string, unknown>;
 };
+type ExtensionUIDialogOptions = { timeout?: number; signal?: AbortSignal };
+
 type TeamcluExtensionUIContext = {
   sessionId?: string;
-  confirm(title: string, message?: string, options?: { timeout?: number }): Promise<boolean>;
+  confirm(title: string, message?: string, options?: ExtensionUIDialogOptions): Promise<boolean>;
   select(
     title: string,
     options: string[],
-    opts?: { timeout?: number; signal?: AbortSignal },
+    opts?: ExtensionUIDialogOptions,
   ): Promise<string | undefined>;
   setTitle?(title: string): void;
 };
 type ExtensionContext = {
   ui: TeamcluExtensionUIContext;
+  /** Turn abort signal; undefined when the agent is not streaming. */
+  signal?: AbortSignal;
   /** Current model; pi sets `.provider` (e.g. `"anthropic"`). */
   model?: unknown;
   modelRegistry?: {
@@ -1613,9 +1619,14 @@ export default async function (pi: ExtensionAPI) {
     const argsJson = (JSON.stringify(event.input ?? {}, null, 2) ?? "{}").slice(0, 2000);
     const message = `${argsJson}\n\nteamclu.always-pattern=${pattern}`;
 
-    const confirmed = await ctx.ui.confirm(title, message);
+    const confirmed = await ctx.ui.confirm(title, message, { signal: ctx.signal });
     if (!confirmed) {
-      return { block: true, reason: "Denied by TeamClu permission gate" };
+      return {
+        block: true,
+        reason: ctx.signal?.aborted
+          ? "Permission request cancelled"
+          : "Denied by TeamClu permission gate",
+      };
     }
     return undefined;
   });

--- a/apps/daemon/src/runtime/pi_rpc/events.rs
+++ b/apps/daemon/src/runtime/pi_rpc/events.rs
@@ -152,6 +152,7 @@ async fn handle_event(
     match event_type {
         "agent_start" => {
             if let Some(route) = shared.routes.lock().get_mut(&session_id) {
+                route.user_cancel_requested = false;
                 route.translate.reset_turn();
                 // A prompt sent while pi was busy is queued as `followUp`, so
                 // it starts its own run after the current one ends — and that
@@ -244,7 +245,15 @@ pub(super) async fn close_turn(shared: &Arc<Shared>, session_id: &str) {
             // a user cancel, a child that died mid-turn. Flushing the held
             // error at this one point is what makes "a failed turn always
             // reports" hold no matter which path fired.
-            let failure = route.translate.take_turn_error();
+            let failure = if route.user_cancel_requested {
+                route.user_cancel_requested = false;
+                route.translate.discard_turn_error();
+                Some(translate::aborted_turn_error(
+                    translate::ABORTED_ERROR_DETAILS,
+                ))
+            } else {
+                route.translate.take_turn_error()
+            };
             Some((route.event_tx.clone(), reply_to, failure))
         }
     };
@@ -626,6 +635,7 @@ mod tests {
                 pool_key,
                 session_path: session_path.to_string(),
                 turn_active: false,
+                user_cancel_requested: false,
                 turn_reply_to: None,
                 turn_requester: None,
                 translate: translate::TranslateState::default(),

--- a/apps/daemon/src/runtime/pi_rpc/mod.rs
+++ b/apps/daemon/src/runtime/pi_rpc/mod.rs
@@ -62,6 +62,10 @@ pub(crate) struct Route {
     /// pi session file path (open_session / switch_session target).
     pub(crate) session_path: String,
     pub(crate) turn_active: bool,
+    /// Set when the client sends `AcpCommand::Cancel` for this session. Consumed
+    /// by `close_turn` to emit an interrupt (not a provider failure) even if pi
+    /// reports `stopReason: "error"` or leaves the turn on `"toolUse"`.
+    pub(crate) user_cancel_requested: bool,
     pub(crate) turn_reply_to: Option<String>,
     pub(crate) turn_requester: Option<String>,
     pub(crate) translate: TranslateState,
@@ -596,6 +600,7 @@ async fn attach(shared: &Arc<Shared>, args: AttachArgs) -> Result<AcpStartupMeta
             pool_key: key,
             session_path: established.session_path,
             turn_active: false,
+            user_cancel_requested: false,
             turn_reply_to: None,
             turn_requester: None,
             translate: TranslateState::default(),
@@ -1275,6 +1280,9 @@ async fn command_loop(shared: Arc<Shared>, mut cmd_rx: mpsc::Receiver<AcpCommand
                 .await;
             }
             AcpCommand::Cancel { acp_session_id } => {
+                if let Some(route) = shared.routes.lock().get_mut(&acp_session_id) {
+                    route.user_cancel_requested = true;
+                }
                 let pool_key = shared
                     .routes
                     .lock()

--- a/apps/daemon/src/runtime/pi_rpc/process.rs
+++ b/apps/daemon/src/runtime/pi_rpc/process.rs
@@ -1133,6 +1133,7 @@ mod tests {
                 pool_key: attached_key.clone(),
                 session_path: "/s.jsonl".into(),
                 turn_active: false,
+                user_cancel_requested: false,
                 turn_reply_to: None,
                 turn_requester: None,
                 translate: super::translate::TranslateState::default(),

--- a/apps/daemon/src/runtime/pi_rpc/translate.rs
+++ b/apps/daemon/src/runtime/pi_rpc/translate.rs
@@ -101,6 +101,35 @@ pub(crate) const PROVIDER_ERROR_MESSAGE: &str = "model provider error";
 pub(crate) const ABORTED_ERROR_MESSAGE: &str = "MessageAbortedError";
 pub(crate) const ABORTED_ERROR_DETAILS: &str = "Aborted";
 
+/// User abort sometimes surfaces as `stopReason: "error"` with an AbortError
+/// message (e.g. tool execution cancelled mid-flight) rather than `"aborted"`.
+/// Treat those as interrupts, not provider failures.
+pub(crate) fn is_abort_like_detail(details: &str) -> bool {
+    let lower = details.trim().to_ascii_lowercase();
+    lower.contains("operation was aborted")
+        || lower.contains("messageaborted")
+        || lower.contains("request was aborted")
+        || lower.contains("aborterror")
+        || lower == "aborted"
+}
+
+/// pi tool layer abort summaries (`bash` → `"aborted"`, agent-loop →
+/// `"Operation aborted"`, harness → `"Command aborted"`).
+pub(crate) fn is_abort_like_tool_result(summary: &str) -> bool {
+    let lower = summary.trim().to_ascii_lowercase();
+    if lower.is_empty() {
+        return false;
+    }
+    lower == "aborted"
+        || lower == "operation aborted"
+        || lower == "command aborted"
+        || is_abort_like_detail(summary)
+}
+
+pub(crate) fn aborted_turn_error(details: impl Into<String>) -> amux::AcpEvent {
+    error_event(ABORTED_ERROR_MESSAGE, details.into())
+}
+
 fn error_event(message: &str, details: String) -> amux::AcpEvent {
     amux::AcpEvent {
         event: Some(amux::acp_event::Event::Error(amux::AcpError {
@@ -317,8 +346,20 @@ pub fn translate_event(
                 // detail when pi gives none — the frontend renders the
                 // localized message alone.
                 "error" => {
-                    state.stash_turn_error(PROVIDER_ERROR_MESSAGE, details.unwrap_or_default());
-                    vec![]
+                    let details_str = details.unwrap_or_default();
+                    if is_abort_like_detail(&details_str) {
+                        vec![error_event(
+                            ABORTED_ERROR_MESSAGE,
+                            if details_str.is_empty() {
+                                ABORTED_ERROR_DETAILS.to_string()
+                            } else {
+                                details_str
+                            },
+                        )]
+                    } else {
+                        state.stash_turn_error(PROVIDER_ERROR_MESSAGE, details_str);
+                        vec![]
+                    }
                 }
                 // Emitted straight away: an abort is never retried (pi-ai's
                 // `retryAssistantCall` returns it terminally, and
@@ -834,6 +875,31 @@ mod tests {
             }
             other => panic!("unexpected: {other:?}"),
         }
+    }
+
+    #[test]
+    fn abort_like_tool_result_strings() {
+        assert!(super::is_abort_like_tool_result("aborted"));
+        assert!(super::is_abort_like_tool_result("Operation aborted"));
+        assert!(super::is_abort_like_tool_result("Command aborted"));
+        assert!(!super::is_abort_like_tool_result("permission denied"));
+    }
+
+    #[test]
+    fn abort_like_error_stop_reason_becomes_interrupt_not_provider_failure() {
+        let mut s = TranslateState::default();
+        let e = ev(
+            &mut s,
+            r#"{"type":"message_end","message":{"role":"assistant","content":[],"stopReason":"error","errorMessage":"This operation was aborted"}}"#,
+        );
+        match e[0].event.as_ref().unwrap() {
+            amux::acp_event::Event::Error(err) => {
+                assert_eq!(err.message, ABORTED_ERROR_MESSAGE);
+                assert_eq!(err.details, "This operation was aborted");
+            }
+            other => panic!("unexpected: {other:?}"),
+        }
+        assert!(s.take_turn_error().is_none());
     }
 
     #[test]

--- a/apps/daemon/src/runtime/turn_aggregator.rs
+++ b/apps/daemon/src/runtime/turn_aggregator.rs
@@ -85,6 +85,8 @@ fn is_turn_abort_error(err: &amux::AcpError) -> bool {
         || details.contains("messageaborted")
         || message.contains("turninterrupted")
         || details.contains("turninterrupted")
+        || crate::runtime::pi_rpc::translate::is_abort_like_detail(&err.details)
+        || crate::runtime::pi_rpc::translate::is_abort_like_detail(&err.message)
 }
 
 fn tool_use_metadata(tu: &amux::AcpToolUse) -> String {
@@ -183,6 +185,9 @@ pub struct TurnAggregator {
     /// carry opposite meanings to the model: one is "the user stopped you",
     /// the other is "the call failed".
     turn_failed: bool,
+    /// pi aborted a tool mid-flight (`tool_execution_end` with an abort-shaped
+    /// summary) without emitting assistant `stopReason: "aborted"`.
+    turn_saw_abort_tool_result: bool,
 }
 
 impl TurnAggregator {
@@ -223,6 +228,11 @@ impl TurnAggregator {
             Some(amux::acp_event::Event::ToolResult(tr)) => {
                 self.ensure_turn_started();
                 self.turn_had_activity = true;
+                if !tr.success
+                    && crate::runtime::pi_rpc::translate::is_abort_like_tool_result(&tr.summary)
+                {
+                    self.turn_saw_abort_tool_result = true;
+                }
                 let metadata = tool_result_metadata(tr);
                 out.push(EmittedMessage {
                     kind: MessageKind::AgentToolResult,
@@ -258,6 +268,7 @@ impl TurnAggregator {
                     self.turn_had_reply = false;
                     self.turn_was_interrupted = false;
                     self.turn_failed = false;
+                    self.turn_saw_abort_tool_result = false;
                     self.ensure_turn_started();
                 }
                 // Active -> Idle is the canonical "turn ended" signal.
@@ -265,6 +276,12 @@ impl TurnAggregator {
                 // turn allocates a fresh id.
                 if sc.old_status == active && sc.new_status == idle {
                     self.flush_thinking_into(&mut out);
+                    if self.turn_saw_abort_tool_result {
+                        // Tool-phase user abort: assistant stopReason stays
+                        // `"toolUse"`; the abort lives only in the tool result.
+                        self.turn_was_interrupted = true;
+                        self.turn_failed = false;
+                    }
                     let ended_badly = self.turn_was_interrupted || self.turn_failed;
                     if ended_badly && self.turn_had_activity {
                         // Single durable AGENT_REPLY: keep any unflushed prose in
@@ -319,6 +336,7 @@ impl TurnAggregator {
                     self.turn_had_reply = false;
                     self.turn_was_interrupted = false;
                     self.turn_failed = false;
+                    self.turn_saw_abort_tool_result = false;
                     self.current_turn_id = None;
                 }
             }
@@ -705,6 +723,28 @@ mod tests {
             .contains("\"turn_status\":\"no_final_reply\""));
         assert!(emitted[0].cloud_persist);
         assert!(!emitted[0].turn_id.is_empty());
+        assert!(TurnAggregator::cloud_persistent(&emitted[0]));
+    }
+
+    #[test]
+    fn abort_shaped_tool_result_marks_turn_interrupted_at_idle() {
+        let mut agg = TurnAggregator::new();
+        agg.ingest(&status_change(
+            amux::AgentStatus::Idle,
+            amux::AgentStatus::Active,
+        ));
+        agg.ingest(&tool_use("t1", "bash", "sleep 30"));
+        agg.ingest(&tool_result("t1", false, "aborted"));
+
+        let emitted = agg.ingest(&status_change(
+            amux::AgentStatus::Active,
+            amux::AgentStatus::Idle,
+        ));
+        assert_eq!(emitted.len(), 1);
+        assert_eq!(emitted[0].kind, MessageKind::AgentReply);
+        assert!(emitted[0]
+            .metadata_json
+            .contains("\"turn_status\":\"interrupted\""));
         assert!(TurnAggregator::cloud_persistent(&emitted[0]));
     }
 

--- a/packages/app/src/components/mqtt-live-wiring/handle-acp-event.ts
+++ b/packages/app/src/components/mqtt-live-wiring/handle-acp-event.ts
@@ -427,7 +427,7 @@ export function handleAcpEvent(
                 // SessionErrorAlert bubble in the thread instead.
                 {
                   const detail = (er.details ?? "").trim();
-                  const errorName = classifyAgentTurnErrorName(er.message);
+                  const errorName = classifyAgentTurnErrorName(er.message, er.details);
                   useSessionStore.getState().setSessionErrorEvent({
                     sessionId: sid,
                     error: {

--- a/packages/app/src/lib/agent/__tests__/agent-turn-error.test.ts
+++ b/packages/app/src/lib/agent/__tests__/agent-turn-error.test.ts
@@ -24,6 +24,12 @@ describe('isAgentTurnAbortError', () => {
     expect(isAgentTurnAbortError(undefined, 'Aborted')).toBe(false)
   })
 
+  it('treats abort-shaped provider error details as interrupt', () => {
+    expect(
+      isAgentTurnAbortError('model provider error', 'This operation was aborted'),
+    ).toBe(true)
+  })
+
   it('does not match unrelated failures', () => {
     expect(isAgentTurnAbortError('model stalled', 'No output')).toBe(false)
   })
@@ -32,6 +38,12 @@ describe('isAgentTurnAbortError', () => {
 describe('classifyAgentTurnErrorName', () => {
   it('maps abort to TurnInterrupted', () => {
     expect(classifyAgentTurnErrorName('MessageAbortedError')).toBe('TurnInterrupted')
+  })
+
+  it('maps abort-shaped provider error to TurnInterrupted', () => {
+    expect(
+      classifyAgentTurnErrorName('model provider error', 'This operation was aborted'),
+    ).toBe('TurnInterrupted')
   })
 
   it('maps model stalled to AgentTimeoutError', () => {

--- a/packages/app/src/lib/agent/agent-turn-error.ts
+++ b/packages/app/src/lib/agent/agent-turn-error.ts
@@ -16,14 +16,22 @@ export function isAgentTurnAbortError(
   if (name.includes('messageaborted')) return true
   // Display form already joined as "MessageAbortedError: Aborted"
   if (name.includes('messageabortederror')) return true
+  if (name.includes('operation was aborted') || det.includes('operation was aborted')) {
+    return true
+  }
+  if (det === 'request was aborted') return true
+  if (name.includes('aborterror') || det.includes('aborterror')) return true
   return false
 }
 
 /** Classify daemon-emitted AcpError.message into a UI error name. */
-export function classifyAgentTurnErrorName(message: string | undefined): string {
+export function classifyAgentTurnErrorName(
+  message: string | undefined,
+  detail?: string | undefined,
+): string {
   const raw = (message ?? '').trim()
   const lower = raw.toLowerCase()
-  if (isAgentTurnAbortError(raw)) {
+  if (isAgentTurnAbortError(raw, detail)) {
     return TURN_INTERRUPTED_ERROR_NAME
   }
   if (lower === 'model stalled' || lower === 'model provider not responding') {

--- a/packages/app/src/lib/stream/streaming-persist.ts
+++ b/packages/app/src/lib/stream/streaming-persist.ts
@@ -42,11 +42,22 @@ export function snapshotTranscriptParts(
  * Prevents reload from restoring a permanent "running" spinner when idle
  * arrives before the late toolResult (opencode abort order).
  */
+function turnStatusFromMetadata(metadataJson: string | undefined): string | undefined {
+  if (!metadataJson?.trim()) return undefined;
+  try {
+    const parsed = JSON.parse(metadataJson) as { turn_status?: unknown };
+    return typeof parsed.turn_status === "string" ? parsed.turn_status : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 function finalizeStreamEntryForPersist(
   entry: AgentStreamEntry,
+  opts?: { interrupted?: boolean },
 ): AgentStreamEntry {
   const cloned = cloneStreamEntrySnapshot(entry);
-  const toolCalls = finishUnresolvedTools(cloned.toolCalls);
+  const toolCalls = finishUnresolvedTools(cloned.toolCalls, opts);
   return {
     ...cloned,
     toolCalls,
@@ -179,8 +190,9 @@ export async function persistStreamingPartsForReply(
   const rawSnapshot =
     opts?.streamEntrySnapshot ??
     resolveStreamEntryForPersist(sessionId, actorId);
+  const interrupted = turnStatusFromMetadata(reply.metadataJson) === "interrupted";
   const snapshot = rawSnapshot
-    ? finalizeStreamEntryForPersist(rawSnapshot)
+    ? finalizeStreamEntryForPersist(rawSnapshot, { interrupted })
     : undefined;
   const parts = mergeSubagentSnapshotsIntoParts(
     snapshotTranscriptParts(snapshot),

--- a/packages/app/src/stores/v2-stream-parts.ts
+++ b/packages/app/src/stores/v2-stream-parts.ts
@@ -295,10 +295,26 @@ export function mergeToolCallFromEnrichedParts(
   return enriched;
 }
 
+export type FinishUnresolvedToolsOptions = {
+  /** User stopped the turn — show a clean abort, not a provider-style failure. */
+  interrupted?: boolean;
+};
+
 /** Mark in-flight tools failed so idle flush / reload never leave a spinner. */
-export function finishUnresolvedTools(toolCalls: ToolCall[]): ToolCall[] {
+export function finishUnresolvedTools(
+  toolCalls: ToolCall[],
+  opts?: FinishUnresolvedToolsOptions,
+): ToolCall[] {
   return toolCalls.map((tc) => {
     if (tc.status !== "calling" && tc.status !== "waiting") return tc;
+    if (opts?.interrupted) {
+      return {
+        ...tc,
+        status: "completed" as const,
+        result: "Command aborted",
+        duration: Date.now() - tc.startTime.getTime(),
+      };
+    }
     return {
       ...tc,
       status: "failed" as const,

--- a/packages/app/src/stores/v2-streaming-store.ts
+++ b/packages/app/src/stores/v2-streaming-store.ts
@@ -1226,7 +1226,8 @@ export const useV2StreamingStore = create<State>((set, get) => ({
       return;
     }
     const before = summarizeToolCallsForDiag(existing.toolCalls);
-    const toolCalls = finishUnresolvedTools(existing.toolCalls);
+    const interrupted = opts?.reason === "interrupt";
+    const toolCalls = finishUnresolvedTools(existing.toolCalls, { interrupted });
     set({
       byKey: {
         ...state.byKey,


### PR DESCRIPTION
## Summary

- **#1331**: Bind pi extension permission `confirm()` to `ctx.signal` so user cancel can unwind while a permission dialog is pending (avoids pi host deadlock).
- **Interrupt UX**: When the user stops a turn during tool execution (e.g. `sleep 30`), classify the outcome as **interrupted/stopped** instead of **Provider Error**.
  - Daemon: track `user_cancel_requested` on ACP Cancel; `close_turn` emits `MessageAbortedError` instead of stashed provider errors.
  - Daemon: detect abort-shaped tool results in `turn_aggregator` and mark turn interrupted at idle.
  - Daemon: translate abort-like `stopReason: "error"` strings as interrupt (fallback).
  - Frontend: pass error detail into turn classification; finish unresolved tools as `Command aborted`; persist interrupted turn status for tool cards.

## Test plan

- [ ] Default permission mode: start a tool that triggers permission prompt → interrupt before approving → pi host stays responsive (no deadlock).
- [ ] Run `sleep 30` (or similar long tool) → interrupt mid-execution → UI shows Stopped/interrupted, not Provider Error; tool card shows Command aborted.
- [ ] Normal provider failures (non-abort) still surface as errors.
- [ ] `pnpm test:unit packages/app/src/lib/agent/__tests__/agent-turn-error.test.ts`
- [ ] Restart amuxd after merge (pi extension asset change).

## Notes

- #1332 (full-access permission not synced to daemon for desktop sessions) is out of scope here; verified partially on main.

Made with [Cursor](https://cursor.com)