### PR TITLE
chore(introspect): 清掉 sidecar 里经由 teamclu-team 的遗留读取

### DIFF
--- a/apps/desktop/crates/teamclu-introspect/src/capabilities.rs
+++ b/apps/desktop/crates/teamclu-introspect/src/capabilities.rs
@@ -47,7 +47,6 @@ pub async fn handle(workspace: &str, arguments: &Value) -> Result<Value, String>
         None => build_overview(workspace),
         Some("channels") => build_channels(workspace),
         Some("role") => build_role(workspace),
-        Some("team_members") => build_team_members(workspace),
         Some("env_vars") => build_env_vars(workspace),
         Some("team_info") => build_team_info(workspace),
         Some("cron_jobs") => build_cron_jobs(workspace),
@@ -90,9 +89,6 @@ fn build_overview(workspace: &str) -> Result<Value, String> {
     let roles = crate::config::read_roles(workspace).unwrap_or_default();
     let role_count = roles.len();
 
-    let members = crate::config::read_team_members(workspace).unwrap_or(json!({}));
-    let member_count = members.as_object().map(|m| m.len()).unwrap_or(0);
-
     let cron_jobs = crate::config::cron_jobs_from_value(&crate::config::read_cron_jobs(workspace)?);
     let cron_total = cron_jobs.len();
     let cron_enabled = cron_jobs
@@ -107,9 +103,6 @@ fn build_overview(workspace: &str) -> Result<Value, String> {
         },
         "roles": {
             "count": role_count
-        },
-        "team_members": {
-            "count": member_count
         },
         "env_vars": {
             "count": env_vars
@@ -231,54 +224,6 @@ fn build_role(workspace: &str) -> Result<Value, String> {
     let roles = crate::config::read_roles(workspace)?;
     Ok(json!({
         "available_roles": roles
-    }))
-}
-
-// ─── Team members ────────────────────────────────────────────────────────────
-
-fn build_team_members(workspace: &str) -> Result<Value, String> {
-    let raw = crate::config::read_team_members(workspace)?;
-
-    // members.json is an object keyed by member id/name
-    // Each value may have name, role, label fields
-    let members: Vec<Value> = match raw {
-        Value::Object(map) => map
-            .values()
-            .map(|m| {
-                let mut entry = serde_json::Map::new();
-                if let Some(n) = m.get("name").and_then(|v| v.as_str()) {
-                    entry.insert("name".to_string(), Value::String(n.to_string()));
-                }
-                if let Some(r) = m.get("role").and_then(|v| v.as_str()) {
-                    entry.insert("role".to_string(), Value::String(r.to_string()));
-                }
-                if let Some(l) = m.get("label") {
-                    entry.insert("label".to_string(), l.clone());
-                }
-                Value::Object(entry)
-            })
-            .collect(),
-        Value::Array(arr) => arr
-            .into_iter()
-            .map(|m| {
-                let mut entry = serde_json::Map::new();
-                if let Some(n) = m.get("name").and_then(|v| v.as_str()) {
-                    entry.insert("name".to_string(), Value::String(n.to_string()));
-                }
-                if let Some(r) = m.get("role").and_then(|v| v.as_str()) {
-                    entry.insert("role".to_string(), Value::String(r.to_string()));
-                }
-                if let Some(l) = m.get("label") {
-                    entry.insert("label".to_string(), l.clone());
-                }
-                Value::Object(entry)
-            })
-            .collect(),
-        _ => vec![],
-    };
-
-    Ok(json!({
-        "team_members": members
     }))
 }
 

--- a/apps/desktop/crates/teamclu-introspect/src/config.rs
+++ b/apps/desktop/crates/teamclu-introspect/src/config.rs
@@ -4,7 +4,6 @@ use std::path::{Path, PathBuf};
 
 pub const TEAMCLU_DIR: &str = ".teamclu";
 pub const CONFIG_FILE_NAME: &str = "teamclu.json";
-pub const TEAM_REPO_DIR: &str = "teamclu-team";
 
 // ---------------------------------------------------------------------------
 // Path helpers
@@ -26,13 +25,6 @@ fn cron_runs_path(workspace: &str, job_id: &str) -> PathBuf {
     teamclu_dir(workspace)
         .join("cron-runs")
         .join(format!("{job_id}.jsonl"))
-}
-
-fn team_members_path(workspace: &str) -> PathBuf {
-    Path::new(workspace)
-        .join(TEAM_REPO_DIR)
-        .join("_team")
-        .join("members.json")
 }
 
 fn roles_dir(workspace: &str) -> PathBuf {
@@ -133,14 +125,6 @@ pub fn read_cron_runs(workspace: &str, job_id: &str, limit: usize) -> Result<Vec
         }
     }
     Ok(result)
-}
-
-/// Read `{workspace}/teamclu-team/_team/members.json`. Returns `{}` if missing.
-pub fn read_team_members(workspace: &str) -> Result<Value, String> {
-    read_json_file_or_default(
-        &team_members_path(workspace),
-        Value::Object(Default::default()),
-    )
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/desktop/crates/teamclu-introspect/src/main.rs
+++ b/apps/desktop/crates/teamclu-introspect/src/main.rs
@@ -57,14 +57,14 @@ fn tool_definitions() -> Value {
     let mut tools = json!([
         {
             "name": "get_my_capabilities",
-            "description": "Query the AI agent's configured capabilities including channels, role, team members, environment variables, team info, and cron jobs.",
+            "description": "Query the AI agent's configured capabilities including channels, role, environment variables, team info, and cron jobs.",
             "inputSchema": {
                 "type": "object",
                 "properties": {
                     "category": {
                         "type": "string",
                         "description": "Optional category filter",
-                        "enum": ["channels", "role", "team_members", "env_vars", "team_info", "cron_jobs"]
+                        "enum": ["channels", "role", "env_vars", "team_info", "cron_jobs"]
                     }
                 }
             }
@@ -268,7 +268,7 @@ fn tool_definitions() -> Value {
         },
         {
             "name": "manage_mcp",
-            "description": "Manage MCP servers for this workspace: list configured servers, get one by name, add/update a local (stdio) or remote (HTTP) server, enable/disable, or remove a custom server. Built-in servers (teamclu-introspect, playwright, chrome-control, autoui) cannot be deleted; team-shared servers under teamclu-team/.mcp cannot be edited or deleted here. Env/header secret values are redacted on list/get. Changes require an agent runtime restart to take effect.",
+            "description": "Manage MCP servers for this workspace: list configured servers, get one by name, add/update a local (stdio) or remote (HTTP) server, enable/disable, or remove a custom server. Built-in servers (teamclu-introspect, playwright, chrome-control, autoui) cannot be deleted; servers installed from the team MCP catalog cannot be edited or deleted here. Env/header secret values are redacted on list/get. Changes require an agent runtime restart to take effect.",
             "inputSchema": {
                 "type": "object",
                 "properties": {

--- a/apps/desktop/crates/teamclu-introspect/src/mcp.rs
+++ b/apps/desktop/crates/teamclu-introspect/src/mcp.rs
@@ -105,7 +105,7 @@ async fn add_server(workspace: &str, api_port: u16, arguments: &Value) -> Result
     if let Some(existing) = servers.get(name) {
         if source_of(existing) == Some("team") {
             return Err(format!(
-                "'{name}' is a team-shared MCP server (managed under teamclu-team/.mcp). Cannot overwrite from here."
+                "'{name}' is installed from the team MCP catalog. Cannot overwrite it from here — manage it in the team MCP settings."
             ));
         }
         return Err(format!(
@@ -135,7 +135,7 @@ async fn update_server(workspace: &str, api_port: u16, arguments: &Value) -> Res
 
     if source_of(&existing) == Some("team") {
         return Err(format!(
-            "'{name}' is a team-shared MCP server (managed under teamclu-team/.mcp). Edit the team file and sync instead."
+            "'{name}' is installed from the team MCP catalog. Edit it in the team catalog instead."
         ));
     }
 
@@ -168,7 +168,7 @@ async fn remove_server(workspace: &str, api_port: u16, name: &str) -> Result<Val
         .ok_or_else(|| format!("MCP server '{name}' not found"))?;
     if source_of(existing) == Some("team") {
         return Err(format!(
-            "'{name}' is a team-shared MCP server and cannot be deleted from the workspace. Remove it from teamclu-team/.mcp instead."
+            "'{name}' is installed from the team MCP catalog and cannot be deleted from the workspace. Uninstall it in the team MCP settings instead."
         ));
     }
 
@@ -197,7 +197,7 @@ async fn set_enabled(
 
     if source_of(&existing) == Some("team") {
         return Err(format!(
-            "'{name}' is a team-shared MCP server (managed under teamclu-team/.mcp). Enable/disable it there."
+            "'{name}' is installed from the team MCP catalog. Install or uninstall it in the team MCP settings instead."
         ));
     }
 


### PR DESCRIPTION
#1367 之后 workspace 里不再有 `teamclu-team` 链接，introspect sidecar 里还有两处挂在它身上。只改 `apps/desktop/crates/teamclu-introspect/src/` 下四个文件。

## 一、`get_my_capabilities` 的 `team_members` —— 删掉

它读的是 `{workspace}/teamclu-team/_team/members.json`。**全仓库没有任何代码写这个文件**（`git grep` 只有这个读取和一句注释），本机所有团队的 `shared/teamclu-team/_team/` 下也一个都没有。所以它一直在返回空：

- `category: "team_members"` → 永远 `{"team_members": []}`
- overview → 永远 `"team_members": { "count": 0 }`

一个读到「团队成员数 0」的 agent 会得出错误结论，这比不给这个字段更糟。

删掉：category 分支、overview 里的字段、`build_team_members`、`config::read_team_members`、`team_members_path`、`TEAM_REPO_DIR`；tool schema 的 `enum` 和描述里同步去掉 team members。

**影响面**：仓库里没有别处引用 `get_my_capabilities`（没有 skill 文档、pi 扩展、测试），sidecar 是 bin-only crate，没有外部使用者。agent 只能从 schema 发现 category，schema 里没了就不会再有人调；万一有旧 prompt 硬写了这个 category，会拿到现有的 `Unknown category: team_members`，而不是一个看起来权威的空列表。

真正的成员列表在 Cloud API 里有 —— desktop 的 `introspect_api/apps/settings.rs::team_members` 就在用。要恢复这个 section 应该接那里，而不是给旧路径换个名字。

## 二、`manage_mcp` 的四条报错 + tool 描述 —— 只改文案

判断「团队共享 server」本身是对的：它看的是 `/mcp-get` 返回的 `source: "team"`，**不读磁盘**，保护一直有效。过时的只有文案 —— 还在让人去 `teamclu-team/.mcp` 里改。

团队 MCP 早已搬到 Cloud API，改成「团队目录 + 每人自己安装」（`docs/architecture/team-mcp-and-env-cloud.md`），界面上叫「团队目录 / Team catalog」「安装」。四条报错和 tool 描述按这个叫法重写，不带品牌名（多品牌构建共用这份 sidecar）。

| 场景 | 原文 | 现在 |
|---|---|---|
| add 撞名 | managed under teamclu-team/.mcp. Cannot overwrite | installed from the team MCP catalog. Cannot overwrite it from here — manage it in the team MCP settings |
| update | Edit the team file and sync instead | Edit it in the team catalog instead |
| remove | Remove it from teamclu-team/.mcp instead | Uninstall it in the team MCP settings instead |
| enable/disable | Enable/disable it there | Install or uninstall it in the team MCP settings instead |

## 验证

- `cargo test -p teamclu-introspect`：**99 passed**
- `cargo clippy -p teamclu-introspect --all-targets -- -D warnings`：main 和本分支都是**同样 12 条**，逐条 diff 为空 —— 全是存量，本改动**没有新增一条**
- 我改的四个文件 `cargo fmt` 干净

那 12 条 clippy 存量，以及 `send.rs:646` 一处存量 fmt 问题，CI 一直看不见：`cargo fmt/clippy --manifest-path apps/desktop/Cargo.toml` 只覆盖 `teamclu` 这个包，不覆盖 introspect 成员。这件事和本 PR 无关，单独处理。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Gs7sQhSPLWPAiBp6aA66p
