### PR TITLE
fix(apps): 容器应用只能部署一次 —— 连带修镜像 tag 对不上和 finalize 不校验镜像归属

### DIFF
--- a/apps/daemon/src/sync/app_build.rs
+++ b/apps/daemon/src/sync/app_build.rs
@@ -388,13 +388,59 @@ fn is_inside_workdir(path: &str) -> bool {
 /// see [`push_image`] for why the password reaches `docker` through a config
 /// file rather than an argument.
 pub struct ImagePushTarget<'a> {
-    /// Full reference to push: `<registry>/<namespace>/<repo>:<tag>`.
+    /// Full reference to push: `<registry>/<namespace>/<repo>:<tag>`. The tag
+    /// is the control plane's best guess at the time it minted this; the build
+    /// corrects it when it turns out to name the wrong commit, which is what
+    /// [`image_tagged_with`] is for.
     pub image: &'a str,
     /// Registry host, as it appears in the reference — the key `docker` looks
     /// its credentials up under.
     pub registry: &'a str,
     pub username: &'a str,
     pub password: &'a str,
+}
+
+/// The same repository, tagged with the commit the build actually used.
+///
+/// The push target is minted before the build runs, from the sha the client
+/// read off the forge. But the build publishes whatever the agent left
+/// uncommitted first (see [`prepare_git_build`]), and after that HEAD is a
+/// commit the minted tag never named. Pushing under it does two wrong things:
+/// the image is labelled with a commit it was not built from, and the tag
+/// stops being immutable — two deploys off the same forge HEAD carrying
+/// different uncommitted work put different bytes on one tag, and Function
+/// Compute pulls by tag, so a function that was never redeployed can come back
+/// from a cold start running someone else's build.
+///
+/// Only the tag is rewritten. The registry, namespace and repository stay
+/// exactly what the control plane authorised, so this cannot push anywhere it
+/// was not given credentials for. `None` leaves the minted reference alone:
+/// when it names a digest there is no tag to correct, and a tag the registry
+/// would reject is not an improvement on a stale one.
+fn image_tagged_with(reference: &str, tag: &str) -> Option<String> {
+    if reference.contains('@') || !is_docker_tag(tag) {
+        return None;
+    }
+    // A registry host may carry a port, so the tag separator is the last `:`
+    // *after* the last `/` — in `localhost:5000/app` that colon is the port and
+    // the reference has no tag at all.
+    let repo = match reference.rfind('/') {
+        Some(slash) => reference[slash + 1..]
+            .rfind(':')
+            .map_or(reference, |colon| &reference[..slash + 1 + colon]),
+        None => reference.rfind(':').map_or(reference, |c| &reference[..c]),
+    };
+    Some(format!("{repo}:{tag}"))
+}
+
+/// The tag grammar a registry accepts: 1–128 of `[A-Za-z0-9_.-]`, not opening
+/// with a separator.
+fn is_docker_tag(tag: &str) -> bool {
+    (1..=128).contains(&tag.len())
+        && tag.starts_with(|c: char| c.is_ascii_alphanumeric() || c == '_')
+        && tag
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '_' | '.' | '-'))
 }
 
 /// What a build produced, which is not the same kind of thing for every app.
@@ -462,8 +508,20 @@ pub fn build_artifact(
     }
     let manifest = read_runtime_manifest(workdir);
     if manifest.is_container() {
-        let target = push.ok_or_else(|| anyhow::anyhow!("{ERR_NO_PUSH_TARGET}"))?;
-        build_image(workdir, &manifest, target)?;
+        let minted = push.ok_or_else(|| anyhow::anyhow!("{ERR_NO_PUSH_TARGET}"))?;
+        // `git_commit_sha` is set only when the build published work the client
+        // did not know about, which is exactly when the minted tag is stale.
+        // Nothing to correct otherwise — the tag already names this commit.
+        let corrected = git_commit_sha
+            .as_deref()
+            .and_then(|sha| image_tagged_with(minted.image, sha));
+        let target = ImagePushTarget {
+            image: corrected.as_deref().unwrap_or(minted.image),
+            registry: minted.registry,
+            username: minted.username,
+            password: minted.password,
+        };
+        build_image(workdir, &manifest, &target)?;
         return Ok(BuildOutput {
             product: BuildProduct::Image(target.image.to_string()),
             git_commit_sha,
@@ -838,6 +896,44 @@ mod tests {
             Ok(_) => panic!("a container app with no registry must not build"),
         };
         assert_eq!(err, ERR_NO_PUSH_TARGET);
+    }
+
+    #[test]
+    fn an_image_is_retagged_with_the_commit_that_was_built() {
+        assert_eq!(
+            image_tagged_with("registry.example.com/apps/tc-app-1:303adca", "a43b715").as_deref(),
+            Some("registry.example.com/apps/tc-app-1:a43b715"),
+        );
+    }
+
+    #[test]
+    fn retagging_leaves_a_registry_port_alone() {
+        // The last `:` is the port, not a tag — appending must not eat it.
+        assert_eq!(
+            image_tagged_with("localhost:5000/apps/tc-app-1", "a43b715").as_deref(),
+            Some("localhost:5000/apps/tc-app-1:a43b715"),
+        );
+        assert_eq!(
+            image_tagged_with("localhost:5000/apps/tc-app-1:old", "a43b715").as_deref(),
+            Some("localhost:5000/apps/tc-app-1:a43b715"),
+        );
+    }
+
+    #[test]
+    fn a_digest_reference_and_an_unusable_tag_are_left_as_minted() {
+        // Already immutable; there is no tag to correct.
+        assert_eq!(
+            image_tagged_with("registry.example.com/apps/a@sha256:abc", "a43b715"),
+            None,
+        );
+        // A tag the registry would reject is not an improvement on a stale one.
+        for bad in ["", "-leading", "has space", "has/slash"] {
+            assert_eq!(
+                image_tagged_with("registry.example.com/apps/a:old", bad),
+                None,
+                "{bad:?}",
+            );
+        }
     }
 
     #[test]

--- a/packages/app/src/components/apps/AppDeployFooter.tsx
+++ b/packages/app/src/components/apps/AppDeployFooter.tsx
@@ -143,12 +143,7 @@ export function AppDeployFooter({ app }: AppDeployFooterProps) {
 
       {deployBlocked && (
         <p className="mt-1.5 text-[11px] leading-snug text-faint">
-          {t(
-            deployBlocked,
-            deployBlocked === 'apps.deployDisabledThird'
-              ? '第三方登录尚未支持部署'
-              : '容器运行时暂不支持部署',
-          )}
+          {t(deployBlocked, '第三方登录尚未支持部署')}
         </p>
       )}
     </div>

--- a/packages/app/src/components/apps/__tests__/AppDeployFooter.test.tsx
+++ b/packages/app/src/components/apps/__tests__/AppDeployFooter.test.tsx
@@ -87,4 +87,16 @@ describe('AppDeployFooter', () => {
     expect(screen.getByText(/第三方登录尚未支持部署/)).toBeInTheDocument()
     expect(screen.getByTestId('app-deploy-footer-deploy')).toBeDisabled()
   })
+
+  it('lets a live container app deploy again', () => {
+    // The row carries `container` only because a deploy wrote it there, so a
+    // gate on that field disabled the button on every app that had just
+    // deployed successfully — the first deploy passed, no second one could.
+    render(
+      <AppDeployFooter
+        app={app({ runtime: 'container', fcStatus: 'live', fcEndpoint: 'https://fc.example' })}
+      />,
+    )
+    expect(screen.getByTestId('app-deploy-footer-deploy')).toBeEnabled()
+  })
 })

--- a/packages/app/src/lib/apps/__tests__/app-list-helpers.test.ts
+++ b/packages/app/src/lib/apps/__tests__/app-list-helpers.test.ts
@@ -103,10 +103,16 @@ describe('appStatusMeta', () => {
 })
 
 describe('deployDisabledReason', () => {
-  test('blocks third-party auth and container runtime', () => {
-    expect(deployDisabledReason({ authMode: 'third', runtime: 'node' })).toBe('apps.deployDisabledThird')
-    expect(deployDisabledReason({ authMode: 'none', runtime: 'container' })).toBe('apps.deployDisabledContainer')
-    expect(deployDisabledReason({ authMode: 'none', runtime: 'node' })).toBeNull()
+  test('blocks third-party auth', () => {
+    expect(deployDisabledReason({ authMode: 'third' })).toBe('apps.deployDisabledThird')
+    expect(deployDisabledReason({ authMode: 'none' })).toBeNull()
+  })
+
+  test('a container app that already deployed can deploy again', () => {
+    // The row says `container` only because a deploy wrote it, so blocking on
+    // it disabled the button on exactly the apps that had just proved it works.
+    const deployed = { authMode: 'none', runtime: 'container' } as const
+    expect(deployDisabledReason(deployed)).toBeNull()
   })
 })
 

--- a/packages/app/src/lib/apps/app-list-helpers.ts
+++ b/packages/app/src/lib/apps/app-list-helpers.ts
@@ -8,12 +8,21 @@ export function canReseed(status: string): boolean {
   return status === 'pending' || status === 'repo_created' || status === 'error'
 }
 
-/** i18n key when deploy is blocked by auth/runtime policy, or null when allowed. */
+/**
+ * i18n key when deploy is blocked by auth policy, or null when allowed.
+ *
+ * `runtime` is deliberately not consulted. It used to block `container`, back
+ * when nothing could build an image — but the row only says `container` once a
+ * deploy has written it, so the gate let the first deploy through and then
+ * disabled the button for every one after it. An app that had just shipped read
+ * as "not supported". Whether a runtime can deploy is the control plane's
+ * answer (it knows which registries and layers exist), and it gives it by
+ * refusing `startDeploy`; a list helper cannot know it.
+ */
 export function deployDisabledReason(
-  app: Pick<AppRow, 'authMode' | 'runtime'>,
+  app: Pick<AppRow, 'authMode'>,
 ): string | null {
   if (app.authMode === 'third') return 'apps.deployDisabledThird'
-  if (app.runtime === 'container') return 'apps.deployDisabledContainer'
   return null
 }
 

--- a/packages/app/src/locales/en.json
+++ b/packages/app/src/locales/en.json
@@ -1291,7 +1291,6 @@
     "visibilityHint": "Visibility only controls who in the team can see this app. Once live without login, anyone with the link can access it.",
     "publicBadge": "Public",
     "deployDisabledThird": "Third-party login is not supported for deploy yet",
-    "deployDisabledContainer": "Container runtime is not supported for deploy yet",
     "submit": "Create",
     "cancel": "Cancel",
     "createError": "Failed to create app",

--- a/packages/app/src/locales/zh-CN.json
+++ b/packages/app/src/locales/zh-CN.json
@@ -1291,7 +1291,6 @@
     "visibilityHint": "可见性只控制团队内谁能看到此应用；上线后若未启用登录，任何拿到链接的人均可访问。",
     "publicBadge": "公开",
     "deployDisabledThird": "第三方登录尚未支持部署",
-    "deployDisabledContainer": "容器运行时暂不支持部署",
     "submit": "创建",
     "cancel": "取消",
     "createError": "创建失败",

--- a/services/fc/src/index.ts
+++ b/services/fc/src/index.ts
@@ -33,6 +33,7 @@ import { makeAppStorageOps, type AppStorageOps } from "./lib/provisioning/app-st
 import {
   appImageReference,
   appImageTag,
+  imageBelongsToApp,
   resolveAppsRegistry,
 } from "./lib/provisioning/apps-registry.js";
 import { resolveAppsSls, getSlsClient, makeSlsOps, type SlsOps } from "./lib/provisioning/sls-client.js";
@@ -173,6 +174,7 @@ function makeDeployDeps() {
   // with no registry configured keeps working for every other app: only a
   // container deploy is refused, and it is refused naming the variable.
   const registry = resolveAppsRegistry();
+  const registryConfig = registry.config;
   const mintImagePush = registry.config
     ? async (appId: string, gitCommitSha: string | null | undefined) => {
         const cfg = registry.config;
@@ -233,7 +235,17 @@ function makeDeployDeps() {
       platformAuthEnv?: Record<string, string>;
     }) =>
       finalizeDeployImpl(
-        { appsAdminUrl, appsAppUrl, fcOps, ensureLogStore: () => appLogsProvisioner().ensure() },
+        {
+          appsAdminUrl,
+          appsAppUrl,
+          fcOps,
+          ensureLogStore: () => appLogsProvisioner().ensure(),
+          // Bound to this deployment's registry, so finalize can tell an image
+          // this app's build pushed from any other the registry holds.
+          ownsImage: registryConfig
+            ? (appId: string, image: string) => imageBelongsToApp(registryConfig, appId, image)
+            : undefined,
+        },
         a,
       ),
   };

--- a/services/fc/src/lib/provisioning/app-deploy.ts
+++ b/services/fc/src/lib/provisioning/app-deploy.ts
@@ -373,6 +373,15 @@ export interface FinalizeDeps {
   appsAppUrl?: string;
   /** Optional override of {@link provisionAppPostgres} for tests. */
   provisionDb?: typeof provisionAppPostgres;
+  /**
+   * Whether a finalized image is one this app's own build could have pushed —
+   * `imageBelongsToApp`, bound to this deployment's registry.
+   *
+   * Absent leaves the image unchecked, which is what a deployment with no
+   * registry configured gets. That deployment has no container app to finalize
+   * either: `startDeploy` refuses one before a build ever runs.
+   */
+  ownsImage?: (appId: string, image: string) => boolean;
   fcOps: {
     ensureFunction: (
       name: string,
@@ -448,6 +457,20 @@ export function needsDatabase(appType: string): boolean {
 }
 
 export async function finalizeDeploy(deps: FinalizeDeps, input: FinalizeInput): Promise<{ fcEndpoint: string }> {
+  // First, before anything is provisioned. `parseDeployedImage` has already
+  // checked that an image is present iff the runtime is `container`, but not
+  // *which* image — and this value is what the function is pointed at. An
+  // image the app's own build could not have pushed makes this a rejected
+  // deploy, so it must not also be a half-provisioned one: past here a
+  // Postgres schema is created and a log store ensured.
+  if (input.image && deps.ownsImage && !deps.ownsImage(input.appId, input.image)) {
+    throw new ApiError(
+      400,
+      "validation_failed",
+      "image must name this app's own repository in this deployment's registry — finalize with the reference the build reported",
+    );
+  }
+
   const env: Record<string, string> = { PORT: "9000", NODE_ENV: "production" };
 
   if (needsDatabase(input.appType)) {

--- a/services/fc/src/lib/provisioning/apps-registry.ts
+++ b/services/fc/src/lib/provisioning/apps-registry.ts
@@ -102,6 +102,43 @@ export function appImageReference(
 }
 
 /**
+ * Whether an image reference names the repository this app pushes to.
+ *
+ * The finalize call carries the image the build says it pushed, and that value
+ * is what the function is pointed at — so unchecked, a client could finalize
+ * one app's deploy onto any image its registry can reach, including another
+ * app's. Nothing about the deploy token prevents it: the token proves who
+ * started *this* app's deploy, not what the image is.
+ *
+ * The tag is deliberately not checked. The build corrects it when it publishes
+ * work the control plane did not know about (the daemon's `image_tagged_with`),
+ * so pinning a tag here would refuse the correct answer; the repository is the
+ * part that must not move. A digest reference is accepted the same way.
+ *
+ * Both hosts count: the daemon reports what it pushed, which is the push host,
+ * but a client that normalised to the pull host has still named the same image.
+ */
+export function imageBelongsToApp(
+  cfg: AppsRegistryConfig,
+  appId: string,
+  image: string,
+): boolean {
+  const repo = imageRepositoryOf(image.trim());
+  const path = `/${cfg.namespace}/${appImageRepository(appId)}`;
+  return repo === `${cfg.host}${path}` || repo === `${cfg.pullHost}${path}`;
+}
+
+/** Everything before the tag or digest, whichever a reference carries. */
+function imageRepositoryOf(image: string): string {
+  const at = image.indexOf("@");
+  const ref = at < 0 ? image : image.slice(0, at);
+  // A registry host may carry a port, so only a `:` after the last `/`
+  // separates a tag — in `localhost:5000/apps/a` that colon is the port.
+  const colon = ref.indexOf(":", ref.lastIndexOf("/") + 1);
+  return colon < 0 ? ref : ref.slice(0, colon);
+}
+
+/**
  * The image tag for one deploy.
  *
  * The commit is the tag when there is one, so an image can be traced back to

--- a/services/fc/test/provisioning/app-deploy.test.ts
+++ b/services/fc/test/provisioning/app-deploy.test.ts
@@ -546,3 +546,75 @@ test("the deploy gate no longer refuses a container app outright", () => {
     /not available on this deployment/,
   );
 });
+
+test("finalizeDeploy refuses an image outside the app's own repository", async () => {
+  // Unchecked, this is how one app's deploy points its function at another
+  // app's image: the deploy token proves who started *this* deploy, not what
+  // the image is. And the refusal has to land before anything is provisioned.
+  const calls: string[] = [];
+  const deps = {
+    appsAdminUrl: "postgres://host:5432/postgres",
+    provisionDb: async () => {
+      calls.push("provisionDb");
+      throw new Error("must not be reached");
+    },
+    ensureLogStore: async () => { calls.push("ensureLogStore"); },
+    fcOps: {
+      ensureFunction: async () => { calls.push("ensureFunction"); },
+      ensureHttpTrigger: async () => { calls.push("trigger"); return "https://fn.example.fcapp.run"; },
+    },
+    ownsImage: (appId: string, image: string) =>
+      image.startsWith(`registry.example.com/apps/tc-app-${appId}:`),
+  };
+  const input = {
+    appId: "app-1",
+    slug: "demo",
+    orgId: "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee",
+    appType: "data_app",
+    fcFunctionName: "tc-app-app-1",
+    ossObjectName: "apps/app-1/code.zip",
+  };
+
+  await assert.rejects(
+    () => finalizeDeploy(deps as never, { ...input, image: "registry.example.com/apps/tc-app-app-2:sha" }),
+    /this app's own repository/,
+  );
+  assert.deepEqual(calls, [], "nothing was provisioned for a rejected image");
+
+  // The app's own image still finalizes.
+  const out = await finalizeDeploy(
+    { ...deps, provisionDb: async () => ({
+        schema: "app_demo",
+        role: "app_role",
+        database: "tc_org_x",
+        connectionString: "postgres://app_role:pw@host:5432/tc_org_x?options=-c%20search_path%3Dapp_demo",
+      }) } as never,
+    { ...input, image: "registry.example.com/apps/tc-app-app-1:sha" },
+  );
+  assert.deepEqual(out, { fcEndpoint: "https://fn.example.fcapp.run" });
+});
+
+test("finalizeDeploy leaves the image unchecked where no registry is configured", async () => {
+  // A deployment with no registry has no container app to finalize —
+  // startDeploy refuses one before a build runs — so an absent `ownsImage`
+  // must not turn into a refusal for the archive apps that do deploy there.
+  let ensured: any;
+  const out = await finalizeDeploy(
+    {
+      fcOps: {
+        ensureFunction: async (_n: string, a: any) => { ensured = a; },
+        ensureHttpTrigger: async () => "https://fn.example.fcapp.run",
+      },
+    } as never,
+    {
+      appId: "app-1",
+      slug: "demo",
+      appType: "static_web",
+      fcFunctionName: "tc-app-app-1",
+      ossObjectName: "apps/app-1/code.zip",
+      image: "anything.example.com/whatever:1",
+    },
+  );
+  assert.deepEqual(out, { fcEndpoint: "https://fn.example.fcapp.run" });
+  assert.equal(ensured.image, "anything.example.com/whatever:1");
+});

--- a/services/fc/test/provisioning/apps-registry.test.ts
+++ b/services/fc/test/provisioning/apps-registry.test.ts
@@ -4,6 +4,7 @@ import {
   appImageReference,
   appImageRepository,
   appImageTag,
+  imageBelongsToApp,
   imageForPull,
   resolveAppsRegistry,
 } from "../../src/lib/provisioning/apps-registry.js";
@@ -93,4 +94,33 @@ test("the pull host replaces the push host, and nothing else", () => {
   assert.equal(imageForPull("registry.example.com/apps/x:1", undefined), "registry.example.com/apps/x:1");
   assert.equal(imageForPull("registry.example.com/apps/x:1", "registry.example.com"), "registry.example.com/apps/x:1");
   assert.equal(imageForPull("library/nginx:latest", "registry.internal"), "library/nginx:latest");
+});
+
+test("an image is this app's only when it names this app's repository", () => {
+  const { config } = resolveAppsRegistry({
+    APPS_REGISTRY_HOST: "registry.example.com",
+    APPS_REGISTRY_PULL_HOST: "registry.internal:5000",
+    ...creds,
+  });
+  const cfg = config!;
+  const own = (image: string) => imageBelongsToApp(cfg, "app-1", image);
+
+  // Any tag, because the build corrects the tag the control plane minted.
+  assert.equal(own("registry.example.com/apps/tc-app-app-1:abc1234"), true);
+  assert.equal(own("registry.example.com/apps/tc-app-app-1:whatever"), true);
+  // A digest names the same repository, and is already immutable.
+  assert.equal(own("registry.example.com/apps/tc-app-app-1@sha256:deadbeef"), true);
+  // The daemon reports the push host; a client that normalised to the pull host
+  // has still named the same image.
+  assert.equal(own("registry.internal:5000/apps/tc-app-app-1:abc1234"), true);
+
+  // Another app's image is the whole point of the check.
+  assert.equal(own("registry.example.com/apps/tc-app-app-2:abc1234"), false);
+  // A repository that merely starts the same way is not the same repository.
+  assert.equal(own("registry.example.com/apps/tc-app-app-1-evil:abc1234"), false);
+  // Nor is another namespace, or another registry entirely.
+  assert.equal(own("registry.example.com/other/tc-app-app-1:abc1234"), false);
+  assert.equal(own("evil.example.com/apps/tc-app-app-1:abc1234"), false);
+  // A bare tag with no repository at all cannot be it either.
+  assert.equal(own("tc-app-app-1:abc1234"), false);
 });


### PR DESCRIPTION
第一个真实的容器应用部署跑通了，然后立刻发现三个问题。

`python-test`（Flask + Vite）在 belayo 上从桌面端点「部署」到 `/api/health` 返回 200，
全程约 2.5 分钟：daemon 构建 + 推送 18.4s（buildx 缓存热的），finalize 之后 FC 有 ~30s
处于 `PreconditionFailed: function is pending state`（拉 166MB 镜像 + 起容器），之后热
请求 130–310ms。镜像落在 `registry.service.ucar.cc/apps/tc-app-<appId>:<sha>`。

三条本来要一起验的 P0，两条有答案了：**FC 能拉我们的私有镜像**；**冷启动 ~30 秒**。
第三条（已有 `custom.debian10` 函数**原地**改成 `custom-container`）**没验到** —— 之前
几次部署都挂在构建阶段，压根没建过函数，这次是全新创建。`runtimeInput` 只发 `runtime` +
`customContainerConfig`，不清 `layers` / `code` / `customRuntimeConfig`，而 FC 的
UpdateFunction 是合并语义，所以那条仍有可能被顶回来。留着。

---

## 1. 容器应用能部署一次，然后再也不能

`deployDisabledReason` 拒绝任何行上写着 `runtime: "container"` 的应用 —— 一条「还没有
东西能构建镜像」年代的门禁。

但**这一行在部署写进去之前不会是 `container`**。所以这个门禁从来没挡住它想挡的东西：
第一次部署原样通过，finalize 记下 runtime，从那一刻起按钮变灰，下面还挂着「容器运行时
暂不支持部署」—— 挂在一个刚刚部署成功的应用底下。实测确认：python-test 上线之后按钮
`disabled=true`，再也点不动。

「某个 runtime 能不能部署」是控制面的答案：它知道这个部署环境有哪些 registry 和 layer，
它拒绝的方式是 `startDeploy` 返 503 并点名缺哪个变量。列表 helper 读一个字段判断不出来，
所以不再尝试 —— 签名收窄成 `Pick<AppRow, 'authMode'>`，在类型上就读不到 `runtime`。
`authMode: "third"` 是唯一剩下的、客户端能自己拿主意的策略。

i18n key 一起删掉（两份 locale），footer 去掉那个二选一分支 —— 只剩一种可能了。

## 2. 推上去的镜像，tag 名的不是它自己的 commit

registry handle 是在构建**之前**铸的，用的是客户端从 forge 上读的 sha。然后构建会先把
agent 留下的在制品发布出去（`publish_pending_work`）并构建**那个** —— 于是镜像被推到了
一个不包含它的 commit 名下。第一次真实部署上实测：行里记的是 `a43b715`，registry 里是
`…/apps/tc-app-5c714425-…:303adca`。

对不上账只是看得见的那一半。另一半是 **tag 不再不可变**：同一个 forge HEAD 上带不同在制品
部署两次，会把不同的字节压到同一个 tag 上，而 Function Compute 是按 tag 拉的 —— 一个谁也
没重新部署过的函数，冷启动之后可能跑起了另一次构建的产物。

所以构建会纠正 tag，且**仅在**它发布了客户端不知道的工作时纠正：`prepare_git_build` 恰好
只在那种情况返回 sha，铸出来的 tag 已经指向这个 commit 时返回 `None`。**只改 tag** ——
registry、namespace、repository 仍是控制面授权的那些，所以它推不到任何没给凭证的地方。
digest 引用和 registry 会拒的 tag 都原样保留。

两条编排链路（桌面端 `apps-store`、agent 的 `introspect_api`）本来就是拿 **build 报回来的**
image 去 finalize，而不是自己请求时那个，所以纠正后的引用自然流到函数配置上，两边都不用改。

## 3. finalize 不校验镜像归属

`parseDeployedImage` 查了「容器应用必须带 image、非容器不许带」，但没查**是哪个** ——
而这个值就是函数被指向的地方。于是客户端可以把一个应用的部署收尾在它的 registry 能触到的
任意引用上，包括别的应用的。deploy token 不覆盖这个：它证明的是谁发起了**这个**应用的部署，
不是构建产出了什么。

`imageBelongsToApp` 比对引用的**仓库那一半**。tag 故意不比 —— 上面那条改动刚让构建去纠正
tag，这里钉住铸出来的 tag 就会把正确答案拒掉；digest 同样接受。push host 和 pull host
都算，两者指的是同一个镜像。

门放在 `finalizeDeploy` 最前面，在 Postgres schema 被 provision、log store 被 ensure
之前：被拒的部署不能同时是一个半配好的部署。

没配 registry 的部署不校验镜像，那种部署也压根没有容器应用能收尾 —— `startDeploy` 在任何
构建开始之前就把它拒了。

---

## 验证

- `services/fc`：`npm test` **1161 tests / 1148 pass / 0 fail**（13 skipped 是要本地
  Supabase 的 sync-flow 用例）；`tsc --noEmit` 干净。
- `apps/daemon`：`cargo test -p amuxd --locked --bin amuxd` **1649 passed / 0 failed**；
  `cargo test -p amuxd --all-targets --no-run` 通过；改动的文件 rustfmt 干净（逐行 diff
  过 rustfmt 输出，所以没跑会重排 51 个无关文件的 `cargo fmt`）。
- `packages/app`：`src/components/apps` + `src/lib/apps` + i18n-parity **120 passed**；
  `pnpm typecheck` 干净，`pnpm lint` 0 error。
- 三处新增用例都先把对应的修复短路掉跑过一遍、确认会红，不是恒绿断言。

## 部署注意

带了 `services/fc/**`，合并会触发 self-host 自动部署。**belayo 是手工的** ——
`services/fc/deploy-aliyun-fc.sh teamclaw-belayo-live-api .env.belayo.local`，
不发就没有第 3 条那个校验。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VfQ9zPVaEr73zXDhsrUCvz
