### PR TITLE
ci: 把 introspect sidecar 纳入 fmt 和 clippy，并清掉它积下的 12 条 clippy 错误

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,6 +156,19 @@ jobs:
       - name: Run Clippy
         run: cargo clippy --manifest-path apps/desktop/Cargo.toml --all-targets -- -D warnings
 
+      # The two steps above name apps/desktop/Cargo.toml, which covers the
+      # `teamclu` package and whatever it depends on. The introspect sidecar is
+      # neither: it is its own workspace member and a bin-only crate, built
+      # separately by release*.yml, so it can never be a dependency. Neither step
+      # ever reached it, and by the time anyone looked it had twelve clippy
+      # errors and a formatting drift — including an if/else with two identical
+      # branches that nothing had flagged.
+      - name: Check Rust formatting (introspect sidecar)
+        run: cargo fmt --check -p teamclu-introspect
+
+      - name: Run Clippy (introspect sidecar)
+        run: cargo clippy -p teamclu-introspect --all-targets -- -D warnings
+
       # `--lib` below compiles and runs only the unit tests. The crate also has
       # integration tests under apps/desktop/tests/ that nothing in CI ever
       # compiled, so a signature change could break them silently until someone

--- a/apps/desktop/crates/teamclu-introspect/src/capabilities.rs
+++ b/apps/desktop/crates/teamclu-introspect/src/capabilities.rs
@@ -47,7 +47,6 @@ pub async fn handle(workspace: &str, arguments: &Value) -> Result<Value, String>
         None => build_overview(workspace),
         Some("channels") => build_channels(workspace),
         Some("role") => build_role(workspace),
-        Some("team_members") => build_team_members(workspace),
         Some("env_vars") => build_env_vars(workspace),
         Some("team_info") => build_team_info(workspace),
         Some("cron_jobs") => build_cron_jobs(workspace),
@@ -90,9 +89,6 @@ fn build_overview(workspace: &str) -> Result<Value, String> {
     let roles = crate::config::read_roles(workspace).unwrap_or_default();
     let role_count = roles.len();
 
-    let members = crate::config::read_team_members(workspace).unwrap_or(json!({}));
-    let member_count = members.as_object().map(|m| m.len()).unwrap_or(0);
-
     let cron_jobs = crate::config::cron_jobs_from_value(&crate::config::read_cron_jobs(workspace)?);
     let cron_total = cron_jobs.len();
     let cron_enabled = cron_jobs
@@ -107,9 +103,6 @@ fn build_overview(workspace: &str) -> Result<Value, String> {
         },
         "roles": {
             "count": role_count
-        },
-        "team_members": {
-            "count": member_count
         },
         "env_vars": {
             "count": env_vars
@@ -231,54 +224,6 @@ fn build_role(workspace: &str) -> Result<Value, String> {
     let roles = crate::config::read_roles(workspace)?;
     Ok(json!({
         "available_roles": roles
-    }))
-}
-
-// ─── Team members ────────────────────────────────────────────────────────────
-
-fn build_team_members(workspace: &str) -> Result<Value, String> {
-    let raw = crate::config::read_team_members(workspace)?;
-
-    // members.json is an object keyed by member id/name
-    // Each value may have name, role, label fields
-    let members: Vec<Value> = match raw {
-        Value::Object(map) => map
-            .values()
-            .map(|m| {
-                let mut entry = serde_json::Map::new();
-                if let Some(n) = m.get("name").and_then(|v| v.as_str()) {
-                    entry.insert("name".to_string(), Value::String(n.to_string()));
-                }
-                if let Some(r) = m.get("role").and_then(|v| v.as_str()) {
-                    entry.insert("role".to_string(), Value::String(r.to_string()));
-                }
-                if let Some(l) = m.get("label") {
-                    entry.insert("label".to_string(), l.clone());
-                }
-                Value::Object(entry)
-            })
-            .collect(),
-        Value::Array(arr) => arr
-            .into_iter()
-            .map(|m| {
-                let mut entry = serde_json::Map::new();
-                if let Some(n) = m.get("name").and_then(|v| v.as_str()) {
-                    entry.insert("name".to_string(), Value::String(n.to_string()));
-                }
-                if let Some(r) = m.get("role").and_then(|v| v.as_str()) {
-                    entry.insert("role".to_string(), Value::String(r.to_string()));
-                }
-                if let Some(l) = m.get("label") {
-                    entry.insert("label".to_string(), l.clone());
-                }
-                Value::Object(entry)
-            })
-            .collect(),
-        _ => vec![],
-    };
-
-    Ok(json!({
-        "team_members": members
     }))
 }
 

--- a/apps/desktop/crates/teamclu-introspect/src/config.rs
+++ b/apps/desktop/crates/teamclu-introspect/src/config.rs
@@ -4,7 +4,6 @@ use std::path::{Path, PathBuf};
 
 pub const TEAMCLU_DIR: &str = ".teamclu";
 pub const CONFIG_FILE_NAME: &str = "teamclu.json";
-pub const TEAM_REPO_DIR: &str = "teamclu-team";
 
 // ---------------------------------------------------------------------------
 // Path helpers
@@ -26,13 +25,6 @@ fn cron_runs_path(workspace: &str, job_id: &str) -> PathBuf {
     teamclu_dir(workspace)
         .join("cron-runs")
         .join(format!("{job_id}.jsonl"))
-}
-
-fn team_members_path(workspace: &str) -> PathBuf {
-    Path::new(workspace)
-        .join(TEAM_REPO_DIR)
-        .join("_team")
-        .join("members.json")
 }
 
 fn roles_dir(workspace: &str) -> PathBuf {
@@ -133,14 +125,6 @@ pub fn read_cron_runs(workspace: &str, job_id: &str, limit: usize) -> Result<Vec
         }
     }
     Ok(result)
-}
-
-/// Read `{workspace}/teamclu-team/_team/members.json`. Returns `{}` if missing.
-pub fn read_team_members(workspace: &str) -> Result<Value, String> {
-    read_json_file_or_default(
-        &team_members_path(workspace),
-        Value::Object(Default::default()),
-    )
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/desktop/crates/teamclu-introspect/src/config.rs
+++ b/apps/desktop/crates/teamclu-introspect/src/config.rs
@@ -1,5 +1,4 @@
 use serde_json::Value;
-use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
 
 pub const TEAMCLU_DIR: &str = ".teamclu";
@@ -21,12 +20,6 @@ fn cron_jobs_path(workspace: &str) -> PathBuf {
     teamclu_dir(workspace).join("cron-jobs.json")
 }
 
-fn cron_runs_path(workspace: &str, job_id: &str) -> PathBuf {
-    teamclu_dir(workspace)
-        .join("cron-runs")
-        .join(format!("{job_id}.jsonl"))
-}
-
 fn roles_dir(workspace: &str) -> PathBuf {
     teamclu_dir(workspace).join("roles")
 }
@@ -42,17 +35,6 @@ fn read_json_file_or_default(path: &Path, default: Value) -> Result<Value, Strin
     let raw = std::fs::read_to_string(path)
         .map_err(|e| format!("Failed to read {}: {e}", path.display()))?;
     serde_json::from_str(&raw).map_err(|e| format!("Failed to parse {}: {e}", path.display()))
-}
-
-fn write_json_file(path: &Path, value: &Value) -> Result<(), String> {
-    if let Some(parent) = path.parent() {
-        std::fs::create_dir_all(parent)
-            .map_err(|e| format!("Failed to create dir {}: {e}", parent.display()))?;
-    }
-    let mut content = serde_json::to_string_pretty(value)
-        .map_err(|e| format!("Failed to serialize JSON: {e}"))?;
-    content.push('\n');
-    std::fs::write(path, content).map_err(|e| format!("Failed to write {}: {e}", path.display()))
 }
 
 // ---------------------------------------------------------------------------
@@ -72,11 +54,6 @@ pub fn read_cron_jobs(workspace: &str) -> Result<Value, String> {
     )
 }
 
-/// Write `{workspace}/.teamclu/cron-jobs.json`.
-pub fn write_cron_jobs(workspace: &str, data: &Value) -> Result<(), String> {
-    write_json_file(&cron_jobs_path(workspace), data)
-}
-
 /// Extract cron jobs from the native `{ jobs: [...] }` shape, while accepting the
 /// legacy bare-array shape written by older introspect versions.
 pub fn cron_jobs_from_value(data: &Value) -> Vec<Value> {
@@ -85,46 +62,6 @@ pub fn cron_jobs_from_value(data: &Value) -> Vec<Value> {
         .or_else(|| data.as_array())
         .cloned()
         .unwrap_or_default()
-}
-
-/// Read last `limit` lines from `{workspace}/.teamclu/cron-runs/{job_id}.jsonl`.
-/// Returns `[]` if file is missing.
-pub fn read_cron_runs(workspace: &str, job_id: &str, limit: usize) -> Result<Vec<Value>, String> {
-    let path = cron_runs_path(workspace, job_id);
-    if !path.exists() {
-        return Ok(vec![]);
-    }
-
-    let file = std::fs::File::open(&path)
-        .map_err(|e| format!("Failed to open {}: {e}", path.display()))?;
-    let reader = BufReader::new(file);
-
-    // Collect all non-empty lines then take the last `limit`.
-    let lines: Vec<String> = reader
-        .lines()
-        .filter_map(|l| l.ok())
-        .filter(|l| !l.trim().is_empty())
-        .collect();
-
-    let start = if lines.len() > limit {
-        lines.len() - limit
-    } else {
-        0
-    };
-
-    let mut result = Vec::new();
-    for line in &lines[start..] {
-        match serde_json::from_str::<Value>(line) {
-            Ok(v) => result.push(v),
-            Err(e) => {
-                eprintln!(
-                    "Warning: skipping malformed JSONL line in {}: {e}",
-                    path.display()
-                );
-            }
-        }
-    }
-    Ok(result)
 }
 
 // ---------------------------------------------------------------------------
@@ -193,8 +130,7 @@ fn parse_role_md(path: &Path) -> Result<Value, String> {
     let mut working_style = String::new();
 
     // --- Parse YAML frontmatter ---
-    let rest = if content.starts_with("---") {
-        let after_open = &content[3..];
+    let rest = if let Some(after_open) = content.strip_prefix("---") {
         if let Some(close_pos) = after_open.find("\n---") {
             let frontmatter = &after_open[..close_pos];
             let rest = &after_open[close_pos + 4..]; // skip "\n---"
@@ -209,7 +145,7 @@ fn parse_role_md(path: &Path) -> Result<Value, String> {
             }
             rest
         } else {
-            &content[3..]
+            after_open
         }
     } else {
         &content

--- a/apps/desktop/crates/teamclu-introspect/src/cron.rs
+++ b/apps/desktop/crates/teamclu-introspect/src/cron.rs
@@ -280,7 +280,7 @@ fn normalize_schedule_kind(kind: &str) -> String {
     }
 }
 
-fn require_job_id<'a>(args: &'a Value) -> Result<&'a str, String> {
+fn require_job_id(args: &Value) -> Result<&str, String> {
     args.get("job_id")
         .and_then(|v| v.as_str())
         .filter(|s| !s.is_empty())

--- a/apps/desktop/crates/teamclu-introspect/src/main.rs
+++ b/apps/desktop/crates/teamclu-introspect/src/main.rs
@@ -57,14 +57,14 @@ fn tool_definitions() -> Value {
     let mut tools = json!([
         {
             "name": "get_my_capabilities",
-            "description": "Query the AI agent's configured capabilities including channels, role, team members, environment variables, team info, and cron jobs.",
+            "description": "Query the AI agent's configured capabilities including channels, role, environment variables, team info, and cron jobs.",
             "inputSchema": {
                 "type": "object",
                 "properties": {
                     "category": {
                         "type": "string",
                         "description": "Optional category filter",
-                        "enum": ["channels", "role", "team_members", "env_vars", "team_info", "cron_jobs"]
+                        "enum": ["channels", "role", "env_vars", "team_info", "cron_jobs"]
                     }
                 }
             }
@@ -268,7 +268,7 @@ fn tool_definitions() -> Value {
         },
         {
             "name": "manage_mcp",
-            "description": "Manage MCP servers for this workspace: list configured servers, get one by name, add/update a local (stdio) or remote (HTTP) server, enable/disable, or remove a custom server. Built-in servers (teamclu-introspect, playwright, chrome-control, autoui) cannot be deleted; team-shared servers under teamclu-team/.mcp cannot be edited or deleted here. Env/header secret values are redacted on list/get. Changes require an agent runtime restart to take effect.",
+            "description": "Manage MCP servers for this workspace: list configured servers, get one by name, add/update a local (stdio) or remote (HTTP) server, enable/disable, or remove a custom server. Built-in servers (teamclu-introspect, playwright, chrome-control, autoui) cannot be deleted; servers installed from the team MCP catalog cannot be edited or deleted here. Env/header secret values are redacted on list/get. Changes require an agent runtime restart to take effect.",
             "inputSchema": {
                 "type": "object",
                 "properties": {

--- a/apps/desktop/crates/teamclu-introspect/src/main.rs
+++ b/apps/desktop/crates/teamclu-introspect/src/main.rs
@@ -24,10 +24,6 @@ use std::io::{BufRead, BufReader, Write};
 // CLI args
 // ---------------------------------------------------------------------------
 
-/// Default port of the internal TeamClu introspect HTTP API (must match
-/// `commands::introspect_api::INTROSPECT_API_PORT` in the desktop crate).
-const DEFAULT_INTROSPECT_API_PORT: u16 = 13144;
-
 #[derive(Parser, Debug)]
 #[command(
     name = "teamclu-introspect",

--- a/apps/desktop/crates/teamclu-introspect/src/mcp.rs
+++ b/apps/desktop/crates/teamclu-introspect/src/mcp.rs
@@ -105,7 +105,7 @@ async fn add_server(workspace: &str, api_port: u16, arguments: &Value) -> Result
     if let Some(existing) = servers.get(name) {
         if source_of(existing) == Some("team") {
             return Err(format!(
-                "'{name}' is a team-shared MCP server (managed under teamclu-team/.mcp). Cannot overwrite from here."
+                "'{name}' is installed from the team MCP catalog. Cannot overwrite it from here — manage it in the team MCP settings."
             ));
         }
         return Err(format!(
@@ -135,7 +135,7 @@ async fn update_server(workspace: &str, api_port: u16, arguments: &Value) -> Res
 
     if source_of(&existing) == Some("team") {
         return Err(format!(
-            "'{name}' is a team-shared MCP server (managed under teamclu-team/.mcp). Edit the team file and sync instead."
+            "'{name}' is installed from the team MCP catalog. Edit it in the team catalog instead."
         ));
     }
 
@@ -168,7 +168,7 @@ async fn remove_server(workspace: &str, api_port: u16, name: &str) -> Result<Val
         .ok_or_else(|| format!("MCP server '{name}' not found"))?;
     if source_of(existing) == Some("team") {
         return Err(format!(
-            "'{name}' is a team-shared MCP server and cannot be deleted from the workspace. Remove it from teamclu-team/.mcp instead."
+            "'{name}' is installed from the team MCP catalog and cannot be deleted from the workspace. Uninstall it in the team MCP settings instead."
         ));
     }
 
@@ -197,7 +197,7 @@ async fn set_enabled(
 
     if source_of(&existing) == Some("team") {
         return Err(format!(
-            "'{name}' is a team-shared MCP server (managed under teamclu-team/.mcp). Enable/disable it there."
+            "'{name}' is installed from the team MCP catalog. Install or uninstall it in the team MCP settings instead."
         ));
     }
 

--- a/apps/desktop/crates/teamclu-introspect/src/roles.rs
+++ b/apps/desktop/crates/teamclu-introspect/src/roles.rs
@@ -10,7 +10,10 @@ pub async fn handle(workspace: &str, arguments: &Value) -> Result<Value, String>
 
     match action {
         "list" => {
-            let roles = config::read_roles(workspace)?;
+            // Not for its value — `roles_with_slugs` builds the answer and
+            // swallows read errors. This call is what still turns an
+            // unreadable roles dir into an error instead of an empty list.
+            config::read_roles(workspace)?;
             let with_slugs = roles_with_slugs(workspace);
             Ok(json!({ "roles": with_slugs }))
         }
@@ -193,8 +196,7 @@ fn parse_role_fields(raw: &str) -> (String, String, String) {
     let mut description = String::new();
     let mut working_style = String::new();
 
-    let rest = if raw.starts_with("---") {
-        let after = &raw[3..];
+    let rest = if let Some(after) = raw.strip_prefix("---") {
         if let Some(close) = after.find("\n---") {
             let fm = &after[..close];
             for line in fm.lines() {

--- a/apps/desktop/crates/teamclu-introspect/src/send.rs
+++ b/apps/desktop/crates/teamclu-introspect/src/send.rs
@@ -423,19 +423,13 @@ async fn kook_send_message(
         "https://www.kookapp.cn/api/v3/message/create"
     };
 
-    let body = if is_dm {
-        json!({
-            "target_id": target_id,
-            "type": 1,
-            "content": content
-        })
-    } else {
-        json!({
-            "target_id": target_id,
-            "type": 1,
-            "content": content
-        })
-    };
+    // Same body for both: a DM and a channel message differ only in the
+    // endpoint above, where `target_id` names a user or a channel respectively.
+    let body = json!({
+        "target_id": target_id,
+        "type": 1,
+        "content": content
+    });
 
     let resp = client
         .post(url)
@@ -646,7 +640,10 @@ mod daemon_send_result_tests {
     #[test]
     fn a_delivered_send_still_reads_as_message_sent() {
         let reply = json!({ "ok": true, "result": { "message_sent": true } });
-        assert_eq!(text_of(&tool_result_from_daemon_send(&reply)), "Message sent.");
+        assert_eq!(
+            text_of(&tool_result_from_daemon_send(&reply)),
+            "Message sent."
+        );
     }
 
     #[test]

--- a/apps/desktop/crates/teamclu-introspect/src/sync.rs
+++ b/apps/desktop/crates/teamclu-introspect/src/sync.rs
@@ -22,7 +22,6 @@ pub async fn handle(_workspace: &str, api_port: u16, _arguments: &Value) -> Resu
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use serde_json::json;
 
     #[test]


### PR DESCRIPTION
> [!NOTE]
> **叠在 #1370 之上，只需要看最后一个 commit `f932e1a53`。**
> 两者都改 `config.rs` 里相邻的几行，从 main 开会冲突。base 设成 `main` 而不是 #1370 的分支，是因为 `ci.yml` 只对目标为 `main` 的 PR 触发 —— 设成 #1370 的分支，这个 PR 新加的两个 CI 步骤在合并前就一次都不会跑。#1370 合进 main 后我会 rebase，git 按 patch-id 跳过已在上游的那个 commit，这里只剩 CI 这一个。

## 为什么

`Rust Format & Clippy` 的两步都写着 `--manifest-path apps/desktop/Cargo.toml`，只覆盖 `teamclu` 包及其依赖。introspect sidecar 是独立的 workspace 成员，而且是 **bin-only crate**，由 `release*.yml` 单独构建，永远不可能成为 `teamclu` 的依赖。

所以 `ci.yml` 里提到它的只有两行建 stub 二进制的 —— fmt 和 clippy 从来没碰过它。main 上它 `clippy -D warnings` 有 **12 条错误**，`send.rs` 有一处格式漂移，一直没人发现。

## CI 改动

```yaml
- name: Check Rust formatting (introspect sidecar)
  run: cargo fmt --check -p teamclu-introspect

- name: Run Clippy (introspect sidecar)
  run: cargo clippy -p teamclu-introspect --all-targets -- -D warnings
```

放在桌面端 clippy 之后，复用同一 job 已装好的系统依赖、工具链和缓存。

## 先让它过：12 条逐条核实

**死代码** —— `DEFAULT_INTROSPECT_API_PORT`、`read_cron_runs` + `cron_runs_path`、`write_cron_jobs` + `write_json_file`。全仓库引用数为 0，或只被同一条死链上的函数调用。crate 里唯一的 cfg 门控在 `daemon_sock.rs`，与它们无关，**排除了「只在 Windows 上用到」的假报**（clippy 在 Linux/macOS 上看不到 `cfg(windows)` 分支里的用法）。cron 早就改走 introspect API，这几个是直接读写文件的旧实现。删掉 `read_cron_runs` 后 `BufRead`/`BufReader` 也没人用了，一并去掉；它里面那条 `lines().filter_map(Result::ok)` 的 lint 随之消失。

**`roles.rs` 未使用的 `roles`** —— 值确实没用上（答案来自 `roles_with_slugs`，它会吞掉读错误），但这个 `?` 是角色目录读不了时**报错而不是回空列表**的唯一原因。保留调用、去掉绑定，注释写明为什么留着。

**`send.rs` KOOK 的 if/else 两个分支一字不差** —— 不是 bug。DM 和频道已经靠上面的 endpoint 区分（`direct-message/create` vs `message/create`），`target_id` 分别是用户和频道，body 本来就该相同。合成一个，值完全不变。

**机械修复** —— 两处 `starts_with` + 切片 → `strip_prefix`（else 分支里的 `&content[3..]` 就是 `after_open`，等价）；`require_job_id` 省掉多余的生命周期；`sync.rs` 测试模块里用不到的 `use super::*`；`cargo fmt` 顺带修了 `send.rs:646`。

## 验证

- `cargo fmt --check -p teamclu-introspect`：通过
- `cargo clippy -p teamclu-introspect --all-targets -- -D warnings`：**零错误**（改前 12 条）
- `cargo test -p teamclu-introspect`：**99 passed**，与改动前相同 —— 删掉的函数本来就没有测试
- `actionlint .github/workflows/ci.yml`：通过
- CI 里两条命令都在仓库根目录原样本地跑过

## 没做的

这个 crate 的 **99 个单元测试在 CI 里也从没跑过**。这个 PR 只按要求加 fmt 和 clippy；要补的话是一条 `cargo test -p teamclu-introspect`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Gs7sQhSPLWPAiBp6aA66p
