### PR TITLE
fix(pi): settle turns on agent_settled and surface compaction in UI

### DIFF
--- a/apps/daemon/src/runtime/pi_rpc/events.rs
+++ b/apps/daemon/src/runtime/pi_rpc/events.rs
@@ -156,37 +156,37 @@ async fn handle_event(
                 route.translate.reset_turn();
                 // A prompt sent while pi was busy is queued as `followUp`, so
                 // it starts its own run after the current one ends — and that
-                // first `agent_end` already cleared `turn_active`. Without
+                // first `agent_settled` already cleared `turn_active`. Without
                 // re-arming here the queued run would finish with `close_turn`
                 // bailing on `!turn_active`, leaving the caller without the
                 // Active→Idle for a reply it did receive.
                 route.turn_active = true;
             }
         }
-        // A pi agent run can contain multiple turns: each tool-use cycle ends
-        // one `turn_end` and begins another `turn_start`. Ending the TeamClu
-        // stream there finalizes the first partial reply, so subsequent text
-        // is rendered as a second message. Only `agent_end` completes the
-        // prompt as a whole. `turn_active` keeps the stdout-EOF fallback
-        // idempotent if pi exits immediately after this event.
+        // One low-level pi run finished. Retry, auto-compaction, and queued
+        // continuations may still follow — do not settle the TeamClu turn here.
+        "agent_end" => on_agent_end(shared, &session_id, event),
+        // Session-level run fully settled: no automatic retry/compaction retry/
+        // queued continuation remains. Only then may we emit Active→Idle and let
+        // turn_aggregator decide the turn outcome (incl. no_final_reply).
         event_type if completes_agent_run(event_type) => {
-            // The host stamps the session's leaf entry id onto `agent_end`;
-            // remembered per route as the "since" cursor for crash backfill.
-            if let Some(leaf) = event.get("leafId").and_then(|v| v.as_str()) {
-                if let Some(route) = shared.routes.lock().get_mut(&session_id) {
-                    route.last_entry_id = Some(leaf.to_string());
-                }
-            }
-            // pi is about to re-run this agent run after a transient failure:
-            // the attempt's error is not the turn's outcome, so drop it before
-            // `close_turn` would flush it. Without this a retried 429 leaves a
-            // durable error banner per attempt even when the retry succeeds.
-            if will_retry(event) {
-                if let Some(route) = shared.routes.lock().get_mut(&session_id) {
-                    route.translate.discard_turn_error();
-                }
-            }
             close_turn(shared, &session_id).await;
+        }
+        "compaction_start" | "compaction_end" => {
+            let completed = event_type == "compaction_end";
+            let payload = compaction_wire_payload(event, completed);
+            let (event_tx, reply_to) = {
+                let routes = shared.routes.lock();
+                let Some(route) = routes.get(&session_id) else {
+                    return;
+                };
+                (route.event_tx.clone(), route.turn_reply_to.clone())
+            };
+            let ev = translate::compaction_event(event_type, &payload);
+            crate::runtime::agent_trace::log_acp_event(&session_id, &ev);
+            let _ = event_tx
+                .send(AcpEventFrame::new(session_id, ev).with_reply_to(reply_to))
+                .await;
         }
         _ => {
             let (events, event_tx, reply_to) = {
@@ -219,7 +219,35 @@ async fn handle_event(
 }
 
 fn completes_agent_run(event_type: &str) -> bool {
-    event_type == "agent_end"
+    event_type == "agent_settled"
+}
+
+/// Bookkeeping for a finished low-level pi run — leaf cursor and retry error
+/// discard. Turn settlement waits for `agent_settled`.
+fn on_agent_end(shared: &Arc<Shared>, session_id: &str, event: &serde_json::Value) {
+    if let Some(leaf) = event.get("leafId").and_then(|v| v.as_str()) {
+        if let Some(route) = shared.routes.lock().get_mut(session_id) {
+            route.last_entry_id = Some(leaf.to_string());
+        }
+    }
+    if will_retry(event) {
+        if let Some(route) = shared.routes.lock().get_mut(session_id) {
+            route.translate.discard_turn_error();
+        }
+    }
+}
+
+fn compaction_wire_payload(event: &serde_json::Value, completed: bool) -> serde_json::Value {
+    let reason = event
+        .get("reason")
+        .and_then(|v| v.as_str())
+        .unwrap_or("threshold");
+    serde_json::json!({
+        "reason": reason,
+        "auto": reason != "manual",
+        "overflow": reason == "overflow",
+        "completed": completed,
+    })
 }
 
 /// `agent_end.willRetry` — pi's `AgentSession` will re-run this agent run
@@ -241,7 +269,7 @@ pub(super) async fn close_turn(shared: &Arc<Shared>, session_id: &str) {
             route.turn_active = false;
             let reply_to = route.turn_reply_to.take();
             route.turn_requester = None;
-            // Every path that settles a turn funnels through here — `agent_end`,
+            // Every path that settles a turn funnels through here — `agent_settled`,
             // a user cancel, a child that died mid-turn. Flushing the held
             // error at this one point is what makes "a failed turn always
             // reports" hold no matter which path fired.
@@ -598,10 +626,11 @@ mod tests {
     use super::*;
 
     #[test]
-    fn only_agent_end_completes_the_prompt() {
-        assert!(completes_agent_run("agent_end"));
+    fn only_agent_settled_completes_the_prompt() {
+        assert!(completes_agent_run("agent_settled"));
+        // A low-level run may end on agent_end while compaction or retry continues.
+        assert!(!completes_agent_run("agent_end"));
         // A tool-using prompt has one turn_end for each model/tool cycle.
-        // Closing here splits a single streamed reply into separate messages.
         assert!(!completes_agent_run("turn_end"));
         assert!(!completes_agent_run("turn_start"));
         assert!(!completes_agent_run("agent_start"));
@@ -693,11 +722,11 @@ mod tests {
 
     #[cfg(unix)]
     #[tokio::test]
-    async fn agent_end_closes_only_its_own_session() {
+    async fn agent_end_records_leaf_without_settling_turn() {
         let shared = test_shared();
         let key = super::super::process::test_pool_key("/w");
         let (mut route_a, mut rx_a) = test_route(key.clone(), "/s/a.jsonl");
-        let (mut route_b, mut rx_b) = test_route(key.clone(), "/s/b.jsonl");
+        let (mut route_b, _rx_b) = test_route(key.clone(), "/s/b.jsonl");
         route_a.turn_active = true;
         route_b.turn_active = true;
         shared.routes.lock().insert("pi:/s/a.jsonl".into(), route_a);
@@ -709,17 +738,80 @@ mod tests {
         });
         handle_event(&shared, &key, &client, &end).await;
 
-        // A settled (status frame emitted, turn closed, leaf recorded)…
-        assert!(rx_a.try_recv().is_ok(), "A gets its Active→Idle");
+        assert!(rx_a.try_recv().is_err(), "agent_end alone must not settle");
         {
             let routes = shared.routes.lock();
             let a = routes.get("pi:/s/a.jsonl").unwrap();
-            assert!(!a.turn_active);
+            assert!(a.turn_active, "turn stays open until agent_settled");
             assert_eq!(a.last_entry_id.as_deref(), Some("e-42"));
-            // …while B is still mid-turn.
+            assert!(routes.get("pi:/s/b.jsonl").unwrap().turn_active);
+        }
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn agent_settled_closes_only_its_own_session() {
+        let shared = test_shared();
+        let key = super::super::process::test_pool_key("/w");
+        let (mut route_a, mut rx_a) = test_route(key.clone(), "/s/a.jsonl");
+        let (mut route_b, mut rx_b) = test_route(key.clone(), "/s/b.jsonl");
+        route_a.turn_active = true;
+        route_b.turn_active = true;
+        shared.routes.lock().insert("pi:/s/a.jsonl".into(), route_a);
+        shared.routes.lock().insert("pi:/s/b.jsonl".into(), route_b);
+        let client = test_client();
+
+        let settled: serde_json::Value = serde_json::json!({
+            "type": "agent_settled", "sessionId": "pi:/s/a.jsonl"
+        });
+        handle_event(&shared, &key, &client, &settled).await;
+
+        assert!(rx_a.try_recv().is_ok(), "A gets its Active→Idle");
+        {
+            let routes = shared.routes.lock();
+            assert!(!routes.get("pi:/s/a.jsonl").unwrap().turn_active);
             assert!(routes.get("pi:/s/b.jsonl").unwrap().turn_active);
         }
         assert!(rx_b.try_recv().is_err(), "B keeps streaming");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn compaction_events_forward_as_raw_acp() {
+        let shared = test_shared();
+        let key = super::super::process::test_pool_key("/w");
+        let (route, mut rx) = test_route(key.clone(), "/s/a.jsonl");
+        shared.routes.lock().insert("pi:/s/a.jsonl".into(), route);
+        let client = test_client();
+
+        let start = serde_json::json!({
+            "type": "compaction_start", "sessionId": "pi:/s/a.jsonl", "reason": "overflow"
+        });
+        handle_event(&shared, &key, &client, &start).await;
+        let frame = rx.try_recv().expect("compaction_start forwarded");
+        match frame.event.event.as_ref().unwrap() {
+            amux::acp_event::Event::Raw(raw) => {
+                assert_eq!(raw.method, "compaction_start");
+                let body: serde_json::Value = serde_json::from_slice(&raw.json_payload).unwrap();
+                assert_eq!(body["overflow"], true);
+                assert_eq!(body["completed"], false);
+            }
+            other => panic!("unexpected: {other:?}"),
+        }
+
+        let end = serde_json::json!({
+            "type": "compaction_end", "sessionId": "pi:/s/a.jsonl", "reason": "overflow"
+        });
+        handle_event(&shared, &key, &client, &end).await;
+        let frame = rx.try_recv().expect("compaction_end forwarded");
+        match frame.event.event.as_ref().unwrap() {
+            amux::acp_event::Event::Raw(raw) => {
+                assert_eq!(raw.method, "compaction_end");
+                let body: serde_json::Value = serde_json::from_slice(&raw.json_payload).unwrap();
+                assert_eq!(body["completed"], true);
+            }
+            other => panic!("unexpected: {other:?}"),
+        }
     }
 
     #[cfg(unix)]
@@ -832,8 +924,14 @@ mod tests {
             "type": "agent_end", "sessionId": "pi:/s/a.jsonl", "willRetry": true
         });
         handle_event(&shared, &key, &client, &retrying).await;
+        assert!(rx.try_recv().is_err(), "willRetry must not settle the turn");
 
-        let frame = rx.try_recv().expect("the turn still settles");
+        let settled = serde_json::json!({
+            "type": "agent_settled", "sessionId": "pi:/s/a.jsonl"
+        });
+        handle_event(&shared, &key, &client, &settled).await;
+
+        let frame = rx.try_recv().expect("the turn settles after agent_settled");
         assert!(
             is_status_change(&frame),
             "a retried attempt must not leave a durable error banner"
@@ -849,11 +947,16 @@ mod tests {
         let client = test_client();
         let mut rx = session_with_held_failure(&shared, &key, &client).await;
 
-        // No `willRetry`: this run's failure is the turn's outcome.
         let end = serde_json::json!({
             "type": "agent_end", "sessionId": "pi:/s/a.jsonl", "leafId": "e-1"
         });
         handle_event(&shared, &key, &client, &end).await;
+        assert!(rx.try_recv().is_err(), "agent_end alone must not settle");
+
+        let settled = serde_json::json!({
+            "type": "agent_settled", "sessionId": "pi:/s/a.jsonl"
+        });
+        handle_event(&shared, &key, &client, &settled).await;
 
         // Error first: turn_aggregator decides the turn's outcome from an
         // Error seen *before* Active→Idle.

--- a/apps/daemon/src/runtime/pi_rpc/events.rs
+++ b/apps/daemon/src/runtime/pi_rpc/events.rs
@@ -242,11 +242,36 @@ fn compaction_wire_payload(event: &serde_json::Value, completed: bool) -> serde_
         .get("reason")
         .and_then(|v| v.as_str())
         .unwrap_or("threshold");
-    serde_json::json!({
-        "reason": reason,
-        "auto": reason != "manual",
-        "overflow": reason == "overflow",
-        "completed": completed,
+    let result = event.get("result");
+    let tokens_before = result.and_then(|r| r.get("tokensBefore")).and_then(json_u64);
+    let tokens_after = result
+        .and_then(|r| r.get("estimatedTokensAfter"))
+        .and_then(json_u64);
+    let mut payload = serde_json::Map::new();
+    payload.insert(
+        "reason".into(),
+        serde_json::Value::String(reason.to_string()),
+    );
+    payload.insert("auto".into(), serde_json::Value::Bool(reason != "manual"));
+    payload.insert(
+        "overflow".into(),
+        serde_json::Value::Bool(reason == "overflow"),
+    );
+    payload.insert("completed".into(), serde_json::Value::Bool(completed));
+    if let Some(n) = tokens_before {
+        payload.insert("tokensBefore".into(), serde_json::json!(n));
+    }
+    if let Some(n) = tokens_after {
+        payload.insert("tokensAfter".into(), serde_json::json!(n));
+    }
+    serde_json::Value::Object(payload)
+}
+
+fn json_u64(v: &serde_json::Value) -> Option<u64> {
+    v.as_u64().or_else(|| {
+        v.as_f64()
+            .filter(|f| f.is_finite() && *f >= 0.0)
+            .map(|f| f as u64)
     })
 }
 
@@ -800,7 +825,13 @@ mod tests {
         }
 
         let end = serde_json::json!({
-            "type": "compaction_end", "sessionId": "pi:/s/a.jsonl", "reason": "overflow"
+            "type": "compaction_end",
+            "sessionId": "pi:/s/a.jsonl",
+            "reason": "threshold",
+            "result": {
+                "tokensBefore": 150000,
+                "estimatedTokensAfter": 32000
+            }
         });
         handle_event(&shared, &key, &client, &end).await;
         let frame = rx.try_recv().expect("compaction_end forwarded");
@@ -809,6 +840,8 @@ mod tests {
                 assert_eq!(raw.method, "compaction_end");
                 let body: serde_json::Value = serde_json::from_slice(&raw.json_payload).unwrap();
                 assert_eq!(body["completed"], true);
+                assert_eq!(body["tokensBefore"], 150000);
+                assert_eq!(body["tokensAfter"], 32000);
             }
             other => panic!("unexpected: {other:?}"),
         }

--- a/apps/daemon/src/runtime/pi_rpc/translate.rs
+++ b/apps/daemon/src/runtime/pi_rpc/translate.rs
@@ -517,6 +517,18 @@ pub fn session_title_event(title: &str) -> amux::AcpEvent {
     }
 }
 
+/// Live compaction marker for the chat thread (`compaction_start` /
+/// `compaction_end`). Payload matches the frontend compaction row contract.
+pub fn compaction_event(phase: &str, payload: &serde_json::Value) -> amux::AcpEvent {
+    amux::AcpEvent {
+        event: Some(amux::acp_event::Event::Raw(amux::AcpRawJson {
+            method: phase.to_string(),
+            json_payload: serde_json::to_vec(payload).unwrap_or_default(),
+        })),
+        model: String::new(),
+    }
+}
+
 /// Build the `question_asked` raw event clients already render for opencode's
 /// question tool: `{id, questions, tool: {callID}}`. `request_id` is the
 /// extension_ui_request id — the same id `AnswerQuestion` sends back, which is

--- a/apps/daemon/tests/fixtures/pi-host-stub/dist/index.js
+++ b/apps/daemon/tests/fixtures/pi-host-stub/dist/index.js
@@ -320,6 +320,7 @@ class StubAgentSession {
       this.sessionManager.appendEntry("assistant", `echo:${text}!`);
     }
     this.emit({ type: "agent_end", aborted: this.aborted });
+    this.emit({ type: "agent_settled" });
   }
 
   async abort() {

--- a/docs/design-mock/compaction-ui-placement.html
+++ b/docs/design-mock/compaction-ui-placement.html
@@ -1,0 +1,444 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>上下文压缩 · UI 放置方案 · TeamClu Editorial Calm</title>
+<style>
+  :root {
+    --font: "PingFang SC", "Noto Sans SC", -apple-system, BlinkMacSystemFont, sans-serif;
+    --mono: "JetBrains Mono", "SF Mono", ui-monospace, Menlo, Consolas, monospace;
+    --bg: #fbfaf7;
+    --paper: #ffffff;
+    --panel: #efece4;
+    --ink: #1a1a14;
+    --ink-2: #3d3c34;
+    --mute: #75736a;
+    --faint: #a8a6a0;
+    --border: rgba(26, 26, 20, 0.08);
+    --border-soft: rgba(26, 26, 20, 0.05);
+    --coral: #e85a4a;
+    --success: #2eb872;
+    --pending: #e8b54a;
+  }
+
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body {
+    font-family: var(--font);
+    background: #e8e5dd;
+    color: var(--ink);
+    padding: 28px 20px 64px;
+    -webkit-font-smoothing: antialiased;
+  }
+
+  .page-h { max-width: 1180px; margin: 0 auto 18px; }
+  .page-h h1 { font-size: 17px; font-weight: 700; }
+  .page-h p { margin-top: 8px; font-size: 13px; line-height: 1.65; color: var(--ink-2); max-width: 72ch; }
+
+  .legend {
+    max-width: 1180px; margin: 0 auto 16px;
+    display: flex; flex-wrap: wrap; gap: 8px;
+  }
+  .legend span {
+    font-size: 11.5px; padding: 4px 10px; border-radius: 6px;
+    background: var(--paper); border: 1px solid var(--border);
+    color: var(--mute);
+  }
+  .legend .bad { border-color: rgba(232, 90, 74, 0.35); color: #b84336; }
+  .legend .good { border-color: rgba(46, 184, 114, 0.35); color: #1a7a4a; }
+
+  .stage {
+    max-width: 1180px; margin: 0 auto;
+    display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 14px;
+  }
+  @media (max-width: 1050px) { .stage { grid-template-columns: 1fr; } }
+
+  .frame {
+    background: var(--bg);
+    border-radius: 14px;
+    overflow: hidden;
+    border: 1px solid var(--border-soft);
+  }
+  .frame.bad { opacity: 0.92; }
+  .frame-label {
+    display: flex; align-items: center; justify-content: space-between;
+    padding: 10px 14px;
+    border-bottom: 1px solid var(--border-soft);
+    font-size: 10.5px; font-weight: 600; letter-spacing: 0.06em;
+    text-transform: uppercase; color: var(--faint);
+    background: var(--paper);
+  }
+  .badge {
+    font-size: 10px; font-weight: 600; letter-spacing: 0.02em;
+    padding: 2px 7px; border-radius: 5px; text-transform: none;
+  }
+  .badge.bad { background: #fdecea; color: #b84336; }
+  .badge.good { background: #eaf8f0; color: #1a7a4a; }
+  .badge.live { background: var(--panel); color: var(--ink-2); }
+
+  .chat { padding: 16px 20px 18px; min-height: 420px; }
+
+  /* ── User bubble ── */
+  .user-row { display: flex; justify-content: flex-end; margin-bottom: 12px; }
+  .user-bubble {
+    max-width: 72%; background: var(--ink); color: #fefdfa;
+    padding: 10px 14px; border-radius: 16px; border-bottom-right-radius: 6px;
+    font-size: 13.5px; line-height: 1.6;
+  }
+
+  /* ── Wrong: global divider ── */
+  .global-compact {
+    display: flex; align-items: center; gap: 10px;
+    margin: 14px 0; color: var(--mute); font-size: 13px; font-weight: 500;
+  }
+  .global-compact .line { flex: 1; height: 1px; background: var(--border); }
+  .global-compact svg { width: 16px; height: 16px; flex-shrink: 0; opacity: 0.7; }
+  .strike {
+    position: relative; opacity: 0.55;
+  }
+  .strike::after {
+    content: ""; position: absolute; inset: 0;
+    background: linear-gradient(135deg, transparent 46%, rgba(232,90,74,0.55) 48%, rgba(232,90,74,0.55) 52%, transparent 54%);
+    pointer-events: none;
+  }
+
+  /* ── Agent note header ── */
+  .agent-meta {
+    display: flex; align-items: center; gap: 8px;
+    margin-bottom: 6px; font-size: 12px; color: var(--mute);
+  }
+  .agent-meta .ai-pill {
+    font-size: 9.5px; font-weight: 600; font-family: var(--mono);
+    border: 1px solid rgba(232, 90, 74, 0.45); color: var(--coral);
+    padding: 1px 5px; border-radius: 4px;
+  }
+  .reply-body {
+    margin-left: 33px; font-size: 13.5px; line-height: 1.7; color: var(--ink-2);
+  }
+
+  /* ── Process collapsible ── */
+  .process-trigger {
+    margin-left: 33px; margin-top: 4px; margin-bottom: 8px;
+    display: inline-flex; align-items: center; gap: 6px;
+    font-size: 12px; color: var(--mute); cursor: pointer;
+  }
+  .process-trigger .mono { font-family: var(--mono); font-size: 11px; color: var(--faint); }
+  .process-trigger .chev { font-size: 10px; color: var(--faint); transform: rotate(90deg); }
+
+  .process-body {
+    margin-left: 33px; padding-left: 18px;
+    border-left: 1px solid var(--border);
+    display: flex; flex-direction: column; gap: 6px;
+  }
+
+  /* ── Tool call card (simplified) ── */
+  .tool-card {
+    background: var(--paper); border: 1px solid var(--border-soft);
+    border-radius: 8px; overflow: hidden; font-family: var(--mono); font-size: 11.5px;
+  }
+  .tool-top {
+    display: flex; align-items: center; gap: 6px;
+    padding: 6px 10px; background: #fbf9f4; color: var(--ink-2);
+    border-bottom: 1px solid var(--border-soft);
+  }
+  .dot { width: 7px; height: 7px; border-radius: 50%; flex-shrink: 0; }
+  .dot.ok { background: var(--success); }
+  .dot.pending { background: var(--pending); }
+  .tool-bottom {
+    padding: 6px 10px; color: var(--mute); white-space: nowrap;
+    overflow: hidden; text-overflow: ellipsis;
+  }
+
+  /* ── Compaction row (inside process / live panel) ── */
+  .compact-row {
+    background: var(--paper); border: 1px solid var(--border-soft);
+    border-radius: 8px; overflow: hidden;
+    font-family: var(--mono); font-size: 11.5px;
+  }
+  .compact-top {
+    display: flex; align-items: center; gap: 6px;
+    padding: 6px 10px; background: #fbf9f4; color: var(--ink-2);
+  }
+  .compact-icon {
+    width: 14px; height: 14px; flex-shrink: 0;
+    display: inline-flex; align-items: center; justify-content: center;
+    color: var(--mute);
+  }
+  .compact-top .label { color: var(--ink-2); }
+  .compact-top .meta { margin-left: auto; color: var(--faint); font-size: 11px; }
+  .compact-bottom {
+    padding: 6px 10px; color: var(--mute); font-size: 11px;
+    border-top: 1px solid var(--border-soft);
+  }
+  .spin {
+    display: inline-block; width: 12px; height: 12px;
+    border: 2px solid var(--border); border-top-color: var(--mute);
+    border-radius: 50%; animation: spin 0.8s linear infinite;
+  }
+  @keyframes spin { to { transform: rotate(360deg); } }
+
+  /* ── Live dock strip ── */
+  .live-dock {
+    margin: 12px 0 0; padding: 10px 12px;
+    background: var(--paper); border: 1px solid var(--border-soft);
+    border-radius: 14px;
+    box-shadow: 0 4px 16px -10px rgba(20, 20, 15, 0.1);
+  }
+  .live-dock-h {
+    font-size: 10.5px; font-weight: 600; letter-spacing: 0.05em;
+    text-transform: uppercase; color: var(--faint); margin-bottom: 8px;
+  }
+  .agent-pill {
+    display: inline-flex; align-items: center; gap: 6px;
+    background: var(--panel); padding: 4px 9px; border-radius: 7px;
+    font-size: 12px; color: var(--ink-2); margin-bottom: 10px;
+  }
+  .agent-pill .disc {
+    width: 18px; height: 18px; border-radius: 4px;
+    background: #7c6af0; color: #fff; font-size: 10px; font-weight: 700;
+    display: grid; place-items: center;
+  }
+
+  .note {
+    max-width: 1180px; margin: 18px auto 0;
+    padding: 14px 16px; background: var(--paper);
+    border: 1px solid var(--border); border-radius: 12px;
+    font-size: 12.5px; line-height: 1.65; color: var(--ink-2);
+  }
+  .note strong { color: var(--ink); font-weight: 600; }
+  .note ul { margin: 8px 0 0 18px; }
+  .note li { margin: 4px 0; }
+
+  .tabs {
+    max-width: 1180px; margin: 0 auto 12px;
+    display: flex; gap: 6px;
+  }
+  .tabs button {
+    font: inherit; border: 1px solid var(--border); cursor: pointer;
+    padding: 6px 12px; border-radius: 8px; background: var(--paper);
+    font-size: 12.5px; color: var(--ink-2);
+  }
+  .tabs button.on { background: var(--ink); color: #fefdfa; border-color: var(--ink); }
+
+  .panel { display: none; }
+  .panel.on { display: block; }
+</style>
+</head>
+<body>
+  <div class="page-h">
+    <h1>上下文压缩 · UI 放置方案</h1>
+    <p>
+      压缩状态不应作为<strong>全局 timeline 分隔线</strong>出现在会话流里；
+      应绑定在<strong>当前 agent turn 的直播面板</strong>（StreamingAgentBubble / Composer live dock），
+      turn 结束后归档进该条的<strong>处理过程</strong>（AgentProcessCollapsible），与 tool / thinking 同级。
+    </p>
+  </div>
+
+  <div class="legend">
+    <span class="bad">❌ 现状：chat 外层 divider</span>
+    <span class="good">✓ 目标：直播面板内联</span>
+    <span class="good">✓ 目标：Process 内可展开回看</span>
+  </div>
+
+  <div class="tabs">
+    <button class="on" data-tab="compare">三栏对比</button>
+    <button data-tab="live">直播 · 压缩中</button>
+    <button data-tab="done">结束 · Process 展开</button>
+  </div>
+
+  <!-- ── Tab: 三栏对比 ── -->
+  <div id="compare" class="panel on">
+    <div class="stage">
+      <!-- WRONG -->
+      <section class="frame bad">
+        <div class="frame-label">
+          <span>现状（错误）</span>
+          <span class="badge bad">全局 timeline</span>
+        </div>
+        <div class="chat">
+          <div class="user-row"><div class="user-bubble">读 10MB 文件触发压缩</div></div>
+          <div class="global-compact strike">
+            <div class="line"></div>
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><path d="M14 2v6h6M16 13H8M16 17H8M10 9H8"/></svg>
+            <span>已自动压缩上下文</span>
+            <div class="line"></div>
+          </div>
+          <div class="global-compact strike">
+            <div class="line"></div>
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><path d="M14 2v6h6M16 13H8M16 17H8M10 9H8"/></svg>
+            <span>已自动压缩上下文</span>
+            <div class="line"></div>
+          </div>
+          <div class="agent-meta"><span class="ai-pill">AI</span> MDC · shopee/gpt-5.6-luna</div>
+          <div class="reply-body">已继续读取第二轮测试文件…</div>
+        </div>
+      </section>
+
+      <!-- LIVE -->
+      <section class="frame">
+        <div class="frame-label">
+          <span>直播中</span>
+          <span class="badge live">StreamingAgentBubble</span>
+        </div>
+        <div class="chat">
+          <div class="user-row"><div class="user-bubble">读 10MB 文件触发压缩</div></div>
+          <div class="live-dock">
+            <div class="live-dock-h">Agent 直播面板</div>
+            <div class="agent-pill"><span class="disc">M</span> MDC ▾</div>
+            <div class="tool-card" style="margin-bottom:6px">
+              <div class="tool-top"><span class="dot ok"></span> read(offset=278) · 0.3s</div>
+              <div class="tool-bottom">→ [50KB truncated] ROUND2-LINE-00278…</div>
+            </div>
+            <div class="compact-row">
+              <div class="compact-top">
+                <span class="compact-icon"><span class="spin"></span></span>
+                <span class="label">compact</span>
+                <span class="meta">threshold · in progress</span>
+              </div>
+              <div class="compact-bottom">正在自动压缩上下文…</div>
+            </div>
+            <div style="height:8px"></div>
+            <div style="display:flex;gap:4px;padding-left:4px">
+              <span class="spin" style="width:6px;height:6px;border-width:1.5px"></span>
+              <span class="spin" style="width:6px;height:6px;border-width:1.5px;animation-delay:.16s"></span>
+              <span class="spin" style="width:6px;height:6px;border-width:1.5px;animation-delay:.32s"></span>
+            </div>
+          </div>
+          <p style="margin-top:12px;font-size:12px;color:var(--faint);margin-left:4px">最终回复尚未落库 — 仅 live 区显示</p>
+        </div>
+      </section>
+
+      <!-- DONE -->
+      <section class="frame">
+        <div class="frame-label">
+          <span>Turn 结束后</span>
+          <span class="badge good">Process 内归档</span>
+        </div>
+        <div class="chat">
+          <div class="user-row"><div class="user-bubble">读 10MB 文件触发压缩</div></div>
+          <div class="agent-meta"><span class="ai-pill">AI</span> MDC · 14:32</div>
+          <button type="button" class="process-trigger">
+            <span>处理过程</span>
+            <span class="mono">Thinking · 32 tool · 1 compact</span>
+            <span class="chev">▸</span>
+          </button>
+          <div class="process-body">
+            <div class="tool-card">
+              <div class="tool-top"><span class="dot ok"></span> read · 0.4s</div>
+              <div class="tool-bottom">→ [50KB truncated] …</div>
+            </div>
+            <div class="compact-row">
+              <div class="compact-top">
+                <span class="compact-icon">📜</span>
+                <span class="label">compact</span>
+                <span class="meta">ok · 4.2s</span>
+              </div>
+              <div class="compact-bottom">345,294 → ~35,160 tokens · threshold</div>
+            </div>
+            <div class="tool-card">
+              <div class="tool-top"><span class="dot ok"></span> read · 0.3s</div>
+              <div class="tool-bottom">→ 压缩后继续读取…</div>
+            </div>
+          </div>
+          <div class="reply-body" style="margin-top:10px">
+            已继续读取第二轮测试文件。目前工具结果仍无法直接证明 pi 已压缩 — 但 Process 里可回看 compact 行。
+          </div>
+        </div>
+      </section>
+    </div>
+  </div>
+
+  <!-- ── Tab: 直播细节 ── -->
+  <div id="live" class="panel">
+    <div class="stage" style="grid-template-columns:1fr 1fr">
+      <section class="frame">
+        <div class="frame-label"><span>压缩中 · 主聊天区</span><span class="badge live">无全局 divider</span></div>
+        <div class="chat">
+          <div class="user-row"><div class="user-bubble">继续 read 大文件</div></div>
+          <!-- 注意：此处 intentionally 空白 — 压缩不在外层 -->
+          <div style="margin:40px 0;text-align:center;font-size:12px;color:var(--faint)">
+            （主 timeline 无「已自动压缩上下文」分隔线）
+          </div>
+        </div>
+      </section>
+      <section class="frame">
+        <div class="frame-label"><span>压缩中 · Live Dock</span><span class="badge good">内联 compact 行</span></div>
+        <div class="chat">
+          <div class="live-dock">
+            <div class="live-dock-h">正在回复 · MDC</div>
+            <div class="tool-card" style="margin-bottom:6px">
+              <div class="tool-top"><span class="dot ok"></span> read · 0.2s</div>
+              <div class="tool-bottom">→ …</div>
+            </div>
+            <div class="compact-row">
+              <div class="compact-top">
+                <span class="compact-icon"><span class="spin"></span></span>
+                <span class="label">compact</span>
+                <span class="meta">overflow · in progress</span>
+              </div>
+              <div class="compact-bottom">正在自动压缩上下文…</div>
+            </div>
+          </div>
+        </div>
+      </section>
+    </div>
+  </div>
+
+  <!-- ── Tab: Process 展开 ── -->
+  <div id="done" class="panel">
+    <div class="stage" style="grid-template-columns:1fr">
+      <section class="frame" style="max-width:640px;margin:0 auto">
+        <div class="frame-label"><span>完成后 · Agent 回复 note</span><span class="badge good">Process 默认折叠</span></div>
+        <div class="chat">
+          <div class="agent-meta"><span class="ai-pill">AI</span> MDC · shopee/gpt-5.6-luna · 14:32</div>
+          <button type="button" class="process-trigger">
+            <span>处理过程</span>
+            <span class="mono">32 tool · 1 compact</span>
+            <span class="chev">▸</span>
+          </button>
+          <div class="reply-body">
+            上下文压缩测试已完成。Process 内可看到 compact 发生在第 32 个 tool 之后、继续 read 之前。
+          </div>
+          <div style="margin-top:20px;padding-top:16px;border-top:1px dashed var(--border-soft)">
+            <div style="font-size:11px;color:var(--faint);margin-bottom:8px">展开后（用户点击「处理过程」）</div>
+            <div class="process-body" style="margin-left:0">
+              <div class="tool-card"><div class="tool-top"><span class="dot ok"></span> read ×32 …</div></div>
+              <div class="compact-row">
+                <div class="compact-top">
+                  <span class="compact-icon">📜</span>
+                  <span class="label">compact</span>
+                  <span class="meta">ok · 4.2s</span>
+                </div>
+                <div class="compact-bottom">345,294 → ~35,160 tokens · auto · threshold</div>
+              </div>
+              <div class="tool-card"><div class="tool-top"><span class="dot ok"></span> read · post-compact</div></div>
+            </div>
+          </div>
+        </div>
+      </section>
+    </div>
+  </div>
+
+  <div class="note">
+    <strong>实现要点（供后续改代码）</strong>
+    <ul>
+      <li>移除 <code>mergeCompactionTimelineMessages</code> 往主 timeline 插 divider 的逻辑。</li>
+      <li>在 <code>v2-streaming-store</code> 的 <code>AgentStreamEntry</code> 增加 <code>compactionEvents[]</code>（进行中 / 已完成，含 reason、tokensBefore/After）。</li>
+      <li><code>StreamingAgentBubble</code>：在 tool 流中按时间插入 compact 行（样式对齐 ToolCallCard，mono 11.5px）。</li>
+      <li>Turn finalize 时把 compact 行写入 <code>parts[]</code> 或 process meta，供 <code>AgentProcessCollapsible</code> 展开；summary 追加 <code>· 1 compact</code>。</li>
+      <li>不持久化到 Cloud API；与 thinking/tool 一样，live + 本地 process 可见即可。</li>
+    </ul>
+  </div>
+
+  <script>
+    document.querySelectorAll('.tabs button').forEach((btn) => {
+      btn.addEventListener('click', () => {
+        document.querySelectorAll('.tabs button').forEach((b) => b.classList.remove('on'));
+        document.querySelectorAll('.panel').forEach((p) => p.classList.remove('on'));
+        btn.classList.add('on');
+        document.getElementById(btn.dataset.tab).classList.add('on');
+      });
+    });
+  </script>
+</body>
+</html>

--- a/packages/app/src/__tests__/i18n-parity.test.ts
+++ b/packages/app/src/__tests__/i18n-parity.test.ts
@@ -98,6 +98,8 @@ const DYNAMIC_PREFIXES = [
   // Keyed by the schedule preset and the run status in AppCronTabContent.tsx.
   'apps.cron.preset.',
   'apps.cron.status.',
+  // Keyed by pi compaction reason (manual | threshold | overflow).
+  'chat.compaction.reason.',
 ]
 // i18next plural/context suffixes resolve from the base key at runtime.
 const PLURAL_SUFFIX = /_(plural|one|two|few|many|other|zero|\d+)$/

--- a/packages/app/src/components/chat/ChatMessage.tsx
+++ b/packages/app/src/components/chat/ChatMessage.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { useTranslation } from "react-i18next";
-import { Check, Copy, Loader2, ScrollText } from "lucide-react";
+import { Check, Copy, Loader2 } from "lucide-react";
 import { ErrorBoundary } from "@/components/ErrorBoundary";
 import { cn, copyToClipboard } from "@/lib/utils";
 import type { Message as StoreMessage } from "@/stores/session-types";
@@ -16,6 +16,7 @@ import { extractUITreeFromResponse } from "@/lib/dynamic-ui/generator";
 import { parseStreamingUITree } from "@/lib/dynamic-ui/streaming";
 import { lazyNamed } from "@/lib/lazy-component";
 import { ToolCallCard } from "./ToolCallCard";
+import { CompactionRow } from "./CompactionRow";
 import { StreamMarkdown } from "./StreamMarkdown";
 import { ThinkingBlock } from "./ThinkingBlock";
 import { AgentProcessCollapsible } from "./AgentProcessCollapsible";
@@ -27,9 +28,15 @@ import { MessageTokenSummary } from "./MessageTokenSummary";
 import { MessageFeedback } from "./MessageFeedback";
 import { MessageStarRating } from "./MessageStarRating";
 import { splitAssistantProcessAndFinalParts } from "@/lib/agent/agent-reply-transcript";
+import {
+  countCompactionParts,
+  formatAgentProcessSummary,
+  mergeProcessPartsWithCompaction,
+} from "@/lib/stream/compaction-display";
 import { hydrateDeferredProcessParts } from "@/lib/stream/lazy-process-parts";
 import type { MessagePart } from "@/stores/session-types";
 import { useSessionMessageStore } from "@/stores/session-message-store";
+import { useV2StreamingStore } from "@/stores/v2-streaming-store";
 import {
   AgentReplyQuote,
   jumpToMessageById,
@@ -44,17 +51,12 @@ const DynamicUIMessage = lazyNamed(
   "DynamicUIMessage",
 );
 
-function formatProcessMetaSummary(meta: {
-  toolCount: number;
-  hasThinking: boolean;
-}): string | undefined {
-  const bits: string[] = [];
-  if (meta.hasThinking) bits.push("Thinking");
-  if (meta.toolCount > 0) bits.push(`${meta.toolCount} tool`);
-  return bits.join(" · ") || undefined;
-}
+const EMPTY_COMPACTION_PARTS: MessagePart[] = [];
 
 function renderAgentProcessPart(part: MessagePart, basePath?: string) {
+  if (part.type === "compaction") {
+    return <CompactionRow key={part.id} part={part} />;
+  }
   if (part.type === "reasoning") {
     const reasoningText = part.text || part.content || "";
     if (!reasoningText) return null;
@@ -147,6 +149,14 @@ export const ChatMessage = React.memo(function ChatMessage({
   // (StreamingAgentBubble); a persisted ChatMessage always shows its own
   // content.
   const latestMessage = message;
+  const isSpecialTimelineRow =
+    latestMessage.hidden ||
+    latestMessage.displayKind === "synthetic" ||
+    latestMessage.displayKind === "compaction-summary";
+  const messageParts = latestMessage.parts ?? [];
+  const compactionParts = useV2StreamingStore(
+    (s) => s.compactionPartsByMessageId[latestMessage.id]?.parts ?? EMPTY_COMPACTION_PARTS,
+  );
   const textContent = latestMessage.content || "";
 
   const isDeferredProcess =
@@ -175,57 +185,80 @@ export const ChatMessage = React.memo(function ChatMessage({
   // Extract reasoning/thinking content from parts — memoized to avoid
   // re-filtering on every render during streaming.
   const { reasoningContent, hasReasoning, hasThinking } = React.useMemo(() => {
-    const rParts = latestMessage.parts.filter((p) => p.type === "reasoning");
+    if (isSpecialTimelineRow) {
+      return { reasoningContent: "", hasReasoning: false, hasThinking: false };
+    }
+    const rParts = messageParts.filter((p) => p.type === "reasoning");
     const rContent = rParts.map((p) => p.text || "").filter(Boolean).join("\n");
     return {
       reasoningContent: rContent,
       hasReasoning: rContent.length > 0,
-      hasThinking: latestMessage.parts.some(
+      hasThinking: messageParts.some(
         (p) => p.type === "step-start" || p.type === "step-finish",
       ),
     };
-  }, [latestMessage.parts]);
+  }, [isSpecialTimelineRow, messageParts]);
 
   const hasToolCalls = latestMessage.toolCalls && latestMessage.toolCalls.length > 0;
   const orderedRenderableParts = React.useMemo(
     () =>
-      latestMessage.parts.filter(
-        (p) =>
-          (p.type === "reasoning" && Boolean(p.text || p.content)) ||
-          (p.type === "text" && Boolean(p.text || p.content)) ||
-          (p.type === "tool-call" && Boolean(p.toolCall)),
-      ),
-    [latestMessage.parts],
+      isSpecialTimelineRow
+        ? []
+        : messageParts.filter(
+            (p) =>
+              (p.type === "reasoning" && Boolean(p.text || p.content)) ||
+              (p.type === "text" && Boolean(p.text || p.content)) ||
+              (p.type === "tool-call" && Boolean(p.toolCall)),
+          ),
+    [isSpecialTimelineRow, messageParts],
   );
   const hasOrderedToolParts = orderedRenderableParts.some((p) => p.type === "tool-call");
   const hasOrderedReasoningParts = orderedRenderableParts.some((p) => p.type === "reasoning");
-  const { processParts: orderedProcessParts, finalTextParts: orderedTextParts } =
+  const { processParts: rawOrderedProcessParts, finalTextParts: orderedTextParts } =
     React.useMemo(
       () => splitAssistantProcessAndFinalParts(orderedRenderableParts),
       [orderedRenderableParts],
     );
+  const orderedProcessParts = React.useMemo(
+    () => mergeProcessPartsWithCompaction(rawOrderedProcessParts, compactionParts),
+    [rawOrderedProcessParts, compactionParts],
+  );
+  const compactionCount = React.useMemo(
+    () => countCompactionParts(orderedProcessParts),
+    [orderedProcessParts],
+  );
   const shouldRenderOrderedAssistantParts =
     !isUser &&
     (hasOrderedToolParts ||
       (hasOrderedReasoningParts &&
         (orderedRenderableParts.some((p) => p.type === "text") || !textContent)));
 
-  const fallbackProcessSummary = React.useMemo(() => {
-    const bits: string[] = [];
-    if (hasReasoning) bits.push("Thinking");
-    if (hasToolCalls && !hasOrderedToolParts) {
-      bits.push(`${latestMessage.toolCalls!.length} tool`);
-    }
-    return bits.join(" · ") || undefined;
-  }, [hasReasoning, hasToolCalls, hasOrderedToolParts, latestMessage.toolCalls]);
+  const fallbackProcessSummary = React.useMemo(
+    () =>
+      formatAgentProcessSummary(t, {
+        hasThinking: hasReasoning,
+        toolCount:
+          hasToolCalls && !hasOrderedToolParts ? latestMessage.toolCalls!.length : 0,
+        compactionCount,
+      }),
+    [
+      t,
+      hasReasoning,
+      hasToolCalls,
+      hasOrderedToolParts,
+      latestMessage.toolCalls,
+      compactionCount,
+    ],
+  );
 
   const orderedProcessSummary = React.useMemo(() => {
     const toolCount = orderedProcessParts.filter((p) => p.type === "tool-call").length;
-    const bits: string[] = [];
-    if (hasOrderedReasoningParts) bits.push("Thinking");
-    if (toolCount > 0) bits.push(`${toolCount} tool`);
-    return bits.join(" · ") || undefined;
-  }, [orderedProcessParts, hasOrderedReasoningParts]);
+    return formatAgentProcessSummary(t, {
+      hasThinking: hasOrderedReasoningParts,
+      toolCount,
+      compactionCount,
+    });
+  }, [t, orderedProcessParts, hasOrderedReasoningParts, compactionCount]);
 
   const hasActiveToolCalls =
     latestMessage.toolCalls?.some(
@@ -286,38 +319,12 @@ export const ChatMessage = React.memo(function ChatMessage({
     Boolean(textContent) &&
     !(tokenGroupInfo?.hideTokenUsage ?? false);
 
-  if (latestMessage.hidden || latestMessage.displayKind === "synthetic" || latestMessage.displayKind === "compaction-summary") {
+  if (
+    latestMessage.hidden ||
+    latestMessage.displayKind === "synthetic" ||
+    latestMessage.displayKind === "compaction-summary"
+  ) {
     return null;
-  }
-
-  if (latestMessage.displayKind === "compaction") {
-    const completed = latestMessage.compaction?.completed !== false;
-    const title = completed
-      ? t("chat.compaction.title", "Context automatically compacted")
-      : t("chat.compaction.inProgressTitle", "Compacting context automatically...");
-
-    return (
-      <div
-        className="group/msg my-4 flex items-center gap-3 text-muted-foreground"
-        data-testid="chat-message"
-        data-message-id={message.id}
-        data-message-role={message.role}
-        data-message-kind="compaction"
-      >
-        <div className="h-px min-w-8 flex-1 bg-border/80" />
-        <div className="flex min-w-0 max-w-[70%] items-center gap-2 text-sm font-medium text-muted-foreground">
-          <span className="flex h-4 w-4 shrink-0 items-center justify-center">
-            {completed ? (
-              <ScrollText className="h-4 w-4" />
-            ) : (
-              <Loader2 className="h-4 w-4 animate-spin" />
-            )}
-          </span>
-          <span className="truncate">{title}</span>
-        </div>
-        <div className="h-px min-w-8 flex-1 bg-border/80" />
-      </div>
-    );
   }
 
   return (
@@ -347,11 +354,18 @@ export const ChatMessage = React.memo(function ChatMessage({
       {!isUser && isDeferredProcess && latestMessage.processMeta ? (
         <div className="mb-0.5 pl-1">
           <AgentProcessCollapsible
-            summary={formatProcessMetaSummary(latestMessage.processMeta)}
+            summary={formatAgentProcessSummary(t, {
+              ...latestMessage.processMeta,
+              compactionCount:
+                latestMessage.processMeta.compactionCount ?? compactionCount,
+            })}
             loading={processHydrating}
             onOpenChange={handleProcessOpenChange}
           >
-            {hydratedProcessParts?.map((part) => renderAgentProcessPart(part, basePath))}
+            {mergeProcessPartsWithCompaction(
+              hydratedProcessParts ?? [],
+              compactionParts,
+            ).map((part) => renderAgentProcessPart(part, basePath))}
           </AgentProcessCollapsible>
         </div>
       ) : null}
@@ -361,7 +375,9 @@ export const ChatMessage = React.memo(function ChatMessage({
         !isDeferredProcess &&
         !latestMessage.isStreaming &&
         !shouldRenderOrderedAssistantParts &&
-        (hasReasoning || (hasToolCalls && !hasOrderedToolParts)) && (
+        (hasReasoning ||
+          (hasToolCalls && !hasOrderedToolParts) ||
+          compactionCount > 0) && (
           <div className="mb-0.5 pl-1">
             <AgentProcessCollapsible summary={fallbackProcessSummary}>
               {hasReasoning ? (
@@ -372,6 +388,7 @@ export const ChatMessage = React.memo(function ChatMessage({
                     <ToolCallCard key={toolCall.id} toolCall={toolCall} />
                   ))
                 : null}
+              {compactionParts.map((part) => renderAgentProcessPart(part, basePath))}
             </AgentProcessCollapsible>
           </div>
         )}
@@ -461,34 +478,7 @@ export const ChatMessage = React.memo(function ChatMessage({
         <div className="mt-2 space-y-1">
           {orderedProcessParts.length > 0 && !latestMessage.isStreaming ? (
             <AgentProcessCollapsible summary={orderedProcessSummary}>
-              {orderedProcessParts.map((part) => {
-                if (part.type === "reasoning") {
-                  const reasoningText = part.text || part.content || "";
-                  if (!reasoningText) return null;
-                  return (
-                    <ThinkingBlock
-                      key={part.id}
-                      content={reasoningText}
-                      isOpen={false}
-                    />
-                  );
-                }
-                if (part.type === "tool-call" && part.toolCall) {
-                  return <ToolCallCard key={part.id} toolCall={part.toolCall} />;
-                }
-                if (part.type === "text") {
-                  const partText = part.text || part.content || "";
-                  if (!partText) return null;
-                  return (
-                    <Message key={part.id} from="assistant" basePath={basePath}>
-                      <MessageContent>
-                        <MessageResponse>{partText}</MessageResponse>
-                      </MessageContent>
-                    </Message>
-                  );
-                }
-                return null;
-              })}
+              {orderedProcessParts.map((part) => renderAgentProcessPart(part, basePath))}
             </AgentProcessCollapsible>
           ) : null}
           {(latestMessage.isStreaming

--- a/packages/app/src/components/chat/CompactionRow.tsx
+++ b/packages/app/src/components/chat/CompactionRow.tsx
@@ -1,0 +1,54 @@
+import * as React from "react";
+import { Loader2, ScrollText } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import type { MessagePart } from "@/stores/session-types";
+import {
+  compactionReasonLabel,
+  formatCompactionDurationMs,
+  formatCompactionTokenLine,
+} from "@/lib/stream/compaction-display";
+
+export const CompactionRow = React.memo(function CompactionRow({
+  part,
+}: {
+  part: MessagePart;
+}) {
+  const { t } = useTranslation();
+  const completed = part.completed !== false;
+  const reason = compactionReasonLabel(t, part.reason);
+  const duration = formatCompactionDurationMs(t, part.durationMs);
+  const meta = completed
+    ? duration
+      ? t("chat.compaction.completedMeta", "ok · {{duration}}", { duration })
+      : t("chat.compaction.completedShort", "ok")
+    : t("chat.compaction.inProgressMeta", "{{reason}} · in progress", { reason });
+  const bottom = completed
+    ? formatCompactionTokenLine(t, part) ??
+      t("chat.compaction.title", "Context automatically compacted")
+    : t("chat.compaction.inProgressTitle", "Compacting context automatically...");
+
+  return (
+    <div
+      className="overflow-hidden rounded-lg border border-border-soft bg-paper font-mono text-[11.5px]"
+      data-testid="compaction-row"
+      data-compaction-status={completed ? "completed" : "in_progress"}
+    >
+      <div className="flex items-center gap-1.5 border-b border-border-soft bg-[#fbf9f4] px-2.5 py-1.5 text-ink-2">
+        <span className="inline-flex h-3.5 w-3.5 shrink-0 items-center justify-center text-muted-foreground">
+          {completed ? (
+            <ScrollText className="h-3.5 w-3.5" aria-hidden />
+          ) : (
+            <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden />
+          )}
+        </span>
+        <span className="text-ink-2">
+          {t("chat.compaction.label", "compact")}
+        </span>
+        <span className="ml-auto text-[11px] text-faint">{meta}</span>
+      </div>
+      <div className="truncate px-2.5 py-1.5 text-[11px] text-muted-foreground">
+        {bottom}
+      </div>
+    </div>
+  );
+});

--- a/packages/app/src/components/chat/MessageList.tsx
+++ b/packages/app/src/components/chat/MessageList.tsx
@@ -151,7 +151,13 @@ const MessageListInner = React.forwardRef<MessageListHandle, MessageListProps>(
       let groupStart = -1;
       for (let i = 0; i <= renderedMessages.length; i++) {
         const msg = renderedMessages[i];
-        const isAssistant = msg && msg.role !== "user";
+        const isAssistant =
+          msg &&
+          msg.role !== "user" &&
+          !msg.hidden &&
+          msg.displayKind !== "compaction" &&
+          msg.displayKind !== "compaction-summary" &&
+          msg.displayKind !== "synthetic";
         if (!isAssistant || i === renderedMessages.length) {
           // End of a group — finalize
           if (groupStart !== -1) {

--- a/packages/app/src/components/chat/StreamingAgentBubble.tsx
+++ b/packages/app/src/components/chat/StreamingAgentBubble.tsx
@@ -10,6 +10,7 @@ import { Message, MessageContent, MessageResponse } from "@/packages/ai/message"
 import { useStreamAwaitingNextEvent } from "@/hooks/use-stream-awaiting-next-event";
 import { useStreamRevealText } from "@/hooks/use-stream-reveal-text";
 import { ToolCallCard } from "./ToolCallCard";
+import { CompactionRow } from "./CompactionRow";
 import { ActorLabel } from "./ActorLabel";
 import { ThinkingBlock } from "./ThinkingBlock";
 import { StreamMarkdown } from "./StreamMarkdown";
@@ -121,6 +122,14 @@ function renderOrderedPart(
     );
   }
 
+  if (part.type === "compaction") {
+    return (
+      <div key={part.id} data-testid="v2-streaming-compaction">
+        <CompactionRow part={part} />
+      </div>
+    );
+  }
+
   if (!showText || part.type !== "text") return null;
   const text = part.text || part.content || "";
   if (!text) return null;
@@ -167,7 +176,8 @@ export const StreamingAgentBubble = React.memo(function StreamingAgentBubble({
         (part) =>
           (part.type === "reasoning" && Boolean(part.text || part.content)) ||
           (part.type === "text" && Boolean(part.text || part.content)) ||
-          (part.type === "tool-call" && Boolean(part.toolCall)),
+          (part.type === "tool-call" && Boolean(part.toolCall)) ||
+          part.type === "compaction",
       );
       const visible = ordered.filter(
         (part) =>
@@ -192,6 +202,7 @@ export const StreamingAgentBubble = React.memo(function StreamingAgentBubble({
   const showOutput =
     showText && !hasVisibleOrderedParts && entry.outputText.length > 0;
   const hasFallbackToolCalls = !hasVisibleOrderedParts && entry.toolCalls.length > 0;
+  const hasCompactionParts = entry.parts.some((part) => part.type === "compaction");
   const hasThinking = !hasOrderedThinking && entry.thinkingText.length > 0;
   const hasError = !!entry.errorMessage;
 
@@ -235,6 +246,7 @@ export const StreamingAgentBubble = React.memo(function StreamingAgentBubble({
     !hasVisibleOrderedParts &&
     !showOutput &&
     !hasFallbackToolCalls &&
+    !hasCompactionParts &&
     !hasThinking &&
     !hasError
   ) {

--- a/packages/app/src/components/chat/__tests__/ChatMessage.test.tsx
+++ b/packages/app/src/components/chat/__tests__/ChatMessage.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen, cleanup } from '@testing-library/react';
+import { render, screen, cleanup, fireEvent } from '@testing-library/react';
 import { useSessionStore } from '@/stores/session-store';
+import { useV2StreamingStore } from '@/stores/v2-streaming-store';
 import { ChatMessage } from '../ChatMessage';
 
 // ── Mocks ──────────────────────────────────────────────────────────────
@@ -53,6 +54,11 @@ function makeMessage(overrides: Record<string, unknown> = {}) {
 describe('ChatMessage', () => {
   beforeEach(() => {
     useSessionStore.setState({ activeSessionId: null });
+    useV2StreamingStore.setState({
+      byKey: {},
+      archived: [],
+      compactionPartsByMessageId: {},
+    });
   });
 
   afterEach(() => {
@@ -186,26 +192,42 @@ describe('ChatMessage', () => {
     expect(firstChild?.textContent).toMatch(/Thinking|analyzing/i);
   });
 
-  it('renders completed compaction messages as a divider row without copy actions', () => {
+  it('renders attached compaction rows inside the process collapsible', () => {
+    useV2StreamingStore.setState({
+      compactionPartsByMessageId: {
+        'msg-compaction': {
+          sessionId: 'sess-1',
+          parts: [
+            {
+              id: 'compaction-1',
+              type: 'compaction',
+              completed: true,
+              reason: 'overflow',
+              tokensBefore: 345294,
+              tokensAfter: 35160,
+            },
+          ],
+        },
+      },
+    });
     const message = makeMessage({
       id: 'msg-compaction',
-      role: 'user',
-      content: '',
-      displayKind: 'compaction',
-      compaction: { auto: true, overflow: true, completed: true },
+      role: 'assistant',
+      content: 'done after compact',
     });
 
     const { container } = render(<ChatMessage message={message} />);
 
-    expect(container.textContent).toContain('Context automatically compacted');
+    expect(container.textContent).toMatch(/compact/);
+    fireEvent.click(screen.getByRole('button', { name: /处理过程|Process/i }));
+    expect(container.querySelector('[data-testid="compaction-row"]')).toBeTruthy();
     expect(container.textContent).not.toContain('Copy');
-    expect(container.querySelector('[data-message-kind="compaction"]')).toBeTruthy();
   });
 
-  it('renders in-progress compaction messages with a pending title', () => {
+  it('does not render legacy timeline compaction divider rows', () => {
     const message = makeMessage({
-      id: 'msg-compaction-pending',
-      role: 'user',
+      id: 'msg-compaction-legacy',
+      role: 'assistant',
       content: '',
       displayKind: 'compaction',
       compaction: { auto: true, overflow: true, completed: false },
@@ -213,7 +235,7 @@ describe('ChatMessage', () => {
 
     const { container } = render(<ChatMessage message={message} />);
 
-    expect(container.textContent).toContain('Compacting context automatically...');
+    expect(container.querySelector('[data-message-kind="compaction"]')).toBeNull();
   });
 
   it('renders interrupted agent reply from turnStatus (scheme B)', () => {

--- a/packages/app/src/components/chat/__tests__/StreamingAgentBubble.test.tsx
+++ b/packages/app/src/components/chat/__tests__/StreamingAgentBubble.test.tsx
@@ -708,4 +708,40 @@ describe("StreamingAgentBubble", () => {
     expect(expandedText).toContain("Plan first.");
     expect(expandedText).toContain("Plan second.");
   });
+
+  it("renders in-progress compaction rows in the live bubble", () => {
+    const { getByTestId } = render(
+      <StreamingAgentBubble
+        entry={{
+          sessionId: "s1",
+          actorId: "agent-a",
+          outputText: "",
+          thinkingText: "",
+          parts: [
+            {
+              id: "compaction-1",
+              type: "compaction",
+              completed: false,
+              reason: "overflow",
+              startedAt: Date.now(),
+            },
+          ],
+          toolCalls: [],
+          planEntries: [],
+          pendingPermissionsByRequestId: {},
+          errorMessage: null,
+          errorDetails: null,
+          lastUpdate: Date.now(),
+          active: true,
+          streamId: "s1::agent-a::stream-1",
+        }}
+      />,
+    );
+
+    expect(getByTestId("v2-streaming-compaction")).toBeTruthy();
+    expect(getByTestId("compaction-row")).toHaveAttribute(
+      "data-compaction-status",
+      "in_progress",
+    );
+  });
 });

--- a/packages/app/src/components/mqtt-live-wiring/handle-acp-event.ts
+++ b/packages/app/src/components/mqtt-live-wiring/handle-acp-event.ts
@@ -15,6 +15,7 @@ import { reportSkillUsage } from "@/lib/telemetry/skill-usage";
 import { resolveOrphanSubagentParentToolId, shouldBufferUnboundChildAcpEvent, shouldRouteOrphanSubagentEvent } from "@/lib/teamclu/subagent-acp-routing";
 import { routeSubagentAcpEvent } from "@/lib/teamclu/subagent-acp-route";
 import { tryBindChildFromPermission } from "@/lib/teamclu/subagent-acp-binding";
+import { handleCompactionRawEvent } from "@/lib/stream/handle-compaction-raw-event";
 import { useSessionStore } from "@/stores/session-store";
 import type { TFunction } from "i18next";
 import type { DecodedLiveEvent } from "@/lib/daemon/teamclu-events";
@@ -442,6 +443,11 @@ export function handleAcpEvent(
             } else if (event?.case === "raw") {
               const raw = event.value as { method?: string; jsonPayload?: Uint8Array };
               const method = raw.method ?? "";
+              if (
+                handleCompactionRawEvent(sid, actorId, method, raw.jsonPayload)
+              ) {
+                return;
+              }
               if (
                 method === "question_asked" ||
                 method === "question_replied" ||

--- a/packages/app/src/lib/agent/agent-reply-transcript.ts
+++ b/packages/app/src/lib/agent/agent-reply-transcript.ts
@@ -107,7 +107,7 @@ export function splitAssistantProcessAndFinalParts<T extends TranscriptPart>(
   for (let index = 0; index < parts.length; index += 1) {
     const part = parts[index];
     const type = part?.type;
-    if (type === "reasoning" || (type === "tool-call" && !isBookkeepingToolPart(part))) {
+    if (type === "reasoning" || type === "compaction" || (type === "tool-call" && !isBookkeepingToolPart(part))) {
       lastProcessIndex = index;
     }
   }

--- a/packages/app/src/lib/agent/agent-turn-flush.ts
+++ b/packages/app/src/lib/agent/agent-turn-flush.ts
@@ -6,7 +6,11 @@ import { bumpSessionListLastMessage } from "@/lib/session/session-list-preview";
 import { persistStreamingPartsForReply, resolveStreamEntryForPersist } from "@/lib/stream/streaming-persist";
 import { upsertMessagesBatch, type MessageRow } from "@/lib/cache/local-cache";
 import { useSessionMessageStore } from "@/stores/session-message-store";
-import { useV2StreamingStore, type AgentStreamEntry } from "@/stores/v2-streaming-store";
+import {
+  extractCompactionPartsFromEntry,
+  useV2StreamingStore,
+  type AgentStreamEntry,
+} from "@/stores/v2-streaming-store";
 import { flushStreamDeltasFor } from "@/lib/stream/stream-delta-buffer";
 import {
   registerFlushedTurn,
@@ -130,6 +134,16 @@ function commitFlushedAgentReply(
     .replaceTurnAgentRepliesInStore(sessionId, enrichedReply);
   upsertAgentReplyToCache(opts.teamId, enrichedReply);
   const persistedPartsJson = (enrichedReply as { partsJson?: string }).partsJson;
+  const compactionParts = extractCompactionPartsFromEntry(opts.streamEntrySnapshot);
+  if (compactionParts.length > 0) {
+    useV2StreamingStore
+      .getState()
+      .attachCompactionPartsForMessage(
+        sessionId,
+        enrichedReply.messageId,
+        compactionParts,
+      );
+  }
   registerFlushedTurn(sessionId, actorId, {
     messageId: enrichedReply.messageId,
     streamId: opts.streamEntrySnapshot?.streamId ?? "",

--- a/packages/app/src/lib/stream/compaction-display.ts
+++ b/packages/app/src/lib/stream/compaction-display.ts
@@ -1,0 +1,108 @@
+import type { TFunction } from "i18next";
+import type { MessagePart } from "@/stores/session-types";
+
+export function compactionReasonLabel(
+  t: TFunction,
+  reason: string | undefined,
+): string {
+  const key = reason?.trim() || "threshold";
+  return t(`chat.compaction.reason.${key}`, key);
+}
+
+export function formatCompactionDurationMs(
+  t: TFunction,
+  durationMs: number | undefined,
+): string | undefined {
+  if (durationMs == null || !Number.isFinite(durationMs) || durationMs < 0) {
+    return undefined;
+  }
+  if (durationMs < 1000) {
+    return t("chat.compaction.durationMs", "{{ms}}ms", {
+      ms: Math.round(durationMs),
+    });
+  }
+  return t("chat.compaction.durationSec", "{{sec}}s", {
+    sec: (durationMs / 1000).toFixed(1),
+  });
+}
+
+export function formatCompactionTokenLine(
+  t: TFunction,
+  part: MessagePart,
+): string | undefined {
+  const before = part.tokensBefore;
+  const after = part.tokensAfter;
+  if (before == null && after == null) return undefined;
+  const reason = compactionReasonLabel(t, part.reason);
+  const beforeText =
+    before != null
+      ? t("chat.compaction.tokenCount", "{{count, number}}", { count: before })
+      : "?";
+  const afterText =
+    after != null
+      ? t("chat.compaction.tokenCountApprox", "~{{count, number}}", {
+          count: after,
+        })
+      : "?";
+  return t("chat.compaction.tokenChange", "{{before}} → {{after}} tokens · {{reason}}", {
+    before: beforeText,
+    after: afterText,
+    reason,
+  });
+}
+
+export function formatAgentProcessSummary(
+  t: TFunction,
+  meta: {
+    toolCount: number;
+    hasThinking: boolean;
+    compactionCount?: number;
+  },
+): string | undefined {
+  const bits: string[] = [];
+  if (meta.hasThinking) {
+    bits.push(t("chat.processSummary.thinking", "Thinking"));
+  }
+  if (meta.toolCount > 0) {
+    bits.push(
+      t("chat.processSummary.tools", "{{count}} tool", { count: meta.toolCount }),
+    );
+  }
+  const compactionCount = meta.compactionCount ?? 0;
+  if (compactionCount > 0) {
+    bits.push(
+      t("chat.processSummary.compacts", "{{count}} compact", {
+        count: compactionCount,
+      }),
+    );
+  }
+  return bits.join(" · ") || undefined;
+}
+
+export function countCompactionParts(parts: MessagePart[]): number {
+  return parts.filter((part) => part.type === "compaction").length;
+}
+
+/** Merge persisted process parts with live-only compaction rows in timeline order. */
+export function mergeProcessPartsWithCompaction(
+  processParts: MessagePart[],
+  compactionParts: MessagePart[],
+): MessagePart[] {
+  if (compactionParts.length === 0) return processParts;
+  if (processParts.length === 0) return compactionParts;
+  const merged = [...processParts];
+  for (const compaction of compactionParts) {
+    const at = compaction.startedAt ?? 0;
+    let insertAt = merged.length;
+    for (let i = 0; i < merged.length; i += 1) {
+      const candidate = merged[i];
+      const candidateAt = candidate?.startedAt ?? 0;
+      if (candidateAt > at) {
+        insertAt = i;
+        break;
+      }
+    }
+    merged.splice(insertAt, 0, compaction);
+  }
+  return merged;
+}

--- a/packages/app/src/lib/stream/compaction-display.ts
+++ b/packages/app/src/lib/stream/compaction-display.ts
@@ -83,26 +83,11 @@ export function countCompactionParts(parts: MessagePart[]): number {
   return parts.filter((part) => part.type === "compaction").length;
 }
 
-/** Merge persisted process parts with live-only compaction rows in timeline order. */
+/** Merge persisted process parts with live-only compaction rows (append in flush order). */
 export function mergeProcessPartsWithCompaction(
   processParts: MessagePart[],
   compactionParts: MessagePart[],
 ): MessagePart[] {
   if (compactionParts.length === 0) return processParts;
-  if (processParts.length === 0) return compactionParts;
-  const merged = [...processParts];
-  for (const compaction of compactionParts) {
-    const at = compaction.startedAt ?? 0;
-    let insertAt = merged.length;
-    for (let i = 0; i < merged.length; i += 1) {
-      const candidate = merged[i];
-      const candidateAt = candidate?.startedAt ?? 0;
-      if (candidateAt > at) {
-        insertAt = i;
-        break;
-      }
-    }
-    merged.splice(insertAt, 0, compaction);
-  }
-  return merged;
+  return [...processParts, ...compactionParts];
 }

--- a/packages/app/src/lib/stream/handle-compaction-raw-event.ts
+++ b/packages/app/src/lib/stream/handle-compaction-raw-event.ts
@@ -1,0 +1,33 @@
+import {
+  useV2StreamingStore,
+  type CompactionWirePayload,
+} from "@/stores/v2-streaming-store";
+
+export function handleCompactionRawEvent(
+  sessionId: string,
+  actorId: string,
+  method: string,
+  jsonPayload: Uint8Array | undefined,
+): boolean {
+  if (method !== "compaction_start" && method !== "compaction_end") {
+    return false;
+  }
+  let payload: CompactionWirePayload = {};
+  try {
+    payload = JSON.parse(
+      new TextDecoder().decode(jsonPayload ?? new Uint8Array()),
+    ) as CompactionWirePayload;
+  } catch {
+    // Best-effort: still show a generic compaction row.
+  }
+  const store = useV2StreamingStore.getState();
+  if (method === "compaction_start") {
+    store.beginCompaction(sessionId, actorId, payload);
+  } else {
+    store.completeCompaction(sessionId, actorId, {
+      ...payload,
+      completed: true,
+    });
+  }
+  return true;
+}

--- a/packages/app/src/locales/en.json
+++ b/packages/app/src/locales/en.json
@@ -579,7 +579,28 @@
     "loadEarlierMessages": "Load {{count}} earlier messages",
     "compaction": {
       "title": "Context automatically compacted",
-      "inProgressTitle": "Compacting context automatically..."
+      "inProgressTitle": "Compacting context automatically...",
+      "label": "compact",
+      "inProgressMeta": "{{reason}} · in progress",
+      "completedMeta": "ok · {{duration}}",
+      "completedShort": "ok",
+      "durationMs": "{{ms}}ms",
+      "durationSec": "{{sec}}s",
+      "tokenCount": "{{count, number}}",
+      "tokenCountApprox": "~{{count, number}}",
+      "tokenChange": "{{before}} → {{after}} tokens · {{reason}}",
+      "reason": {
+        "threshold": "threshold",
+        "overflow": "overflow",
+        "manual": "manual"
+      }
+    },
+    "processSummary": {
+      "thinking": "Thinking",
+      "tools": "{{count}} tool",
+      "tools_other": "{{count}} tools",
+      "compacts": "{{count}} compact",
+      "compacts_other": "{{count}} compacts"
     },
     "analyzing": "Agent is analyzing and planning...",
     "generatingComponents": "Generating... ({{count}} components)",

--- a/packages/app/src/locales/zh-CN.json
+++ b/packages/app/src/locales/zh-CN.json
@@ -579,7 +579,28 @@
     "loadEarlierMessages": "加载前 {{count}} 条消息",
     "compaction": {
       "title": "已自动压缩上下文",
-      "inProgressTitle": "正在自动压缩上下文..."
+      "inProgressTitle": "正在自动压缩上下文...",
+      "label": "compact",
+      "inProgressMeta": "{{reason}} · 进行中",
+      "completedMeta": "完成 · {{duration}}",
+      "completedShort": "完成",
+      "durationMs": "{{ms}}ms",
+      "durationSec": "{{sec}}s",
+      "tokenCount": "{{count, number}}",
+      "tokenCountApprox": "~{{count, number}}",
+      "tokenChange": "{{before}} → {{after}} tokens · {{reason}}",
+      "reason": {
+        "threshold": "阈值",
+        "overflow": "溢出",
+        "manual": "手动"
+      }
+    },
+    "processSummary": {
+      "thinking": "思考",
+      "tools": "{{count}} 工具",
+      "tools_other": "{{count}} 工具",
+      "compacts": "{{count}} 次压缩",
+      "compacts_other": "{{count}} 次压缩"
     },
     "analyzing": "助手正在分析规划...",
     "generatingComponents": "生成中... ({{count}} 个组件)",

--- a/packages/app/src/stores/__tests__/v2-streaming-store.test.ts
+++ b/packages/app/src/stores/__tests__/v2-streaming-store.test.ts
@@ -16,6 +16,7 @@ beforeEach(() => {
     persistedPlansBySession: {},
     interruptedFlushPending: {},
     revisionBySession: {},
+    compactionPartsByMessageId: {},
   });
 });
 
@@ -925,5 +926,37 @@ describe("revisionBySession", () => {
       vi.unstubAllGlobals();
       vi.useRealTimers();
     }
+  });
+
+  it("records compaction rows on the live stream and attaches them to flushed replies", () => {
+    const store = useV2StreamingStore.getState();
+    store.beginCompaction("s1", "a1", {
+      auto: true,
+      overflow: true,
+      reason: "overflow",
+    });
+    flushPendingSessionRevisionsForTests();
+    let [stream] = selectStreamsForSession(useV2StreamingStore.getState(), "s1");
+    expect(stream.parts.some((part) => part.type === "compaction" && !part.completed)).toBe(
+      true,
+    );
+
+    store.completeCompaction("s1", "a1", {
+      auto: true,
+      overflow: true,
+      reason: "overflow",
+      tokensBefore: 1000,
+      tokensAfter: 100,
+    });
+    flushPendingSessionRevisionsForTests();
+    [stream] = selectStreamsForSession(useV2StreamingStore.getState(), "s1");
+    const compactionPart = stream.parts.find((part) => part.type === "compaction");
+    expect(compactionPart?.completed).toBe(true);
+    expect(compactionPart?.tokensBefore).toBe(1000);
+
+    store.attachCompactionPartsForMessage("s1", "reply-1", stream.parts.filter(
+      (part) => part.type === "compaction",
+    ));
+    expect(store.getCompactionPartsForMessage("reply-1")).toHaveLength(1);
   });
 });

--- a/packages/app/src/stores/session-types.ts
+++ b/packages/app/src/stores/session-types.ts
@@ -135,6 +135,14 @@ export interface MessagePart {
   auto?: boolean;
   overflow?: boolean;
   completed?: boolean;
+  /** Compaction reason from pi (`threshold` | `overflow` | `manual`). */
+  reason?: string;
+  tokensBefore?: number;
+  tokensAfter?: number;
+  /** Epoch ms — orders compaction rows among process parts. */
+  startedAt?: number;
+  /** Wall time for completed compaction rows. */
+  durationMs?: number;
   tool?: {
     name: string;
     id: string;
@@ -215,7 +223,7 @@ export interface Message {
   /** Historical turn: process parts omitted until user expands collapsible. */
   processDeferred?: boolean;
   /** Lightweight process summary while {@link processDeferred} is true. */
-  processMeta?: { toolCount: number; hasThinking: boolean };
+  processMeta?: { toolCount: number; hasThinking: boolean; compactionCount?: number };
   /** Locates proto rows for on-demand process hydration. */
   lazyProcessRef?: {
     sessionId: string;

--- a/packages/app/src/stores/v2-streaming-store.ts
+++ b/packages/app/src/stores/v2-streaming-store.ts
@@ -270,6 +270,36 @@ interface State {
   clearSubagentsForSession: (sessionId: string) => void;
   /** Drop error-only streams and strip error banners once a new turn starts. */
   clearStaleStreamErrors: (sessionId: string, actorId?: string) => void;
+  /** Live-only compaction rows keyed by flushed AGENT_REPLY message id. */
+  compactionPartsByMessageId: Record<
+    string,
+    { sessionId: string; parts: MessagePart[] }
+  >;
+  beginCompaction: (
+    sessionId: string,
+    actorId: string,
+    payload: CompactionWirePayload,
+  ) => void;
+  completeCompaction: (
+    sessionId: string,
+    actorId: string,
+    payload: CompactionWirePayload,
+  ) => void;
+  attachCompactionPartsForMessage: (
+    sessionId: string,
+    messageId: string,
+    parts: MessagePart[],
+  ) => void;
+  getCompactionPartsForMessage: (messageId: string) => MessagePart[];
+}
+
+export interface CompactionWirePayload {
+  auto?: boolean;
+  overflow?: boolean;
+  completed?: boolean;
+  reason?: string;
+  tokensBefore?: number;
+  tokensAfter?: number;
 }
 
 function k(sessionId: string, actorId: string): string {
@@ -292,6 +322,72 @@ function emptyEntry(sessionId: string, actorId: string): AgentStreamEntry {
     active: true,
     streamId: nextStreamId(sessionId, actorId),
   };
+}
+
+function compactionPartId(actorId: string, startedAt: number): string {
+  return `compaction-${startedAt}-${actorId.slice(0, 8)}`;
+}
+
+function buildCompactionPart(
+  actorId: string,
+  payload: CompactionWirePayload,
+  completed: boolean,
+  startedAt: number,
+  durationMs?: number,
+): MessagePart {
+  return {
+    id: compactionPartId(actorId, startedAt),
+    type: "compaction",
+    auto: payload.auto !== false,
+    overflow: payload.overflow === true,
+    completed,
+    reason: payload.reason?.trim() || "threshold",
+    tokensBefore: payload.tokensBefore,
+    tokensAfter: payload.tokensAfter,
+    startedAt,
+    durationMs,
+  };
+}
+
+function upsertCompactionPart(
+  parts: MessagePart[],
+  actorId: string,
+  payload: CompactionWirePayload,
+  completed: boolean,
+): MessagePart[] {
+  let matchedIndex = -1;
+  for (let i = parts.length - 1; i >= 0; i -= 1) {
+    const part = parts[i];
+    if (part?.type !== "compaction" || part.completed) continue;
+    matchedIndex = i;
+    break;
+  }
+  if (matchedIndex >= 0) {
+    const existing = parts[matchedIndex]!;
+    const startedAt = existing.startedAt ?? Date.now();
+    const durationMs = completed ? Date.now() - startedAt : undefined;
+    const next = [...parts];
+    next[matchedIndex] = buildCompactionPart(
+      actorId,
+      payload,
+      completed,
+      startedAt,
+      durationMs,
+    );
+    return next;
+  }
+  const startedAt = Date.now();
+  return [
+    ...parts,
+    buildCompactionPart(actorId, payload, completed, startedAt, completed ? 0 : undefined),
+  ];
+}
+
+export function extractCompactionPartsFromEntry(
+  entry: AgentStreamEntry | undefined,
+): MessagePart[] {
+  if (!entry) return [];
+  return entry.parts.filter((part) => part.type === "compaction");
 }
 
 let archiveCounter = 0;
@@ -601,6 +697,7 @@ export const useV2StreamingStore = create<State>((set, get) => ({
   childAcpSessionToToolId: {},
   pendingSubagentEvents: {},
   archivedSubagentByToolId: {},
+  compactionPartsByMessageId: {},
 
   markInterruptedFlushPending: (sessionId, actorId) => {
     const key = k(sessionId, actorId);
@@ -1004,6 +1101,64 @@ export const useV2StreamingStore = create<State>((set, get) => ({
         nextEntries,
       ),
     });
+  },
+
+  beginCompaction: (sessionId, actorId, payload) => {
+    const state = get();
+    const { entry, toArchive } = prepareMutation(state, sessionId, actorId);
+    set({
+      byKey: {
+        ...state.byKey,
+        [k(sessionId, actorId)]: {
+          ...entry,
+          parts: upsertCompactionPart(entry.parts, actorId, payload, false),
+          lastUpdate: Date.now(),
+          active: true,
+        },
+      },
+      archived: toArchive ? [...state.archived, toArchive] : state.archived,
+      revisionBySession: bumpRevision(state.revisionBySession, sessionId),
+    });
+  },
+
+  completeCompaction: (sessionId, actorId, payload) => {
+    const state = get();
+    const { entry, toArchive } = prepareMutation(state, sessionId, actorId);
+    set({
+      byKey: {
+        ...state.byKey,
+        [k(sessionId, actorId)]: {
+          ...entry,
+          parts: upsertCompactionPart(entry.parts, actorId, payload, true),
+          lastUpdate: Date.now(),
+          active: true,
+        },
+      },
+      archived: toArchive ? [...state.archived, toArchive] : state.archived,
+      revisionBySession: bumpRevision(state.revisionBySession, sessionId),
+    });
+  },
+
+  attachCompactionPartsForMessage: (sessionId, messageId, parts) => {
+    const trimmedMessageId = messageId.trim();
+    const trimmedSessionId = sessionId.trim();
+    if (!trimmedMessageId || !trimmedSessionId || parts.length === 0) return;
+    const state = get();
+    set({
+      compactionPartsByMessageId: {
+        ...state.compactionPartsByMessageId,
+        [trimmedMessageId]: {
+          sessionId: trimmedSessionId,
+          parts: parts.map((part) => ({ ...part })),
+        },
+      },
+    });
+  },
+
+  getCompactionPartsForMessage: (messageId) => {
+    const trimmed = messageId.trim();
+    if (!trimmed) return [];
+    return get().compactionPartsByMessageId[trimmed]?.parts ?? [];
   },
 
   setError: (sessionId, actorId, message, details) => {
@@ -1830,11 +1985,16 @@ export const useV2StreamingStore = create<State>((set, get) => ({
     for (const [key, entry] of Object.entries(state.byKey)) {
       if (entry.sessionId !== sessionId) next[key] = entry;
     }
+    const nextCompactionParts: State["compactionPartsByMessageId"] = {};
+    for (const [messageId, row] of Object.entries(state.compactionPartsByMessageId)) {
+      if (row.sessionId !== sessionId) nextCompactionParts[messageId] = row;
+    }
     const { [sessionId]: _removed, ...persistedPlansBySession } =
       state.persistedPlansBySession;
     set({
       byKey: next,
       archived: state.archived.filter((e) => e.sessionId !== sessionId),
+      compactionPartsByMessageId: nextCompactionParts,
       persistedPlansBySession,
       revisionBySession: bumpRevision(state.revisionBySession, sessionId),
     });

--- a/packages/app/src/stores/v2-streaming-store.ts
+++ b/packages/app/src/stores/v2-streaming-store.ts
@@ -377,6 +377,7 @@ function upsertCompactionPart(
     return next;
   }
   const startedAt = Date.now();
+  // Append in arrival order — compaction_start often lands after post-tool reply text.
   return [
     ...parts,
     buildCompactionPart(actorId, payload, completed, startedAt, completed ? 0 : undefined),


### PR DESCRIPTION
## Summary
- **Daemon (pi_rpc):** End TeamClu turns on `agent_settled` only, not `agent_end`, so auto-compaction/retry can finish before Active→Idle; forward `compaction_start` / `compaction_end` as ACP raw events.
- **Frontend:** Show compaction in Live Dock / Process (not main timeline divider); v2 streaming store tracks compaction parts; i18n for compaction + process summary labels.
- **UI ordering:** Append compaction rows in event arrival order (matches pi: summary often streams before `compaction_start`).

## Test plan
- [ ] Desktop: long turn that triggers threshold compaction — turn stays “replying” through compact, then idle; compact visible in process panel.
- [ ] Verify no `no_final_reply` when agent produced text then compacted.
- [ ] `pnpm test:unit` — v2-streaming-store, ChatMessage, StreamingAgentBubble tests pass.
- [ ] Cron/gateway path: still waits for Active→Idle (unchanged contract).


Made with [Cursor](https://cursor.com)