### PR TITLE
fix(cron): pin MCP announce delivery.to instead of treating empty as this chat

### DIFF
--- a/apps/daemon/src/channels/agent_handle.rs
+++ b/apps/daemon/src/channels/agent_handle.rs
@@ -654,7 +654,9 @@ fn reply_channel_note(token: &str) -> String {
         "[SYSTEM] Reply token for this chat: {token}\n\
 Pass it as `reply_token` to attach a FILE to your reply, e.g. \
 `send_channel_message(reply_token=\"{token}\", file_path=\"/tmp/report.pdf\")`. \
-Your text reply needs no tool — it is delivered on its own."
+Your text reply needs no tool — it is delivered on its own.\n\
+To schedule a job that delivers back here, set manage_cron_job `delivery.to` to this \
+same token (or wecom `single:<userid>` / `group:<chatid>`). An empty `to` is not this chat."
     )
 }
 

--- a/apps/daemon/src/daemon/binding_target.rs
+++ b/apps/daemon/src/daemon/binding_target.rs
@@ -84,6 +84,42 @@ pub(crate) fn resolve_mcp_send_route(
     ))
 }
 
+/// Cron announce delivery stores WeCom as `single:<id>` / `group:<id>`
+/// (the settings picker and `wecom_cron_target_to_dispatch`). Dispatch uses
+/// `user:` / `chat:`. Pin the current chat at job-create time by mapping the
+/// gateway binding onto that stored shape.
+pub(crate) fn cron_delivery_target(binding: &str) -> anyhow::Result<(String, String)> {
+    let (channel, dispatch) = parse_binding_to_target(binding)?;
+    let to = match (channel, dispatch.as_deref()) {
+        ("wecom", Some(t)) => wecom_dispatch_to_cron_to(t)?,
+        ("cron", _) => anyhow::bail!(
+            "this reply_token is a cron run, not a chat — pass single:<userid> or group:<chatid>"
+        ),
+        (_, Some(t)) => t.to_string(),
+        (ch, None) => anyhow::bail!(
+            "channel {ch} has no pin-able chat id; set delivery.to to an explicit target \
+             (wecom: single:<userid> or group:<chatid>)"
+        ),
+    };
+    Ok((channel.to_string(), to))
+}
+
+fn wecom_dispatch_to_cron_to(dispatch: &str) -> anyhow::Result<String> {
+    if let Some(id) = dispatch.strip_prefix("user:") {
+        if id.is_empty() {
+            anyhow::bail!("wecom user id is empty");
+        }
+        return Ok(format!("single:{id}"));
+    }
+    if let Some(id) = dispatch.strip_prefix("chat:") {
+        if id.is_empty() {
+            anyhow::bail!("wecom chat id is empty");
+        }
+        return Ok(format!("group:{id}"));
+    }
+    anyhow::bail!("unexpected wecom dispatch target: {dispatch}");
+}
+
 fn normalize_dispatch_target(channel: &str, target: &str) -> String {
     let target = target.trim();
     if target.starts_with("user:") || target.starts_with("chat:") || target.starts_with("bot:") {
@@ -186,5 +222,27 @@ mod tests {
                 .unwrap();
         assert_eq!(channel, "wecom");
         assert_eq!(target, "user:HuangWeiGan");
+    }
+
+    #[test]
+    fn wecom_dm_binding_pins_cron_single_target() {
+        let (channel, to) = cron_delivery_target("wecom://corp/agent/single/HuangWeiGan").unwrap();
+        assert_eq!(channel, "wecom");
+        assert_eq!(to, "single:HuangWeiGan");
+    }
+
+    #[test]
+    fn wecom_group_binding_pins_cron_group_target() {
+        let (channel, to) = cron_delivery_target("wecom://corp/agent/group/chat-1").unwrap();
+        assert_eq!(channel, "wecom");
+        assert_eq!(to, "group:chat-1");
+    }
+
+    #[test]
+    fn cron_binding_cannot_be_a_delivery_target() {
+        let err = cron_delivery_target("cron://job-key/run-1")
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("cron run"), "got: {err}");
     }
 }

--- a/apps/daemon/src/daemon/server.rs
+++ b/apps/daemon/src/daemon/server.rs
@@ -21,7 +21,9 @@ use crate::config::{DaemonConfig, SessionStore};
 // the bin build, which does not compile them.
 #[cfg(test)]
 use crate::config::SessionBinding;
-use crate::daemon::binding_target::{parse_binding_to_target, resolve_mcp_send_route};
+use crate::daemon::binding_target::{
+    cron_delivery_target, parse_binding_to_target, resolve_mcp_send_route,
+};
 use crate::daemon::runtime_cursor::{
     compute_effective_cursor_from_messages, last_unanswered_mention_idx,
     messages_strictly_after_cursor, slice_has_actionable_inbound,
@@ -2790,6 +2792,39 @@ fn fit_available_commands_in_budget(ac: &mut crate::proto::amux::AcpAvailableCom
     }
 }
 
+/// Map a chat reply token to the `{channel, to}` pair cron announce delivery
+/// persists (`single:<userid>` / `group:<chatid>` for WeCom).
+fn resolve_reply_token_cron_json(token: &str) -> String {
+    let token = token.trim();
+    if token.is_empty() {
+        return serde_json::json!({
+            "ok": false,
+            "error": "missing reply_token"
+        })
+        .to_string();
+    }
+    let Some(binding) = crate::channels::reply_token::binding_for(token) else {
+        return serde_json::json!({
+            "ok": false,
+            "error": "unknown reply_token — use the token from this chat's prompt"
+        })
+        .to_string();
+    };
+    match cron_delivery_target(&binding) {
+        Ok((channel, to)) => serde_json::json!({
+            "ok": true,
+            "channel": channel,
+            "to": to
+        })
+        .to_string(),
+        Err(e) => serde_json::json!({
+            "ok": false,
+            "error": e.to_string()
+        })
+        .to_string(),
+    }
+}
+
 /// Handle one control connection: read a newline-terminated command (line
 /// protocol or `{`-sniffed JSON envelope) and forward it to the main loop.
 /// Generic over the transport: UnixStream on unix, NamedPipeServer on Windows.
@@ -2804,7 +2839,7 @@ where
         Ok(_) => {
             let head = first_line.trim();
 
-            // JSON envelopes (currently just `mcp-send`)
+            // JSON envelopes (mcp-send, channel-send, resolve-reply-token, …)
             // are framed differently from the legacy
             // line-based control protocol — sniff the
             // first byte and branch.
@@ -2813,7 +2848,21 @@ where
                 match parsed {
                     Ok(v) => {
                         let cmd = v.get("cmd").and_then(|c| c.as_str()).unwrap_or("");
-                        if cmd == "channel-send" {
+                        if cmd == "resolve-reply-token" {
+                            // Pure registry lookup — no main-loop state. Cron
+                            // create uses this to pin `delivery.to` to the
+                            // chat that minted the token, instead of storing
+                            // an empty "this conversation" placeholder.
+                            let token = v.get("reply_token").and_then(|c| c.as_str()).unwrap_or("");
+                            let body = resolve_reply_token_cron_json(token);
+                            let mut stream = reader.into_inner();
+                            if let Err(e) = stream.write_all(body.as_bytes()).await {
+                                warn!("amuxd.sock: resolve-reply-token write failed: {e}");
+                                return;
+                            }
+                            let _ = stream.write_all(b"\n").await;
+                            let _ = stream.shutdown().await;
+                        } else if cmd == "channel-send" {
                             let (reply_tx, reply_rx) = oneshot::channel();
                             if tx
                                 .send(SockCommand::ChannelSend {

--- a/apps/desktop/crates/teamclu-introspect/src/cron.rs
+++ b/apps/desktop/crates/teamclu-introspect/src/cron.rs
@@ -51,13 +51,65 @@ fn create_request_body(workspace: &str, args: &Value) -> Result<Value, String> {
             body["description"] = d.clone();
         }
     }
-    if let Some(d) = args.get("delivery") {
-        if !d.is_null() {
-            body["delivery"] = d.clone();
+    if let Some(delivery) = normalize_delivery(args)? {
+        body["delivery"] = delivery;
+    }
+    if let Some(token) = args.get("reply_token").and_then(|v| v.as_str()) {
+        let token = token.trim();
+        if !token.is_empty() {
+            body["reply_token"] = json!(token);
         }
     }
     attach_workspace_path(&mut body, workspace, args, scope);
     Ok(body)
+}
+
+fn normalize_delivery(args: &Value) -> Result<Option<Value>, String> {
+    let Some(delivery) = args.get("delivery") else {
+        return Ok(None);
+    };
+    if delivery.is_null() {
+        return Ok(None);
+    }
+    let Some(obj) = delivery.as_object() else {
+        return Err("delivery must be an object".to_string());
+    };
+    let mode = obj
+        .get("mode")
+        .and_then(|v| v.as_str())
+        .unwrap_or("announce");
+    if mode == "none" {
+        return Ok(Some(delivery.clone()));
+    }
+
+    let mut out = obj.clone();
+    let mut to = out
+        .get("to")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .trim()
+        .to_string();
+    if to.is_empty() {
+        if let Some(token) = args
+            .get("reply_token")
+            .and_then(|v| v.as_str())
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+        {
+            to = token.to_string();
+        }
+    }
+    if to.is_empty() {
+        return Err(
+            "delivery.to is required for announce. An empty value is not this chat. \
+             For the current conversation, set delivery.to to this run's reply_token \
+             (from the prompt); it is stored as a stable chat id. \
+             WeCom also accepts single:<userid> or group:<chatid>."
+                .to_string(),
+        );
+    }
+    out.insert("to".into(), json!(to));
+    Ok(Some(Value::Object(out)))
 }
 
 fn job_action_body(workspace: &str, args: &Value, action: &str) -> Result<Value, String> {
@@ -244,6 +296,7 @@ fn safe_job_summary(job: &Value) -> Value {
         "description",
         "enabled",
         "schedule",
+        "delivery",
         "createdAt",
         "updatedAt",
         "lastRunAt",
@@ -429,5 +482,53 @@ mod tests {
         );
 
         let _ = std::fs::remove_dir_all(workspace);
+    }
+
+    #[test]
+    fn announce_delivery_rejects_empty_to() {
+        let err = create_request_body(
+            "/tmp/ws",
+            &json!({
+                "name": "日报",
+                "schedule": "0 10 * * *",
+                "message": "写日报",
+                "delivery": { "mode": "announce", "channel": "wecom", "to": "" }
+            }),
+        )
+        .unwrap_err();
+        assert!(err.contains("delivery.to is required"), "got: {err}");
+        assert!(err.contains("reply_token"), "got: {err}");
+    }
+
+    #[test]
+    fn announce_delivery_fills_empty_to_from_reply_token() {
+        let token = "0c2a4f9d1ed3c8e310824f6dcf60ff8d";
+        let body = create_request_body(
+            "/tmp/ws",
+            &json!({
+                "name": "日报",
+                "schedule": "0 10 * * *",
+                "message": "写日报",
+                "reply_token": token,
+                "delivery": { "mode": "announce", "channel": "wecom", "to": "" }
+            }),
+        )
+        .unwrap();
+        assert_eq!(body["delivery"]["to"], token);
+        assert_eq!(body["reply_token"], token);
+    }
+
+    #[test]
+    fn safe_job_summary_echoes_delivery() {
+        let summary = safe_job_summary(&json!({
+            "id": "j1",
+            "name": "日报",
+            "schedule": { "kind": "cron", "expr": "0 10 * * *" },
+            "delivery": { "mode": "announce", "channel": "wecom", "to": "single:HuangWeiGan" }
+        }));
+        assert_eq!(
+            summary["delivery"],
+            json!({ "mode": "announce", "channel": "wecom", "to": "single:HuangWeiGan" })
+        );
     }
 }

--- a/apps/desktop/crates/teamclu-introspect/src/main.rs
+++ b/apps/desktop/crates/teamclu-introspect/src/main.rs
@@ -94,7 +94,7 @@ fn tool_definitions() -> Value {
                     },
                     "target": {
                         "type": "string",
-                        "description": "Target recipient within the channel. Format varies by channel: wecom: 'single:<userid>' or 'group:<chatid>' (default: single); discord: 'dm:<user_id>' or 'channel:<channel_id>'; feishu: open_id (ou_xxx), user_id (on_xxx), or chat_id (oc_xxx); kook: 'dm:<user_id>' or 'channel:<channel_id>'; wechat: user identifier. If omitted for wecom, sends to the last active conversation."
+                        "description": "Target recipient within the channel. Format varies by channel: wecom: 'single:<userid>' or 'group:<chatid>' (default: single); discord: 'dm:<user_id>' or 'channel:<channel_id>'; feishu: open_id (ou_xxx), user_id (on_xxx), or chat_id (oc_xxx); kook: 'dm:<user_id>' or 'channel:<channel_id>'; wechat: user identifier. Omit target when using reply_token to address this chat — an empty wecom target is not the current conversation."
                     },
                     "file_path": {
                         "type": "string",
@@ -106,7 +106,7 @@ fn tool_definitions() -> Value {
         },
         {
             "name": "manage_cron_job",
-            "description": "Create, pause, resume, delete, list, or inspect cron jobs. New jobs are stored as Global tasks (the default settings list). The TeamClu desktop app must be running.",
+            "description": "Create, pause, resume, delete, list, or inspect cron jobs. New jobs are stored as Global tasks (the default settings list). The TeamClu desktop app must be running. When announcing results to this chat, set delivery.to to this run's reply_token (from the prompt) or an explicit wecom target such as single:<userid> / group:<chatid> — an empty to is not this conversation.",
             "inputSchema": {
                 "type": "object",
                 "properties": {
@@ -153,13 +153,21 @@ fn tool_definitions() -> Value {
                         "type": "string",
                         "description": "Message or prompt to execute on each run (required for create)."
                     },
+                    "reply_token": {
+                        "type": "string",
+                        "description": "This run's reply_token from the prompt. When creating a job that should announce back to this chat, pass it here or as delivery.to; it is resolved to a stable chat id before the job is stored."
+                    },
                     "delivery": {
                         "type": "object",
-                        "description": "Optional delivery settings for cron results.",
+                        "description": "Optional delivery settings for cron results. Announce needs a real target — empty to does not mean the current conversation.",
                         "properties": {
                             "mode": { "type": "string", "enum": ["announce", "none"] },
                             "channel": { "type": "string", "enum": ["discord", "feishu", "email", "kook", "wechat", "wecom"] },
-                            "to": { "type": "string" },
+                            "to": {
+                                "type": "string",
+                                "minLength": 1,
+                                "description": "Where to send the run result. For the current WeCom/Feishu chat, pass this run's reply_token. WeCom also accepts single:<userid> or group:<chatid>. Do not pass an empty string."
+                            },
                             "bestEffort": { "type": "boolean" }
                         },
                         "required": ["mode", "channel", "to"]

--- a/apps/desktop/src/commands/cron/amuxd_client.rs
+++ b/apps/desktop/src/commands/cron/amuxd_client.rs
@@ -306,6 +306,14 @@ pub async fn channel_send_media_at(
 }
 
 async fn amuxd_json_roundtrip(sock_path: &Path, payload: &serde_json::Value) -> Result<(), String> {
+    amuxd_json_call(sock_path, payload).await.map(|_| ())
+}
+
+/// One JSON line out, one JSON line back. `ok: false` becomes `Err`.
+async fn amuxd_json_call(
+    sock_path: &Path,
+    payload: &serde_json::Value,
+) -> Result<serde_json::Value, String> {
     let mut stream = amuxd_control::connect_at(sock_path).await?;
 
     let line = serde_json::to_string(payload).map_err(|e| format!("encode request: {e}"))?;
@@ -337,22 +345,53 @@ async fn amuxd_json_roundtrip(sock_path: &Path, payload: &serde_json::Value) -> 
         }
     }
 
-    #[derive(serde::Deserialize)]
-    struct Wire {
-        ok: bool,
-        #[serde(default)]
-        error: Option<String>,
-    }
-
     let body = String::from_utf8(buf).map_err(|e| format!("amuxd bad response: not utf8: {e}"))?;
-    let parsed: Wire = serde_json::from_str(body.trim())
+    let parsed: serde_json::Value = serde_json::from_str(body.trim())
         .map_err(|e| format!("amuxd bad response: {e} (body={body:?})"))?;
-    if !parsed.ok {
-        return Err(parsed
-            .error
-            .unwrap_or_else(|| "unknown amuxd error".to_string()));
+    if parsed.get("ok").and_then(|v| v.as_bool()) != Some(true) {
+        let reason = parsed
+            .get("error")
+            .and_then(|v| v.as_str())
+            .unwrap_or("unknown amuxd error");
+        return Err(reason.to_string());
     }
-    Ok(())
+    Ok(parsed)
+}
+
+/// Chat a reply token currently maps to, in the shape cron announce delivery
+/// stores (`single:<userid>` / `group:<chatid>` for WeCom).
+#[derive(Debug)]
+pub struct ResolvedCronTarget {
+    pub channel: String,
+    pub to: String,
+}
+
+pub async fn resolve_reply_token(token: &str) -> Result<ResolvedCronTarget, String> {
+    resolve_reply_token_at(&amuxd_control::endpoint(), token).await
+}
+
+pub async fn resolve_reply_token_at(
+    sock_path: &Path,
+    token: &str,
+) -> Result<ResolvedCronTarget, String> {
+    let payload = serde_json::json!({
+        "cmd": "resolve-reply-token",
+        "reply_token": token,
+    });
+    let parsed = amuxd_json_call(sock_path, &payload).await?;
+    let channel = parsed
+        .get("channel")
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| "amuxd resolve-reply-token missing channel".to_string())?
+        .to_string();
+    let to = parsed
+        .get("to")
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| "amuxd resolve-reply-token missing to".to_string())?
+        .to_string();
+    Ok(ResolvedCronTarget { channel, to })
 }
 
 #[cfg(all(test, unix))]
@@ -740,5 +779,41 @@ mod tests {
         channel_send_at(&sock_path, "wecom", "user:alice", "hello")
             .await
             .unwrap();
+    }
+
+    #[tokio::test]
+    async fn resolve_reply_token_reads_channel_and_to() {
+        let sock_path = mock_server(|req| {
+            assert_eq!(req["cmd"].as_str(), Some("resolve-reply-token"));
+            assert_eq!(req["reply_token"].as_str(), Some("abc"));
+            serde_json::json!({
+                "ok": true,
+                "channel": "wecom",
+                "to": "single:HuangWeiGan"
+            })
+            .to_string()
+        })
+        .await;
+
+        let got = resolve_reply_token_at(&sock_path, "abc").await.unwrap();
+        assert_eq!(got.channel, "wecom");
+        assert_eq!(got.to, "single:HuangWeiGan");
+    }
+
+    #[tokio::test]
+    async fn resolve_reply_token_surfaces_unknown_token() {
+        let sock_path = mock_server(|_req| {
+            serde_json::json!({
+                "ok": false,
+                "error": "unknown reply_token — use the token from this chat's prompt"
+            })
+            .to_string()
+        })
+        .await;
+
+        let err = resolve_reply_token_at(&sock_path, "deadbeef")
+            .await
+            .unwrap_err();
+        assert!(err.contains("unknown reply_token"), "got: {err}");
     }
 }

--- a/apps/desktop/src/commands/cron/mod.rs
+++ b/apps/desktop/src/commands/cron/mod.rs
@@ -260,7 +260,10 @@ pub(crate) async fn mcp_manage(
 
     match action {
         "create" => {
-            let request = parse_create_request(body)?;
+            let mut request = parse_create_request(body)?;
+            if let Some(delivery) = request.delivery.as_mut() {
+                pin_announce_delivery_target(delivery).await?;
+            }
             let job = create_job_on_instance(&instance, request).await;
             log::info!("[Cron] MCP job created: {} ({})", job.name, job.id);
             let job = serde_json::to_value(job).map_err(|e| e.to_string())?;
@@ -336,11 +339,78 @@ fn parse_create_request(body: &serde_json::Value) -> Result<CreateCronJobRequest
     obj.remove("scope");
     obj.remove("workspace_path");
     obj.remove("job_id");
+    let reply_token = obj
+        .remove("reply_token")
+        .and_then(|v| match v {
+            serde_json::Value::String(s) => Some(s),
+            _ => None,
+        })
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty());
     if let Some(schedule) = obj.get("schedule").cloned() {
         obj.insert("schedule".into(), unwrap_stringified_schedule(schedule));
     }
-    serde_json::from_value(serde_json::Value::Object(obj))
-        .map_err(|e| format!("invalid create request: {e}"))
+    let mut request: CreateCronJobRequest = serde_json::from_value(serde_json::Value::Object(obj))
+        .map_err(|e| format!("invalid create request: {e}"))?;
+    fill_announce_delivery_to(&mut request, reply_token.as_deref())?;
+    Ok(request)
+}
+
+fn fill_announce_delivery_to(
+    request: &mut CreateCronJobRequest,
+    reply_token: Option<&str>,
+) -> Result<(), String> {
+    let Some(delivery) = request.delivery.as_mut() else {
+        return Ok(());
+    };
+    if delivery.mode != DeliveryMode::Announce {
+        return Ok(());
+    }
+    delivery.to = delivery.to.trim().to_string();
+    if delivery.to.is_empty() {
+        if let Some(token) = reply_token {
+            delivery.to = token.to_string();
+        }
+    }
+    if delivery.to.is_empty() {
+        return Err(ANNOUNCE_DELIVERY_TO_REQUIRED.to_string());
+    }
+    Ok(())
+}
+
+/// 32-char hex — the shape `reply_token::token_for_binding` mints.
+pub(crate) fn looks_like_reply_token(s: &str) -> bool {
+    let s = s.trim();
+    s.len() == 32 && s.chars().all(|c| c.is_ascii_hexdigit())
+}
+
+async fn pin_announce_delivery_target(delivery: &mut CronDelivery) -> Result<(), String> {
+    if delivery.mode != DeliveryMode::Announce {
+        return Ok(());
+    }
+    let to = delivery.to.trim();
+    if to.is_empty() {
+        return Err(ANNOUNCE_DELIVERY_TO_REQUIRED.to_string());
+    }
+    if !looks_like_reply_token(to) {
+        return Ok(());
+    }
+    let resolved = amuxd_client::resolve_reply_token(to).await.map_err(|e| {
+        format!(
+            "could not pin delivery.to from reply_token: {e}. \
+             Pass wecom single:<userid> or group:<chatid> instead."
+        )
+    })?;
+    if delivery.channel.as_str() != resolved.channel {
+        return Err(format!(
+            "reply_token is a {} chat (`{}`), but delivery.channel is {}",
+            resolved.channel,
+            resolved.to,
+            delivery.channel.as_str()
+        ));
+    }
+    delivery.to = resolved.to;
+    Ok(())
 }
 
 /// Recover when a sidecar stuffed a one-time/interval object into `expr`
@@ -671,5 +741,54 @@ mod mcp_create_tests {
             Some("2026-09-09T20:10:30+08:00")
         );
         assert!(request.schedule.expr.is_none());
+    }
+
+    #[test]
+    fn parse_create_request_rejects_announce_with_empty_to() {
+        let body = serde_json::json!({
+            "action": "create",
+            "name": "日报",
+            "enabled": true,
+            "schedule": { "kind": "cron", "expr": "0 10 * * *" },
+            "payload": { "message": "hello" },
+            "delivery": {
+                "mode": "announce",
+                "channel": "wecom",
+                "to": ""
+            }
+        });
+        let err = parse_create_request(&body).unwrap_err();
+        assert!(err.contains("delivery.to is required"), "got: {err}");
+        assert!(err.contains("reply_token"), "got: {err}");
+    }
+
+    #[test]
+    fn parse_create_request_fills_empty_to_from_reply_token() {
+        let token = "0".repeat(32);
+        let body = serde_json::json!({
+            "action": "create",
+            "name": "日报",
+            "enabled": true,
+            "schedule": { "kind": "cron", "expr": "0 10 * * *" },
+            "payload": { "message": "hello" },
+            "reply_token": token,
+            "delivery": {
+                "mode": "announce",
+                "channel": "wecom",
+                "to": "  "
+            }
+        });
+        let request = parse_create_request(&body).unwrap();
+        let delivery = request.delivery.expect("delivery");
+        assert_eq!(delivery.to, token);
+        assert_eq!(delivery.channel, DeliveryChannel::Wecom);
+    }
+
+    #[test]
+    fn looks_like_reply_token_is_32_hex() {
+        assert!(looks_like_reply_token(&"ab".repeat(16)));
+        assert!(!looks_like_reply_token("single:HuangWeiGan"));
+        assert!(!looks_like_reply_token(""));
+        assert!(!looks_like_reply_token("abcd"));
     }
 }

--- a/apps/desktop/src/commands/cron/types.rs
+++ b/apps/desktop/src/commands/cron/types.rs
@@ -114,6 +114,28 @@ pub enum DeliveryChannel {
     Seatalk,
 }
 
+impl DeliveryChannel {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Discord => "discord",
+            Self::Feishu => "feishu",
+            Self::Email => "email",
+            Self::Kook => "kook",
+            Self::Wechat => "wechat",
+            Self::Wecom => "wecom",
+            Self::Seatalk => "seatalk",
+        }
+    }
+}
+
+/// MCP used to accept `delivery.to: ""` as "this conversation". Cron announce
+/// delivery has no such default — empty falls through to a missing ownerId and
+/// the run's result never leaves the desktop.
+pub const ANNOUNCE_DELIVERY_TO_REQUIRED: &str = "delivery.to is required for announce. \
+An empty value is not this chat. For the current conversation, set delivery.to to this \
+run's reply_token (from the prompt); it is stored as a stable chat id. \
+WeCom also accepts single:<userid> or group:<chatid>.";
+
 /// Delivery configuration for cron job results
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]


### PR DESCRIPTION
## Summary
- MCP `manage_cron_job` used to accept empty `delivery.to` as “this conversation”, but announce delivery has no such default — the run never left the desktop.
- Create now requires an explicit target. An empty `to` can be filled from the chat `reply_token`, then resolved to a stable WeCom id (`single:<userid>` / `group:<chatid>`) before the job is stored.
- Daemon exposes `resolve-reply-token` so desktop/introspect can pin the current chat at create time; the channel prompt tells the model an empty `to` is not this chat.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Test plan
- [ ] From a WeCom DM/group, create an announce cron job with empty `delivery.to` — it should be rejected (or filled only when `reply_token` is present).
- [ ] Create with this run’s `reply_token` — stored `delivery.to` should be `single:<userid>` or `group:<chatid>`, not the raw token or empty.
- [ ] Run the job once — the result should arrive in that WeCom chat, not only on desktop.
- [ ] Existing jobs that were saved with empty `to` are unchanged; recreate them to pick up the pin.
- [ ] `cargo test` coverage: `binding_target` pin mapping, introspect `resolve-reply-token`, desktop `parse_create_request` empty-`to` / reply-token fill.


Made with [Cursor](https://cursor.com)