### PR TITLE
fix(apps): 选本地目录建应用时，不是 git 仓库就初始化一个，而不是 422

### DIFF
--- a/apps/daemon/src/http/apps.rs
+++ b/apps/daemon/src/http/apps.rs
@@ -823,12 +823,42 @@ pub async fn inspect_dir(
     Ok(Json(probe))
 }
 
-/// `POST /v1/apps/:appId/bind-workdir` — point an app at a checkout that is
-/// already here, without touching a single file.
+/// Make `path` something an app can be bound to: an existing directory that is
+/// a git repository, initialising one when it is not.
+///
+/// An app's directory has to be a git directory — nothing deploys from
+/// anything else. It used to be *refused* at this point, which put a 422 in
+/// front of the seed that would have made it one. `init_if_needed` is a no-op on
+/// a repo (it asks `rev-parse`, so a worktree or a submodule whose `.git` is a
+/// file counts too), and `git init` in a folder of loose files adds a `.git/`
+/// and touches nothing else.
+///
+/// Sync, and separate from the handler, so it can be tested on a tempdir
+/// without standing up the HTTP state.
+fn prepare_bind_dir(path: &std::path::Path) -> Result<(), HttpError> {
+    if !path.is_dir() {
+        return Err(HttpError::validation(format!(
+            "not a directory: {}",
+            path.display()
+        )));
+    }
+    crate::sync::app_git::init_if_needed(path)
+        .map_err(|e| HttpError::internal(format!("could not initialise a git repository: {e}")))
+}
+
+/// `POST /v1/apps/:appId/bind-workdir` — point an app at a directory that is
+/// already here, without moving it.
 ///
 /// Deliberately not [`move_app_workdir`]: that one relocates the whole tree,
-/// which is exactly wrong for "I already have this repo, use it where it is".
+/// which is exactly wrong for "I already have this folder, use it where it is".
 /// A user who picks their own project directory expects it to stay put.
+///
+/// A folder that is not yet a git repository is initialised rather than
+/// refused. The create flow promises exactly that (`sourceLocalWillInit`), and
+/// the seed that follows — [`crate::sync::app_seed::adopt_app_repo`] — already
+/// knows how to take a fresh repo from there: default `.gitignore`, first
+/// commit, push. `git init` is the only thing it cannot do from outside, because
+/// this handler runs first and used to stop the flow before seed was reached.
 pub async fn bind_app_workdir(
     principal: Principal,
     State(_state): State<HttpState>,
@@ -849,21 +879,11 @@ pub async fn bind_app_workdir(
     if !path.is_absolute() {
         return Err(HttpError::validation("workdir must be an absolute path"));
     }
-    if !path.is_dir() {
-        return Err(HttpError::validation(format!(
-            "not a directory: {}",
-            path.display()
-        )));
-    }
-    // The requirement is a *git* directory, and checking it here is what turns
-    // "nothing deploys and no one knows why" into a message at the moment of
-    // choosing. `rev-parse` rather than a `.git` stat: that also accepts a
-    // worktree or a submodule, whose `.git` is a file.
-    if !crate::sync::app_git::is_git_repo(&path) {
-        return Err(HttpError::validation(format!(
-            "not a git repository: {}",
-            path.display()
-        )));
+    {
+        let check = path.clone();
+        tokio::task::spawn_blocking(move || prepare_bind_dir(&check))
+            .await
+            .map_err(|e| HttpError::internal(format!("git init task panicked: {e}")))??;
     }
 
     let team_id = body.team_id.clone();
@@ -1137,6 +1157,57 @@ mod tests {
     // `super` here is this module, not `http` — `errors` only resolves from the
     // crate root.
     use crate::http::errors::ErrorCode;
+
+    #[test]
+    fn binding_a_plain_folder_initialises_it_instead_of_refusing() {
+        // The create flow says "we will initialise one" for a folder that is
+        // not a repo, and the seed after this knows how to publish a fresh
+        // one. This step used to 422 first, so it never got the chance.
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(tmp.path().join("app.py"), "print('hi')\n").unwrap();
+        assert!(!crate::sync::app_git::is_git_repo(tmp.path()));
+
+        prepare_bind_dir(tmp.path()).expect("a plain folder must be bindable");
+
+        assert!(crate::sync::app_git::is_git_repo(tmp.path()));
+        // Initialised, not committed: the first commit is the seed's to make,
+        // after it has written a default .gitignore.
+        assert!(!crate::sync::app_git::has_commits(tmp.path()));
+        assert_eq!(
+            std::fs::read_to_string(tmp.path().join("app.py")).unwrap(),
+            "print('hi')\n",
+            "the user's files are left exactly as they were"
+        );
+    }
+
+    #[test]
+    fn binding_an_existing_repo_leaves_it_alone() {
+        let tmp = tempfile::tempdir().unwrap();
+        crate::sync::app_git::init_if_needed(tmp.path()).unwrap();
+        let head_before = std::fs::read_to_string(tmp.path().join(".git/HEAD")).unwrap();
+
+        prepare_bind_dir(tmp.path()).unwrap();
+
+        assert_eq!(
+            std::fs::read_to_string(tmp.path().join(".git/HEAD")).unwrap(),
+            head_before
+        );
+    }
+
+    #[test]
+    fn binding_something_that_is_not_a_directory_is_still_refused() {
+        let tmp = tempfile::tempdir().unwrap();
+        let file = tmp.path().join("not-a-dir.txt");
+        std::fs::write(&file, "x").unwrap();
+        let err = prepare_bind_dir(&file).unwrap_err();
+        assert!(matches!(err.code, ErrorCode::ValidationFailed));
+
+        let missing = tmp.path().join("nowhere");
+        let err = prepare_bind_dir(&missing).unwrap_err();
+        assert!(matches!(err.code, ErrorCode::ValidationFailed));
+        // And nothing was created at the missing path on the way to refusing.
+        assert!(!missing.exists());
+    }
 
     #[test]
     fn body_deserializes_camel_case() {

--- a/packages/app/src/lib/daemon/__tests__/daemon-local-client-bind-workdir.test.ts
+++ b/packages/app/src/lib/daemon/__tests__/daemon-local-client-bind-workdir.test.ts
@@ -1,0 +1,65 @@
+/**
+ * The daemon answers failures as RFC 7807 JSON. Passing that body through as
+ * the error message is how a user was shown
+ * `{"type":"https://teamclu/errors/validation_failed","title":…}` in a toast
+ * titled 无法使用这个目录. The message is the `detail`.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+const h = vi.hoisted(() => ({ body: '', status: 422 }))
+
+vi.mock('@/lib/utils', () => ({ isTauri: () => true }))
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: vi.fn(async (cmd: string) =>
+    cmd === 'get_daemon_http_info' ? { base_url: 'http://127.0.0.1:1111', root_token: 'root' } : null,
+  ),
+}))
+
+import { bindDaemonAppWorkdir, invalidateDaemonConnection } from '@/lib/daemon/daemon-local-client'
+
+beforeEach(() => {
+  invalidateDaemonConnection()
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (url: string) => {
+      if (String(url).endsWith('/v1/auth/exchange')) {
+        return { ok: true, status: 200, json: async () => ({ token: 't', expires_in: 3600 }) } as unknown as Response
+      }
+      return { ok: false, status: h.status, text: async () => h.body } as unknown as Response
+    }),
+  )
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('bindDaemonAppWorkdir', () => {
+  it('throws the problem detail, not the JSON body it arrived in', async () => {
+    h.status = 422
+    h.body = JSON.stringify({
+      type: 'https://teamclu/errors/validation_failed',
+      title: 'Validation failed',
+      status: 422,
+      detail: 'not a directory: /nowhere',
+      code: 'validation_failed',
+    })
+    await expect(bindDaemonAppWorkdir('app-1', 'team-1', '/nowhere')).rejects.toThrow(
+      /^not a directory: \/nowhere$/,
+    )
+  })
+
+  it('still says something when the body is not JSON at all', async () => {
+    h.status = 500
+    h.body = 'upstream exploded'
+    await expect(bindDaemonAppWorkdir('app-1', 'team-1', '/x')).rejects.toThrow('upstream exploded')
+  })
+
+  it('falls back to its own sentence on an empty body', async () => {
+    h.status = 500
+    h.body = ''
+    await expect(bindDaemonAppWorkdir('app-1', 'team-1', '/x')).rejects.toThrow(
+      'could not bind the app to that directory',
+    )
+  })
+})

--- a/packages/app/src/lib/daemon/daemon-local-client.ts
+++ b/packages/app/src/lib/daemon/daemon-local-client.ts
@@ -1201,11 +1201,15 @@ interface BindAppWorkdirResult {
 }
 
 /**
- * Point an app at a git checkout that already exists on this machine.
+ * Point an app at a directory that already exists on this machine.
  *
- * Nothing is moved or written — unlike {@link moveDaemonAppWorkdir}, which
- * relocates the tree. Throws with the daemon's own reason so the picker can say
- * "not a git repository" at the moment of choosing rather than failing later.
+ * Nothing is moved — unlike {@link moveDaemonAppWorkdir}, which relocates the
+ * tree. A folder that is not yet a git repository gets a `git init` from the
+ * daemon; the seed that follows publishes it.
+ *
+ * Throws with the daemon's own `detail`, not the response body. The body is
+ * RFC 7807 JSON, and passing it through verbatim is how a user was once shown
+ * `{"type":"https://teamclu/errors/validation_failed","title":…}` in a toast.
  */
 export async function bindDaemonAppWorkdir(
   appId: string,
@@ -1217,7 +1221,8 @@ export async function bindDaemonAppWorkdir(
     { method: 'POST', body: JSON.stringify({ teamId, workdir }) },
   )
   if (!result.ok) {
-    throw new Error(result.error ?? 'could not bind the app to that directory')
+    const { detail } = problemDetailFromErrorBody(result.error ?? '')
+    throw new Error(detail || 'could not bind the app to that directory')
   }
   return {
     workdir: result.data.workdir,


### PR DESCRIPTION
## 症状

新建应用 →「使用本地目录」选一个普通文件夹，弹出「无法使用这个目录」，内容是一整段原始 JSON：

```
{"type":"https://teamclu/errors/validation_failed","title":"Validation failed","status":422,
 "detail":"not a git repository: /Volumes/openbeta/workspace/banana-hire","code":"validation_failed"}
```

## 原因

前端早就改成不拒绝非 git 目录了。`CreateAppView` 里明确写着：

> 这个目录还不是 git 仓库，我们会初始化一个、写一份 .gitignore（node_modules、.env 等）后把内容推上去。

seed 那边的 `adopt_app_repo`（`apps/daemon/src/sync/app_seed.rs`）也确实实现了这一整套：`git init`、默认 `.gitignore`、首次提交、推送。

但 `POST /v1/apps/:appId/bind-workdir` 还留着旧的 `is_git_repo` 拒绝，而创建流程里它跑在 seed **之前**（`apps-store.ts` 的 `create` 先 bind 再 seed）。所以 422 挡在了本该初始化它的那一步前面，初始化永远轮不到。

## 改动

**daemon** —— `bind_app_workdir` 遇到非 git 目录就 `init_if_needed`，不再拒绝：
- 对已有仓库是 no-op（它用 `rev-parse` 判断，worktree / submodule 这种 `.git` 是文件的也照样认）
- 在一堆散文件里 `git init` 只加一个 `.git/`，不碰用户文件
- **首次提交仍然留给 seed**，在它写完 `.gitignore` 之后做 —— 否则 `node_modules`、`.env` 会被一起提交
- 不是目录的照旧 422

校验和初始化抽成同步的 `prepare_bind_dir`，好在 tempdir 上测，不用搭 HTTP state（和同文件里 `local_apps_in` 一样的做法）。

**前端** —— `bindDaemonAppWorkdir` 原样把 daemon 的 RFC 7807 响应体当错误信息抛出，toast 里才会是那一整段 JSON。同文件里现成的 `problemDetailFromErrorBody` 别的调用方都在用，这里没用上。

`bind-workdir` 只有两个调用方，都在创建流程里；另一个（有远端的本地仓库）永远是 git 仓库，init 对它是 no-op。

## 验证

- daemon：`binding_a_plain_folder_initialises_it_instead_of_refusing`（初始化了、没提交、文件原样）、`binding_an_existing_repo_leaves_it_alone`、`binding_something_that_is_not_a_directory_is_still_refused`（且没在不存在的路径上建出东西）
- 前端：抛出的是 `detail` 而不是 JSON；body 不是 JSON 时照样有信息；空 body 时回落到自己的文案
- `pnpm typecheck` 干净；apps 相关前端测试 178 条全绿

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Gs7sQhSPLWPAiBp6aA66p
