### PR TITLE
fix(apps): 定时任务心跳改用 FC timer trigger（#1357 的补丁）

### DIFF
--- a/docs/specs/2026-09-10-app-control-panel-design.md
+++ b/docs/specs/2026-09-10-app-control-panel-design.md
@@ -154,10 +154,17 @@ update amux.app_cron_jobs
 - **self-host（今天在跑的那个）**：compose 里加一个 `app-cron` 服务，对齐整分钟后
   `curl` 循环。**不放 profile 里** —— 放 profile 就是默认不跑，而一个默认不跑的定时
   任务等于没有。
-- **阿里云 FC**：同一个端点，心跳由外部每分钟 `curl` 一次（一行，跟 sidecar 里那条
-  完全一样）。这里**没有**用 FC 的 timer trigger：timer 事件不是 HTTP 请求，落到 web
-  函数上的路径和头都跟普通请求不同，猜错的结果是这一侧静默没有调度器 —— 而这正是本
-  设计要消灭的失败模式。端点是有鉴权的，谁来打都一样。
+- **阿里云 FC**：`s.yaml` 里声明一个 timer trigger（`app-cron`，六段式 `0 * * * * *`
+  —— 阿里云的表达式第一段是秒）。
+
+  这里原来写的是「不用 timer trigger，因为 timer 事件不是 HTTP 请求」—— **那是猜的，
+  而且是错的**。同账号的 `banana-api` 上跑着 20 多个 timer trigger 打自己的 HTTP 路径，
+  payload 形如 `{"path":"/api/cron/…","method":"POST","body":{…}}`，其中就有每分钟一次
+  的。timer 确实能驱动 web 函数。
+
+  它**不能**做的是加请求头：payload 只有 `path` / `method` / `body` 三个字段。所以密钥
+  走 **body**，端点两种都收（sidecar 发 bearer，timer 放 body）。没走 query 是因为
+  query 会进 URL 和访问日志，body 不会。
 
 `APP_CRON_SECRET` 必须**两边都声明**（compose 的 `environment:` 白名单 + `s.yaml`），
 少一边就是那一边静默没有 —— CLAUDE.md 里点名的坑，`deploy-env-parity.test.ts` 守着。

--- a/services/fc/s.yaml
+++ b/services/fc/s.yaml
@@ -121,11 +121,14 @@ resources:
         APPS_AUTH_SESSION_SECRET: ${env('APPS_AUTH_SESSION_SECRET', '')}
         # Shared secret the app-cron heartbeat presents when it POSTs
         # /v1/internal/app-cron/tick once a minute. On self-host that heartbeat
-        # is the `app-cron` compose sidecar; on this target it is an external
-        # minute cron running the same one-line curl (deliberately NOT an FC
-        # timer trigger — a timer event is not an HTTP request and would not
-        # reach the route). Blank on either target = scheduled tasks never
-        # fire, because the endpoint refuses an unset secret.
+        # is the `app-cron` compose sidecar; here it is the `app-cron` timer
+        # trigger declared below.
+        #
+        # A timer trigger CAN drive a web function: it POSTs to the `path` in
+        # its payload. What it cannot do is attach a header, so the secret rides
+        # in the payload BODY — which the route accepts alongside the bearer the
+        # sidecar sends. Blank on either target = scheduled tasks never fire,
+        # because the endpoint refuses an unset secret.
         APP_CRON_SECRET: ${env('APP_CRON_SECRET', '')}
         # Per-app git repos on Gitea. Blank disables repo provisioning (503
         # gitea_unavailable naming the empty variable).
@@ -229,6 +232,23 @@ resources:
         AUTH_BASE_URL: ${env('AUTH_BASE_URL', 'https://cloud.ucar.cc')}
         PG_POOL_MAX: ${env('PG_POOL_MAX', '1')}
       triggers:
+        # The one-minute heartbeat that fires apps' scheduled tasks. Six cron
+        # fields here, not five — Alibaba's timer takes seconds first, so
+        # `0 * * * * *` is "second 0 of every minute".
+        #
+        # The secret is in the body because a timer payload has no place for a
+        # header; see APP_CRON_SECRET above. Substituted at deploy time, so a
+        # deployment that has not set it gets an empty secret and the route
+        # refuses the tick — which is the same fail-closed shape as everywhere
+        # else, not a silent open door.
+        - triggerName: app-cron
+          triggerType: timer
+          triggerConfig:
+            cronExpression: "0 * * * * *"
+            enable: true
+            # Double-quoted on the outside: the substitution below contains
+            # single quotes, which would end a single-quoted YAML scalar early.
+            payload: "{\"path\":\"/v1/internal/app-cron/tick\",\"method\":\"POST\",\"body\":{\"secret\":\"${env('APP_CRON_SECRET', '')}\"}}"
         # Trigger name is parameterized so we can adopt a pre-existing function's
         # http trigger (FC console default is `defaultTrigger`). Defaults to
         # http-trigger for the legacy teamclu-sync function.

--- a/services/fc/src/lib/hono-adapter.ts
+++ b/services/fc/src/lib/hono-adapter.ts
@@ -141,12 +141,31 @@ export function createHonoRouterAdapter(app: Hono, deps: Deps) {
           // both presenting APP_CRON_SECRET. `sharedSecretMatches` fails closed
           // on an unset secret, so a deployment that never configured one has
           // no scheduler rather than an open one.
-          if (
-            !sharedSecretMatches(
-              extractBearerToken(Object.fromEntries(c.req.raw.headers)),
-              process.env.APP_CRON_SECRET,
-            )
-          ) {
+          // Two ways in, because the two heartbeats cannot both use a header.
+          //
+          // The compose sidecar curls it and sends `Authorization: Bearer`.
+          // An Alibaba FC timer trigger drives a web function by POSTing to a
+          // path from its payload, and that payload carries only `path`,
+          // `method` and `body` — there is no way to attach a header. So the
+          // secret may also arrive in the body, which (unlike a query string)
+          // stays out of URLs and access logs.
+          // Read the header directly rather than through `extractBearerToken`:
+          // that helper THROWS a 401 when the header is absent, which is right
+          // for a route where a bearer is the only way in — and fatal here,
+          // because the timer's request has no header and must still get as far
+          // as the body.
+          const auth = c.req.header("authorization") ?? "";
+          const bearer = /^Bearer\s+(.+)$/i.exec(auth)?.[1]?.trim();
+          let fromBody: string | undefined;
+          if (!bearer) {
+            try {
+              const parsed = JSON.parse(await c.req.raw.clone().text() || "{}");
+              if (parsed && typeof parsed.secret === "string") fromBody = parsed.secret;
+            } catch {
+              // Not JSON, or no body. Falls through to the 401 below.
+            }
+          }
+          if (!sharedSecretMatches(bearer || fromBody, process.env.APP_CRON_SECRET)) {
             throw new ApiError(401, "unauthorized", "app cron secret required");
           }
           // No repository. The tick works on a raw service-role client, not on

--- a/services/fc/test/hono-adapter.test.ts
+++ b/services/fc/test/hono-adapter.test.ts
@@ -69,3 +69,76 @@ test("postRaw route: ctx.rawBody is a Buffer of the raw body", async () => {
   const res = await app.request("/v1/up", { method: "POST", body: Buffer.from([1, 2, 3]) });
   assert.deepEqual(await res.json(), { len: 3 });
 });
+
+// --- the app-cron heartbeat -------------------------------------------------
+
+/** The tick route takes no repository; only the secret decides admission. */
+function cronApp(secret: string | undefined) {
+  const prev = process.env.APP_CRON_SECRET;
+  if (secret === undefined) delete process.env.APP_CRON_SECRET;
+  else process.env.APP_CRON_SECRET = secret;
+  const app = new Hono();
+  const router = createHonoRouterAdapter(app, makeDeps() as any);
+  router.post("/v1/internal/tick", { auth: "cron-tick" }, async () => ({ body: { ran: true } }));
+  return { app, restore: () => { if (prev === undefined) delete process.env.APP_CRON_SECRET; else process.env.APP_CRON_SECRET = prev; } };
+}
+
+test("the heartbeat is admitted by a bearer — what the compose sidecar sends", async () => {
+  const { app, restore } = cronApp("s3cret");
+  try {
+    const res = await app.request("/v1/internal/tick", {
+      method: "POST",
+      headers: { authorization: "Bearer s3cret" },
+    });
+    assert.equal(res.status, 200);
+    assert.deepEqual(await res.json(), { ran: true });
+  } finally { restore(); }
+});
+
+test("the heartbeat is admitted by a body secret — what an FC timer sends", async () => {
+  // A timer payload carries only path/method/body, so there is no header to put
+  // the secret in. The body is the only place left that stays out of URLs and
+  // access logs.
+  const { app, restore } = cronApp("s3cret");
+  try {
+    const res = await app.request("/v1/internal/tick", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ secret: "s3cret" }),
+    });
+    assert.equal(res.status, 200);
+  } finally { restore(); }
+});
+
+test("a wrong or missing secret is refused, in either position", async () => {
+  const { app, restore } = cronApp("s3cret");
+  try {
+    for (const init of [
+      { method: "POST" },
+      { method: "POST", headers: { authorization: "Bearer nope" } },
+      { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify({ secret: "nope" }) },
+      { method: "POST", headers: { "content-type": "application/json" }, body: "not json" },
+      { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify({ secret: 42 }) },
+    ]) {
+      const res = await app.request("/v1/internal/tick", init as any);
+      assert.equal(res.status, 401, `should have refused ${JSON.stringify(init)}`);
+    }
+  } finally { restore(); }
+});
+
+test("an UNSET secret refuses everything, including an empty one", async () => {
+  // Fail-closed: a deployment that never configured a secret has no scheduler,
+  // rather than a tick endpoint anyone who finds it can fire.
+  const { app, restore } = cronApp(undefined);
+  try {
+    for (const init of [
+      { method: "POST", headers: { authorization: "Bearer " } },
+      { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify({ secret: "" }) },
+      { method: "POST" },
+    ]) {
+      const res = await app.request("/v1/internal/tick", init as any);
+      assert.equal(res.status, 401);
+    }
+  } finally { restore(); }
+});
+


### PR DESCRIPTION
#1357 的补丁，那个提交没赶上合并。**belayo 线上已经建了依赖它的 timer trigger（停用状态），
所以这个不合，定时任务在 FC 那侧就跑不起来。**

#1357 的设计文档里写着「不用 FC timer trigger，因为 timer 事件不是 HTTP 请求」——
那是猜的，而且是错的。同一个账号里 `banana-api` 上跑着 20 多个 timer trigger 打自己的
HTTP 路径，payload 形如 `{"path":"/api/cron/…","method":"POST","body":{…}}`，其中就有
每分钟一次的。timer 完全能驱动 web 函数。

它**不能**做的是加请求头 —— payload 只有 `path` / `method` / `body` 三个字段。所以密钥
走 **body**，tick 端点现在两种都收：compose sidecar 继续发 bearer，FC timer 放 body。
没用 query，因为 query 会进 URL 和访问日志，body 不会。

`s.yaml` 里因此声明了真正的 timer trigger（六段式 `0 * * * * *` —— 阿里云的表达式第一段
是秒），替掉原来那句「让运维自己安排一个外部的每分钟 curl」。

## 一个值得记下的坑

header 现在是直接读的，没走 `extractBearerToken` —— 那个 helper 在**没有 Authorization
头时会抛 401**。对一个只能用 bearer 进的路由这是对的，但在这里是致命的：timer 的请求本来
就没有头，必须能走到读 body 那一步。测试抓到了，所以测试同时断言了两种位置和各种错法。

## 验证

FC typecheck + build + **1256 个测试**（新增 4 个覆盖两种鉴权位置、错密钥、以及密钥未配置
时一律拒绝）。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
