### PR TITLE
fix(workspace): 不再往 workspace 里建 teamclu-team 链接；team-documents / team-knowledge 标成软链并置顶

### DIFF
--- a/apps/daemon/src/config/workspace_link.rs
+++ b/apps/daemon/src/config/workspace_link.rs
@@ -1,5 +1,13 @@
-//! Creates and repairs the `teamclu-team` entry inside a workspace so it
-//! points at the team's single global copy (see [`super::global_team_store`]).
+//! Creates and repairs the links that surface a team's synced content inside a
+//! workspace: `team-knowledge` and `team-documents`, both pointing into the
+//! team's single global copy (see [`super::global_team_store`]).
+//!
+//! There used to be a third, `teamclu-team`, pointing at `shared/teamclu-team`.
+//! Everything that lived behind it has moved — knowledge and documents to
+//! `shared/team-sync` (the two links above), `.mcp` and `_secrets` to the Cloud
+//! API, skills to the registry — so it pointed at an empty scaffold that still
+//! sat in every workspace's file tree. It is no longer created, and a stale
+//! symlink by that name is removed.
 //!
 //! Unix/macOS use a symlink. Windows tries a directory junction, then falls
 //! back to "no link, read the global dir directly" so opening a workspace
@@ -19,16 +27,19 @@ pub enum LinkKind {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum LinkStatus {
-    /// `teamclu-team` is a working link to the global dir.
+    /// The link is in place and resolves.
     Linked(LinkKind),
     /// Could not create a link; readers must use the global dir directly.
     Fallback,
-    /// A legacy real dir with un-synced changes was left untouched.
-    LegacyDirRetained { reason: String },
 }
 
-/// Ensure `<workspace_root>/teamclu-team` points at the global team dir for
-/// `team_id`. Idempotent. Never errors — returns the resulting status.
+/// Surface `team_id`'s synced roots in a workspace: `team-knowledge` and
+/// `team-documents`. Idempotent. Never errors — returns the status of the
+/// knowledge link, the one every caller has always meant by "linked".
+///
+/// A stale `teamclu-team` **symlink** from an older build is removed on the
+/// way. A real directory by that name is left exactly as it is: it predates the
+/// global store, and nothing here can prove its contents were ever synced.
 pub fn ensure_workspace_link(workspace_root: &Path, team_id: &str) -> LinkStatus {
     let target = match global_team_store::ensure_initialized(team_id) {
         Ok(t) => t,
@@ -37,59 +48,45 @@ pub fn ensure_workspace_link(workspace_root: &Path, team_id: &str) -> LinkStatus
             return LinkStatus::Fallback;
         }
     };
-    let link = workspace_root.join(TEAM_LINK_NAME);
+    let legacy_link = workspace_root.join(TEAM_LINK_NAME);
 
-    // Never link a "workspace" whose `teamclu-team` path IS the team's own
-    // global store dir (`~/.amuxd/teams/<id>/teamclu-team`). That happens when
-    // a bogus workspace at `~/.amuxd/teams/<id>` gets registered (such entries
-    // have appeared in workspaces.toml, synced from the cloud). With link ==
-    // target the code below would treat the global real dir as a "legacy dir",
-    // `remove_dir_all` it (destroying the synced content), then symlink it to
-    // itself — a self-referential link that makes every `cd` into it fail with
-    // ELOOP. Clean up any such self-symlink and refuse to (re)create it.
-    //
-    // This runs BEFORE `ensure_team_knowledge_link`. Such a "workspace" is the
-    // team's `shared/` dir, so linking knowledge from it plants a
-    // `shared/team-knowledge` symlink inside the sync content root — the exact
-    // class of thing this guard exists to keep out.
-    if link == target {
-        if std::fs::symlink_metadata(&link)
-            .map(|m| m.file_type().is_symlink())
-            .unwrap_or(false)
-        {
-            let _ = remove_link(&link);
+    // Never touch a "workspace" that IS the team's own `shared/` dir. That
+    // happens when a bogus workspace at `~/.amuxd/teams/<id>/shared` gets
+    // registered (such entries have appeared in workspaces.toml, synced from the
+    // cloud): its `teamclu-team` is the global store dir itself, and linking the
+    // synced roots from it would plant `shared/team-knowledge` inside the sync
+    // content root — which the scanner would then walk. A self-symlink left by
+    // an older build is cleaned up.
+    if legacy_link == target {
+        if is_symlink(&legacy_link) {
+            let _ = remove_link(&legacy_link);
         }
         tracing::warn!(
             team_id,
             workspace = %workspace_root.display(),
-            "skipping team link: workspace path is the team's global dir (would self-symlink)"
+            "skipping team links: workspace path is the team's own shared dir"
         );
         return LinkStatus::Fallback;
     }
 
-    // Surface the team knowledge dir in the workspace too. Runs on every link
-    // so opening/switching a workspace always re-creates a stale link.
-    let _ = ensure_team_knowledge_link(workspace_root, team_id);
-    let _ = ensure_team_documents_link(workspace_root, team_id);
-
-    // Already a symlink: repoint if stale or dangling, else done.
-    if let Ok(meta) = std::fs::symlink_metadata(&link) {
-        if meta.file_type().is_symlink() {
-            match std::fs::read_link(&link) {
-                Ok(dest) if dest == target && link.is_dir() => {
-                    return LinkStatus::Linked(LinkKind::Symlink);
-                }
-                _ => {
-                    let _ = remove_link(&link);
-                }
-            }
-        } else if meta.is_dir() {
-            // Legacy real dir → migration (Task 4 fills this in).
-            return migrate_legacy_dir(&link, &target);
+    if is_symlink(&legacy_link) {
+        if let Err(e) = remove_link(&legacy_link) {
+            tracing::debug!(
+                workspace = %workspace_root.display(),
+                "stale teamclu-team link not removed: {e}"
+            );
         }
     }
 
-    create_link(&link, &target)
+    let _ = ensure_team_documents_link(workspace_root, team_id);
+    ensure_team_knowledge_link(workspace_root, team_id)
+}
+
+/// A symlink or junction — never a real directory.
+fn is_symlink(path: &Path) -> bool {
+    std::fs::symlink_metadata(path)
+        .map(|m| m.file_type().is_symlink())
+        .unwrap_or(false)
 }
 
 /// Platform link creation with fallback chain.
@@ -143,57 +140,6 @@ fn junction_create(link: &Path, target: &Path) -> std::io::Result<()> {
             "mklink /J failed",
         ))
     }
-}
-
-/// A legacy real `teamclu-team/` dir was found. If it has no un-synced
-/// changes, consolidate it into the global dir and replace it with a symlink.
-/// If it is dirty, leave it untouched and report it for the UI to resolve.
-fn migrate_legacy_dir(link: &Path, target: &Path) -> LinkStatus {
-    if !global_team_store::is_scaffold_only(target) {
-        // Global is already populated, so we cannot prove this directory's
-        // contents are already synced upstream. Removing it would risk
-        // discarding unsynced edits — retain instead and let the UI surface it
-        // for the user to resolve.
-        return LinkStatus::LegacyDirRetained {
-            reason: "populated global; cannot verify legacy dir is synced".into(),
-        };
-    }
-
-    // First workspace wins: seed the global copy from the legacy content.
-    if let Err(e) = copy_dir_contents(link, target) {
-        tracing::warn!("seed global from legacy {} failed: {e}", link.display());
-        return LinkStatus::LegacyDirRetained {
-            reason: format!("seed-global failed: {e}"),
-        };
-    }
-
-    // Safe to replace: we just seeded this content into an empty global.
-    if let Err(e) = std::fs::remove_dir_all(link) {
-        tracing::warn!("remove legacy dir {} failed: {e}", link.display());
-        return LinkStatus::LegacyDirRetained {
-            reason: format!("remove legacy dir failed: {e}"),
-        };
-    }
-    create_link(link, target)
-}
-
-/// Recursively copy everything under `from` into `to`.
-fn copy_dir_contents(from: &Path, to: &Path) -> std::io::Result<()> {
-    for entry in std::fs::read_dir(from)? {
-        let entry = entry?;
-        let src = entry.path();
-        let dst = to.join(entry.file_name());
-        if entry.file_type()?.is_dir() {
-            std::fs::create_dir_all(&dst)?;
-            copy_dir_contents(&src, &dst)?;
-        } else {
-            if let Some(parent) = dst.parent() {
-                std::fs::create_dir_all(parent)?;
-            }
-            std::fs::copy(&src, &dst)?;
-        }
-    }
-    Ok(())
 }
 
 /// Workspace link name surfacing the team's synced knowledge dir
@@ -283,42 +229,66 @@ pub fn ensure_team_documents_link(workspace_root: &Path, team_id: &str) -> LinkS
 }
 
 /// Workspace-relative variant for call sites with no `team_id` (notably
-/// `prepare_workspace`, which runs on every workspace open/switch). Derives the
-/// team's synced roots by following the workspace's `teamclu-team` link.
+/// `prepare_workspace`, which runs on every workspace open/switch). Finds the
+/// team's synced root by following a link the workspace already has.
 ///
-/// The derived path is validated to sit under this build's teams dir before it
-/// is used. `teamclu-team` can be stale — `ensure_workspace_link` has a test
-/// devoted to repointing one, and this runs before any sweep has had the
-/// chance — and an unvalidated `read_link` result would point `team-knowledge`
-/// at an arbitrary directory that no sync engine owns.
+/// Asked in order: `team-knowledge`, `team-documents`, then the legacy
+/// `teamclu-team`. The first two point straight into `shared/team-sync/`; the
+/// last is only there for a workspace last touched by an older build, and is
+/// removed once the synced roots are linked from it.
+///
+/// Whatever is derived is validated before it is used: it has to sit under this
+/// build's teams dir and be the `team-sync` directory. Any of these links can be
+/// stale — this runs before any sweep has had the chance — and an unvalidated
+/// `read_link` result would point `team-knowledge` at an arbitrary directory
+/// that no sync engine owns.
 pub fn ensure_team_knowledge_link_from_workspace(workspace_root: &Path) -> LinkStatus {
-    let Ok(team_repo) = std::fs::read_link(workspace_root.join(TEAM_LINK_NAME)) else {
+    let Some(sync_root) = sync_root_from_workspace_links(workspace_root) else {
         return LinkStatus::Fallback;
     };
-    // `teamclu-team` -> `<teams>/<id>/shared/teamclu-team`. The synced tree is
-    // its sibling `team-sync/`, NOT `shared/` itself — that separation is what
-    // keeps this very directory out of the tree the scanner walks.
-    let Some(shared) = team_repo.parent() else {
-        return LinkStatus::Fallback;
-    };
-    if !shared.starts_with(super::layout::teams_dir()) {
+    if !sync_root.starts_with(super::layout::teams_dir())
+        || sync_root.file_name() != Some(std::ffi::OsStr::new(global_team_store::SYNC_ROOT_DIR))
+    {
         tracing::warn!(
             workspace = %workspace_root.display(),
-            target = %team_repo.display(),
-            "team-knowledge link skipped: teamclu-team points outside the teams dir"
+            target = %sync_root.display(),
+            "team links skipped: existing link points outside the teams sync root"
         );
         return LinkStatus::Fallback;
     }
-    let sync_root = shared.join(global_team_store::SYNC_ROOT_DIR);
     // Both roots, so a workspace reached this way is not missing one of them.
     let _ = ensure_link_to(
         &workspace_root.join(TEAM_DOCUMENTS_LINK_NAME),
         &sync_root.join("documents"),
     );
-    ensure_link_to(
+    let status = ensure_link_to(
         &workspace_root.join(TEAM_KNOWLEDGE_LINK_NAME),
         &sync_root.join("knowledge"),
-    )
+    );
+    // Only now, with the synced roots in place: until then the legacy link may
+    // have been the only thing to derive them from.
+    if matches!(status, LinkStatus::Linked(_)) {
+        let legacy = workspace_root.join(TEAM_LINK_NAME);
+        if is_symlink(&legacy) {
+            let _ = remove_link(&legacy);
+        }
+    }
+    status
+}
+
+/// The `shared/team-sync` dir a workspace's existing links lead to, if any.
+fn sync_root_from_workspace_links(workspace_root: &Path) -> Option<std::path::PathBuf> {
+    for name in [TEAM_KNOWLEDGE_LINK_NAME, TEAM_DOCUMENTS_LINK_NAME] {
+        if let Ok(dest) = std::fs::read_link(workspace_root.join(name)) {
+            if let Some(root) = dest.parent() {
+                return Some(root.to_path_buf());
+            }
+        }
+    }
+    // `teamclu-team` -> `<teams>/<id>/shared/teamclu-team`. The synced tree is
+    // its sibling `team-sync/`, NOT `shared/` itself.
+    let legacy = std::fs::read_link(workspace_root.join(TEAM_LINK_NAME)).ok()?;
+    Some(legacy.parent()?.join(global_team_store::SYNC_ROOT_DIR))
 }
 
 #[cfg(test)]
@@ -338,20 +308,24 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
-    fn creates_symlink_to_global_dir() {
+    fn links_the_synced_roots_and_not_teamclu_team() {
         let (_home, _guard) = temp_home();
         let ws = tempfile::tempdir().unwrap();
         let status = ensure_workspace_link(ws.path(), "team-1");
         assert_eq!(status, LinkStatus::Linked(LinkKind::Symlink));
-        let link = ws.path().join("teamclu-team");
-        assert!(std::fs::symlink_metadata(&link)
-            .unwrap()
-            .file_type()
-            .is_symlink());
+
+        let sync_root = global_team_store::sync_content_root("team-1");
         assert_eq!(
-            std::fs::read_link(&link).unwrap(),
-            global_team_store::global_team_dir("team-1")
+            std::fs::read_link(ws.path().join(TEAM_KNOWLEDGE_LINK_NAME)).unwrap(),
+            sync_root.join("knowledge")
         );
+        assert_eq!(
+            std::fs::read_link(ws.path().join(TEAM_DOCUMENTS_LINK_NAME)).unwrap(),
+            sync_root.join("documents")
+        );
+        // Nothing lives behind it any more, and it sat at the top of every
+        // workspace's file tree.
+        assert!(std::fs::symlink_metadata(ws.path().join(TEAM_LINK_NAME)).is_err());
     }
 
     #[cfg(unix)]
@@ -372,19 +346,22 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
-    fn repoints_stale_symlink() {
+    fn removes_a_teamclu_team_link_left_by_an_older_build() {
         let (_home, _guard) = temp_home();
         let ws = tempfile::tempdir().unwrap();
-        let link = ws.path().join("teamclu-team");
-        std::os::unix::fs::symlink("/nonexistent/old", &link).unwrap();
+        let link = ws.path().join(TEAM_LINK_NAME);
+        // Both shapes an older build leaves: pointing at the real store, and
+        // dangling.
+        std::os::unix::fs::symlink(global_team_store::global_team_dir("team-1"), &link).unwrap();
         assert_eq!(
             ensure_workspace_link(ws.path(), "team-1"),
             LinkStatus::Linked(LinkKind::Symlink)
         );
-        assert_eq!(
-            std::fs::read_link(&link).unwrap(),
-            global_team_store::global_team_dir("team-1")
-        );
+        assert!(std::fs::symlink_metadata(&link).is_err());
+
+        std::os::unix::fs::symlink("/nonexistent/old", &link).unwrap();
+        ensure_workspace_link(ws.path(), "team-1");
+        assert!(std::fs::symlink_metadata(&link).is_err());
     }
 
     #[cfg(unix)]
@@ -424,6 +401,7 @@ mod tests {
             std::fs::symlink_metadata(ws_root.join(TEAM_KNOWLEDGE_LINK_NAME)).is_err(),
             "self-symlink guard must also refuse the team-knowledge link"
         );
+        assert!(std::fs::symlink_metadata(ws_root.join(TEAM_DOCUMENTS_LINK_NAME)).is_err());
     }
 
     #[cfg(unix)]
@@ -516,59 +494,82 @@ mod tests {
             std::fs::read_link(ws.path().join(TEAM_KNOWLEDGE_LINK_NAME)).unwrap(),
             global_team_store::sync_content_root("team-fw").join("knowledge")
         );
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn migrates_clean_legacy_dir_into_empty_global() {
-        let (_home, _guard) = temp_home();
-        let ws = tempfile::tempdir().unwrap();
-        let legacy = ws.path().join("teamclu-team");
-        std::fs::create_dir_all(legacy.join("knowledge")).unwrap();
-        std::fs::write(legacy.join("knowledge/a.md"), b"hello").unwrap();
-
-        let status = ensure_workspace_link(ws.path(), "team-mig");
-        assert_eq!(status, LinkStatus::Linked(LinkKind::Symlink));
-        // Content moved into the global dir.
-        let global = global_team_store::global_team_dir("team-mig");
         assert_eq!(
-            std::fs::read(global.join("knowledge/a.md")).unwrap(),
-            b"hello"
+            std::fs::read_link(ws.path().join(TEAM_DOCUMENTS_LINK_NAME)).unwrap(),
+            global_team_store::sync_content_root("team-fw").join("documents")
         );
-        // Workspace entry is now a symlink, not a real dir.
-        assert!(std::fs::symlink_metadata(&legacy)
-            .unwrap()
-            .file_type()
-            .is_symlink());
+        // Used once to find the synced roots, then gone.
+        assert!(std::fs::symlink_metadata(ws.path().join(TEAM_LINK_NAME)).is_err());
     }
 
     #[cfg(unix)]
     #[test]
-    fn retains_legacy_dir_when_global_already_populated() {
+    fn from_workspace_repairs_from_team_knowledge_once_teamclu_team_is_gone() {
+        // The state every workspace is in after this change: no `teamclu-team`
+        // to derive anything from. The knowledge link has to be enough to put a
+        // missing documents link back.
         let (_home, _guard) = temp_home();
-        // Pre-populate the global dir for this team with real content.
-        let global = global_team_store::ensure_initialized("team-pop").unwrap();
-        std::fs::write(global.join("README.md"), b"already here").unwrap(); // populated team repo -> retain legacy
-
-        // A legacy dir with its own (possibly unsynced) content.
         let ws = tempfile::tempdir().unwrap();
-        let legacy = ws.path().join("teamclu-team");
+        global_team_store::ensure_initialized("team-k2").unwrap();
+        let sync_root = global_team_store::sync_content_root("team-k2");
+        std::os::unix::fs::symlink(sync_root.join("knowledge"), ws.path().join(TEAM_KNOWLEDGE_LINK_NAME))
+            .unwrap();
+
+        assert_eq!(
+            ensure_team_knowledge_link_from_workspace(ws.path()),
+            LinkStatus::Linked(LinkKind::Symlink)
+        );
+        assert_eq!(
+            std::fs::read_link(ws.path().join(TEAM_DOCUMENTS_LINK_NAME)).unwrap(),
+            sync_root.join("documents")
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn from_workspace_refuses_a_knowledge_link_that_is_not_under_team_sync() {
+        // Under the teams dir is not enough: a link to `<teams>/<id>/elsewhere/
+        // knowledge` would have documents linked to `elsewhere/documents`, which
+        // no sync engine owns.
+        let (_home, _guard) = temp_home();
+        let ws = tempfile::tempdir().unwrap();
+        let odd = crate::config::layout::teams_dir().join("team-x").join("elsewhere").join("knowledge");
+        std::fs::create_dir_all(&odd).unwrap();
+        std::os::unix::fs::symlink(&odd, ws.path().join(TEAM_KNOWLEDGE_LINK_NAME)).unwrap();
+
+        assert_eq!(
+            ensure_team_knowledge_link_from_workspace(ws.path()),
+            LinkStatus::Fallback
+        );
+        assert!(std::fs::symlink_metadata(ws.path().join(TEAM_DOCUMENTS_LINK_NAME)).is_err());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn a_real_teamclu_team_directory_is_never_touched() {
+        // It predates the global store. It used to be migrated into it and
+        // replaced with a link; now that no link is made, there is nothing to
+        // replace it with — and nothing here can prove its contents were ever
+        // synced, so it stays exactly as the user left it.
+        let (_home, _guard) = temp_home();
+        let ws = tempfile::tempdir().unwrap();
+        let legacy = ws.path().join(TEAM_LINK_NAME);
         std::fs::create_dir_all(legacy.join("knowledge")).unwrap();
         std::fs::write(legacy.join("knowledge/unsynced.md"), b"do not lose").unwrap();
 
-        let status = ensure_workspace_link(ws.path(), "team-pop");
-        match status {
-            LinkStatus::LegacyDirRetained { .. } => {}
-            other => panic!("expected LegacyDirRetained, got {other:?}"),
-        }
-        // Legacy content preserved, not deleted.
+        assert_eq!(
+            ensure_workspace_link(ws.path(), "team-real"),
+            LinkStatus::Linked(LinkKind::Symlink)
+        );
+        let meta = std::fs::symlink_metadata(&legacy).unwrap();
+        assert!(meta.is_dir() && !meta.file_type().is_symlink());
         assert_eq!(
             std::fs::read(legacy.join("knowledge/unsynced.md")).unwrap(),
             b"do not lose"
         );
-        assert!(!std::fs::symlink_metadata(&legacy)
-            .unwrap()
-            .file_type()
-            .is_symlink());
+        // Nor copied into the global store behind the user's back.
+        assert!(!global_team_store::global_team_dir("team-real")
+            .join("knowledge/unsynced.md")
+            .exists());
     }
 }

--- a/apps/daemon/src/daemon/server.rs
+++ b/apps/daemon/src/daemon/server.rs
@@ -3563,13 +3563,28 @@ pub(crate) mod tests {
         let ts = test_server_with_cloud_api(mock.clone());
         ts.server.sync_team_shared_dirs_for_known_workspaces().await;
 
+        // The workspace gets the team's synced roots. `teamclu-team` is no
+        // longer one of them — nothing lives behind it any more.
         assert!(
             existing
                 .path()
-                .join(crate::config::global_team_store::TEAM_LINK_NAME)
+                .join(crate::config::workspace_link::TEAM_KNOWLEDGE_LINK_NAME)
                 .exists(),
-            "existing on-disk path should get a teamclu-team link"
+            "existing on-disk path should get a team-knowledge link"
         );
+        assert!(
+            existing
+                .path()
+                .join(crate::config::workspace_link::TEAM_DOCUMENTS_LINK_NAME)
+                .exists(),
+            "existing on-disk path should get a team-documents link"
+        );
+        assert!(std::fs::symlink_metadata(
+            existing
+                .path()
+                .join(crate::config::global_team_store::TEAM_LINK_NAME)
+        )
+        .is_err());
     }
 
     #[cfg(unix)]
@@ -3597,23 +3612,38 @@ pub(crate) mod tests {
             "knowledge scaffold should exist under shared/, not under teamclu-team/"
         );
 
-        // Workspace exposes it via a teamclu-team symlink to that global dir.
-        let link = ws.path().join("teamclu-team");
-        let meta = std::fs::symlink_metadata(&link).unwrap();
-        assert!(
-            meta.file_type().is_symlink(),
-            "workspace entry should be a symlink"
+        // The workspace exposes the team's synced roots — and no longer a
+        // `teamclu-team` link to the empty global dir.
+        let knowledge = ws
+            .path()
+            .join(crate::config::workspace_link::TEAM_KNOWLEDGE_LINK_NAME);
+        let sync_root = crate::config::global_team_store::sync_content_root("team-ondemand");
+        assert!(std::fs::symlink_metadata(&knowledge)
+            .unwrap()
+            .file_type()
+            .is_symlink());
+        assert_eq!(
+            std::fs::read_link(&knowledge).unwrap(),
+            sync_root.join("knowledge")
         );
-        assert_eq!(std::fs::read_link(&link).unwrap(), global);
+        assert!(std::fs::symlink_metadata(ws.path().join("teamclu-team")).is_err());
 
         // Idempotent: a second call must not error or change the target.
         ensure_team_link("team-ondemand", ws_path);
-        assert_eq!(std::fs::read_link(&link).unwrap(), global);
+        assert_eq!(
+            std::fs::read_link(&knowledge).unwrap(),
+            sync_root.join("knowledge")
+        );
 
         // Empty team_id is a no-op (no stray dir/link).
         let ws2 = tempfile::tempdir().unwrap();
         ensure_team_link("", ws2.path().to_str().unwrap());
         assert!(std::fs::symlink_metadata(ws2.path().join("teamclu-team")).is_err());
+        assert!(std::fs::symlink_metadata(
+            ws2.path()
+                .join(crate::config::workspace_link::TEAM_KNOWLEDGE_LINK_NAME)
+        )
+        .is_err());
     }
 
     pub(crate) struct TestServer {

--- a/apps/daemon/src/http/team.rs
+++ b/apps/daemon/src/http/team.rs
@@ -40,8 +40,10 @@ pub struct LinkTeamWorkspaceRequest {
 #[derive(Debug, Serialize)]
 pub struct LinkTeamWorkspaceResponse {
     pub team_id: String,
-    /// Resulting link state: `symlink` | `junction` | `fallback` |
-    /// `legacy_retained` (mirrors `workspace_link::LinkStatus`).
+    /// Resulting link state: `symlink` | `junction` | `fallback` (mirrors
+    /// `workspace_link::LinkStatus`). `legacy_retained` is no longer sent: it
+    /// described migrating a real `teamclu-team` dir into a link, and that link
+    /// is no longer made.
     pub status: &'static str,
     /// `~/.amuxd/teams/<team_id>/teamclu-team`.
     pub global_dir: String,
@@ -52,7 +54,6 @@ fn status_str(status: &LinkStatus) -> &'static str {
         LinkStatus::Linked(LinkKind::Symlink) => "symlink",
         LinkStatus::Linked(LinkKind::Junction) => "junction",
         LinkStatus::Fallback => "fallback",
-        LinkStatus::LegacyDirRetained { .. } => "legacy_retained",
     }
 }
 
@@ -172,11 +173,5 @@ mod tests {
             "junction"
         );
         assert_eq!(status_str(&LinkStatus::Fallback), "fallback");
-        assert_eq!(
-            status_str(&LinkStatus::LegacyDirRetained {
-                reason: "non-empty".into(),
-            }),
-            "legacy_retained"
-        );
     }
 }

--- a/apps/daemon/src/runtime/supervisor.rs
+++ b/apps/daemon/src/runtime/supervisor.rs
@@ -732,15 +732,14 @@ fn ensure_inherent_skills_in_dir(skills_dir: &Path) -> Result<(), WorkspaceContr
     Ok(())
 }
 
-/// Rebuild `<workspace>/team-knowledge` on every workspace init, so a stale,
-/// dangling or missing link never survives one.
+/// Rebuild `<workspace>/team-knowledge` and `team-documents` on every workspace
+/// init, so a stale, dangling or missing link never survives one.
 ///
-/// Two attempts, in order. The workspace-derived one chains through this
-/// workspace's own `teamclu-team` link; when THAT link is the thing that went
-/// missing it can derive nothing, and the workspace was previously stuck
-/// without a knowledge link until something else re-linked the team. So fall
-/// back to the daemon's active team, which is where the knowledge dir lives
-/// anyway.
+/// Two attempts, in order. The workspace-derived one follows a link this
+/// workspace already has (either synced root, or a legacy `teamclu-team`);
+/// when there is none it can derive nothing, and the workspace was previously
+/// stuck without links until something else re-linked the team. So fall back
+/// to the daemon's active team, which is where the synced roots live anyway.
 ///
 /// The fallback only ever re-points at a directory that already exists: it is
 /// gated on the team's synced `knowledge/` dir being there, so it cannot
@@ -749,7 +748,8 @@ fn ensure_inherent_skills_in_dir(skills_dir: &Path) -> Result<(), WorkspaceContr
 /// same reason `ensure_team_link` does.
 fn ensure_workspace_knowledge_link(workspace_path: &Path) {
     use crate::config::workspace_link::{
-        ensure_team_knowledge_link, ensure_team_knowledge_link_from_workspace, LinkStatus,
+        ensure_team_documents_link, ensure_team_knowledge_link,
+        ensure_team_knowledge_link_from_workspace, LinkStatus,
     };
 
     let mut status = ensure_team_knowledge_link_from_workspace(workspace_path);
@@ -762,6 +762,11 @@ fn ensure_workspace_knowledge_link(workspace_path: &Path) {
             .to_str()
             .is_some_and(crate::team_link::is_app_workspace);
         if team_id != crate::config::layout::UNCLAIMED_TEAM && !is_app && knowledge_dir.is_dir() {
+            // Both roots. `teamclu-team` is no longer there to derive them from
+            // on the next open, so this fallback is now the common first path
+            // for a workspace, not a rare one — a documents link left out here
+            // would stay out.
+            let _ = ensure_team_documents_link(workspace_path, &team_id);
             status = ensure_team_knowledge_link(workspace_path, &team_id);
         }
     }

--- a/apps/daemon/src/team_link.rs
+++ b/apps/daemon/src/team_link.rs
@@ -1,4 +1,5 @@
-//! Materialize team global dir + workspace `teamclu-team` link.
+//! Materialize the team's global dir and a workspace's links into it
+//! (`team-knowledge`, `team-documents`).
 //!
 //! Shared by the daemon core and the HTTP `/v1/team/link` handler so HTTP
 //! integration tests do not need to pull in `daemon::server`.
@@ -149,8 +150,8 @@ pub fn materialize_team_link(team_id: &str, ws_path: &str) -> LinkStatus {
     ensure_team_link(team_id, ws_path)
 }
 
-/// Idempotently materialize a team's global shared dir and a workspace's
-/// `teamclu-team` symlink into it.
+/// Idempotently materialize a team's global shared dir and a workspace's links
+/// to its synced roots. A `teamclu-team` symlink from an older build is removed.
 pub fn ensure_team_link(team_id: &str, ws_path: &str) -> LinkStatus {
     if team_id.trim().is_empty() || ws_path.trim().is_empty() {
         return LinkStatus::Fallback;

--- a/packages/app/src/components/workspace/FileTree.tsx
+++ b/packages/app/src/components/workspace/FileTree.tsx
@@ -51,7 +51,7 @@ import {
   duplicateItem,
   readFileContent,
 } from "./file-tree-operations";
-import { TEAM_REPO_DIR, appShortName } from "@/lib/config/build-config";
+import { appShortName } from "@/lib/config/build-config";
 import { filterTree, flattenTree, type FlatTreeNode } from "./file-tree/flatten";
 import { useFileTreeKeyboard } from "./file-tree/use-file-tree-keyboard";
 import { useOsFileDrop } from "./file-tree/use-os-file-drop";
@@ -276,10 +276,9 @@ export function FileTree({
   const pushUndoRef = useRef(pushUndo);
   useEffect(() => { pushUndoRef.current = pushUndo; }, [pushUndo]);
 
-  // Drives the teamclu-team folder spinner / last-sync tooltip. Per-file status
-  // is keyed by SYNC KEY now (see `badges` above), not by a workspace-relative
-  // path — the same document is reachable through two different absolute paths
-  // and only the sync key is the same on both.
+  // Per-file sync status is keyed by SYNC KEY (see `badges` above), not by a
+  // workspace-relative path — the same document is reachable through two
+  // different absolute paths and only the sync key is the same on both.
 
   const collapseCompacted = useCallback((paths: string[]) => {
     const nextExpanded = new Set(useWorkspaceStore.getState().expandedPaths);
@@ -1041,7 +1040,6 @@ export function FileTree({
     isLoading: loadingPaths.has(node.path),
     isRenaming: renamingPath === node.path,
     isDragOver: dragOverPath === node.path,
-    isTeamCluTeam: node.name === TEAM_REPO_DIR && node.type === "directory" && level === 0,
     // Team knowledge only, and on every surface the document appears on: the
     // Knowledge column and the workspace `team-knowledge` link are two
     // spellings of the same file, and `teamSyncKeyForPath` maps both.

--- a/packages/app/src/components/workspace/FileTreeNode.tsx
+++ b/packages/app/src/components/workspace/FileTreeNode.tsx
@@ -24,10 +24,11 @@ import {
   History,
   AlertTriangle,
   Cloud,
+  FolderSymlink,
 } from "lucide-react";
 
 import { cn } from '@/lib/utils';
-import { ObsidianIcon } from './ObsidianIcon';
+import { isTeamLinkDirName } from '@/lib/team/team-skill-paths';
 import { useTabsStore } from '@/stores/tabs';
 import { useCurrentTeamStore } from '@/stores/current-team';
 import { useVersionHistoryStore } from '@/stores/version-history';
@@ -416,7 +417,13 @@ export const FileTreeItem = React.memo(function FileTreeItem({
   const fileIconInfo = !isDirectory ? getFileIcon(node.name) : null;
   const FileIcon = fileIconInfo?.icon || File;
   const fileIconColor = fileIconInfo?.color || "text-muted-foreground";
-  const isKnowledgeDir = isDirectory && node.name === 'team-knowledge' && !node.path.includes('/.trash/');
+  // The workspace's links to the team's synced roots. Root level only — that is
+  // where the daemon puts them, and a user's own nested folder with the same
+  // name is not one. Marked as a link rather than by what opens it: the row is
+  // a pointer into the team's shared tree, which is the thing worth knowing
+  // before editing inside it.
+  const isTeamLink =
+    isDirectory && level === 0 && isTeamLinkDirName(node.name) && !node.path.includes('/.trash/');
   // A team document both sides changed. The row is red either way; this is what
   // decides whether it also offers the way in to resolving it.
   const needsConflictDecision = syncStatus === 'conflict' && !isDirectory;
@@ -502,8 +509,12 @@ export const FileTreeItem = React.memo(function FileTreeItem({
         <img src="/logo-64.png" alt="" className="h-3.5 w-3.5 shrink-0" />
       )}
 
-      {isKnowledgeDir && !isTeamCluTeam && (
-        <ObsidianIcon className="h-3.5 w-3.5 shrink-0" style={{ color: '#7C3AED' }} />
+      {isTeamLink && (
+        <FolderSymlink
+          data-testid="file-tree-team-link-icon"
+          className="h-3.5 w-3.5 shrink-0 text-muted-foreground"
+          aria-label={t("fileExplorer.teamLink", "Linked to the team's shared folder")}
+        />
       )}
 
       {downloadFailed ? (

--- a/packages/app/src/components/workspace/FileTreeNode.tsx
+++ b/packages/app/src/components/workspace/FileTreeNode.tsx
@@ -202,8 +202,6 @@ export interface FileTreeItemProps {
   isLoading: boolean;
   isRenaming: boolean;
   isDragOver: boolean;
-  /** Whether this is the root teamclu-team directory (for visual styling) */
-  isTeamCluTeam?: boolean;
   /**
    * What this document's sync state is, for team knowledge. `null` for
    * everything else — a workspace file has no cloud counterpart to differ from.
@@ -322,7 +320,6 @@ export const FileTreeItem = React.memo(function FileTreeItem({
   isLoading,
   isRenaming,
   isDragOver,
-  isTeamCluTeam,
   isTeamKnowledge,
   syncStatus,
   syncIgnored = false,
@@ -503,10 +500,6 @@ export const FileTreeItem = React.memo(function FileTreeItem({
             syncStatus ? getSyncStatusTextColor(syncStatus) : fileIconColor,
           )}
         />
-      )}
-
-      {isTeamCluTeam && (
-        <img src="/logo-64.png" alt="" className="h-3.5 w-3.5 shrink-0" />
       )}
 
       {isTeamLink && (

--- a/packages/app/src/components/workspace/__tests__/FileTreeNode-team-link.test.tsx
+++ b/packages/app/src/components/workspace/__tests__/FileTreeNode-team-link.test.tsx
@@ -86,8 +86,14 @@ describe('FileTreeItem team links', () => {
     expect(screen.queryByTestId('file-tree-team-link-icon')).toBeNull()
   })
 
-  it('no longer marks teamclu-team', () => {
-    render(<FileTreeItem {...props({ node: { name: 'teamclu-team', path: '/ws/teamclu-team', type: 'directory' }, level: 0 })} />)
+  it('no longer marks teamclu-team — not as a link, and not with the logo', () => {
+    // The daemon no longer creates it; the only `teamclu-team` a tree can still
+    // show is a real directory from a very old layout, and that is just a
+    // folder. It used to carry the app logo at the workspace root.
+    const { container } = render(
+      <FileTreeItem {...props({ node: { name: 'teamclu-team', path: '/ws/teamclu-team', type: 'directory' }, level: 0 })} />,
+    )
     expect(screen.queryByTestId('file-tree-team-link-icon')).toBeNull()
+    expect(container.querySelector('img')).toBeNull()
   })
 })

--- a/packages/app/src/components/workspace/__tests__/FileTreeNode-team-link.test.tsx
+++ b/packages/app/src/components/workspace/__tests__/FileTreeNode-team-link.test.tsx
@@ -1,0 +1,93 @@
+/**
+ * The workspace's links to the team's synced roots are marked as links, at the
+ * workspace root only.
+ *
+ * `team-knowledge` used to carry an Obsidian mark and `team-documents` nothing,
+ * which said what might open the folder rather than what it is: a pointer into
+ * the team's shared tree, where an edit is everyone's edit.
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { FileTreeItem, type FileTreeItemProps } from '../FileTreeNode'
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (_k: string, fallback?: unknown) => (typeof fallback === 'string' ? fallback : _k),
+  }),
+}))
+vi.mock('@/stores/oss-sync', () => ({ useOssSyncStore: () => undefined }))
+vi.mock('@/stores/team-conflicts', () => ({ useTeamConflictsStore: () => undefined }))
+vi.mock('@/stores/ui', () => ({ useUIStore: () => undefined }))
+
+function props(overrides: Partial<FileTreeItemProps> = {}): FileTreeItemProps {
+  const noop = () => {}
+  return {
+    node: { name: 'documents', path: '/vault/team-sync/documents', type: 'directory' },
+    level: 0,
+    isExpanded: false,
+    isSelected: false,
+    isLoading: false,
+    onSelectFile: noop,
+    onSelectFileRange: noop,
+    onToggleFileSelection: noop,
+    onExpandDirectory: noop,
+    onCollapseDirectory: noop,
+    onNewFile: noop,
+    onNewFolder: noop,
+    onRename: noop,
+    onRenameConfirm: noop,
+    onRenameCancel: noop,
+    onDelete: noop,
+    onCopyPath: noop,
+    onCopyRelativePath: noop,
+    onReveal: noop,
+    onOpenDefault: noop,
+    onOpenTerminal: noop,
+    onAddToAgent: noop,
+    onDragStart: noop,
+    onDragOver: noop,
+    onDragLeave: noop,
+    onDragEnd: noop,
+    onDrop: noop,
+    onCut: noop,
+    onCopy: noop,
+    onPaste: noop,
+    onDuplicate: noop,
+    ...overrides,
+  } as unknown as FileTreeItemProps
+}
+
+describe('FileTreeItem team links', () => {
+  it.each(['team-documents', 'team-knowledge'])('marks %s at the workspace root as a link', (name) => {
+    render(<FileTreeItem {...props({ node: { name, path: `/ws/${name}`, type: 'directory' }, level: 0 })} />)
+    expect(screen.getByTestId('file-tree-team-link-icon')).toBeTruthy()
+  })
+
+  it('does not mark a nested folder that happens to share the name', () => {
+    render(
+      <FileTreeItem
+        {...props({ node: { name: 'team-knowledge', path: '/ws/src/team-knowledge', type: 'directory' }, level: 1 })}
+      />,
+    )
+    expect(screen.queryByTestId('file-tree-team-link-icon')).toBeNull()
+  })
+
+  it('does not mark a file, or a link sitting in the trash', () => {
+    const { unmount } = render(
+      <FileTreeItem {...props({ node: { name: 'team-knowledge', path: '/ws/team-knowledge', type: 'file' }, level: 0 })} />,
+    )
+    expect(screen.queryByTestId('file-tree-team-link-icon')).toBeNull()
+    unmount()
+    render(
+      <FileTreeItem
+        {...props({ node: { name: 'team-documents', path: '/ws/.trash/team-documents', type: 'directory' }, level: 0 })}
+      />,
+    )
+    expect(screen.queryByTestId('file-tree-team-link-icon')).toBeNull()
+  })
+
+  it('no longer marks teamclu-team', () => {
+    render(<FileTreeItem {...props({ node: { name: 'teamclu-team', path: '/ws/teamclu-team', type: 'directory' }, level: 0 })} />)
+    expect(screen.queryByTestId('file-tree-team-link-icon')).toBeNull()
+  })
+})

--- a/packages/app/src/lib/team/team-skill-paths.ts
+++ b/packages/app/src/lib/team/team-skill-paths.ts
@@ -114,6 +114,21 @@ const TEAM_KNOWLEDGE_LINK_DIR = 'team-knowledge'
  */
 const TEAM_DOCUMENTS_LINK_DIR = 'team-documents'
 
+/**
+ * The workspace links to the team's synced roots, in the order the file tree
+ * pins them to the top of a workspace.
+ *
+ * `teamclu-team` used to be the one pinned there. Nothing lives behind it any
+ * more and the daemon no longer creates it; these two are what a workspace
+ * actually has of the team.
+ */
+export const TEAM_LINK_DIRS: ReadonlyArray<string> = [TEAM_DOCUMENTS_LINK_DIR, TEAM_KNOWLEDGE_LINK_DIR]
+
+/** Whether a workspace-root entry is one of {@link TEAM_LINK_DIRS}. */
+export function isTeamLinkDirName(name: string): boolean {
+  return TEAM_LINK_DIRS.includes(name)
+}
+
 /** The two fixed roots, paired with the workspace symlink that surfaces each. */
 const SYNC_ROOT_LINKS: ReadonlyArray<readonly [linkDir: string, prefix: string]> = [
   [TEAM_KNOWLEDGE_LINK_DIR, 'knowledge'],

--- a/packages/app/src/locales/en.json
+++ b/packages/app/src/locales/en.json
@@ -987,6 +987,7 @@
   },
   "fileExplorer": {
     "agentNotStarted": "Agent has not started yet",
+    "teamLink": "Linked to the team's shared folder",
     "newFile": "New File",
     "newFolder": "New Folder",
     "copyPath": "Copy Path",

--- a/packages/app/src/locales/zh-CN.json
+++ b/packages/app/src/locales/zh-CN.json
@@ -987,6 +987,7 @@
   },
   "fileExplorer": {
     "agentNotStarted": "Agent 尚未启动",
+    "teamLink": "链接到团队共享目录",
     "newFile": "新建文件",
     "newFolder": "新建文件夹",
     "copyPath": "复制路径",

--- a/packages/app/src/stores/__tests__/workspace-sort-entries.test.ts
+++ b/packages/app/src/stores/__tests__/workspace-sort-entries.test.ts
@@ -1,0 +1,44 @@
+/**
+ * Entry order in a workspace directory.
+ *
+ * The team's links are the team's content, not the project's, so at the root
+ * they sit above it. `teamclu-team` used to be pinned there at every level; the
+ * daemon no longer creates it, and it is no longer special.
+ */
+import { describe, it, expect } from 'vitest'
+import { sortWorkspaceEntries, type FileNode } from '@/stores/workspace'
+
+const dir = (name: string): FileNode => ({ name, path: `/ws/${name}`, type: 'directory' })
+const file = (name: string): FileNode => ({ name, path: `/ws/${name}`, type: 'file' })
+const names = (nodes: FileNode[]) => nodes.map((n) => n.name)
+
+describe('sortWorkspaceEntries', () => {
+  it('pins team-documents then team-knowledge to the top of the root', () => {
+    const out = sortWorkspaceEntries(
+      [file('README.md'), dir('claude'), dir('team-knowledge'), dir('apps'), dir('team-documents')],
+      true,
+    )
+    expect(names(out)).toEqual(['team-documents', 'team-knowledge', 'apps', 'claude', 'README.md'])
+  })
+
+  it('pins nothing below the root', () => {
+    const out = sortWorkspaceEntries([dir('zeta'), dir('team-knowledge'), dir('alpha')], false)
+    expect(names(out)).toEqual(['alpha', 'team-knowledge', 'zeta'])
+  })
+
+  it('does not pin a file that happens to share a link name', () => {
+    const out = sortWorkspaceEntries([dir('b'), file('team-documents')], true)
+    expect(names(out)).toEqual(['b', 'team-documents'])
+  })
+
+  it('no longer pins teamclu-team', () => {
+    const out = sortWorkspaceEntries([dir('claude'), dir('teamclu-team'), dir('apps')], true)
+    expect(names(out)).toEqual(['apps', 'claude', 'teamclu-team'])
+  })
+
+  it('does not mutate its input', () => {
+    const input = [dir('b'), dir('team-knowledge'), dir('a')]
+    sortWorkspaceEntries(input, true)
+    expect(names(input)).toEqual(['b', 'team-knowledge', 'a'])
+  })
+})

--- a/packages/app/src/stores/workspace.ts
+++ b/packages/app/src/stores/workspace.ts
@@ -4,7 +4,8 @@ import { isTauri } from '@/lib/utils'
 import { allowFsScopeDirs } from '@/lib/fs-scope'
 import { ensureGitignoreEntries } from '@/lib/workspace/gitignore-manager'
 import { seedDefaultWorkspaceInstructions } from '@/lib/workspace-seed/seed-default-instructions'
-import { appDisplayName, appStoragePrefix, TEAM_REPO_DIR } from '@/lib/config/build-config'
+import { appDisplayName, appStoragePrefix } from '@/lib/config/build-config'
+import { TEAM_LINK_DIRS } from '@/lib/team/team-skill-paths'
 import { useTeamModeStore } from './team-mode'
 
 // Start watching a directory for file changes
@@ -194,6 +195,38 @@ interface WorkspaceState {
 }
 
 // Extract folder name from path
+/**
+ * The order a directory's entries are shown in.
+ *
+ * At the workspace root the team's links (`team-documents`, `team-knowledge`)
+ * come first, in that order — they are the team's content, not the project's,
+ * and belong above it rather than wherever their names happen to sort. Below
+ * the root nothing is pinned: a user's own folder that happens to be called
+ * `team-documents` is just a folder.
+ *
+ * `teamclu-team` used to be pinned here, at every level. The daemon no longer
+ * creates it (nothing lives behind it), so it is no longer special.
+ */
+export function sortWorkspaceEntries(nodes: FileNode[], atRoot: boolean): FileNode[] {
+  const pinRank = (node: FileNode): number => {
+    if (!atRoot || node.type !== "directory") return -1;
+    return TEAM_LINK_DIRS.indexOf(node.name);
+  };
+  return [...nodes].sort((a, b) => {
+    const ra = pinRank(a);
+    const rb = pinRank(b);
+    if (ra !== rb) {
+      if (ra === -1) return 1;
+      if (rb === -1) return -1;
+      return ra - rb;
+    }
+    if (a.type !== b.type) {
+      return a.type === "directory" ? -1 : 1;
+    }
+    return a.name.localeCompare(b.name);
+  });
+}
+
 function getFolderName(path: string): string {
   const parts = path.replace(/\/$/, "").split("/");
   return parts[parts.length - 1] || path;
@@ -635,23 +668,10 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
       const nodes = await readWorkspaceDirectory(base, fullPath);
       console.log("[Workspace] Found", nodes.length, "entries");
 
-      const visibleNodes = [...nodes];
-
-      visibleNodes.sort((a, b) => {
-        // Always put teamclu-team first
-        if (a.name === TEAM_REPO_DIR && b.name !== TEAM_REPO_DIR) return -1;
-        if (b.name === TEAM_REPO_DIR && a.name !== TEAM_REPO_DIR) return 1;
-        
-        // Then directories before files
-        if (a.type !== b.type) {
-          return a.type === "directory" ? -1 : 1;
-        }
-        
-        // Then alphabetical
-        return a.name.localeCompare(b.name);
-      });
-
-      return visibleNodes;
+      // Root by value, not by the "." shorthand: callers pass either, and a
+      // trailing separator must not decide whether the links get pinned.
+      const trim = (p: string) => p.replace(/[\\/]+$/, "");
+      return sortWorkspaceEntries(nodes, trim(fullPath) === trim(base));
     } catch (error) {
       console.error("[Workspace] Failed to load directory:", error);
       return [];


### PR DESCRIPTION
## 为什么

workspace 文件树最上面挂着一个 `teamclu-team`，带着 logo。它指向 `shared/teamclu-team`，而那里早就是空的：

| 原来在 `teamclu-team/` 下的 | 现在在哪 |
|---|---|
| `knowledge/` | `shared/team-sync/knowledge`（`team-knowledge` 链接） |
| `documents/` | `shared/team-sync/documents`（`team-documents` 链接） |
| `.mcp`、`_secrets` | Cloud API |
| `skills/` | 技能注册表 |

`ensure_initialized` 的注释自己也写着 `shared/teamclu-team` "permanently empty"。真正有内容的是另外两个链接，它们反倒按字母序排在 `claude` 之类的项目目录后面。

## daemon

**不再建 `teamclu-team`** —— `ensure_workspace_link` 只建 `team-knowledge` + `team-documents`，顺手删掉旧版本留下的 `teamclu-team` **符号链接**。同名的**真实目录一律不碰**：它早于全局存储，谁也证明不了里面的东西同步过。原来把它拷进全局存储再换成链接的 `migrate_legacy_dir` 随之删除；`LinkStatus::LegacyDirRetained` 因此没有任何代码能产生，一并删掉（`/v1/team/link` 不再发 `legacy_retained`，前端类型里保留这个值以兼容旧 daemon）。自我链接保护（workspace 恰好就是团队 `shared/` 目录时什么都不建）原样保留。

**修掉一个会被连带弄坏的修复路径** —— 这是这个 PR 里最需要看的地方。每次打开 workspace 都会跑 `ensure_team_knowledge_link_from_workspace`，它原来是**顺着 `teamclu-team` 链接反推团队目录**来重建 `team-knowledge` 的。只删创建、不改这里，这条修复路径就瞎了。现在改成依次从 `team-knowledge` → `team-documents` → 旧 `teamclu-team`（仅升级兜底，用完删掉）反推。

反推出的路径除了原有的「必须在 teams 目录下」，还加了「必须就是 `team-sync` 目录」—— 否则一个指向 `<teams>/<id>/elsewhere/knowledge` 的陈旧链接，会把 `team-documents` 链到 `elsewhere/documents` 这种没有同步引擎管的地方。

**supervisor 兜底补齐** —— `from_workspace` 失败时 supervisor 会回退到 daemon 的 active team 去建链接，原来只建 knowledge。没了 `teamclu-team` 可反推，这条兜底从「罕见」变成了新 workspace 的常规首次路径，漏掉 documents 就会一直漏着，所以两个都建。

**没动的遗留读者**：`refresh_watch`、`team_mcp`、`roles_skills` 里还有经由 `teamclu-team` 的读取，都是给已迁走功能留的路径，且都有全局目录兜底。清理它们是另一件事，这里不扩大范围。

## 前端

- 排序抽成纯函数 `sortWorkspaceEntries`：**只在 workspace 根目录**把 `team-documents`、`team-knowledge` 依次置顶。原来是**每一层**都把 `teamclu-team` 置顶；子目录里用户自己恰好叫 `team-documents` 的文件夹不该跳上去。根目录判断按值比较、忽略末尾分隔符（调用方有传 `"."` 的也有传绝对路径的）。
- 这两行显示 `FolderSymlink` 图标，同样只认根目录。**替掉了 `team-knowledge` 上原来的 Obsidian 图标** —— 它说的是「能用什么打开」，这一行真正该告诉人的是「这是团队共享树的入口，在里面改就是改大家的」；两个图标并排也太挤。「在 Obsidian 中打开」这个操作本身没动。
- 根目录 `teamclu-team` 的特殊待遇（`isTeamCluTeam` + app logo）整个去掉。
- 链接名复用 `team-skill-paths.ts` 里现成的两个常量（注释要求与 daemon 的 `TEAM_*_LINK_NAME` 一致），没有新造一份。

## 验证

- daemon 受影响的 **96 条**全绿（`config::workspace_link`、`team_link`、`http::team`、`runtime::supervisor`、`team_shared_env`、`daemon::server` 里两条 team link 测试）
- `cargo test -p amuxd --all-targets --no-run` 通过，改过的文件**零 warning**（删 `migrate_legacy_dir` 后 `LegacyDirRetained` 在集成测试 target 里报了死变体，已处理）
- 新增 daemon 测试：不建 `teamclu-team`、删旧符号链接（指向真实存储的和悬空的两种）、真实目录原样保留且不被拷进全局存储、没有 `teamclu-team` 时从 `team-knowledge` 修复 `team-documents`、拒绝不在 `team-sync` 下的链接
- 前端：`pnpm test:unit` **3545 条**全绿；新增排序 5 条、图标 5 条
- `pnpm typecheck` 干净，`pnpm lint` 0 errors

## 升级后用户会看到什么

已有 workspace 在下一次打开或下一轮 sweep 时，`teamclu-team` 符号链接会被删掉，文件树顶部变成 `team-documents`、`team-knowledge` 两行带软链图标。如果某个 workspace 里 `teamclu-team` 是个**真实目录**（很早期的布局），它会原样留着，但就是一个普通文件夹：不置顶、不带 logo（`isTeamCluTeam` 这个 prop、它在 `FileTree` 里的计算和 `FileTreeNode` 的 `/logo-64.png` 渲染在第二个 commit 里一并删了）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Gs7sQhSPLWPAiBp6aA66p


