### PR TITLE
fix(apps): roll back empty app when remote clone fails on create

### DIFF
--- a/packages/app/src/locales/en.json
+++ b/packages/app/src/locales/en.json
@@ -1611,6 +1611,7 @@
     "deleteFailed": "Delete failed",
     "deleteDenied": "App not found, or you cannot delete it",
     "deleted": "App deleted",
+    "cloneFailed": "Repository clone failed",
     "seedErrorReason": {
       "cloneTimeout": "The clone timed out. Most often this machine's git credential helper is waiting on a sign-in window that has nowhere to appear — clone the repo once in a terminal, then try again."
     },

--- a/packages/app/src/locales/zh-CN.json
+++ b/packages/app/src/locales/zh-CN.json
@@ -1611,6 +1611,7 @@
     "deleteFailed": "删除失败",
     "deleteDenied": "应用不存在或无权删除",
     "deleted": "应用已删除",
+    "cloneFailed": "仓库克隆失败",
     "seedErrorReason": {
       "cloneTimeout": "克隆超时。多半是这台机器的 git 凭证助手在等一个弹不出来的登录框；先在终端里 clone 一次这个仓库，再回来重试。"
     },

--- a/packages/app/src/stores/apps-store.test.ts
+++ b/packages/app/src/stores/apps-store.test.ts
@@ -4,6 +4,7 @@ import { publicDeployConfirm } from "@/lib/apps/app-deploy-confirm";
 const mocks = vi.hoisted(() => ({
   listApps: vi.fn(),
   createApp: vi.fn(),
+  deleteApp: vi.fn(),
   updateAppProvisionStatus: vi.fn(),
   updateAppDeployStatus: vi.fn(),
   deployApp: vi.fn(),
@@ -37,6 +38,7 @@ vi.mock("@/lib/backend", () => ({
     apps: {
       listApps: mocks.listApps,
       createApp: mocks.createApp,
+      deleteApp: mocks.deleteApp,
       updateAppProvisionStatus: mocks.updateAppProvisionStatus,
       updateAppDeployStatus: mocks.updateAppDeployStatus,
       deployApp: mocks.deployApp,
@@ -141,6 +143,7 @@ describe("apps-store", () => {
     mocks.workdirExists.mockResolvedValue(false);
     mocks.readDir.mockResolvedValue([]);
     mocks.getGitCredential.mockResolvedValue(gitCred);
+    mocks.deleteApp.mockResolvedValue(true);
     const { useAppsStore } = await import("./apps-store");
     useAppsStore.setState({
       items: [],
@@ -413,22 +416,31 @@ describe("apps-store", () => {
 
   it("create: a clone that timed out explains what the raw error does not", async () => {
     mocks.createApp.mockResolvedValueOnce(
-      appRow({ provisionStatus: "pending", gitRemoteUrl: "https://github.com/owner/private.git" }),
+      appRow({
+        id: "app-timeout",
+        provisionStatus: "pending",
+        gitRemoteUrl: "https://github.com/owner/private.git",
+      }),
     );
-    mocks.updateAppProvisionStatus.mockImplementation(async (_id, st) => appRow({ provisionStatus: st }));
+    mocks.updateAppProvisionStatus.mockImplementation(async (_id, st) =>
+      appRow({ id: "app-timeout", provisionStatus: st }),
+    );
+    mocks.deleteApp.mockResolvedValueOnce(true);
     mocks.seedDaemonApp.mockResolvedValueOnce(
       seedResult("failed", { error: '{"error":{"message":"git clone timed out after 5 minutes"}}' }),
     );
     const { useAppsStore } = await import("./apps-store");
-    await useAppsStore.getState().create({
-      teamId: "team-1",
-      name: "N",
-      type: "static_web",
-      visibility: "team",
-      gitRemoteUrl: "https://github.com/owner/private.git",
-    });
-    const [, opts] = mocks.toastError.mock.calls.at(-1) ?? [];
-    expect(String((opts as any)?.description)).toMatch(/凭证助手/);
+    await expect(
+      useAppsStore.getState().create({
+        teamId: "team-1",
+        name: "N",
+        type: "static_web",
+        visibility: "team",
+        gitRemoteUrl: "https://github.com/owner/private.git",
+      }),
+    ).rejects.toThrow(/凭证助手/);
+    expect(mocks.deleteApp).toHaveBeenCalledWith("app-timeout");
+    expect(mocks.toastError).not.toHaveBeenCalled();
   });
 
   it("create: repo_created fetches deploy key and seeds with push", async () => {
@@ -495,27 +507,37 @@ describe("apps-store", () => {
     expect(mocks.updateAppProvisionStatus.mock.calls.map((c) => c[1])).toEqual(["ready"]);
   });
 
-  it("create: a failed clone tells the user what git said", async () => {
+  it("create: a failed remote clone rolls the empty app back and throws", async () => {
     mocks.createApp.mockResolvedValueOnce(
-      appRow({ provisionStatus: "pending", gitRemoteUrl: "https://github.com/owner/nope.git" }),
+      appRow({
+        id: "app-orphan",
+        provisionStatus: "pending",
+        gitRemoteUrl: "https://github.com/owner/nope.git",
+      }),
     );
-    mocks.updateAppProvisionStatus.mockImplementation(async (_id, st) => appRow({ provisionStatus: st }));
+    mocks.updateAppProvisionStatus.mockImplementation(async (_id, st) =>
+      appRow({ id: "app-orphan", provisionStatus: st }),
+    );
+    mocks.deleteApp.mockResolvedValueOnce(true);
     mocks.seedDaemonApp.mockResolvedValueOnce(
       seedResult("failed", { error: "git clone failed: repository not found" }),
     );
     const { useAppsStore } = await import("./apps-store");
-    await useAppsStore.getState().create({
-      teamId: "team-1",
-      name: "N",
-      type: "static_web",
-      visibility: "team",
-      gitRemoteUrl: "https://github.com/owner/nope.git",
-    });
+    await expect(
+      useAppsStore.getState().create({
+        teamId: "team-1",
+        name: "N",
+        type: "static_web",
+        visibility: "team",
+        gitRemoteUrl: "https://github.com/owner/nope.git",
+      }),
+    ).rejects.toThrow("git clone failed: repository not found");
     expect(mocks.updateAppProvisionStatus.mock.calls.map((c) => c[1])).toEqual(["error"]);
-    expect(mocks.toastError).toHaveBeenCalledWith(
-      "仓库克隆失败",
-      { description: "git clone failed: repository not found" },
-    );
+    expect(mocks.deleteApp).toHaveBeenCalledWith("app-orphan");
+    expect(useAppsStore.getState().items).toEqual([]);
+    // The form shows the error; no "clone failed" toast that would make the
+    // create look half-successful.
+    expect(mocks.toastError).not.toHaveBeenCalled();
   });
 
   it("create: a template app that fails to seed does not toast a clone error", async () => {
@@ -530,6 +552,35 @@ describe("apps-store", () => {
       visibility: "team",
     });
     expect(mocks.toastError).not.toHaveBeenCalled();
+    expect(mocks.deleteApp).not.toHaveBeenCalled();
+  });
+
+  it("reseed: a failed clone toasts and keeps the app row", async () => {
+    mocks.updateAppProvisionStatus.mockImplementation(async (_id, st) => appRow({ provisionStatus: st }));
+    mocks.seedDaemonApp.mockResolvedValueOnce(
+      seedResult("failed", { error: "git clone failed: repository not found" }),
+    );
+    const { useAppsStore } = await import("./apps-store");
+    useAppsStore.setState({
+      items: [
+        appRow({
+          provisionStatus: "error",
+          gitRemoteUrl: "https://github.com/owner/nope.git",
+          teamId: "team-1",
+        }),
+      ],
+      loaded: true,
+      loading: false,
+      error: null,
+      teamId: "team-1",
+    });
+    await useAppsStore.getState().reseed("app-1");
+    expect(mocks.deleteApp).not.toHaveBeenCalled();
+    expect(useAppsStore.getState().items).toHaveLength(1);
+    expect(mocks.toastError).toHaveBeenCalledWith(
+      "仓库克隆失败",
+      { description: "git clone failed: repository not found" },
+    );
   });
 
   it("create: a thrown status PATCH does not reject create", async () => {

--- a/packages/app/src/stores/apps-store.ts
+++ b/packages/app/src/stores/apps-store.ts
@@ -356,20 +356,6 @@ function mapCloudDeployError(e: unknown): string {
 }
 
 /**
- * Kick the local daemon seed and write back the terminal status. The desktop
- * writes ONLY `ready`/`error`; `unreachable` writes nothing so the row stays
- * `pending` and a reseed remains available.
- *
- * The daemon reports the directory it wrote to, and that path is written onto
- * the app's own cloud workspace row right here — before any session exists.
- * Leaving it for the session-open path meant the app's workspace stayed
- * path-less until then, and a path-less workspace is one the daemon resolves by
- * falling back to whatever folder the desktop had open.
- *
- * A clone that fails is the one case worth interrupting the user for: they
- * typed the URL, and the app is empty until they fix it.
- */
-/**
  * Explain a seed failure the raw daemon text does not.
  *
  * A clone that ran out of time is the one failure whose cause is invisible:
@@ -389,6 +375,37 @@ function mapSeedErrorReason(raw: string | null): string | undefined {
 }
 
 /**
+ * Drop a cloud app row that was created only so a clone could run, and that
+ * clone then failed. Silent: the user is about to see the clone error on the
+ * form, not a "App deleted" success toast.
+ */
+async function discardCreatedApp(set: SetState, appId: string): Promise<void> {
+  try {
+    await getBackend().apps.deleteApp(appId);
+  } catch (e) {
+    console.warn("discard created app failed", e);
+  }
+  set((s) => ({
+    items: s.items.filter((a) => a.id !== appId),
+    selectedAppId: s.selectedAppId === appId ? null : s.selectedAppId,
+  }));
+}
+
+/**
+ * Kick the local daemon seed and write back the terminal status. The desktop
+ * writes ONLY `ready`/`error`; `unreachable` writes nothing so the row stays
+ * `pending` and a reseed remains available.
+ *
+ * The daemon reports the directory it wrote to, and that path is written onto
+ * the app's own cloud workspace row right here — before any session exists.
+ * Leaving it for the session-open path meant the app's workspace stayed
+ * path-less until then, and a path-less workspace is one the daemon resolves by
+ * falling back to whatever folder the desktop had open.
+ *
+ * Returns the seed outcome so callers can decide what to surface. A remote
+ * import that fails on create is rolled back by `create` (delete the empty
+ * cloud row + throw); a reseed leaves the row at `error` and toasts.
+ *
  * @param cloneUrl the address to clone from, when it differs from the stored
  * one. Credentials pasted into a repo URL are stripped before the row is
  * written, so the create path passes what the user actually typed — that copy
@@ -399,7 +416,7 @@ async function runSeed(
   app: AppRow,
   adoptExisting = false,
   cloneUrl?: string | null,
-): Promise<void> {
+): Promise<SeedAppResult> {
   let deployKeyPem: string | null = null;
   let deployKeyId: number | null = null;
   // Keyed on how the repo is authenticated, not on the status the row happens
@@ -416,14 +433,16 @@ async function runSeed(
       deployKeyId = cred?.deployKeyId ?? null;
       if (!deployKeyPem) {
         await patchStatus(set, app.id, "error");
-        await toastError("仓库初始化失败", "无法获取 Gitea 部署密钥");
-        return;
+        return { outcome: "failed", workdir: null, error: "无法获取 Gitea 部署密钥" };
       }
     } catch (e) {
       console.warn("getGitCredential failed (non-fatal)", e);
       await patchStatus(set, app.id, "error");
-      await toastError("仓库初始化失败", e instanceof Error ? e.message : String(e));
-      return;
+      return {
+        outcome: "failed",
+        workdir: null,
+        error: e instanceof Error ? e.message : String(e),
+      };
     }
   }
 
@@ -453,11 +472,9 @@ async function runSeed(
     await patchStatus(set, app.id, "ready");
   } else if (result.outcome === "failed") {
     await patchStatus(set, app.id, "error");
-    if (app.gitRemoteUrl) {
-      await toastError("仓库克隆失败", mapSeedErrorReason(result.error));
-    }
   }
   // unreachable → no status change; reseed remains available.
+  return result;
 }
 
 /**
@@ -660,15 +677,26 @@ export const useAppsStore = create<AppsState>((set, get) => ({
     // would write the starter template over the user's own files. The guard is
     // the status rather than the flag so an app that somehow arrives `ready` by
     // another route is treated the same way.
+    let seedResult: SeedAppResult | null = null;
     if (row.provisionStatus === "pending" || row.provisionStatus === "repo_created") {
       // The cloud API only inserts the row; the app's files come from the local
-      // daemon, which writes its own embedded template. Non-fatal — a daemon
-      // that is down (unreachable) leaves the row `pending` so the user can
-      // reseed.
+      // daemon, which writes its own embedded template. Non-fatal when the
+      // daemon is unreachable — the row stays `pending` so the user can reseed.
+      //
       // The typed address, not the stored one: `POST /v1/apps` strips any
       // credential out of it before writing the row, and this is the one call
       // that still needs it.
-      await runSeed(set, row, !!adoptLocalDir?.trim(), input.gitRemoteUrl);
+      seedResult = await runSeed(set, row, !!adoptLocalDir?.trim(), input.gitRemoteUrl);
+    }
+    // Remote import whose clone failed: the cloud row is an empty shell. Leaving
+    // it looks like create succeeded while a toast says it failed. Roll it back
+    // and throw so CreateAppView keeps the form open with the reason.
+    if (input.gitRemoteUrl?.trim() && seedResult?.outcome === "failed") {
+      await discardCreatedApp(set, row.id);
+      throw new Error(
+        mapSeedErrorReason(seedResult.error) ??
+          i18n.t("apps.cloneFailed", "仓库克隆失败"),
+      );
     }
     await get().refreshLocalApps(input.teamId);
     // Return the row as it stands AFTER seeding — the caller decides what to do
@@ -692,7 +720,13 @@ export const useAppsStore = create<AppsState>((set, get) => ({
   reseed: async (appId) => {
     const app = get().items.find((a) => a.id === appId);
     if (!app) return;
-    await runSeed(set, app);
+    const result = await runSeed(set, app);
+    // Reseed keeps the row: the user already owns this app and can retry. Toast
+    // only when a remote clone is what failed — template seed failures stay
+    // quiet (status is already `error`).
+    if (result.outcome === "failed" && app.gitRemoteUrl) {
+      await toastError("仓库克隆失败", mapSeedErrorReason(result.error));
+    }
   },
   deploy: async (appId) => {
     const app = get().items.find((a) => a.id === appId);


### PR DESCRIPTION
## Summary
- When creating an app from a remote Git URL, a failed daemon clone no longer leaves an empty cloud app row that looks like a successful create.
- On remote-clone failure: silently delete the orphan app, throw with the clone reason (including the credential-helper hint on timeout), and keep `CreateAppView` open with the error — no misleading toast.
- Reseed still keeps the existing row and toasts; template-only seed failures without a remote URL are unchanged.

## Test plan
- [x] `pnpm exec vitest run src/stores/apps-store.test.ts` (55 passed)
- [ ] Create app from a bad/private HTTPS GitHub URL → form stays open with clone error, no new app in the list
- [ ] Create app from a reachable public repo → still succeeds as before
- [ ] Reseed an existing app whose remote clone fails → row remains, toast shows clone error


Made with [Cursor](https://cursor.com)