### PR TITLE
fix(apps): 定时事件不是 HTTP 请求，handler 里补上翻译（#1358 的补丁）

### DIFF
--- a/docs/specs/2026-09-10-app-control-panel-design.md
+++ b/docs/specs/2026-09-10-app-control-panel-design.md
@@ -157,13 +157,32 @@ update amux.app_cron_jobs
 - **阿里云 FC**：`s.yaml` 里声明一个 timer trigger（`app-cron`，六段式 `0 * * * * *`
   —— 阿里云的表达式第一段是秒）。
 
-  这里原来写的是「不用 timer trigger，因为 timer 事件不是 HTTP 请求」—— **那是猜的，
-  而且是错的**。同账号的 `banana-api` 上跑着 20 多个 timer trigger 打自己的 HTTP 路径，
-  payload 形如 `{"path":"/api/cron/…","method":"POST","body":{…}}`，其中就有每分钟一次
-  的。timer 确实能驱动 web 函数。
+  **timer 事件不是 HTTP 请求，这一段翻过两次车，两次都是同一个坑。**
 
-  它**不能**做的是加请求头：payload 只有 `path` / `method` / `body` 三个字段。所以密钥
-  走 **body**，端点两种都收（sidecar 发 bearer，timer 放 body）。没走 query 是因为
+  最初写的是「不用 timer trigger，因为 timer 事件不是 HTTP 请求」；看到同账号的
+  `banana-api` 上跑着 20 多个 timer trigger 打自己的 HTTP 路径（payload 形如
+  `{"path":"/api/cron/…","method":"POST","body":{…}}`，其中就有每分钟一次的），就改
+  成了「timer 确实能驱动 web 函数」。**后半句同样是错的**：能跑起来的是那个 payload
+  约定，而约定是**函数自己**兑现的，不是 FC 兑现的。
+
+  FC 交给函数的就是 `{triggerTime, triggerName, payload}` —— 没有 rawPath、没有
+  method、没有 header。`hono/aws-lambda` 认不出这个形状，`getProcessor` 退回 v1
+  processor，读 `event.path` / `event.httpMethod` 读到两个 undefined，拼出来的请求
+  404。**没有异常抛出**，所以 FC 记的是一次干净的成功。
+
+  2026-09-10 belayo 上的表现正是如此：`app-cron` 每分钟按时触发（`t-…` 开头的
+  requestId，`hasFunctionError: false`），一条任务都没跑；同一个 tick 走 HTTP 是通的。
+  排查时先怀疑过 `CRON_TZ=` 前缀 —— 也是错的，同一个函数上不带前缀的
+  `oss-abandon-sessions` 一样在触发。**判据只有一条：查 `FCRequestMetrics` 里
+  `invocationType: Async` 的记录，有就是在触发，问题在函数里。**
+
+  所以 `src/index.ts` 的 `handler()` 里有一步 `timerEventToHttpEvent()`：认出 timer
+  事件，把 payload 里的 `path` / `method` / `body` 翻译成 hono 认得的 v2 事件（host 固
+  定 `localhost`，免得撞上按域名路由的应用和登录服务）。不是 timer 事件、或者 payload
+  里没有可路由的 `path`，一律原样放行。
+
+  timer **不能**做的是加请求头：payload 只有 `path` / `method` / `body` 三个字段。所以
+  密钥走 **body**，端点两种都收（sidecar 发 bearer，timer 放 body）。没走 query 是因为
   query 会进 URL 和访问日志，body 不会。
 
 `APP_CRON_SECRET` 必须**两边都声明**（compose 的 `environment:` 白名单 + `s.yaml`），

--- a/services/fc/s.yaml
+++ b/services/fc/s.yaml
@@ -14,7 +14,11 @@ resources:
       functionName: ${env('FC_FUNCTION_NAME', 'teamclu-sync')}
       runtime: ${env('FC_RUNTIME', 'nodejs20')}
       handler: dist/index.handler
-      timeout: 30
+      # Must exceed the cron tick's own budget (MAX_TICK_MS in
+      # app-cron-runner.ts, 45s) — FC kills the invocation at this number, and a
+      # tick killed mid-flight leaves the run it was writing unrecorded. Every
+      # other route on this function answers in milliseconds.
+      timeout: 60
       cpu: 0.4
       memorySize: 512
       diskSize: 512
@@ -124,11 +128,15 @@ resources:
         # is the `app-cron` compose sidecar; here it is the `app-cron` timer
         # trigger declared below.
         #
-        # A timer trigger CAN drive a web function: it POSTs to the `path` in
-        # its payload. What it cannot do is attach a header, so the secret rides
-        # in the payload BODY — which the route accepts alongside the bearer the
-        # sidecar sends. Blank on either target = scheduled tasks never fire,
-        # because the endpoint refuses an unset secret.
+        # A timer trigger does not make an HTTP request — it invokes the function
+        # with `{triggerTime, triggerName, payload}`. `handler()` in src/index.ts
+        # turns the `path`/`method`/`body` in that payload into the HTTP event the
+        # hono adapter routes; without that step the event 404s and FC still
+        # records a clean success. What a timer cannot do at all is attach a
+        # header, so the secret rides in the BODY — which the route accepts
+        # alongside the bearer the sidecar sends. Blank on either target =
+        # scheduled tasks never fire, because the endpoint refuses an unset
+        # secret.
         APP_CRON_SECRET: ${env('APP_CRON_SECRET', '')}
         # Per-app git repos on Gitea. Blank disables repo provisioning (503
         # gitea_unavailable naming the empty variable).

--- a/services/fc/src/index.ts
+++ b/services/fc/src/index.ts
@@ -531,6 +531,71 @@ export function normalizeFcEvent(event: any): any {
   return event;
 }
 
+// A timer trigger does not deliver an HTTP request at all.
+//
+// FC hands the function `{ triggerTime, triggerName, payload }`, where `payload`
+// is the opaque string configured on the trigger — no rawPath, no method, no
+// headers. hono/aws-lambda cannot route that: `getProcessor` falls through to
+// the v1 processor, which reads `event.path` and `event.httpMethod` off an
+// object that has neither, and the request it builds 404s. Nothing throws, so
+// the invocation is recorded as a clean success.
+//
+// That is exactly what belayo did on 2026-09-10: the `app-cron` timer fired
+// every minute (`t-…` request ids, `hasFunctionError: false`) and not one cron
+// job ran, while the same tick over HTTP worked.
+//
+// So the trigger payload names the request to make, and this turns it into the
+// event shape the adapter already understands:
+//
+//   {"path": "/v1/internal/app-cron/tick", "method": "POST", "body": {…}}
+//
+// Returns null for anything that is not a timer event carrying such a payload,
+// so an HTTP event — and a malformed timer payload — is left to the code below.
+export function timerEventToHttpEvent(event: any): any | null {
+  if (!event || typeof event !== "object" || Array.isArray(event)) return null;
+  // An HTTP event never carries these, and a timer event never carries a path.
+  if (typeof event.triggerName !== "string" && typeof event.triggerTime !== "string") return null;
+  if (typeof event.rawPath === "string" || typeof event.path === "string") return null;
+
+  let payload: any = event.payload;
+  if (typeof payload === "string") {
+    try {
+      payload = JSON.parse(payload);
+    } catch {
+      return null;
+    }
+  }
+  const path = payload?.path;
+  if (typeof path !== "string" || !path.startsWith("/")) return null;
+
+  const method = typeof payload?.method === "string" ? payload.method.toUpperCase() : "POST";
+  const body =
+    payload?.body === undefined || payload?.body === null
+      ? undefined
+      : typeof payload.body === "string"
+        ? payload.body
+        : JSON.stringify(payload.body);
+
+  const [rawPath, rawQueryString = ""] = path.split("?", 2);
+  return {
+    version: "2.0",
+    rawPath,
+    rawQueryString,
+    // `localhost` on purpose: the timer has no hostname, and every host-routed
+    // surface (deployed apps, the login service) must NOT match, so the request
+    // reaches the API's own routes.
+    headers: {
+      host: "localhost",
+      "content-type": "application/json",
+      "x-forwarded-proto": "https",
+      "user-agent": `fc-timer/${event.triggerName ?? "unknown"}`,
+    },
+    requestContext: { http: { method, path: rawPath, sourceIp: "127.0.0.1" } },
+    body,
+    isBase64Encoded: false,
+  };
+}
+
 // ---------------------------------------------------------------------------
 export async function handler(event: any, context: any) {
   // FC 3.0 HTTP trigger passes a Buffer; FC 2.0 may pass a JSON string.
@@ -539,6 +604,8 @@ export async function handler(event: any, context: any) {
   } else if (typeof event === "string") {
     event = JSON.parse(event);
   }
+
+  event = timerEventToHttpEvent(event) ?? event;
 
   normalizeFcEvent(event);
   return honoHandler(event, context);

--- a/services/fc/src/lib/app-cron-runner.ts
+++ b/services/fc/src/lib/app-cron-runner.ts
@@ -35,6 +35,11 @@ const TICK_CONCURRENCY = 8;
  * `next_run_at` is untouched, so the following tick picks it up. Overrunning
  * would stack ticks on top of each other, which is the one thing the
  * compare-and-set cannot make safe — it stops double EXECUTION, not pile-up.
+ *
+ * A job already running is bounded by what remains of this budget too (see
+ * executeJob), so the whole tick lands within about a second of it. Both deploy
+ * targets must allow at least that much: the FC function timeout in s.yaml, and
+ * the sidecar's curl budget in docker-compose.yml.
  */
 const MAX_TICK_MS = 45_000;
 /** Execution rows kept per job. Trimmed on write; there is no sweeper. */
@@ -168,7 +173,7 @@ export async function runDueAppCronJobs(deps: AppCronDeps): Promise<AppCronTickR
       if (!job) return;
       const claimed = await claimJob(db, job, now);
       if (!claimed) continue; // Another tick took it. Not an error, not a run.
-      outcomes.push(await executeJob(db, job, { env, doFetch }));
+      outcomes.push(await executeJob(db, job, { env, doFetch, deadline }));
     }
   };
   await Promise.all(
@@ -237,13 +242,16 @@ export async function executeAppCronJob(
   return executeJob(db, job, {
     env: ctx.env ?? process.env,
     doFetch: ctx.doFetch ?? fetch,
+    // A manual run is one request in its own invocation — there is no tick to
+    // share, so the job's own timeout is the whole budget.
+    deadline: Date.now() + job.timeout_ms,
   });
 }
 
 async function executeJob(
   db: any,
   job: JobRow,
-  ctx: { env: NodeJS.ProcessEnv; doFetch: typeof fetch },
+  ctx: { env: NodeJS.ProcessEnv; doFetch: typeof fetch; deadline: number },
 ): Promise<AppCronTickOutcome> {
   const startedAt = new Date();
 
@@ -269,7 +277,19 @@ async function executeJob(
 
   const url = `${base}${job.path.startsWith("/") ? job.path : `/${job.path}`}`;
   const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), job.timeout_ms);
+  // Bounded by whatever is LEFT of the tick, not just by the job's own setting.
+  //
+  // The deadline above only stops new jobs being claimed; a job already in
+  // flight can outlive it by its full timeout. That is survivable on self-host,
+  // where the sidecar's curl gives up but the container keeps writing the run
+  // row — and fatal on Function Compute, which kills the invocation at the
+  // function timeout with the row unwritten. The job would then show no history
+  // at all for that minute, which reads as "never ran" rather than "timed out".
+  //
+  // A floor of one second so a tick that is already past its deadline still
+  // gives the job a real attempt rather than aborting before the connection.
+  const budgetMs = Math.max(1000, Math.min(job.timeout_ms, ctx.deadline - Date.now()));
+  const timer = setTimeout(() => controller.abort(), budgetMs);
   try {
     const method = job.method.toUpperCase();
     const res = await ctx.doFetch(url, {
@@ -311,7 +331,7 @@ async function executeJob(
       status: aborted ? "timeout" : "failed",
       responseStatus: null,
       error: aborted
-        ? `超过 ${job.timeout_ms}ms 没有响应`
+        ? `超过 ${budgetMs}ms 没有响应`
         : e instanceof Error
           ? e.message
           : String(e),

--- a/services/fc/test/app-cron-runner.test.ts
+++ b/services/fc/test/app-cron-runner.test.ts
@@ -319,6 +319,41 @@ test("an aborted request is a timeout, told apart from a failure", async () => {
   assert.match(out.outcomes[0].error!, /1000ms/);
 });
 
+test("a job cannot outlive the tick that started it", async () => {
+  // The deadline only stops new CLAIMS. A job already in flight could outrun it
+  // by its own timeout — 60s is a legal setting — and on Function Compute the
+  // invocation is killed at the function timeout with the run row still
+  // unwritten. That job then shows no history at all for the minute it ran,
+  // which reads as "never fired" rather than "timed out".
+  const db = makeDb({
+    app_cron_jobs: [job({ timeout_ms: 60_000 })],
+    apps: apps(),
+    app_cron_runs: [] as any[],
+  });
+  const startedAt = Date.now();
+  const out = await runDueAppCronJobs({
+    client: db,
+    env: ENV as any,
+    now: new Date("2026-09-10T09:00:30.000Z"),
+    maxTickMs: 1200,
+    // Hangs until aborted, which is the only way the abort is observable.
+    fetchImpl: ((_url: any, init: any) =>
+      new Promise((_resolve, reject) => {
+        init.signal.addEventListener("abort", () => {
+          const e = new Error("aborted");
+          e.name = "AbortError";
+          reject(e);
+        });
+      })) as any,
+  });
+
+  assert.equal(out.outcomes[0].status, "timeout");
+  assert.ok(Date.now() - startedAt < 10_000, "the tick waited out the job's own timeout");
+  // And the message says what was actually waited for, not the stored setting.
+  const ms = Number(/(\d+)ms/.exec(out.outcomes[0].error!)?.[1]);
+  assert.ok(ms >= 1000 && ms <= 1200, `budget should be what was left of the tick, got ${ms}`);
+});
+
 test("a stored expression that no longer parses parks the job instead of spinning", async () => {
   const rows = [job({ schedule_expr: "not a cron" })];
   const db = makeDb({ app_cron_jobs: rows, apps: apps(), app_cron_runs: [] });

--- a/services/fc/test/fc-adapter.test.ts
+++ b/services/fc/test/fc-adapter.test.ts
@@ -2,7 +2,7 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import { Hono } from "hono";
 import { handle } from "hono/aws-lambda";
-import { handler, normalizeFcEvent } from "../src/index.js";
+import { handler, normalizeFcEvent, timerEventToHttpEvent } from "../src/index.js";
 
 function fcEvent(method: string, path: string, opts: { headers?: any; body?: any } = {}) {
   return {
@@ -131,4 +131,79 @@ test("hono/aws-lambda base64-encodes binary (png) round-trip", async () => {
   );
   assert.equal(res.isBase64Encoded, true);
   assert.deepEqual(Buffer.from(res.body, "base64"), png);
+});
+
+
+// ---- timer triggers ---------------------------------------------------------
+//
+// A timer trigger invokes the function with an event, not an HTTP request. On
+// belayo that difference was invisible: hono/aws-lambda routed the timer event
+// to a 404 without throwing, so FC recorded a successful invocation every
+// minute while the cron tick never ran once.
+
+const timerEvent = (payload: unknown) => ({
+  triggerTime: "2026-09-10T02:03:00Z",
+  triggerName: "app-cron",
+  payload: typeof payload === "string" ? payload : JSON.stringify(payload),
+});
+
+test("a timer payload becomes the request it names", () => {
+  const ev = timerEventToHttpEvent(
+    timerEvent({ path: "/v1/internal/app-cron/tick", method: "POST", body: { secret: "s" } }),
+  );
+  assert.equal(ev.rawPath, "/v1/internal/app-cron/tick");
+  assert.equal(ev.requestContext.http.method, "POST");
+  assert.equal(ev.body, JSON.stringify({ secret: "s" }));
+  // v2 is the processor that reads rawPath; without requestContext.http the
+  // adapter silently falls back to v1 and reads `path`, which is not set.
+  assert.ok(Object.hasOwn(ev, "rawPath") && Object.hasOwn(ev.requestContext, "http"));
+});
+
+test("a query string in the payload path is split out, not left in the path", () => {
+  // The v2 processor reads the two separately; a path carrying "?" would be
+  // matched literally and never hit the route.
+  const ev = timerEventToHttpEvent(timerEvent({ path: "/v1/x?a=1&b=2" }));
+  assert.equal(ev.rawPath, "/v1/x");
+  assert.equal(ev.rawQueryString, "a=1&b=2");
+  assert.equal(ev.requestContext.http.method, "POST", "POST is the default for a timer");
+});
+
+test("the synthesized host matches no app, so app routing cannot swallow the tick", () => {
+  const ev = timerEventToHttpEvent(timerEvent({ path: "/v1/internal/app-cron/tick" }));
+  assert.equal(ev.headers.host, "localhost");
+  assert.equal(ev.body, undefined, "no body means no body, not an empty JSON object");
+});
+
+test("anything that is not a timer payload is left alone", () => {
+  // An HTTP event must pass through untouched...
+  assert.equal(timerEventToHttpEvent(fcEvent("GET", "/v1/teams")), null);
+  // ...and so must a timer whose payload names nothing routable, rather than
+  // being turned into a request to "/undefined".
+  assert.equal(timerEventToHttpEvent(timerEvent({ task: "oss-gc-blobs" })), null);
+  assert.equal(timerEventToHttpEvent(timerEvent("not json at all")), null);
+  assert.equal(timerEventToHttpEvent(timerEvent({ path: "no-leading-slash" })), null);
+  assert.equal(timerEventToHttpEvent(null), null);
+  assert.equal(timerEventToHttpEvent({ payload: '{"path":"/v1/x"}' }), null);
+});
+
+test("the timer reaches the tick route's auth check instead of a 404", async () => {
+  // The discriminator: a 404 here means the translation did not happen, and is
+  // precisely the failure that hid for a day. 401 means the request arrived at
+  // the route with a body the auth kind could read.
+  const before = process.env.APP_CRON_SECRET;
+  process.env.APP_CRON_SECRET = "the-real-secret";
+  try {
+    const res: any = await handler(
+      timerEvent({
+        path: "/v1/internal/app-cron/tick",
+        method: "POST",
+        body: { secret: "not-the-real-secret" },
+      }),
+      {},
+    );
+    assert.equal(res.statusCode, 401, `expected 401, got ${res.statusCode}: ${res.body}`);
+  } finally {
+    if (before === undefined) delete process.env.APP_CRON_SECRET;
+    else process.env.APP_CRON_SECRET = before;
+  }
 });


### PR DESCRIPTION
#1358 把 apps 的定时任务心跳改成了 FC timer trigger。触发器**确实每分钟都在触发**，
但一条任务都没跑。

## 根因：timer 事件不是 HTTP 请求

FC 交给函数的是 `{triggerTime, triggerName, payload}` —— 没有 rawPath、没有 method、
没有 header。`hono/aws-lambda` 认不出这个形状：`getProcessor` 退回 v1 processor，读
`event.path` / `event.httpMethod` 读到两个 undefined，拼出来的请求 404。

**没有异常抛出**，所以 FC 记的是一次干净的成功。SLS 上的表现（belayo，2026-09-10）：

```
09:45:00 Async err=false  ms=9.7      ← t- 开头的 requestId，每分钟一条
09:51:00 Async err=false  ms=10.3
...
FCLogs: 只有 "FC Invoke Start" / "FC Invoke End"，中间什么都没有
```

同一个 tick 走 HTTP 是通的（`{"due":1,"ran":1,...}` 200），所以问题不在 tick 逻辑里。

`banana-api` 上那 20 多个同样形状的 timer 能跑，靠的是**那个函数自己**兑现 payload
约定，不是 FC 兑现的 —— #1358 的描述把这一点看反了。排查中途还怀疑过 `CRON_TZ=`
前缀，也是错的：同一个函数上不带前缀的 `oss-abandon-sessions` 一样在触发。

**判据只有一条**：`FCRequestMetrics` 里有没有 `invocationType: Async` 的记录。
有 = 在触发，问题在函数里；没有 = 才去查触发器。

## 改了什么

**1. `timerEventToHttpEvent()`（`src/index.ts`）**

认出 timer 事件，把 payload 里的 `path` / `method` / `body` 翻译成 hono 认得的 v2
事件。host 固定 `localhost`，免得撞上按域名路由的应用和登录服务。不是 timer 事件、
或者 payload 里没有可路由的 `path`，一律原样放行。

**2. 单个任务的超时受 tick 剩余预算约束（`app-cron-runner.ts`）**

顺手补的同类漏洞：原来 deadline 只拦「还没认领的」，已经在跑的任务能按自己的
`timeout_ms`（最大 60s）跑过头。在 FC 上这意味着调用被函数超时杀掉、run 记录没写成
—— 那一分钟的历史里什么都没有，看起来像「从没触发过」而不是「超时」。

手动「立即执行」不共享 tick，预算就是任务自己的超时。

**3. FC 函数超时 30s → 60s（`s.yaml`）**

必须大于 tick 自己的 45s 预算，否则第 2 条杀不掉。compose 那边 sidecar 的
`curl -m 55` 本来就够，没动。

## 线上核实

belayo（`teamclaw-belayo-live-api`）已部署两次，每次都做了端到端验证：探针任务分别在
`10:19:00` 和 `10:27:00` 被 timer 自动跑到，HTTP 200。探针任务和它的 run 记录已删净
（`app_cron_jobs` / `app_cron_runs` 现在都是 0 行）。部署后每分钟的 tick 稳定在
22–25ms（零任务时一条索引查询），`hasFunctionError: false`。

## 测试

`services/fc`：1276 个，0 失败（13 个 skip 是本地没起 Supabase）。新增 6 个用例，其中
关键的一个断言 timer 事件打到 tick 路由拿的是 **401 而不是 404** —— 404 正是这次藏了
一天的失败形态。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SzpoWAivBCni18ohGeUXZH
