### PR TITLE
fix(session): stamp agent workspace on new sessions so the file tree can open

### DIFF
--- a/docs/openapi/teamclu-api.v1.yaml
+++ b/docs/openapi/teamclu-api.v1.yaml
@@ -1071,6 +1071,12 @@ paths:
                   format: uuid
                 title:
                   type: string
+                workspaceId:
+                  type: string
+                  format: uuid
+                  description: |
+                    Cloud workspace the primary agent runs this job in.
+                    When omitted, FC stamps `agents.default_workspace_id`.
       responses:
         "200":
           description: Cron session result.
@@ -8968,6 +8974,20 @@ components:
           items:
             type: string
             format: uuid
+        additionalActorIds:
+          type: array
+          items:
+            type: string
+            format: uuid
+        workspaceByActorId:
+          type: object
+          additionalProperties:
+            type: string
+            format: uuid
+          description: |
+            Cloud workspace UUID for each agent participant. Overrides
+            `agents.default_workspace_id` for that actor. Member seats stay
+            unbound (workspace_id is not applicable).
     SessionThreadSummary:
       type: object
       required: [threadSessionId, rootMessageId, messageCount, participantCount]

--- a/packages/app/src/components/chat/use-chat-send.ts
+++ b/packages/app/src/components/chat/use-chat-send.ts
@@ -734,17 +734,19 @@ export function useChatSend({
       : (firstMessage.text ?? '').trim() || 'New chat';
 
     try {
-      const { createSessionShell } = await import('@/lib/session/session-create');
+      const { createSessionShell, resolveLocalDaemonWorkspaceBinding } = await import('@/lib/session/session-create');
       const memberIds = picks.members.map((m) => m.id);
       const agentIds = picks.agents.map((a) => a.id);
       const allAdditional = Array.from(new Set([...memberIds, ...agentIds]));
       const draftIdeaId = useUIStore.getState().draftIdeaId;
+      const localWorkspace = await resolveLocalDaemonWorkspaceBinding(teamIdForSend, agentIds);
       sessionFlowLog("session_create.shell.begin", {
         teamId: teamIdForSend,
         creatorActorId: myActorId,
         additionalActorCount: allAdditional.length,
         agentActorCount: agentIds.length,
         hasIdeaId: !!draftIdeaId,
+        hasLocalWorkspace: !!localWorkspace,
         title: titleSource,
       });
       const { sessionId } = await createSessionShell({
@@ -753,6 +755,7 @@ export function useChatSend({
         title: titleSource,
         additionalActorIds: allAdditional,
         ideaId: draftIdeaId,
+        localWorkspace,
       });
       if (soloActor) {
         const { markSessionNeedsAutoTitle } = await import("@/lib/session/session-auto-title");

--- a/packages/app/src/lib/backend/cloud-api/__tests__/sessions.test.ts
+++ b/packages/app/src/lib/backend/cloud-api/__tests__/sessions.test.ts
@@ -99,6 +99,39 @@ describe("sessions module", () => {
     expect("appId" in bodies[1]).toBe(false);
   });
 
+  it("createSessionShell forwards workspaceByActorId when provided, omits otherwise", async () => {
+    const bodies: Array<Record<string, unknown>> = [];
+    const client = {
+      async get() { throw new Error("unexpected"); },
+      async post(_path: string, body: Record<string, unknown>) { bodies.push(body); return cloudSession as never; },
+      async patch() { throw new Error("unexpected"); },
+      async put() { throw new Error("unexpected"); },
+      async delete() { throw new Error("unexpected"); },
+      async postRaw() { throw new Error("unexpected"); },
+      async getRaw() { throw new Error("unexpected"); },
+    } as unknown as CloudApiClient;
+    const mod = createSessionsModule(client);
+
+    await mod.createSessionShell({
+      id: "s-ws",
+      teamId: "team-1",
+      createdByActorId: "a1",
+      title: "T",
+      additionalActorIds: ["agent-1"],
+      workspaceByActorId: { "agent-1": "ws-picked" },
+    });
+    expect(bodies[0].workspaceByActorId).toEqual({ "agent-1": "ws-picked" });
+
+    await mod.createSessionShell({
+      id: "s-nows",
+      teamId: "team-1",
+      createdByActorId: "a1",
+      title: "T",
+      additionalActorIds: ["agent-1"],
+    });
+    expect("workspaceByActorId" in bodies[1]).toBe(false);
+  });
+
   it("getSession calls /v1/sessions/:id with teamId and maps detail fields", async () => {
     const client = mockClient({
       "GET /v1/sessions/session-1?teamId=team-1": {

--- a/packages/app/src/lib/backend/cloud-api/sessions.ts
+++ b/packages/app/src/lib/backend/cloud-api/sessions.ts
@@ -126,6 +126,9 @@ export function createSessionsModule(client: CloudApiClient): SessionsBackend {
         ideaId: input.ideaId ?? null,
         additionalActorIds: input.additionalActorIds,
         ...(input.appId ? { appId: input.appId } : {}),
+        ...(input.workspaceByActorId && Object.keys(input.workspaceByActorId).length > 0
+          ? { workspaceByActorId: input.workspaceByActorId }
+          : {}),
       });
       return { sessionId: input.id };
     },

--- a/packages/app/src/lib/backend/types.ts
+++ b/packages/app/src/lib/backend/types.ts
@@ -148,6 +148,8 @@ export interface SessionCreateInput {
   additionalActorIds: string[];
   ideaId?: string | null;
   appId?: string;
+  /** Cloud workspace UUID for each agent participant (ADR-0005). */
+  workspaceByActorId?: Record<string, string>;
 }
 
 export interface SessionParticipant {

--- a/packages/app/src/lib/session/__tests__/session-create.test.ts
+++ b/packages/app/src/lib/session/__tests__/session-create.test.ts
@@ -27,6 +27,16 @@ const daemonAdminMocks = vi.hoisted(() => ({
   getLocalDaemonActorId: vi.fn().mockResolvedValue(null),
 }))
 
+const localCacheMocks = vi.hoisted(() => ({
+  upsertSessionsBatch: vi.fn().mockResolvedValue(undefined),
+  upsertSessionParticipantsBatch: vi.fn().mockResolvedValue(undefined),
+  upsertSessionWorkspacesBatch: vi.fn().mockResolvedValue(undefined),
+}))
+
+const currentTeamMocks = vi.hoisted(() => ({
+  currentMember: { id: 'member-1' } as { id: string } | null,
+}))
+
 vi.mock('@/lib/utils', () => ({
   isTauri: () => true,
 }))
@@ -72,6 +82,24 @@ vi.mock('@/lib/actor/current-actor', () => ({
   resolveCurrentMemberActorId: vi.fn().mockResolvedValue('member-1'),
 }))
 
+vi.mock('@/lib/cache/local-cache', () => ({
+  upsertSessionsBatch: (...args: unknown[]) => localCacheMocks.upsertSessionsBatch(...args),
+  upsertSessionParticipantsBatch: (...args: unknown[]) =>
+    localCacheMocks.upsertSessionParticipantsBatch(...args),
+  upsertSessionWorkspacesBatch: (...args: unknown[]) =>
+    localCacheMocks.upsertSessionWorkspacesBatch(...args),
+}))
+
+vi.mock('@/stores/current-team', () => ({
+  useCurrentTeamStore: {
+    getState: () => ({ currentMember: currentTeamMocks.currentMember }),
+  },
+}))
+
+vi.mock('@/lib/mqtt/mqtt-bridge', () => ({
+  mqttPublish: vi.fn().mockResolvedValue(undefined),
+}))
+
 describe('startAgentRuntimesAsync', () => {
   beforeEach(() => {
     mockRuntimeStart.mockClear()
@@ -85,6 +113,13 @@ describe('startAgentRuntimesAsync', () => {
     backendMocks.createDaemonWorkspace.mockReset()
     daemonAdminMocks.getLocalDaemonActorId.mockReset()
     daemonAdminMocks.getLocalDaemonActorId.mockResolvedValue(null)
+    localCacheMocks.upsertSessionsBatch.mockReset()
+    localCacheMocks.upsertSessionParticipantsBatch.mockReset()
+    localCacheMocks.upsertSessionWorkspacesBatch.mockReset()
+    localCacheMocks.upsertSessionsBatch.mockResolvedValue(undefined)
+    localCacheMocks.upsertSessionParticipantsBatch.mockResolvedValue(undefined)
+    localCacheMocks.upsertSessionWorkspacesBatch.mockResolvedValue(undefined)
+    currentTeamMocks.currentMember = { id: 'member-1' }
     workspaceStoreMocks.workspacePath = ''
     backendMocks.createSessionShell.mockResolvedValue({ sessionId: 'sess-1' })
     backendMocks.insertOutgoingMessage.mockResolvedValue({})
@@ -153,6 +188,145 @@ describe('startAgentRuntimesAsync', () => {
       createdByActorId: 'member-1',
       additionalActorIds: ['agent-1'],
     }))
+    expect(backendMocks.createSessionShell.mock.calls[0][0]).not.toHaveProperty('workspaceByActorId')
+  })
+
+  it('forwards localWorkspace as workspaceByActorId and binds the local cache', async () => {
+    backendMocks.createSessionShell.mockResolvedValueOnce({ sessionId: 'sess-ws' })
+
+    const { createSessionShell } = await import('@/lib/session/session-create')
+    await createSessionShell({
+      teamId: 'team-1',
+      creatorActorId: 'member-1',
+      title: 'hello',
+      additionalActorIds: ['agent-local'],
+      localWorkspace: {
+        agentId: 'agent-local',
+        workspaceId: 'ws-picked',
+        path: '/Users/me/copilot',
+      },
+    })
+
+    expect(backendMocks.createSessionShell).toHaveBeenCalledWith(expect.objectContaining({
+      workspaceByActorId: { 'agent-local': 'ws-picked' },
+    }))
+    expect(localCacheMocks.upsertSessionWorkspacesBatch).toHaveBeenCalledWith([
+      expect.objectContaining({
+        sessionId: 'sess-ws',
+        teamId: 'team-1',
+        viewerMemberId: 'member-1',
+        agentId: 'agent-local',
+        workspaceId: 'ws-picked',
+        workspacePath: '/Users/me/copilot',
+      }),
+    ])
+  })
+
+  it('does not stamp workspaceByActorId when the local agent is not a participant', async () => {
+    const { createSessionShell } = await import('@/lib/session/session-create')
+    await createSessionShell({
+      teamId: 'team-1',
+      creatorActorId: 'member-1',
+      title: 'hello',
+      additionalActorIds: ['remote-agent'],
+      localWorkspace: {
+        agentId: 'agent-local',
+        workspaceId: 'ws-picked',
+        path: '/Users/me/copilot',
+      },
+    })
+
+    expect(backendMocks.createSessionShell.mock.calls[0][0]).not.toHaveProperty('workspaceByActorId')
+    expect(localCacheMocks.upsertSessionWorkspacesBatch).not.toHaveBeenCalled()
+  })
+
+  it('createSessionWithFirstMessage passes localWorkspace into the shell', async () => {
+    const { createSessionWithFirstMessage } = await import('@/lib/session/session-create')
+    await createSessionWithFirstMessage({
+      teamId: 'team-1',
+      creatorActorId: 'member-1',
+      additionalActorIds: ['agent-local'],
+      agentActorIds: ['agent-local'],
+      messageText: 'hi',
+      localWorkspace: {
+        agentId: 'agent-local',
+        workspaceId: 'ws-dialog',
+        path: '/tmp/other',
+      },
+    })
+
+    expect(backendMocks.createSessionShell).toHaveBeenCalledWith(expect.objectContaining({
+      workspaceByActorId: { 'agent-local': 'ws-dialog' },
+    }))
+  })
+
+  it('resolveLocalDaemonWorkspaceBinding maps the current folder for the local daemon', async () => {
+    daemonAdminMocks.getLocalDaemonActorId.mockResolvedValue('agent-local')
+    workspaceStoreMocks.workspacePath = '/Users/me/copilot'
+    backendMocks.listDaemonWorkspaces.mockResolvedValue([
+      {
+        id: 'ws-copilot',
+        team_id: 'team-1',
+        agent_id: 'agent-local',
+        created_by_member_id: null,
+        name: 'copilot',
+        path: '/Users/me/copilot',
+        archived: false,
+        created_at: '2026-05-18T00:00:00.000Z',
+        updated_at: '2026-05-18T00:00:00.000Z',
+      },
+    ])
+
+    const { resolveLocalDaemonWorkspaceBinding } = await import('@/lib/session/session-create')
+    await expect(
+      resolveLocalDaemonWorkspaceBinding('team-1', ['agent-local']),
+    ).resolves.toEqual({
+      agentId: 'agent-local',
+      workspaceId: 'ws-copilot',
+      path: '/Users/me/copilot',
+    })
+  })
+
+  it('resolveLocalDaemonWorkspaceBinding returns null when the local daemon is not a participant', async () => {
+    daemonAdminMocks.getLocalDaemonActorId.mockResolvedValue('agent-local')
+    workspaceStoreMocks.workspacePath = '/Users/me/copilot'
+
+    const { resolveLocalDaemonWorkspaceBinding } = await import('@/lib/session/session-create')
+    await expect(
+      resolveLocalDaemonWorkspaceBinding('team-1', ['remote-agent']),
+    ).resolves.toBeNull()
+  })
+
+  it('resolveLocalDaemonWorkspaceBinding creates a cloud workspace when the path is unknown', async () => {
+    daemonAdminMocks.getLocalDaemonActorId.mockResolvedValue('agent-local')
+    workspaceStoreMocks.workspacePath = '/Users/me/brand-new'
+    backendMocks.listDaemonWorkspaces.mockResolvedValue([])
+    backendMocks.createDaemonWorkspace.mockResolvedValue({
+      id: 'ws-created',
+      team_id: 'team-1',
+      agent_id: 'agent-local',
+      name: 'brand-new',
+      path: '/Users/me/brand-new',
+      archived: false,
+      created_at: '',
+      updated_at: '',
+    })
+
+    const { resolveLocalDaemonWorkspaceBinding } = await import('@/lib/session/session-create')
+    await expect(
+      resolveLocalDaemonWorkspaceBinding('team-1', ['agent-local']),
+    ).resolves.toEqual({
+      agentId: 'agent-local',
+      workspaceId: 'ws-created',
+      path: '/Users/me/brand-new',
+    })
+    expect(backendMocks.createDaemonWorkspace).toHaveBeenCalledWith(
+      expect.objectContaining({
+        teamId: 'team-1',
+        agentId: 'agent-local',
+        path: '/Users/me/brand-new',
+      }),
+    )
   })
 
   it('sends opencode runtimeStart requests for this-session runtime workspace', async () => {

--- a/packages/app/src/lib/session/session-create.ts
+++ b/packages/app/src/lib/session/session-create.ts
@@ -46,6 +46,13 @@ import {
 } from '@/lib/teamclu/resolve-runtime-start-workspace'
 import { resolveSessionWorkspacePath } from '@/lib/session/session-by-workspace'
 import { RUNTIME_START_RPC_TIMEOUT_MS } from '@/lib/teamclu/runtime-rpc-timeouts'
+
+export type LocalDaemonWorkspaceBinding = {
+  agentId: string
+  workspaceId: string
+  path: string
+}
+
 interface CreateSessionShellArgs {
   teamId: string
   creatorActorId: string
@@ -56,6 +63,12 @@ interface CreateSessionShellArgs {
   ideaId?: string | null
   /** When set, the new session row is linked to this app_id at insert time. */
   appId?: string
+  /**
+   * Folder the local daemon agent should run this session in. Sent as
+   * `workspaceByActorId` so Cloud API stamps `session_participants.workspace_id`
+   * at insert (the file tree reads that column, not the local cache).
+   */
+  localWorkspace?: LocalDaemonWorkspaceBinding | null
 }
 
 interface CreateSessionShellResult {
@@ -84,6 +97,7 @@ export async function createSessionShell(
   })
 
   const participantActorIds = Array.from(new Set([args.creatorActorId, ...args.additionalActorIds]))
+  const workspaceByActorId = workspaceByActorIdFromLocal(args.localWorkspace, participantActorIds)
   let sessionId = requestedSessionId
   try {
     const created = await getBackend().sessions.createSessionShell({
@@ -94,6 +108,7 @@ export async function createSessionShell(
       additionalActorIds: args.additionalActorIds,
       ideaId: args.ideaId ?? null,
       ...(args.appId ? { appId: args.appId } : {}),
+      ...(workspaceByActorId ? { workspaceByActorId } : {}),
     })
     sessionId = created.sessionId
   } catch (error) {
@@ -168,11 +183,74 @@ export async function createSessionShell(
     }
   }
 
+  await bindLocalDaemonSessionWorkspace(sessionId, {
+    teamId: args.teamId,
+    agentActorIds: args.additionalActorIds,
+    localWorkspace: args.localWorkspace,
+  })
+
   sessionFlowLog('session_shell.ok', {
     sessionId,
     teamId: args.teamId,
   })
   return { sessionId }
+}
+
+function workspaceByActorIdFromLocal(
+  localWorkspace: LocalDaemonWorkspaceBinding | null | undefined,
+  participantActorIds: string[],
+): Record<string, string> | undefined {
+  const agentId = localWorkspace?.agentId?.trim()
+  const workspaceId = localWorkspace?.workspaceId?.trim()
+  if (!agentId || !workspaceId) return undefined
+  if (!participantActorIds.some((id) => id.trim() === agentId)) return undefined
+  return { [agentId]: workspaceId }
+}
+
+/**
+ * Map the current window folder to a cloud workspace UUID for the local
+ * daemon, when that agent is among the new session's participants.
+ *
+ * Used by the composer quick-create path (no folder picker). The advanced
+ * dialog already has an explicit `localWorkspace` from the user.
+ */
+export async function resolveLocalDaemonWorkspaceBinding(
+  teamId: string,
+  agentActorIds: readonly string[],
+): Promise<LocalDaemonWorkspaceBinding | null> {
+  if (!isTauri()) return null
+  const trimmedTeam = teamId.trim()
+  if (!trimmedTeam) return null
+
+  let localDaemonActorId: string | null = null
+  try {
+    const { getLocalDaemonActorId } = await import('@/lib/daemon/daemon-agent-admin')
+    localDaemonActorId = (await getLocalDaemonActorId())?.trim() || null
+  } catch {
+    localDaemonActorId = null
+  }
+  if (!localDaemonActorId) return null
+  if (!agentActorIds.some((id) => id.trim() === localDaemonActorId)) return null
+
+  const path = useWorkspaceStore.getState().workspacePath?.trim() || ''
+  if (!path) return null
+
+  let workspaceId =
+    (await resolveCloudWorkspaceIdForLocalPath(trimmedTeam, path, {
+      agentActorId: localDaemonActorId,
+    })) ?? ''
+  if (!workspaceId) {
+    const createdByMemberId = useCurrentTeamStore.getState().currentMember?.id?.trim() || null
+    workspaceId = await ensureCloudWorkspaceIdForAgentRuntime({
+      teamId: trimmedTeam,
+      agentActorId: localDaemonActorId,
+      localWorkspacePath: path,
+      createdByMemberId,
+    })
+  }
+  const trimmedId = workspaceId.trim()
+  if (!trimmedId) return null
+  return { agentId: localDaemonActorId, workspaceId: trimmedId, path }
 }
 
 interface CreateSessionWithFirstMessageArgs {
@@ -207,7 +285,7 @@ interface CreateSessionWithFirstMessageArgs {
    * daemon names a row that daemon cannot resolve — it would fall back to its
    * own onboarded default and run in the wrong directory, silently.
    */
-  localWorkspace?: { agentId: string; workspaceId: string; path: string } | null
+  localWorkspace?: LocalDaemonWorkspaceBinding | null
 }
 
 /**
@@ -228,7 +306,11 @@ interface CreateSessionWithFirstMessageArgs {
  */
 async function bindLocalDaemonSessionWorkspace(
   sessionId: string,
-  args: CreateSessionWithFirstMessageArgs,
+  args: {
+    teamId: string
+    agentActorIds: readonly string[]
+    localWorkspace?: LocalDaemonWorkspaceBinding | null
+  },
 ): Promise<void> {
   const workspaceId = args.localWorkspace?.workspaceId?.trim()
   const workspacePath = args.localWorkspace?.path?.trim()
@@ -309,10 +391,8 @@ export async function createSessionWithFirstMessage(
     additionalActorIds: args.additionalActorIds,
     ideaId: args.ideaId ?? null,
     ...(args.appId ? { appId: args.appId } : {}),
+    localWorkspace: args.localWorkspace,
   })
-
-  // Before the first message exists, so no runtime can start ahead of it.
-  await bindLocalDaemonSessionWorkspace(sessionId, args)
 
   const messageId = crypto.randomUUID()
   const createdAt = BigInt(Math.floor(Date.now() / 1000))

--- a/services/fc/src/lib/supabase-repo.ts
+++ b/services/fc/src/lib/supabase-repo.ts
@@ -179,6 +179,49 @@ function guardedFetch(input: any, init?: any) {
 }
 
 /**
+ * Agent seats carry a workspace (ADR-0005); member seats do not.
+ * Callers that already picked a folder pass it in `overrideByActorId`.
+ */
+async function workspaceIdByAgentActor(
+  supabase: any,
+  actorIds: string[],
+  overrideByActorId: Record<string, string> = {},
+): Promise<Map<string, string>> {
+  const ids = [...new Set(actorIds.filter((id) => typeof id === "string" && id.length > 0))];
+  const defaults = new Map<string, string>();
+  if (ids.length > 0) {
+    const rows = await chunkedIn(ids, async (chunk: string[]) => {
+      const { data, error } = await supabase
+        .from("agents")
+        .select("id, default_workspace_id")
+        .in("id", chunk);
+      if (error) throw error;
+      return data ?? [];
+    });
+    for (const row of rows) {
+      const id = typeof row?.id === "string" ? row.id.trim() : "";
+      const workspaceId =
+        typeof row?.default_workspace_id === "string" ? row.default_workspace_id.trim() : "";
+      if (id && workspaceId) defaults.set(id, workspaceId);
+    }
+  }
+  const out = new Map<string, string>();
+  for (const actorId of ids) {
+    const override =
+      typeof overrideByActorId[actorId] === "string" ? overrideByActorId[actorId].trim() : "";
+    const workspaceId = override || defaults.get(actorId) || "";
+    if (workspaceId) out.set(actorId, workspaceId);
+  }
+  return out;
+}
+
+function participantSeedRow(sessionId: string, actorId: string, workspaceId: string | null) {
+  const row: Record<string, string> = { session_id: sessionId, actor_id: actorId };
+  if (workspaceId) row.workspace_id = workspaceId;
+  return row;
+}
+
+/**
  * Archive sessions bound to a workspace via session_participants.workspace_id.
  *
  * This used to read `agent_runtimes`, which 20260803010000 dropped once
@@ -2709,7 +2752,18 @@ export function createSupabaseBusinessRepository(options) {
         ),
       );
       if (seedActorIds.length > 0) {
-        const rows = seedActorIds.map((actorId) => ({ session_id: id, actor_id: actorId }));
+        const overrideByActorId =
+          input.workspaceByActorId && typeof input.workspaceByActorId === "object"
+            ? input.workspaceByActorId
+            : {};
+        const workspaceByActor = await workspaceIdByAgentActor(
+          supabase,
+          seedActorIds,
+          overrideByActorId,
+        );
+        const rows = seedActorIds.map((actorId) =>
+          participantSeedRow(id, actorId, workspaceByActor.get(actorId) ?? null),
+        );
         const { error: partError } = await supabase
           .from("session_participants")
           .upsert(rows, { onConflict: "session_id,actor_id" });
@@ -2870,11 +2924,28 @@ export function createSupabaseBusinessRepository(options) {
         .select(SESSION_FULL_COLUMNS)
         .single();
       if (error) throw error;
-      // Bootstrap primary agent as participant.
+      // Bootstrap primary agent as participant, with the folder it will run
+      // in. Without this the desktop file tree has nothing to adopt and shows
+      // "Agent 尚未启动" even after the cron turn has already replied.
+      const overrideByActorId: Record<string, string> = {};
+      if (typeof input.workspaceId === "string" && input.workspaceId.trim()) {
+        overrideByActorId[input.primaryAgentActorId] = input.workspaceId.trim();
+      }
+      const workspaceByActor = await workspaceIdByAgentActor(
+        supabase,
+        [input.primaryAgentActorId],
+        overrideByActorId,
+      );
       const { error: partError } = await supabase
         .from("session_participants")
         .upsert(
-          [{ session_id: id, actor_id: input.primaryAgentActorId }],
+          [
+            participantSeedRow(
+              id,
+              input.primaryAgentActorId,
+              workspaceByActor.get(input.primaryAgentActorId) ?? null,
+            ),
+          ],
           { onConflict: "session_id,actor_id" },
         );
       if (partError) throw partError;

--- a/services/fc/test/supabase-repo.test.ts
+++ b/services/fc/test/supabase-repo.test.ts
@@ -1464,6 +1464,8 @@ function appsSupabase({ seed = {}, actorRow = { id: "actor-app-1" }, calls = [] 
     // resolveTeamOrgId reads this; unseeded it yields no row, i.e. "team has
     // no org", which is what most apps tests want.
     teams: [...(seed.teams ?? [])],
+    agents: [...(seed.agents ?? [])],
+    session_participants: [...(seed.session_participants ?? [])],
   };
   return {
     auth: appsAuth(),
@@ -3143,6 +3145,98 @@ test("createSession returns 403 when the caller is not a member of the team", as
     () => repo.createSession({ id: "sess-x", teamId: "team-1", title: "Nope" }),
     (err: any) => err?.statusCode === 403,
   );
+});
+
+function participantUpsertRows(calls: any[]) {
+  return calls
+    .filter((c) => c.table === "session_participants" && c.op === "upsert")
+    .flatMap((c) => (Array.isArray(c.row) ? c.row : [c.row]));
+}
+
+test("createSession stamps the agent's default_workspace_id on the agent seat, not the member", async () => {
+  const calls: any[] = [];
+  const supabase = appsSupabase({
+    actorRow: { id: "actor-app-1", actor_type: "member" },
+    calls,
+    seed: {
+      agents: [{ id: "agent-1", default_workspace_id: "ws-default" }],
+    },
+  });
+  const repo = appsRepo(supabase);
+  await repo.createSession({
+    id: "sess-ws-1",
+    teamId: "team-1",
+    title: "Chat",
+    additionalActorIds: ["agent-1"],
+  });
+  const rows = participantUpsertRows(calls);
+  const agentRow = rows.find((r) => r.actor_id === "agent-1");
+  const memberRow = rows.find((r) => r.actor_id === "actor-app-1");
+  assert.equal(agentRow?.workspace_id, "ws-default");
+  assert.equal(memberRow?.workspace_id, undefined);
+});
+
+test("createSession honors workspaceByActorId over the agent default", async () => {
+  const calls: any[] = [];
+  const supabase = appsSupabase({
+    actorRow: { id: "actor-app-1", actor_type: "member" },
+    calls,
+    seed: {
+      agents: [{ id: "agent-1", default_workspace_id: "ws-default" }],
+    },
+  });
+  const repo = appsRepo(supabase);
+  await repo.createSession({
+    id: "sess-ws-2",
+    teamId: "team-1",
+    title: "Chat",
+    additionalActorIds: ["agent-1"],
+    workspaceByActorId: { "agent-1": "ws-picked" },
+  });
+  const rows = participantUpsertRows(calls);
+  const agentRow = rows.find((r) => r.actor_id === "agent-1");
+  assert.equal(agentRow?.workspace_id, "ws-picked");
+});
+
+test("createCronSession stamps the primary agent's default_workspace_id", async () => {
+  const calls: any[] = [];
+  const supabase = appsSupabase({
+    actorRow: { id: "actor-app-1", actor_type: "member" },
+    calls,
+    seed: {
+      agents: [{ id: "agent-1", default_workspace_id: "ws-cron" }],
+    },
+  });
+  const repo = appsRepo(supabase);
+  await repo.createCronSession({
+    teamId: "team-1",
+    primaryAgentActorId: "agent-1",
+    title: "Cron: daily",
+  });
+  const rows = participantUpsertRows(calls);
+  const agentRow = rows.find((r) => r.actor_id === "agent-1");
+  assert.equal(agentRow?.workspace_id, "ws-cron");
+});
+
+test("createCronSession uses the caller workspaceId when provided", async () => {
+  const calls: any[] = [];
+  const supabase = appsSupabase({
+    actorRow: { id: "actor-app-1", actor_type: "member" },
+    calls,
+    seed: {
+      agents: [{ id: "agent-1", default_workspace_id: "ws-cron" }],
+    },
+  });
+  const repo = appsRepo(supabase);
+  await repo.createCronSession({
+    teamId: "team-1",
+    primaryAgentActorId: "agent-1",
+    title: "Cron: scoped",
+    workspaceId: "ws-job",
+  });
+  const rows = participantUpsertRows(calls);
+  const agentRow = rows.find((r) => r.actor_id === "agent-1");
+  assert.equal(agentRow?.workspace_id, "ws-job");
 });
 
 // --- App data browser -------------------------------------------------------


### PR DESCRIPTION
## Description

Fixes #1364.

New sessions (cron, 新会话 dialog, and composer quick-create) inserted `session_participants` without `workspace_id`. The desktop file pane treats that as “Agent 尚未启动” even after the agent has already replied.

This stamps `agents.default_workspace_id` on agent seats at create. Desktop callers that already picked a folder (dialog) or are sitting in one (quick-create) send `workspaceByActorId` so the stamp matches the folder the runtime will use. Member seats stay unbound.

Existing unbound sessions are left as-is (no backfill).

### vs issue #1364

Same diagnosis: ADR-0005 moved the **read** of `session_participants.workspace_id`, but create never wrote it. `bindingsFromRuntimes` then always skipped, and regular chats had no `session_viewer_workspace` row either.

This PR writes at **insert** instead of the issue’s suggested `PATCH …/participants/:actorId/workspace` after `runtimeStart`. Create-time stamp is enough for the issue’s reproduce path (新建普通聊天会话). Not in this PR:

- PATCH-after-start (join later / change folder after create)
- `model` column (issue noted it may be the same hole)
- backfill of already-created rows

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Test plan

- [ ] Create a new session with the local agent via composer send (quick-create). File pane should show the current window folder, not “Agent 尚未启动”.
- [ ] Create a session from 新会话 dialog, pick a non-default folder. File pane should show that folder.
- [ ] Let a cron job create a new session. After the agent replies, opening it should show the agent’s default workspace (not the empty-state copy).
- [ ] Member-only seats stay unbound (no workspace_id on human participants).
