### PR TITLE
fix(config): gate SeaTalk to the copilot361 profile

### DIFF
--- a/packages/app/src/lib/config/__tests__/remote-features.test.ts
+++ b/packages/app/src/lib/config/__tests__/remote-features.test.ts
@@ -64,6 +64,13 @@ describe("merging", () => {
     expect(channels.discord).toBe(true);
     expect(channels.feishu).toBe(false);
     expect(channels.wecom).toBe(false);
+    expect(channels.seatalk).toBe(false);
+  });
+
+  it("honours seatalk from the server — the client allowlist used to drop it", async () => {
+    const { applyRemoteFeatures, getFeatures } = await loadModule();
+    applyRemoteFeatures("session", { channels: { seatalk: true } });
+    expect(getFeatures().channels.seatalk).toBe(true);
   });
 
   it("ignores channels sent to the public scope (auth-only endpoint)", async () => {

--- a/packages/app/src/lib/config/remote-features.ts
+++ b/packages/app/src/lib/config/remote-features.ts
@@ -59,7 +59,7 @@ interface ResolvedFeatures {
 // as well as the UI, so a remote `false` would strand the fleet with no way to
 // update out of it. It stays build-time.
 const AUTH_KEYS = ["google", "wechat", "phone", "password", "webSSO"] as const;
-const CHANNEL_KEYS = ["discord", "feishu", "email", "kook", "wecom", "wechat"] as const;
+const CHANNEL_KEYS = ["discord", "feishu", "email", "kook", "wecom", "wechat", "seatalk"] as const;
 const BOOL_KEYS = ["apps", "lockLlmConfig"] as const;
 
 interface RemoteFeaturePatch {

--- a/services/fc/src/lib/feature-profiles.ts
+++ b/services/fc/src/lib/feature-profiles.ts
@@ -128,7 +128,8 @@ export const FEATURE_PROFILES: Record<string, FeatureFlags> = {
   // Mirrors build.config.production.json (in this repo).
   "self-host": {
     auth: { google: true, wechat: false, phone: false, password: false, webSSO: false },
-    channels: { discord: true, feishu: true, email: true, kook: true, wecom: true, wechat: true, seatalk: true },
+    // SeaTalk is Copilot 361 only — official TeamClu never shipped it.
+    channels: { discord: true, feishu: true, email: true, kook: true, wecom: true, wechat: true, seatalk: false },
     // Entry point only. Creating an app needs GITEA_* (see makeGiteaDeps in
     // src/index.ts); deploy needs ACCESS_KEY_ID + APPS_FC_ENDPOINT (see
     // makeDeployDeps). With those unset this box answers 503 naming the empty
@@ -143,7 +144,7 @@ export const FEATURE_PROFILES: Record<string, FeatureFlags> = {
   // deployment, not from anything baked into the build.
   belayo: {
     auth: { google: false, wechat: false, phone: true, password: false, webSSO: true },
-    channels: { discord: true, feishu: true, email: true, kook: true, wecom: true, wechat: true, seatalk: true },
+    channels: { discord: true, feishu: true, email: true, kook: true, wecom: true, wechat: true, seatalk: false },
     // Entry point only, same as self-host. Creating an app needs GITEA_*, which
     // this deployment now has (its own Gitea, reached over the VPC). Deploying
     // one additionally needs ACCESS_KEY_ID + APPS_FC_ENDPOINT, which it does
@@ -159,6 +160,8 @@ export const FEATURE_PROFILES: Record<string, FeatureFlags> = {
   // carries no `auth` block at all — every alternative sign-in method is off and
   // only email OTP remains. Restated explicitly here so it is a decision on the
   // record rather than an omission.
+  //
+  // SeaTalk is this brand's channel: self-host and belayo keep it off.
   copilot361: {
     auth: { google: false, wechat: false, phone: false, password: false, webSSO: false },
     channels: { discord: true, feishu: true, email: true, kook: true, wecom: true, wechat: true, seatalk: true },

--- a/services/fc/test/config-route.test.ts
+++ b/services/fc/test/config-route.test.ts
@@ -420,6 +420,12 @@ test("every shipped profile survives sanitization intact — no silently dropped
   }
 });
 
+test("seatalk is on only for the copilot361 profile", () => {
+  assert.equal(FEATURE_PROFILES["self-host"].channels?.seatalk, false);
+  assert.equal(FEATURE_PROFILES.belayo.channels?.seatalk, false);
+  assert.equal(FEATURE_PROFILES.copilot361.channels?.seatalk, true);
+});
+
 test("no shipped profile tries to control the updater", () => {
   for (const [name, profile] of Object.entries(FEATURE_PROFILES)) {
     assert.equal("updater" in profile, false, `profile ${name} must not set updater`);


### PR DESCRIPTION
## Summary
- Turn SeaTalk off on the official TeamClu (`self-host`) and belayo feature profiles; leave it on only for Copilot 361.
- Accept `seatalk` in the desktop feature-flag allowlist. The server already sent the flag, but the client dropped it, so Settings never rendered SeaTalk on any brand.
- Other channels are unchanged. This only gates the Settings panel — a gateway still starts only when the user has configured it.

## Test plan
- [ ] `pnpm --filter @teamclu/app exec vitest run src/lib/config/__tests__/remote-features.test.ts`
- [ ] `services/fc` `config-route` tests (includes the new copilot361-only assertion)
- [ ] TeamClu / belayo: after FC deploy, Settings → Channels does not show SeaTalk
- [ ] Copilot 361: after FC deploy **and** a desktop build with this client fix, Settings → Channels shows SeaTalk
- [ ] Existing Discord / 飞书 / 企微 / etc. panels still appear on each brand that already had them


Made with [Cursor](https://cursor.com)