### PR TITLE
docs(apps): 补上应用文件存储的上线记录与两条待办

### DIFF
--- a/docs/specs/2026-09-09-app-storage-design.md
+++ b/docs/specs/2026-09-09-app-storage-design.md
@@ -611,11 +611,17 @@ FC ListFunctions 与 GetFunction 通、AssumeRole 通；而同区的
 ⚠️ **`ram:PassRole` 是唯一没能实测的一条**：验证它要真的建一个 FC 函数。它会在下次
 真实的 app 部署时得到验证——如果那次报 `Forbidden.RAM`，就是这一条写错了。
 
-**留在人工手上的三件事**：
+**上线状态（2026-09-09 收尾）**：
 
-1. self-host 的主账号旧 AK 仍未禁用（控制台操作，无 OpenAPI）。
-2. belayo 要等代码合并后手工部署一次，STS 变量和新 key 才会真正到函数上。
-3. 那次部署之后：确认 app 部署仍然正常（顺带验 `ram:PassRole`），再把
-   `teamclu-app-storage-assume` 从 `sre` 上摘掉、信任策略收回到只剩
-   `teamclu-belayo`。
+- self-host：随 main 自动部署上线，路由实测 401（存在且在校验），容器已带
+  `APPS_STS_ROLE_ARN` / `APPS_CLOUD_API_URL`。
+- belayo：手工部署完成（`RUN_MIGRATIONS=1`，5 条待办迁移全部落库，含另外 4 条别人
+  的）。函数已换到受限 key `teamclu-belayo`，env 73 → 83 无一被清空。
+- 收尾已完成：`teamclu-app-storage-assume` 从 `sre` 摘除、信任策略收回到只剩
+  `teamclu-belayo`；实测新 key 能 assume、`sre` 已 `NoPermission`。
+
+**仍留在人工手上的一件事**：self-host 的主账号旧 AK 未禁用（控制台操作，无 OpenAPI）。
+
+**尚未实测的一条**：`ram:PassRole`。要等 belayo 上一次真实的 app 部署才验得到；
+若报 `Forbidden.RAM`，就是 `teamclu-belayo-fc-oss` 里那条写错了。
 


### PR DESCRIPTION
#1346 合并后我把两个环境都部署了，这份记录当时没跟上车。只改设计稿一个文件。

## 记的是什么

- **两个环境的上线状态**：self-host 随 main 自动部署；belayo 手工部署，带 5 条待办迁移（其中 4 条是别人的——它的库本来就落后于它正在跑的代码，不迁移只会更糟）。
- **key 切换结果**：两个环境的 FC key 都换成了受限 RAM 用户；belayo 的环境变量 73 → 83，无一被清空。
- **RAM 收尾**：`teamclu-app-storage-assume` 已从共享用户 `sre` 摘除，角色信任策略收回到只剩 `teamclu-belayo`。实测新 key 能 assume、`sre` 返回 `NoPermission`。

## 留给下一个人的两条

1. **self-host 的主账号旧 AK 仍未禁用** —— 主账号 AccessKey 没有 OpenAPI，只能在控制台做。在那之前它的历史副本仍是有效凭证。
2. **`ram:PassRole` 尚未实测** —— 要等 belayo 上一次真实的 app 部署才验得到。若报 `Forbidden.RAM`，就是 `teamclu-belayo-fc-oss` 里那条写错了，改策略即可，不用回滚。

## 顺带一条值得知道的

`deploy-aliyun-fc.sh` 的 `RUN_MIGRATIONS=1` **根本不查账本**——它把 `migrations/*.sql` 全部重放一遍，因此每次都会产出约 45 条 "already exists / does not exist" 的 ERROR。**那是这条路径的常态噪音，不是失败**；判据是最终对象状态，不是错误条数。我这次逐条核实过，belayo 的库与 self-host 一致。

（这条已经写进记忆，也值得有人考虑让那个脚本去读 `_selfhost.schema_migrations`。）

🤖 Generated with [Claude Code](https://claude.com/claude-code)