### PR TITLE
fix(daemon): keep WeCom waiting through pi extension errors

### DIFF
--- a/apps/daemon/assets/pi-extension/session-context.test.mjs
+++ b/apps/daemon/assets/pi-extension/session-context.test.mjs
@@ -799,6 +799,13 @@ test("session title source never calls pi.getSessionName or setSessionName", () 
   assert.doesNotMatch(src, /pi\.setSessionName\s*\??\s*\(/);
 });
 
+test("before_agent_start and tool_call swallow stale extension ctx", () => {
+  const src = fs.readFileSync(fileURLToPath(new URL("./teamclu.ts", import.meta.url)), "utf8");
+  assert.match(src, /function isStaleExtensionCtxError/);
+  assert.match(src, /before_agent_start skipped stale ctx/);
+  assert.match(src, /tool_call skipped stale ctx/);
+});
+
 test("session title still runs when a session already has a pi name", async () => {
   // Skip is sidecar-only. Reading pi.getSessionName() hits the shared
   // ExtensionRuntime, which any session dispose() marks stale.

--- a/apps/daemon/assets/pi-extension/teamclu.ts
+++ b/apps/daemon/assets/pi-extension/teamclu.ts
@@ -182,6 +182,15 @@ function backendSessionIdFromContext(ctx?: ExtensionContext): string | undefined
   return ctx?.ui?.sessionId?.trim() || undefined;
 }
 
+/** pi marks a captured ExtensionContext stale after session replace/reload. */
+function isStaleExtensionCtxError(e: unknown): boolean {
+  const msg = String((e as { message?: unknown })?.message ?? e);
+  return (
+    msg.includes("stale after session replacement") ||
+    msg.includes("extension ctx is stale")
+  );
+}
+
 async function resolveTeamcluSessionId(backendSessionId: string): Promise<string> {
   const baseUrl = process.env.TEAMCLU_RUNTIME_CONTEXT_URL?.trim()?.replace(/\/$/, "");
   const token = process.env.TEAMCLU_RUNTIME_CONTEXT_TOKEN?.trim();
@@ -1584,51 +1593,67 @@ export default async function (pi: ExtensionAPI) {
 
   // -- Permission gate -------------------------------------------------------
   pi.on("before_agent_start", async (event, ctx) => {
-    startSessionTitle(event, ctx);
+    try {
+      startSessionTitle(event, ctx);
 
-    const original = String(event.systemPrompt ?? "").trim();
-    let base = original;
-    if (shouldStripPiSelfDocumentation(ctx)) {
-      base = stripPiSelfDocumentation(base);
+      const original = String(event.systemPrompt ?? "").trim();
+      let base = original;
+      if (shouldStripPiSelfDocumentation(ctx)) {
+        base = stripPiSelfDocumentation(base);
+      }
+
+      const backendSessionId = backendSessionIdFromContext(ctx);
+      const append = backendSessionId
+        ? await fetchSessionPromptAppend(backendSessionId)
+        : undefined;
+
+      if (base === original && !append) return undefined;
+
+      const systemPrompt = append ? (base ? `${base}\n\n${append}` : append) : base;
+      return { systemPrompt };
+    } catch (e) {
+      if (isStaleExtensionCtxError(e)) {
+        console.error(`[teamclu] before_agent_start skipped stale ctx: ${e}`);
+        return undefined;
+      }
+      throw e;
     }
-
-    const backendSessionId = backendSessionIdFromContext(ctx);
-    const append = backendSessionId
-      ? await fetchSessionPromptAppend(backendSessionId)
-      : undefined;
-
-    if (base === original && !append) return undefined;
-
-    const systemPrompt = append ? (base ? `${base}\n\n${append}` : append) : base;
-    return { systemPrompt };
   });
 
   pi.on("tool_call", async (event, ctx) => {
-    if (ownTools.has(event.toolName)) return undefined;
+    try {
+      if (ownTools.has(event.toolName)) return undefined;
 
-    const rules = loadRules(); // re-read per call: daemon appends "always" grants
-    if (rules.defaultAction === "allow") return undefined;
+      const rules = loadRules(); // re-read per call: daemon appends "always" grants
+      if (rules.defaultAction === "allow") return undefined;
 
-    const key = matchKey(event.toolName, event.input ?? {});
-    if (rules.alwaysAllowed.some((p) => patternMatches(p, key))) return undefined;
+      const key = matchKey(event.toolName, event.input ?? {});
+      if (rules.alwaysAllowed.some((p) => patternMatches(p, key))) return undefined;
 
-    const pattern = alwaysPattern(event.toolName, event.input ?? {});
-    const title = `${event.toolName}: ${summarize(event.toolName, event.input ?? {})}`;
-    // Trailer line is machine-read by amuxd (and its "always" substring makes
-    // the host offer an "Always allow" option).
-    const argsJson = (JSON.stringify(event.input ?? {}, null, 2) ?? "{}").slice(0, 2000);
-    const message = `${argsJson}\n\nteamclu.always-pattern=${pattern}`;
+      const pattern = alwaysPattern(event.toolName, event.input ?? {});
+      const title = `${event.toolName}: ${summarize(event.toolName, event.input ?? {})}`;
+      // Trailer line is machine-read by amuxd (and its "always" substring makes
+      // the host offer an "Always allow" option).
+      const argsJson = (JSON.stringify(event.input ?? {}, null, 2) ?? "{}").slice(0, 2000);
+      const message = `${argsJson}\n\nteamclu.always-pattern=${pattern}`;
 
-    const confirmed = await ctx.ui.confirm(title, message, { signal: ctx.signal });
-    if (!confirmed) {
-      return {
-        block: true,
-        reason: ctx.signal?.aborted
-          ? "Permission request cancelled"
-          : "Denied by TeamClu permission gate",
-      };
+      const confirmed = await ctx.ui.confirm(title, message, { signal: ctx.signal });
+      if (!confirmed) {
+        return {
+          block: true,
+          reason: ctx.signal?.aborted
+            ? "Permission request cancelled"
+            : "Denied by TeamClu permission gate",
+        };
+      }
+      return undefined;
+    } catch (e) {
+      if (isStaleExtensionCtxError(e)) {
+        console.error(`[teamclu] tool_call skipped stale ctx: ${e}`);
+        return undefined;
+      }
+      throw e;
     }
-    return undefined;
   });
 
   // -- MCP bridges (pi has no native MCP) -----------------------------------

--- a/apps/daemon/src/channels/agent_handle.rs
+++ b/apps/daemon/src/channels/agent_handle.rs
@@ -878,12 +878,29 @@ impl AmuxdAgentHandle {
             );
 
             if let Some(crate::proto::amux::acp_event::Event::Error(err)) = &event.event.event {
-                let details = if err.details.is_empty() {
-                    err.message.clone()
-                } else {
-                    err.details.clone()
-                };
-                break Err(AgentError::Send(format!("agent turn failed: {details}")));
+                match crate::runtime::turn_reply::gateway_error_action(err, &segments, &live) {
+                    crate::runtime::turn_reply::GatewayErrorAction::Continue => {
+                        tracing::warn!(
+                            session = %session,
+                            details = %if err.details.is_empty() {
+                                err.message.as_str()
+                            } else {
+                                err.details.as_str()
+                            },
+                            "ignoring side-channel ACP error; gateway turn continues"
+                        );
+                    }
+                    crate::runtime::turn_reply::GatewayErrorAction::ReturnReply(reply) => {
+                        tracing::warn!(
+                            session = %session,
+                            "ACP error after reply text; salvaging for the channel"
+                        );
+                        break Ok(reply);
+                    }
+                    crate::runtime::turn_reply::GatewayErrorAction::Fail(details) => {
+                        break Err(AgentError::Send(format!("agent turn failed: {details}")));
+                    }
+                }
             }
 
             // Mirror the aggregator's unflushed reply buffer so streamed

--- a/apps/daemon/src/channels/core/mod.rs
+++ b/apps/daemon/src/channels/core/mod.rs
@@ -483,9 +483,19 @@ impl Core {
             updates += 1;
         }
 
-        let reply = turn
+        let reply = match turn
             .await
-            .map_err(|e| CoreError::Turn(format!("turn task: {e}")))??;
+            .map_err(|e| CoreError::Turn(format!("turn task: {e}")))?
+        {
+            Ok(reply) => reply,
+            Err(e) => {
+                // The progress bubble is already on the channel. Close it even
+                // when the wait loop fails, otherwise WeCom stays on
+                // "thinking…" after desktop already has the (failed) row.
+                let _ = driver.update(&handle, "", Some(TurnEnd::NoAnswer)).await;
+                return Err(e);
+            }
+        };
         let attachments = self.collect_attachments(&session.session_id).await;
         let outbound = render(driver, &reply, attachments.clone());
 

--- a/apps/daemon/src/channels/core/tests.rs
+++ b/apps/daemon/src/channels/core/tests.rs
@@ -147,6 +147,23 @@ impl TurnRunner for FakeTurns {
     }
 }
 
+struct FailingTurns;
+
+#[async_trait]
+impl TurnRunner for FailingTurns {
+    async fn run(
+        &self,
+        _acp: &str,
+        _sender_display: &str,
+        _prompt: &str,
+        _on_delta: Option<tokio::sync::mpsc::Sender<String>>,
+    ) -> Result<String, CoreError> {
+        Err(CoreError::Turn(
+            "agent turn failed: pi extension error".into(),
+        ))
+    }
+}
+
 #[derive(Default)]
 struct FakeCommands {
     /// Commands this fake claims to handle, with their canned reply.
@@ -432,6 +449,37 @@ async fn a_turn_that_produced_nothing_closes_as_cancelled_and_writes_no_message(
     assert!(
         f.writer.replies.lock().unwrap().is_empty(),
         "nothing was said, so nothing belongs in the session"
+    );
+}
+
+#[tokio::test]
+async fn a_failed_turn_still_closes_the_stream_bubble() {
+    // WeCom opens a progress bubble before the turn. If the wait loop
+    // returns Err, that bubble used to stay "thinking…" forever even
+    // though desktop already had the (failed) reply.
+    let writer = Arc::new(FakeWriter::default());
+    let identity = Arc::new(FakeIdentity::default());
+    let router = Arc::new(FakeRouter::default());
+    let core = Core {
+        dedup: Arc::new(FakeDedup::default()),
+        router: router.clone(),
+        identity: identity.clone(),
+        writer: writer.clone(),
+        turns: Arc::new(FailingTurns),
+        commands: Arc::new(FakeCommands::default()),
+    };
+    let d = driver(IM);
+
+    let err = core.handle(&d, inbound("今天的数据")).await.unwrap_err();
+    assert!(
+        err.to_string().contains("pi extension error"),
+        "the turn error must still surface: {err}"
+    );
+    let ends = d.ends.lock().unwrap();
+    assert_eq!(
+        ends.last().copied().flatten(),
+        Some(TurnEnd::NoAnswer),
+        "the open stream bubble must close even when the turn fails"
     );
 }
 

--- a/apps/daemon/src/daemon/server/cron.rs
+++ b/apps/daemon/src/daemon/server/cron.rs
@@ -840,12 +840,32 @@ Pass it as `reply_token` to the `send_channel_message` tool, together with an ex
             );
 
             if let Some(crate::proto::amux::acp_event::Event::Error(err)) = &event.event.event {
-                let details = if err.details.is_empty() {
-                    err.message.clone()
-                } else {
-                    err.details.clone()
-                };
-                break Err(anyhow::anyhow!("agent turn failed: {details}"));
+                match crate::runtime::turn_reply::gateway_error_action(err, &segments, &live) {
+                    crate::runtime::turn_reply::GatewayErrorAction::Continue => {
+                        tracing::warn!(
+                            details = %if err.details.is_empty() {
+                                err.message.as_str()
+                            } else {
+                                err.details.as_str()
+                            },
+                            "ignoring side-channel ACP error; cron turn continues"
+                        );
+                    }
+                    crate::runtime::turn_reply::GatewayErrorAction::ReturnReply(_) => {
+                        tracing::warn!("ACP error after reply text; salvaging for cron");
+                        break crate::runtime::turn_reply::salvage_timeout_emitted(
+                            &segments, &live,
+                        )
+                        .map(|reply| CronTurnOutcome {
+                            reply,
+                            timed_out: false,
+                        })
+                        .map_err(anyhow::Error::msg);
+                    }
+                    crate::runtime::turn_reply::GatewayErrorAction::Fail(details) => {
+                        break Err(anyhow::anyhow!("agent turn failed: {details}"));
+                    }
+                }
             }
 
             if let Some(crate::proto::amux::acp_event::Event::Output(o)) = &event.event.event {

--- a/apps/daemon/src/runtime/pi_rpc/translate.rs
+++ b/apps/daemon/src/runtime/pi_rpc/translate.rs
@@ -80,6 +80,14 @@ fn text_event(kind: BlockKind, text: String) -> amux::AcpEvent {
     }
 }
 
+/// `AcpError.message` for a pi `extension_error` event.
+///
+/// Host/extension noise (stale ctx after session replacement, title LLM
+/// side-effects). The model turn is still running. `turn_aggregator` and the
+/// gateway wait loop must *not* treat this as a provider failure — doing so
+/// is how WeCom dropped a finished reply that desktop still rendered.
+pub(crate) const EXTENSION_ERROR_MESSAGE: &str = "pi extension error";
+
 /// `AcpError.message` for a turn whose model call failed outright.
 ///
 /// The exact string is a contract with two consumers: `turn_aggregator`'s
@@ -312,7 +320,7 @@ pub fn translate_event(
                 .map(json_value_to_string)
                 .filter(|s| !s.is_empty())
                 .unwrap_or_else(|| event.to_string());
-            vec![error_event("pi extension error", details)]
+            vec![error_event(EXTENSION_ERROR_MESSAGE, details)]
         }
         // pi reports a failed or cancelled model call as the turn's *final*
         // assistant message — `stopReason` "error" / "aborted" plus
@@ -776,7 +784,7 @@ mod tests {
         );
         match e[0].event.as_ref().unwrap() {
             amux::acp_event::Event::Error(err) => {
-                assert_eq!(err.message, "pi extension error");
+                assert_eq!(err.message, EXTENSION_ERROR_MESSAGE);
                 assert_eq!(err.details, "boom in extension");
             }
             other => panic!("unexpected: {other:?}"),

--- a/apps/daemon/src/runtime/turn_aggregator.rs
+++ b/apps/daemon/src/runtime/turn_aggregator.rs
@@ -22,6 +22,7 @@
 //!   agent-facing English content plus:
 //!   - `{"turn_status":"interrupted"}` — user abort
 //!   - `{"turn_status":"failed"}` — the model provider errored out
+//!     (host/extension noise is *not* this; see `AcpErrorKind::SideChannel`)
 //!   - `{"turn_status":"no_final_reply"}` — Idle with no final prose
 //!     (frontends hide the English notice and render a localized strip)
 //!   - `{"turn_status":"skill_created_in_unsupported_directory", ...}` —
@@ -60,8 +61,35 @@ the user explicitly asks.";
 
 const NO_FINAL_REPLY_METADATA_JSON: &str = r#"{"turn_status":"no_final_reply"}"#;
 
+/// How an ACP `Error` event should affect the open turn.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum AcpErrorKind {
+    /// User pressed stop / the run was cancelled. Stamp `interrupted`.
+    UserAbort,
+    /// Host/extension noise while the model is still running (stale ctx after
+    /// session replacement, title-LLM side-effects). Must not abort a channel
+    /// wait and must not stamp `turn_status: failed`.
+    SideChannel,
+    /// The model provider actually failed. Stamp `failed`.
+    TurnFailure,
+}
+
+pub(crate) fn classify_acp_error(err: &amux::AcpError) -> AcpErrorKind {
+    if is_turn_abort_error(err) {
+        AcpErrorKind::UserAbort
+    } else if is_side_channel_error(err) {
+        AcpErrorKind::SideChannel
+    } else {
+        AcpErrorKind::TurnFailure
+    }
+}
+
+fn is_side_channel_error(err: &amux::AcpError) -> bool {
+    err.message == crate::runtime::pi_rpc::translate::EXTENSION_ERROR_MESSAGE
+}
+
 /// Durable AGENT_REPLY body when the turn ends because the model provider
-/// failed — an `AcpError` that is not a user abort.
+/// failed — an `AcpError` that is neither a user abort nor host/extension noise.
 ///
 /// English for the same reason as the notices above. Frontends hide it when
 /// `metadata.turn_status == "failed"` and render a localized strip.
@@ -180,10 +208,11 @@ pub struct TurnAggregator {
     turn_had_reply: bool,
     /// True when an ACP Error for user abort arrived before Active→Idle.
     turn_was_interrupted: bool,
-    /// True when a non-abort ACP Error (a provider failure) arrived before
-    /// Active→Idle. Kept separate from `turn_was_interrupted` because the two
-    /// carry opposite meanings to the model: one is "the user stopped you",
-    /// the other is "the call failed".
+    /// True when a provider-failure ACP Error arrived before Active→Idle.
+    /// Side-channel noise (`pi extension error`) does not set this. Kept
+    /// separate from `turn_was_interrupted` because the two carry opposite
+    /// meanings to the model: one is "the user stopped you", the other is
+    /// "the call failed".
     turn_failed: bool,
     /// pi aborted a tool mid-flight (`tool_execution_end` with an abort-shaped
     /// summary) without emitting assistant `stopReason: "aborted"`.
@@ -243,16 +272,26 @@ impl TurnAggregator {
                 });
             }
             Some(amux::acp_event::Event::Error(err)) => {
-                // Both kinds arrive before Active→Idle. Remember which one so
-                // turn end can emit the matching durable AGENT_REPLY (catchup
-                // + UI); marking activity guarantees the turn produces a row
-                // even when nothing else was streamed.
-                self.ensure_turn_started();
-                self.turn_had_activity = true;
-                if is_turn_abort_error(err) {
-                    self.turn_was_interrupted = true;
-                } else {
-                    self.turn_failed = true;
+                // Abort and provider failure arrive before Active→Idle.
+                // Remember which one so turn end can emit the matching durable
+                // AGENT_REPLY (catchup + UI); marking activity guarantees the
+                // turn produces a row even when nothing else was streamed.
+                //
+                // Side-channel noise (pi extension error after session
+                // replacement) must not mark the turn failed: the model is
+                // still running and the real answer lands at Idle.
+                match classify_acp_error(err) {
+                    AcpErrorKind::SideChannel => {}
+                    AcpErrorKind::UserAbort => {
+                        self.ensure_turn_started();
+                        self.turn_had_activity = true;
+                        self.turn_was_interrupted = true;
+                    }
+                    AcpErrorKind::TurnFailure => {
+                        self.ensure_turn_started();
+                        self.turn_had_activity = true;
+                        self.turn_failed = true;
+                    }
                 }
             }
             Some(amux::acp_event::Event::StatusChange(sc)) => {
@@ -419,13 +458,28 @@ mod tests {
     /// failed turn is shown to the user.
     #[test]
     fn pi_turn_stop_reasons_route_to_the_intended_rendering() {
-        use crate::runtime::pi_rpc::translate::{ABORTED_ERROR_MESSAGE, PROVIDER_ERROR_MESSAGE};
+        use crate::runtime::pi_rpc::translate::{
+            ABORTED_ERROR_MESSAGE, EXTENSION_ERROR_MESSAGE, PROVIDER_ERROR_MESSAGE,
+        };
         let err = |message: &str| amux::AcpError {
             message: message.to_string(),
             details: String::new(),
         };
         assert!(is_turn_abort_error(&err(ABORTED_ERROR_MESSAGE)));
         assert!(!is_turn_abort_error(&err(PROVIDER_ERROR_MESSAGE)));
+        assert!(!is_turn_abort_error(&err(EXTENSION_ERROR_MESSAGE)));
+        assert_eq!(
+            classify_acp_error(&err(ABORTED_ERROR_MESSAGE)),
+            AcpErrorKind::UserAbort
+        );
+        assert_eq!(
+            classify_acp_error(&err(PROVIDER_ERROR_MESSAGE)),
+            AcpErrorKind::TurnFailure
+        );
+        assert_eq!(
+            classify_acp_error(&err(EXTENSION_ERROR_MESSAGE)),
+            AcpErrorKind::SideChannel
+        );
     }
 
     fn thinking_chunk(text: &str) -> amux::AcpEvent {
@@ -536,6 +590,16 @@ mod tests {
         }
     }
 
+    fn extension_error() -> amux::AcpEvent {
+        amux::AcpEvent {
+            event: Some(amux::acp_event::Event::Error(amux::AcpError {
+                message: crate::runtime::pi_rpc::translate::EXTENSION_ERROR_MESSAGE.into(),
+                details: "This extension ctx is stale after session replacement or reload.".into(),
+            })),
+            model: String::new(),
+        }
+    }
+
     #[test]
     fn a_failed_turn_is_not_recorded_as_a_completed_one() {
         let mut agg = TurnAggregator::new();
@@ -562,6 +626,35 @@ mod tests {
         assert_ne!(emitted[0].content, NO_FINAL_REPLY_AGENT_CONTENT);
         assert!(!emitted[0].metadata_json.contains("no_final_reply"));
         assert!(TurnAggregator::cloud_persistent(&emitted[0]));
+    }
+
+    #[test]
+    fn an_extension_error_does_not_fail_a_turn_that_then_answers() {
+        // WeCom re-spawn after idle eviction emits `pi extension error`
+        // (stale ctx) in the first 300ms. The model keeps going and writes
+        // the real answer; that must land as a completed reply, not
+        // `turn_status: failed` — otherwise the channel aborts the wait
+        // and desktop shows "provider error" under a finished report.
+        let mut agg = TurnAggregator::new();
+        agg.ingest(&status_change(
+            amux::AgentStatus::Idle,
+            amux::AgentStatus::Active,
+        ));
+        assert!(agg.ingest(&extension_error()).is_empty());
+        agg.ingest(&output_chunk("今日抖音来客数据"));
+
+        let emitted = agg.ingest(&status_change(
+            amux::AgentStatus::Active,
+            amux::AgentStatus::Idle,
+        ));
+        assert_eq!(emitted.len(), 1);
+        assert_eq!(emitted[0].kind, MessageKind::AgentReply);
+        assert_eq!(emitted[0].content, "今日抖音来客数据");
+        assert!(
+            !emitted[0].metadata_json.contains("failed"),
+            "extension noise must not stamp the answer as a provider failure: {}",
+            emitted[0].metadata_json
+        );
     }
 
     #[test]

--- a/apps/daemon/src/runtime/turn_reply.rs
+++ b/apps/daemon/src/runtime/turn_reply.rs
@@ -7,7 +7,9 @@ use std::time::{Duration, Instant};
 
 use crate::proto::amux;
 use crate::proto::teamclu::MessageKind;
-use crate::runtime::turn_aggregator::{EmittedMessage, TurnAggregator};
+use crate::runtime::turn_aggregator::{
+    classify_acp_error, AcpErrorKind, EmittedMessage, TurnAggregator,
+};
 
 /// Extra wait after a tool's own `timeout` before the daemon treats it as stuck.
 /// Pi may still be killing the process tree when the declared second elapses.
@@ -99,6 +101,49 @@ pub fn apply_tool_deadline_unix(event: &amux::AcpEvent, deadline: &mut Option<i6
             *deadline = None;
         }
         _ => {}
+    }
+}
+
+/// What a gateway / cron wait loop should do with an ACP `Error` event.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum GatewayErrorAction {
+    /// Host/extension noise. Keep waiting for Active→Idle.
+    Continue,
+    /// The model already produced prose; return it instead of failing empty.
+    ReturnReply(String),
+    /// Abort the wait. Payload is the error details for `agent turn failed: …`.
+    Fail(String),
+}
+
+fn acp_error_details(err: &amux::AcpError) -> String {
+    if err.details.is_empty() {
+        err.message.clone()
+    } else {
+        err.details.clone()
+    }
+}
+
+/// Classify an ACP error for the gateway / cron wait loop.
+///
+/// A `pi extension error` (stale ctx after WeCom re-spawn) must not abort the
+/// wait — the model is still running. A real provider failure salvages any
+/// accumulated text the way a timeout does. User abort still fails the turn.
+pub fn gateway_error_action(
+    err: &amux::AcpError,
+    segments: &[String],
+    live: &str,
+) -> GatewayErrorAction {
+    match classify_acp_error(err) {
+        AcpErrorKind::SideChannel => GatewayErrorAction::Continue,
+        AcpErrorKind::UserAbort => GatewayErrorAction::Fail(acp_error_details(err)),
+        AcpErrorKind::TurnFailure => {
+            let acc = compose_reply(segments, live);
+            if acc.trim().is_empty() {
+                GatewayErrorAction::Fail(acp_error_details(err))
+            } else {
+                GatewayErrorAction::ReturnReply(acc)
+            }
+        }
     }
 }
 
@@ -207,6 +252,65 @@ mod tests {
             idle_remaining_at(t0, idle, nine_min),
             Duration::from_secs(60),
             "silence from the prompt would have only a minute left"
+        );
+    }
+
+    fn acp_err(message: &str, details: &str) -> amux::AcpError {
+        amux::AcpError {
+            message: message.into(),
+            details: details.into(),
+        }
+    }
+
+    #[test]
+    fn gateway_keeps_waiting_on_extension_noise() {
+        use crate::runtime::pi_rpc::translate::EXTENSION_ERROR_MESSAGE;
+        assert_eq!(
+            gateway_error_action(
+                &acp_err(
+                    EXTENSION_ERROR_MESSAGE,
+                    "This extension ctx is stale after session replacement or reload."
+                ),
+                &[],
+                ""
+            ),
+            GatewayErrorAction::Continue
+        );
+    }
+
+    #[test]
+    fn gateway_fails_user_abort_even_when_text_exists() {
+        use crate::runtime::pi_rpc::translate::{ABORTED_ERROR_DETAILS, ABORTED_ERROR_MESSAGE};
+        let segments = vec!["partial".to_string()];
+        assert_eq!(
+            gateway_error_action(
+                &acp_err(ABORTED_ERROR_MESSAGE, ABORTED_ERROR_DETAILS),
+                &segments,
+                ""
+            ),
+            GatewayErrorAction::Fail(ABORTED_ERROR_DETAILS.to_string())
+        );
+    }
+
+    #[test]
+    fn gateway_salvages_provider_error_after_prose() {
+        use crate::runtime::pi_rpc::translate::PROVIDER_ERROR_MESSAGE;
+        let segments = vec!["今日抖音来客数据".to_string()];
+        assert_eq!(
+            gateway_error_action(
+                &acp_err(PROVIDER_ERROR_MESSAGE, "400 out of extra usage."),
+                &segments,
+                ""
+            ),
+            GatewayErrorAction::ReturnReply("今日抖音来客数据".into())
+        );
+        assert_eq!(
+            gateway_error_action(
+                &acp_err(PROVIDER_ERROR_MESSAGE, "400 out of extra usage."),
+                &[],
+                ""
+            ),
+            GatewayErrorAction::Fail("400 out of extra usage.".into())
         );
     }
 


### PR DESCRIPTION
## Summary
- Idle eviction + WeCom re-spawn emits `pi extension error` (stale ctx). The gateway used to abort the wait on any ACP Error, so WeCom never got the finished reply while desktop still rendered it.
- Classify extension noise as a side-channel: keep waiting for Active→Idle, do not stamp `turn_status: failed`, and salvage real provider errors that already produced prose. Close the WeCom stream bubble with `NoAnswer` if the turn still fails.
- Swallow stale-ctx throws in the pi `before_agent_start` / `tool_call` hooks so they do not emit `extension_error` in the first place.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Test plan
- [x] `node scripts/daemon-cargo.js test --bin amuxd turn_aggregator`
- [x] `node scripts/daemon-cargo.js test --bin amuxd turn_reply`
- [x] `node scripts/daemon-cargo.js test --bin amuxd a_failed_turn_still_closes`
- [x] `node --test apps/daemon/assets/pi-extension/session-context.test.mjs`
- [ ] Restart amuxd / desktop, then from a WeCom DM that has been idle long enough to evict: send a prompt and confirm the full answer arrives on WeCom (not only desktop), with no false “provider error” banner.

## Additional Notes
Restart amuxd (or the desktop app) to pick up the daemon + pi extension change. A message already dropped from WeCom will not be resent automatically.


Made with [Cursor](https://cursor.com)