### PR TITLE
feat(apps): FC custom runtime passthrough (build+start)

### DIFF
--- a/apps/daemon/src/http/apps.rs
+++ b/apps/daemon/src/http/apps.rs
@@ -1129,6 +1129,7 @@ fn map_build_error(err: anyhow::Error) -> HttpError {
         crate::sync::app_build::ERR_NO_JAVA_BUILD,
         crate::sync::app_build::ERR_INSTALL_TIMEOUT,
         crate::sync::app_build::ERR_BUILD_TIMEOUT,
+        crate::sync::app_build::ERR_BUILD_COMMAND_TIMEOUT,
         // Container builds: every one of these is a fact about the machine the
         // build ran on or about the app's own files, so it belongs to the
         // caller. A 500 would send them to the daemon log for something the

--- a/apps/daemon/src/http/apps.rs
+++ b/apps/daemon/src/http/apps.rs
@@ -1124,6 +1124,9 @@ fn map_build_error(err: anyhow::Error) -> HttpError {
         crate::sync::app_build::ERR_ARTIFACT_TOO_LARGE,
         crate::sync::app_build::ERR_LOCKFILE_MISMATCH,
         crate::sync::app_build::ERR_NO_PACKAGE_JSON,
+        crate::sync::app_build::ERR_NO_PYTHON_PROJECT,
+        crate::sync::app_build::ERR_NO_GO_MOD,
+        crate::sync::app_build::ERR_NO_JAVA_BUILD,
         crate::sync::app_build::ERR_INSTALL_TIMEOUT,
         crate::sync::app_build::ERR_BUILD_TIMEOUT,
         // Container builds: every one of these is a fact about the machine the

--- a/apps/daemon/src/http/apps.rs
+++ b/apps/daemon/src/http/apps.rs
@@ -339,12 +339,9 @@ fn daemon_device_name() -> String {
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AppManifestResponse {
-    /// What the checkout declares, or the built-in contract when it declares
-    /// nothing — the same value a build would report.
-    pub manifest: crate::sync::app_build::AppRuntimeManifest,
-    /// False when this machine holds no checkout for the app. The manifest is
-    /// then the default, which is a guess, and the caller should not deploy on
-    /// it.
+    /// The checkout's required build and start declaration.
+    pub declaration: crate::sync::app_build::AppDeclaration,
+    /// False when this machine holds no checkout for the app.
     pub workdir_exists: bool,
 }
 
@@ -364,12 +361,13 @@ pub async fn app_manifest(
     let team_id = query.team_id.as_deref().unwrap_or("");
     let path = resolve_workdir("", &app_id, team_id)?;
     let workdir_exists = path.is_dir();
-    let manifest =
-        tokio::task::spawn_blocking(move || crate::sync::app_build::read_runtime_manifest(&path))
+    let declaration =
+        tokio::task::spawn_blocking(move || crate::sync::app_build::read_app_declaration(&path))
             .await
-            .map_err(|e| HttpError::internal(format!("manifest read panicked: {e}")))?;
+            .map_err(|e| HttpError::internal(format!("declaration read panicked: {e}")))?
+            .map_err(map_build_error)?;
     Ok(Json(AppManifestResponse {
-        manifest,
+        declaration,
         workdir_exists,
     }))
 }
@@ -585,10 +583,8 @@ impl std::fmt::Debug for ImagePushBody {
 #[serde(rename_all = "camelCase")]
 pub struct BuildAppResponse {
     pub status: &'static str,
-    /// What the app declared about how it is built and run. Always present —
-    /// an app with no declaration reports the built-in contract, so the control
-    /// plane never has to know whether the file existed.
-    pub manifest: crate::sync::app_build::AppRuntimeManifest,
+    /// What the app declared about how it is built and run.
+    pub declaration: crate::sync::app_build::AppDeclaration,
     /// The commit that was actually built, when the daemon published work the
     /// caller did not know about. Absent when it built the sha it was given —
     /// the caller then finalizes with its own.
@@ -709,7 +705,7 @@ pub async fn build_app(
 
     let pushed = built.product.image().map(str::to_string);
     let git_commit_sha = built.git_commit_sha;
-    let manifest = built.manifest;
+    let declaration = built.declaration;
 
     // A container build has already put its result where the deployment reads
     // it from; only an archive still has to travel.
@@ -736,7 +732,7 @@ pub async fn build_app(
     Ok(Json(BuildAppResponse {
         status: "built",
         git_commit_sha,
-        manifest,
+        declaration,
         image: pushed,
     }))
 }
@@ -1141,6 +1137,7 @@ fn map_build_error(err: anyhow::Error) -> HttpError {
         crate::sync::app_build::ERR_IMAGE_BUILD_TIMEOUT,
         crate::sync::app_build::ERR_IMAGE_PUSH_TIMEOUT,
         crate::sync::app_build::ERR_IMAGE_PUSH_DENIED,
+        "teamclu.app.json",
         "git repo URL",
         "deploy key PEM",
     ];

--- a/apps/daemon/src/http/apps.rs
+++ b/apps/daemon/src/http/apps.rs
@@ -545,10 +545,11 @@ pub struct BuildAppBody {
     pub deploy_key_pem: String,
     /// Presigned OSS PUT URL for the build artifact. Short-lived signed-URL
     /// secret — never logged. Required for an app that builds to an archive,
-    /// which is every app that does not declare `runtime: "container"`.
+    /// which is every app whose declaration does not use `build.kind:
+    /// "container"`.
     #[serde(default)]
     pub presigned_put: String,
-    /// Where to push the image, for an app that declares `runtime:
+    /// Where to push the image, for an app that declares `build.kind:
     /// "container"`. Carries a registry password — never logged.
     #[serde(default)]
     pub image: Option<ImagePushBody>,
@@ -627,9 +628,9 @@ fn build_destination(
 }
 
 /// `POST /v1/apps/build` — build the app and put the result where the deploy
-/// reads it from: `pnpm build` + zip `.output` to the presigned OSS URL, or —
-/// for an app declaring `runtime: "container"` — a cross-built image pushed to
-/// the registry named in `image`.
+/// reads it from: an archive sent to the presigned OSS URL, or — for an app
+/// declaring `build.kind: "container"` — a cross-built image pushed to the
+/// registry named in `image`.
 ///
 /// Requires `workspace:write`. The workdir MUST already exist (it's the seeded
 /// checkout). Returns `{ "status": "built" }`. The presigned URL is a

--- a/apps/daemon/src/sync/app_build.rs
+++ b/apps/daemon/src/sync/app_build.rs
@@ -32,6 +32,7 @@ pub const ERR_LOCKFILE_MISMATCH: &str =
     "lockfile out of sync with package.json; commit updated pnpm-lock.yaml";
 pub const ERR_INSTALL_TIMEOUT: &str = "pnpm install timed out after 10 minutes";
 pub const ERR_BUILD_TIMEOUT: &str = "pnpm build timed out after 10 minutes";
+pub const ERR_BUILD_COMMAND_TIMEOUT: &str = "build command timed out after 10 minutes";
 /// pnpm could not be started at all. Distinct from every failure above, which
 /// are pnpm's own: this one is a fact about the machine, and on Windows it used
 /// to surface as a bare "the system cannot find the file specified" with no
@@ -280,7 +281,7 @@ fn run_shell_override(command: &str, workdir: &Path, image: Option<&str>) -> any
         &["-c", command],
         workdir,
         BUILD_TIMEOUT,
-        ERR_BUILD_TIMEOUT,
+        ERR_BUILD_COMMAND_TIMEOUT,
         image_env.as_ref().map_or(&[], |env| env.as_slice()),
     )
     .map(|_| ())
@@ -328,7 +329,11 @@ fn run_default_build(kind: &str, output: &str, workdir: &Path) -> anyhow::Result
                 .env("GOOS", "linux")
                 .env("GOARCH", "amd64");
             let out =
-                crate::sync::bounded_proc::run_bounded(command, BUILD_TIMEOUT, ERR_BUILD_TIMEOUT)?;
+                crate::sync::bounded_proc::run_bounded(
+                    command,
+                    BUILD_TIMEOUT,
+                    ERR_BUILD_COMMAND_TIMEOUT,
+                )?;
             if !out.status.success() {
                 let combined = [
                     String::from_utf8_lossy(&out.stdout).trim().to_string(),
@@ -360,7 +365,7 @@ fn run_default_build(kind: &str, output: &str, workdir: &Path) -> anyhow::Result
                         &["package"],
                         workdir,
                         BUILD_TIMEOUT,
-                        ERR_BUILD_TIMEOUT,
+                        ERR_BUILD_COMMAND_TIMEOUT,
                     )?;
                 } else {
                     run_with_timeout(
@@ -368,7 +373,7 @@ fn run_default_build(kind: &str, output: &str, workdir: &Path) -> anyhow::Result
                         &["package"],
                         workdir,
                         BUILD_TIMEOUT,
-                        ERR_BUILD_TIMEOUT,
+                        ERR_BUILD_COMMAND_TIMEOUT,
                     )?;
                 }
             } else if workdir.join("gradlew").is_file() {
@@ -377,7 +382,7 @@ fn run_default_build(kind: &str, output: &str, workdir: &Path) -> anyhow::Result
                     &["build"],
                     workdir,
                     BUILD_TIMEOUT,
-                    ERR_BUILD_TIMEOUT,
+                    ERR_BUILD_COMMAND_TIMEOUT,
                 )?;
             } else {
                 run_with_timeout(
@@ -385,7 +390,7 @@ fn run_default_build(kind: &str, output: &str, workdir: &Path) -> anyhow::Result
                     &["build"],
                     workdir,
                     BUILD_TIMEOUT,
-                    ERR_BUILD_TIMEOUT,
+                    ERR_BUILD_COMMAND_TIMEOUT,
                 )?;
             }
         }
@@ -719,10 +724,13 @@ pub fn build_artifact(
         git_commit_sha = prepare_git_build(workdir, ctx)?;
     }
     let declaration = read_app_declaration(workdir)?;
+    let build_override = declaration
+        .build
+        .command
+        .as_deref()
+        .map(str::trim)
+        .filter(|command| !command.is_empty());
     if declaration.build.kind == "container" {
-        if !workdir.join(&declaration.build.dockerfile).is_file() {
-            anyhow::bail!("{ERR_NO_DOCKERFILE}: {}", declaration.build.dockerfile);
-        }
         let minted = push.ok_or_else(|| anyhow::anyhow!("{ERR_NO_PUSH_TARGET}"))?;
         // `git_commit_sha` is set only when the build published work the client
         // did not know about, which is exactly when the minted tag is stale.
@@ -736,13 +744,7 @@ pub fn build_artifact(
             username: minted.username,
             password: minted.password,
         };
-        if let Some(command) = declaration
-            .build
-            .command
-            .as_deref()
-            .map(str::trim)
-            .filter(|command| !command.is_empty())
-        {
+        if let Some(command) = build_override {
             // For containers the override must build and tag
             // `$TEAMCLU_IMAGE`; pushing remains daemon-owned so registry
             // credentials stay out of the app command and the user's Docker
@@ -760,38 +762,31 @@ pub fn build_artifact(
     }
 
     let output_dir = workdir.join(&declaration.build.output);
-    match declaration.build.kind.as_str() {
-        "node" if !workdir.join("package.json").is_file() => {
-            anyhow::bail!("{ERR_NO_PACKAGE_JSON}")
-        }
-        "python"
-            if !workdir.join("requirements.txt").is_file()
-                && !workdir.join("pyproject.toml").is_file()
-                && (!output_dir.is_dir() || !output_dir_has_files(&output_dir)) =>
-        {
-            anyhow::bail!("{ERR_NO_PYTHON_PROJECT}")
-        }
-        "go" if !workdir.join("go.mod").is_file() => anyhow::bail!("{ERR_NO_GO_MOD}"),
-        "java"
-            if !workdir.join("pom.xml").is_file()
-                && !workdir.join("build.gradle").is_file()
-                && !workdir.join("build.gradle.kts").is_file() =>
-        {
-            anyhow::bail!("{ERR_NO_JAVA_BUILD}")
-        }
-        _ => {}
-    }
-
-    if let Some(command) = declaration
-        .build
-        .command
-        .as_deref()
-        .map(str::trim)
-        .filter(|command| !command.is_empty())
-    {
+    if let Some(command) = build_override {
         // An override is the complete build, not an extra post-build step.
         run_shell_override(command, workdir, None)?;
     } else {
+        match declaration.build.kind.as_str() {
+            "node" if !workdir.join("package.json").is_file() => {
+                anyhow::bail!("{ERR_NO_PACKAGE_JSON}")
+            }
+            "python"
+                if !workdir.join("requirements.txt").is_file()
+                    && !workdir.join("pyproject.toml").is_file()
+                    && (!output_dir.is_dir() || !output_dir_has_files(&output_dir)) =>
+            {
+                anyhow::bail!("{ERR_NO_PYTHON_PROJECT}")
+            }
+            "go" if !workdir.join("go.mod").is_file() => anyhow::bail!("{ERR_NO_GO_MOD}"),
+            "java"
+                if !workdir.join("pom.xml").is_file()
+                    && !workdir.join("build.gradle").is_file()
+                    && !workdir.join("build.gradle.kts").is_file() =>
+            {
+                anyhow::bail!("{ERR_NO_JAVA_BUILD}")
+            }
+            _ => {}
+        }
         run_default_build(&declaration.build.kind, &declaration.build.output, workdir)?;
     }
 
@@ -1226,9 +1221,8 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
-    fn build_command_replaces_the_node_default_steps() {
+    fn build_command_replaces_node_defaults_and_their_preconditions() {
         let tmp = tempfile::tempdir().unwrap();
-        std::fs::write(tmp.path().join("package.json"), "{}").unwrap();
         std::fs::write(
             tmp.path().join(MANIFEST_FILE),
             serde_json::json!({
@@ -1257,6 +1251,40 @@ mod tests {
             .read_to_string(&mut result)
             .unwrap();
         assert_eq!(result, "overridden");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn container_override_replaces_dockerfile_precondition_through_build_artifact() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(
+            tmp.path().join(MANIFEST_FILE),
+            serde_json::json!({
+                "build": {
+                    "kind": "container",
+                    "command": "printf reached > override-ran && exit 23"
+                },
+                "start": {"port": 9000}
+            })
+            .to_string(),
+        )
+        .unwrap();
+        let target = ImagePushTarget {
+            image: "registry.example.com/apps/a:sha",
+            registry: "registry.example.com",
+            username: "u",
+            password: "p",
+        };
+
+        let err = match build_artifact(tmp.path(), None, Some(&target)) {
+            Err(err) => err.to_string(),
+            Ok(_) => panic!("the intentionally failing override must stop the build"),
+        };
+        assert_eq!(
+            std::fs::read_to_string(tmp.path().join("override-ran")).unwrap(),
+            "reached"
+        );
+        assert!(!err.contains(ERR_NO_DOCKERFILE), "{err}");
     }
 
     #[cfg(unix)]

--- a/apps/daemon/src/sync/app_build.rs
+++ b/apps/daemon/src/sync/app_build.rs
@@ -23,6 +23,11 @@ pub const ERR_ARTIFACT_TOO_LARGE: &str = "artifact exceeds 50 MiB limit";
 /// `ERR_PNPM_NO_PKG_MANIFEST`, which is accurate and says nothing a user can
 /// act on; the desktop turns this marker into the two things they can do.
 pub const ERR_NO_PACKAGE_JSON: &str = "the app's folder has no package.json to build";
+pub const ERR_NO_PYTHON_PROJECT: &str =
+    "the app declares build.kind \"python\" but has no requirements.txt, pyproject.toml, or build output";
+pub const ERR_NO_GO_MOD: &str = "the app declares build.kind \"go\" but has no go.mod";
+pub const ERR_NO_JAVA_BUILD: &str =
+    "the app declares build.kind \"java\" but has no pom.xml, build.gradle, or build.gradle.kts";
 pub const ERR_LOCKFILE_MISMATCH: &str =
     "lockfile out of sync with package.json; commit updated pnpm-lock.yaml";
 pub const ERR_INSTALL_TIMEOUT: &str = "pnpm install timed out after 10 minutes";
@@ -40,12 +45,8 @@ pub const ERR_NO_DOCKER: &str =
 pub const ERR_DOCKER_NOT_RUNNING: &str = "Docker is installed but not running; start it and retry";
 pub const ERR_NO_BUILDX: &str =
     "this Docker has no buildx; a container app is cross-built for linux/amd64 with it";
-pub const ERR_NO_DOCKERFILE: &str = "the app declares runtime \"container\" but has no Dockerfile";
-/// Neither of the two things a build can start from. Its own message because
-/// the app is not "a container app missing a Dockerfile" — it is an app with no
-/// code at all, and the two call for different next moves.
-pub const ERR_NO_CODE: &str =
-    "the app's folder has neither a package.json nor a Dockerfile, so there is nothing to build";
+pub const ERR_NO_DOCKERFILE: &str =
+    "the app declares build.kind \"container\" but has no Dockerfile";
 pub const ERR_IMAGE_BUILD_TIMEOUT: &str = "docker build timed out after 30 minutes";
 pub const ERR_IMAGE_PUSH_TIMEOUT: &str = "docker push timed out after 15 minutes";
 pub const ERR_IMAGE_PUSH_DENIED: &str =
@@ -197,12 +198,24 @@ fn run_with_timeout(
     timeout: Duration,
     timeout_msg: &str,
 ) -> anyhow::Result<Output> {
+    run_with_timeout_env(cmd, args, cwd, timeout, timeout_msg, &[])
+}
+
+fn run_with_timeout_env(
+    cmd: &str,
+    args: &[&str],
+    cwd: &Path,
+    timeout: Duration,
+    timeout_msg: &str,
+    env: &[(&str, &str)],
+) -> anyhow::Result<Output> {
     let mut command = Command::new(build_tool_program(cmd));
     command
         .no_window()
         .args(args)
         .current_dir(cwd)
-        .env("GIT_TERMINAL_PROMPT", "0");
+        .env("GIT_TERMINAL_PROMPT", "0")
+        .envs(env.iter().copied());
 
     // The spawn, the pipe draining and the kill live in `bounded_proc`: the
     // clone path needs exactly the same thing, and two copies of a poll loop
@@ -221,15 +234,164 @@ fn run_with_timeout(
         }
     };
     if !out.status.success() {
-        let msg = map_pnpm_failure(
-            cmd,
-            args,
-            &String::from_utf8_lossy(&out.stdout),
-            &String::from_utf8_lossy(&out.stderr),
-        );
+        let stdout = String::from_utf8_lossy(&out.stdout);
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        let msg = if cmd == "pnpm" {
+            map_pnpm_failure(cmd, args, &stdout, &stderr)
+        } else {
+            let combined = [stdout.trim(), stderr.trim()]
+                .into_iter()
+                .filter(|part| !part.is_empty())
+                .collect::<Vec<_>>()
+                .join("\n");
+            format!(
+                "{cmd} {:?} failed: {}",
+                args,
+                tail(&combined, MAX_FAILURE_OUTPUT)
+            )
+        };
         anyhow::bail!("{msg}");
     }
     Ok(out)
+}
+
+/// The default command table. Conditional rows are selected by
+/// [`run_default_build`]; this pure view keeps the six-kind contract explicit
+/// and cheaply testable.
+pub fn default_build_plan(kind: &str) -> Option<&'static [&'static str]> {
+    match kind {
+        "node" => Some(&["pnpm install --frozen-lockfile", "pnpm build"]),
+        "python" => Some(&["pip install -r requirements.txt -t <output> (when present)"]),
+        "go" => Some(&["CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o <output>/main ."]),
+        "php" => Some(&["composer install --no-dev (when composer.json is present)"]),
+        "java" => Some(&[
+            "./mvnw package or mvn package",
+            "./gradlew build or gradle build",
+        ]),
+        "container" => Some(&["docker buildx build", "docker push"]),
+        _ => None,
+    }
+}
+
+fn run_shell_override(command: &str, workdir: &Path, image: Option<&str>) -> anyhow::Result<()> {
+    let image_env = image.map(|value| [("TEAMCLU_IMAGE", value)]);
+    run_with_timeout_env(
+        "sh",
+        &["-c", command],
+        workdir,
+        BUILD_TIMEOUT,
+        ERR_BUILD_TIMEOUT,
+        image_env.as_ref().map_or(&[], |env| env.as_slice()),
+    )
+    .map(|_| ())
+}
+
+fn run_default_build(kind: &str, output: &str, workdir: &Path) -> anyhow::Result<()> {
+    match kind {
+        "node" => {
+            run_with_timeout(
+                "pnpm",
+                &["install", "--frozen-lockfile"],
+                workdir,
+                INSTALL_TIMEOUT,
+                ERR_INSTALL_TIMEOUT,
+            )?;
+            run_with_timeout(
+                "pnpm",
+                &["build"],
+                workdir,
+                BUILD_TIMEOUT,
+                ERR_BUILD_TIMEOUT,
+            )?;
+        }
+        "python" => {
+            if workdir.join("requirements.txt").is_file() {
+                run_with_timeout(
+                    "pip",
+                    &["install", "-r", "requirements.txt", "-t", output],
+                    workdir,
+                    INSTALL_TIMEOUT,
+                    ERR_INSTALL_TIMEOUT,
+                )?;
+            }
+        }
+        "go" => {
+            std::fs::create_dir_all(workdir.join(output))?;
+            let output_main = format!("{output}/main");
+            let mut command = Command::new(build_tool_program("go"));
+            command
+                .no_window()
+                .args(["build", "-o", &output_main, "."])
+                .current_dir(workdir)
+                .env("GIT_TERMINAL_PROMPT", "0")
+                .env("CGO_ENABLED", "0")
+                .env("GOOS", "linux")
+                .env("GOARCH", "amd64");
+            let out =
+                crate::sync::bounded_proc::run_bounded(command, BUILD_TIMEOUT, ERR_BUILD_TIMEOUT)?;
+            if !out.status.success() {
+                let combined = [
+                    String::from_utf8_lossy(&out.stdout).trim().to_string(),
+                    String::from_utf8_lossy(&out.stderr).trim().to_string(),
+                ]
+                .into_iter()
+                .filter(|part| !part.is_empty())
+                .collect::<Vec<_>>()
+                .join("\n");
+                anyhow::bail!("go build failed: {}", tail(&combined, MAX_FAILURE_OUTPUT));
+            }
+        }
+        "php" => {
+            if workdir.join("composer.json").is_file() {
+                run_with_timeout(
+                    "composer",
+                    &["install", "--no-dev"],
+                    workdir,
+                    INSTALL_TIMEOUT,
+                    ERR_INSTALL_TIMEOUT,
+                )?;
+            }
+        }
+        "java" => {
+            if workdir.join("pom.xml").is_file() {
+                if workdir.join("mvnw").is_file() {
+                    run_with_timeout(
+                        "./mvnw",
+                        &["package"],
+                        workdir,
+                        BUILD_TIMEOUT,
+                        ERR_BUILD_TIMEOUT,
+                    )?;
+                } else {
+                    run_with_timeout(
+                        "mvn",
+                        &["package"],
+                        workdir,
+                        BUILD_TIMEOUT,
+                        ERR_BUILD_TIMEOUT,
+                    )?;
+                }
+            } else if workdir.join("gradlew").is_file() {
+                run_with_timeout(
+                    "./gradlew",
+                    &["build"],
+                    workdir,
+                    BUILD_TIMEOUT,
+                    ERR_BUILD_TIMEOUT,
+                )?;
+            } else {
+                run_with_timeout(
+                    "gradle",
+                    &["build"],
+                    workdir,
+                    BUILD_TIMEOUT,
+                    ERR_BUILD_TIMEOUT,
+                )?;
+            }
+        }
+        other => anyhow::bail!("unsupported build.kind {other}"),
+    }
+    Ok(())
 }
 
 /// Message on the commit a deploy makes for work the agent left uncommitted.
@@ -539,8 +701,8 @@ pub struct BuildOutput {
 ///
 /// When `git` is present the workdir is fetched, published and checked out
 /// first (see [`prepare_git_build`]). What happens after that is the app's own
-/// declaration: `container` builds and pushes an image, everything else runs
-/// `pnpm install` then `pnpm build` and zips the output directory.
+/// declaration: `container` builds and pushes an image; the five archive kinds
+/// use their row in the build table (or `build.command`) and zip `build.output`.
 ///
 /// The manifest is read **before** the build rather than after. It used to be
 /// read only to find the output directory, which a node build has already
@@ -557,17 +719,10 @@ pub fn build_artifact(
         git_commit_sha = prepare_git_build(workdir, ctx)?;
     }
     let declaration = read_app_declaration(workdir)?;
-    // Neither of the two things a build can start from. Checked here rather
-    // than inside each branch because this app has no code of *either* kind:
-    // the container branch would report a missing registry (the control plane's
-    // problem, not the user's) and the node branch a missing package.json,
-    // neither of which says the app was never given any files.
-    if !workdir.join("package.json").is_file()
-        && !workdir.join(&declaration.build.dockerfile).is_file()
-    {
-        anyhow::bail!("{ERR_NO_CODE}");
-    }
     if declaration.build.kind == "container" {
+        if !workdir.join(&declaration.build.dockerfile).is_file() {
+            anyhow::bail!("{ERR_NO_DOCKERFILE}: {}", declaration.build.dockerfile);
+        }
         let minted = push.ok_or_else(|| anyhow::anyhow!("{ERR_NO_PUSH_TARGET}"))?;
         // `git_commit_sha` is set only when the build published work the client
         // did not know about, which is exactly when the minted tag is stale.
@@ -581,29 +736,65 @@ pub fn build_artifact(
             username: minted.username,
             password: minted.password,
         };
-        build_image(workdir, &declaration.build, &target)?;
+        if let Some(command) = declaration
+            .build
+            .command
+            .as_deref()
+            .map(str::trim)
+            .filter(|command| !command.is_empty())
+        {
+            // For containers the override must build and tag
+            // `$TEAMCLU_IMAGE`; pushing remains daemon-owned so registry
+            // credentials stay out of the app command and the user's Docker
+            // config.
+            run_shell_override(command, workdir, Some(target.image))?;
+            push_image(workdir, &target)?;
+        } else {
+            build_image(workdir, &declaration.build, &target)?;
+        }
         return Ok(BuildOutput {
             product: BuildProduct::Image(target.image.to_string()),
             git_commit_sha,
             declaration,
         });
     }
-    run_with_timeout(
-        "pnpm",
-        &["install", "--frozen-lockfile"],
-        workdir,
-        INSTALL_TIMEOUT,
-        ERR_INSTALL_TIMEOUT,
-    )?;
-    run_with_timeout(
-        "pnpm",
-        &["build"],
-        workdir,
-        BUILD_TIMEOUT,
-        ERR_BUILD_TIMEOUT,
-    )?;
 
     let output_dir = workdir.join(&declaration.build.output);
+    match declaration.build.kind.as_str() {
+        "node" if !workdir.join("package.json").is_file() => {
+            anyhow::bail!("{ERR_NO_PACKAGE_JSON}")
+        }
+        "python"
+            if !workdir.join("requirements.txt").is_file()
+                && !workdir.join("pyproject.toml").is_file()
+                && (!output_dir.is_dir() || !output_dir_has_files(&output_dir)) =>
+        {
+            anyhow::bail!("{ERR_NO_PYTHON_PROJECT}")
+        }
+        "go" if !workdir.join("go.mod").is_file() => anyhow::bail!("{ERR_NO_GO_MOD}"),
+        "java"
+            if !workdir.join("pom.xml").is_file()
+                && !workdir.join("build.gradle").is_file()
+                && !workdir.join("build.gradle.kts").is_file() =>
+        {
+            anyhow::bail!("{ERR_NO_JAVA_BUILD}")
+        }
+        _ => {}
+    }
+
+    if let Some(command) = declaration
+        .build
+        .command
+        .as_deref()
+        .map(str::trim)
+        .filter(|command| !command.is_empty())
+    {
+        // An override is the complete build, not an extra post-build step.
+        run_shell_override(command, workdir, None)?;
+    } else {
+        run_default_build(&declaration.build.kind, &declaration.build.output, workdir)?;
+    }
+
     if !output_dir.is_dir() || !output_dir_has_files(&output_dir) {
         // Name what was looked for. The message used to say only ".output/",
         // which is unhelpful precisely when an app builds somewhere else — the
@@ -876,6 +1067,22 @@ mod tests {
         .unwrap();
     }
 
+    fn write_code_declaration(workdir: &Path, kind: &str, output: &str) {
+        std::fs::write(
+            workdir.join(MANIFEST_FILE),
+            serde_json::json!({
+                "build": {"kind": kind, "output": output},
+                "start": {
+                    "fcRuntime": "custom.debian12",
+                    "command": ["run"],
+                    "port": 9000
+                }
+            })
+            .to_string(),
+        )
+        .unwrap();
+    }
+
     #[test]
     fn an_app_with_no_manifest_is_refused() {
         let tmp = node_checkout();
@@ -985,14 +1192,98 @@ mod tests {
     }
 
     #[test]
-    fn an_app_with_neither_package_json_nor_dockerfile_says_so() {
+    fn default_build_table_covers_all_six_kinds() {
+        for kind in VALID_BUILD_KINDS {
+            let plan = default_build_plan(kind).unwrap_or_else(|| panic!("missing {kind} plan"));
+            assert!(!plan.is_empty(), "{kind} plan must have a default step");
+        }
+        assert_eq!(
+            default_build_plan("node").unwrap(),
+            ["pnpm install --frozen-lockfile", "pnpm build"]
+        );
+        assert!(default_build_plan("ruby").is_none());
+    }
+
+    #[test]
+    fn project_preconditions_follow_declared_kind_not_file_inference() {
+        for (kind, marker) in [
+            ("node", ERR_NO_PACKAGE_JSON),
+            ("python", ERR_NO_PYTHON_PROJECT),
+            ("go", ERR_NO_GO_MOD),
+            ("java", ERR_NO_JAVA_BUILD),
+        ] {
+            let tmp = tempfile::tempdir().unwrap();
+            write_code_declaration(tmp.path(), kind, ".output");
+            // A Dockerfile must not make any of these kinds pass.
+            std::fs::write(tmp.path().join("Dockerfile"), "FROM scratch\n").unwrap();
+            let err = match build_artifact(tmp.path(), None, None) {
+                Err(e) => e.to_string(),
+                Ok(_) => panic!("{kind} app without its project marker must not build"),
+            };
+            assert_eq!(err, marker, "{kind}");
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn build_command_replaces_the_node_default_steps() {
         let tmp = tempfile::tempdir().unwrap();
-        write_container_declaration(tmp.path(), "Dockerfile", None);
-        let err = match build_artifact(tmp.path(), None, None) {
-            Err(e) => e.to_string(),
-            Ok(_) => panic!("an app with no code must not build"),
-        };
-        assert_eq!(err, ERR_NO_CODE);
+        std::fs::write(tmp.path().join("package.json"), "{}").unwrap();
+        std::fs::write(
+            tmp.path().join(MANIFEST_FILE),
+            serde_json::json!({
+                "build": {
+                    "kind": "node",
+                    "output": "custom-out",
+                    "command": "mkdir -p custom-out && printf overridden > custom-out/result.txt"
+                },
+                "start": {
+                    "fcRuntime": "custom.debian12",
+                    "command": ["node"],
+                    "port": 9000
+                }
+            })
+            .to_string(),
+        )
+        .unwrap();
+
+        let built = build_artifact(tmp.path(), None, None).unwrap();
+        let bytes = built.product.archive().unwrap();
+        let mut archive = zip::ZipArchive::new(std::io::Cursor::new(bytes)).unwrap();
+        let mut result = String::new();
+        archive
+            .by_name("result.txt")
+            .unwrap()
+            .read_to_string(&mut result)
+            .unwrap();
+        assert_eq!(result, "overridden");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn container_override_receives_the_minted_image_reference() {
+        let tmp = tempfile::tempdir().unwrap();
+        run_shell_override(
+            "printf %s \"$TEAMCLU_IMAGE\" > image.txt",
+            tmp.path(),
+            Some("registry.example.com/apps/a:sha"),
+        )
+        .unwrap();
+        assert_eq!(
+            std::fs::read_to_string(tmp.path().join("image.txt")).unwrap(),
+            "registry.example.com/apps/a:sha"
+        );
+    }
+
+    #[test]
+    fn php_without_composer_archives_declared_output() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_code_declaration(tmp.path(), "php", "public");
+        std::fs::create_dir(tmp.path().join("public")).unwrap();
+        std::fs::write(tmp.path().join("public/index.php"), "<?php echo 'ok';").unwrap();
+
+        let built = build_artifact(tmp.path(), None, None).unwrap();
+        assert!(built.product.archive().is_some());
     }
 
     #[test]

--- a/apps/daemon/src/sync/app_build.rs
+++ b/apps/daemon/src/sync/app_build.rs
@@ -57,7 +57,7 @@ pub const ERR_IMAGE_PUSH_DENIED: &str =
 /// rather than anything the user can fix — but it must not read as a build
 /// failure in their app.
 pub const ERR_NO_PUSH_TARGET: &str =
-    "this deploy supplied no image registry, and the app declares runtime \"container\"";
+    "this deploy supplied no image registry, and the app declares build.kind \"container\"";
 
 /// Cap on the command output carried in a failure message.
 ///
@@ -101,7 +101,26 @@ pub fn zip_dir(dir: &Path) -> anyhow::Result<Vec<u8>> {
     let mut zip = zip::ZipWriter::new(buf);
     let opts = zip::write::SimpleFileOptions::default()
         .compression_method(zip::CompressionMethod::Deflated);
-    for entry in walkdir::WalkDir::new(dir) {
+    let mut excluded = vec![".git".to_string()];
+    excluded.extend(app_git::runtime_exclude_entries(
+        &teamclu_runtime_env::brand_short_name_from_env(),
+    ));
+    let excluded: Vec<_> = excluded
+        .iter()
+        .map(|entry| Path::new(entry.trim_end_matches('/')))
+        .collect();
+    for entry in walkdir::WalkDir::new(dir)
+        .into_iter()
+        .filter_entry(|entry| {
+            let Ok(relative) = entry.path().strip_prefix(dir) else {
+                return false;
+            };
+            relative.as_os_str().is_empty()
+                || !excluded
+                    .iter()
+                    .any(|excluded| relative == *excluded || relative.starts_with(excluded))
+        })
+    {
         let entry = entry?;
         let path = entry.path();
         if path.is_file() {
@@ -451,9 +470,16 @@ const DEFAULT_OUTPUT: &str = ".output";
 const DEFAULT_DOCKERFILE: &str = "Dockerfile";
 const DEFAULT_CONTEXT: &str = ".";
 const VALID_BUILD_KINDS: &[&str] = &["node", "python", "go", "php", "java", "container"];
+const VALID_CODE_FC_RUNTIMES: &[&str] = &[
+    "custom",
+    "custom.debian10",
+    "custom.debian11",
+    "custom.debian12",
+];
+const CONTAINER_FC_RUNTIME: &str = "custom-container";
 
-pub const ERR_LEGACY_MANIFEST: &str = "teamclu.app.json uses legacy runtime/entry; declare build+start (see docs/specs/2026-09-11-fc-runtime-passthrough-design.md)";
-pub const ERR_MISSING_MANIFEST: &str = "teamclu.app.json is required (build+start)";
+pub const ERR_LEGACY_MANIFEST: &str = r#"teamclu.app.json uses legacy runtime/entry; replace it with build+start, e.g. {"build":{"kind":"node","output":".output"},"start":{"fcRuntime":"custom.debian10","command":["node"],"args":["server/index.mjs"],"port":9000}} (see docs/specs/2026-09-11-fc-runtime-passthrough-design.md)"#;
+pub const ERR_MISSING_MANIFEST: &str = r#"teamclu.app.json is required; add e.g. {"build":{"kind":"node","output":".output"},"start":{"fcRuntime":"custom.debian10","command":["node"],"args":["server/index.mjs"],"port":9000}} (see docs/specs/2026-09-11-fc-runtime-passthrough-design.md)"#;
 
 fn default_output() -> String {
     DEFAULT_OUTPUT.to_string()
@@ -532,6 +558,10 @@ pub fn read_app_declaration(workdir: &Path) -> anyhow::Result<AppDeclaration> {
         anyhow::bail!("{ERR_LEGACY_MANIFEST}");
     }
 
+    let output_was_omitted = value
+        .get("build")
+        .and_then(|build| build.get("output"))
+        .is_none();
     let mut declaration: AppDeclaration = serde_json::from_value(value)
         .map_err(|e| anyhow::anyhow!("invalid {MANIFEST_FILE} build+start declaration: {e}"))?;
     declaration.build.kind = declaration.build.kind.trim().to_string();
@@ -541,6 +571,13 @@ pub fn read_app_declaration(workdir: &Path) -> anyhow::Result<AppDeclaration> {
             declaration.build.kind,
             VALID_BUILD_KINDS.join(", ")
         );
+    }
+    if output_was_omitted {
+        declaration.build.output = if declaration.build.kind == "node" {
+            ".output".to_string()
+        } else {
+            ".".to_string()
+        };
     }
     for (name, path) in [
         ("build.output", &declaration.build.output),
@@ -554,16 +591,39 @@ pub fn read_app_declaration(workdir: &Path) -> anyhow::Result<AppDeclaration> {
     if declaration.start.port == 0 {
         anyhow::bail!("{MANIFEST_FILE} start.port must be between 1 and 65535");
     }
-    if declaration.build.kind != "container" {
-        let runtime_present = declaration
+    declaration.start.fc_runtime = declaration
+        .start
+        .fc_runtime
+        .take()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty());
+    if declaration.build.kind == "container" {
+        if declaration
             .start
             .fc_runtime
             .as_deref()
-            .is_some_and(|value| !value.trim().is_empty());
+            .is_some_and(|runtime| runtime != CONTAINER_FC_RUNTIME)
+        {
+            anyhow::bail!(
+                "{MANIFEST_FILE} start.fcRuntime for container must be {CONTAINER_FC_RUNTIME:?} when set"
+            );
+        }
+    } else {
+        let runtime = declaration.start.fc_runtime.as_deref().ok_or_else(|| {
+            anyhow::anyhow!(
+                "{MANIFEST_FILE} code apps require non-empty start.fcRuntime and start.command"
+            )
+        })?;
+        if !VALID_CODE_FC_RUNTIMES.contains(&runtime) {
+            anyhow::bail!(
+                "{MANIFEST_FILE} has invalid start.fcRuntime {runtime:?}; expected one of {}",
+                VALID_CODE_FC_RUNTIMES.join(", ")
+            );
+        }
         let command_present = declaration.start.command.as_ref().is_some_and(|command| {
             !command.is_empty() && command.iter().all(|part| !part.trim().is_empty())
         });
-        if !runtime_present || !command_present {
+        if !command_present {
             anyhow::bail!(
                 "{MANIFEST_FILE} code apps require non-empty start.fcRuntime and start.command"
             );
@@ -1008,6 +1068,30 @@ mod tests {
     }
 
     #[test]
+    fn zip_dir_excludes_git_and_daemon_runtime_files_from_checkout_root() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(tmp.path().join("app.py"), b"print('ok')").unwrap();
+        std::fs::create_dir_all(tmp.path().join(".git/objects")).unwrap();
+        std::fs::write(tmp.path().join(".git/HEAD"), b"ref: refs/heads/main").unwrap();
+        let runtime_dir =
+            teamclu_runtime_env::workspace_meta_dir_name(&teamclu_runtime_env::brand_short_name_from_env());
+        std::fs::create_dir_all(tmp.path().join(&runtime_dir)).unwrap();
+        std::fs::write(tmp.path().join(&runtime_dir).join("state.json"), b"{}").unwrap();
+
+        let bytes = zip_dir(tmp.path()).unwrap();
+        let mut archive = zip::ZipArchive::new(std::io::Cursor::new(bytes)).unwrap();
+        let names: Vec<String> = (0..archive.len())
+            .map(|i| archive.by_index(i).unwrap().name().to_string())
+            .collect();
+        assert!(names.iter().any(|name| name == "app.py"), "{names:?}");
+        assert!(!names.iter().any(|name| name.starts_with(".git/")), "{names:?}");
+        assert!(
+            !names.iter().any(|name| name.starts_with(&runtime_dir)),
+            "{names:?}"
+        );
+    }
+
+    #[test]
     fn output_dir_has_files_detects_empty_tree() {
         let tmp = tempfile::tempdir().unwrap();
         let empty = tmp.path().join("empty");
@@ -1083,6 +1167,8 @@ mod tests {
         let tmp = node_checkout();
         let err = read_app_declaration(tmp.path()).unwrap_err().to_string();
         assert_eq!(err, ERR_MISSING_MANIFEST);
+        assert!(err.contains(r#""build""#) && err.contains(r#""start""#), "{err}");
+        assert!(err.contains("fc-runtime-passthrough-design.md"), "{err}");
     }
 
     #[test]
@@ -1169,6 +1255,61 @@ mod tests {
         assert_eq!(wire["start"]["fcRuntime"], "custom.debian12");
         assert_eq!(wire["start"]["healthCheckPath"], "/health");
         assert!(wire["start"].get("fc_runtime").is_none());
+    }
+
+    #[test]
+    fn omitted_build_output_defaults_by_kind() {
+        for (kind, expected) in [
+            ("node", ".output"),
+            ("python", "."),
+            ("go", "."),
+            ("php", "."),
+            ("java", "."),
+        ] {
+            let tmp = tempfile::tempdir().unwrap();
+            std::fs::write(
+                tmp.path().join(MANIFEST_FILE),
+                serde_json::json!({
+                    "build": {"kind": kind},
+                    "start": {
+                        "fcRuntime": "custom.debian10",
+                        "command": ["run"],
+                        "port": 9000
+                    }
+                })
+                .to_string(),
+            )
+            .unwrap();
+            assert_eq!(
+                read_app_declaration(tmp.path()).unwrap().build.output,
+                expected,
+                "{kind}"
+            );
+        }
+    }
+
+    #[test]
+    fn fc_runtime_is_validated_before_building() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_code_declaration(tmp.path(), "python", ".");
+        let mut raw: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(tmp.path().join(MANIFEST_FILE)).unwrap())
+                .unwrap();
+        raw["start"]["fcRuntime"] = serde_json::json!("python3.10");
+        std::fs::write(tmp.path().join(MANIFEST_FILE), raw.to_string()).unwrap();
+        let err = read_app_declaration(tmp.path()).unwrap_err().to_string();
+        assert!(err.contains("invalid start.fcRuntime"), "{err}");
+
+        let container = tempfile::tempdir().unwrap();
+        write_container_declaration(container.path(), "Dockerfile", None);
+        let mut raw: serde_json::Value = serde_json::from_str(
+            &std::fs::read_to_string(container.path().join(MANIFEST_FILE)).unwrap(),
+        )
+        .unwrap();
+        raw["start"]["fcRuntime"] = serde_json::json!("custom.debian12");
+        std::fs::write(container.path().join(MANIFEST_FILE), raw.to_string()).unwrap();
+        let err = read_app_declaration(container.path()).unwrap_err().to_string();
+        assert!(err.contains("custom-container"), "{err}");
     }
 
     #[test]

--- a/apps/daemon/src/sync/app_build.rs
+++ b/apps/daemon/src/sync/app_build.rs
@@ -280,65 +280,63 @@ pub fn prepare_git_build(
     Ok(None)
 }
 
-/// What an app declares about how it is built and run.
-///
-/// Every field was a constant until an app turned up that builds to `dist/` and
-/// starts `node dist/index.js`: the deploy failed on a missing `.output/`, and
-/// the only place the real contract was written down was a template file the
-/// agent had already rewritten to describe its own code. A declaration in the
-/// repo is something an app can satisfy without us guessing.
-///
-/// Absent or unparseable means the defaults, which are exactly what every app
-/// deployed before this got — so nothing that works today needs the file.
+const DEFAULT_OUTPUT: &str = ".output";
+const DEFAULT_DOCKERFILE: &str = "Dockerfile";
+const DEFAULT_CONTEXT: &str = ".";
+const VALID_BUILD_KINDS: &[&str] = &["node", "python", "go", "php", "java", "container"];
+
+pub const ERR_LEGACY_MANIFEST: &str = "teamclu.app.json uses legacy runtime/entry; declare build+start (see docs/specs/2026-09-11-fc-runtime-passthrough-design.md)";
+pub const ERR_MISSING_MANIFEST: &str = "teamclu.app.json is required (build+start)";
+
+fn default_output() -> String {
+    DEFAULT_OUTPUT.to_string()
+}
+
+fn default_dockerfile() -> String {
+    DEFAULT_DOCKERFILE.to_string()
+}
+
+fn default_context() -> String {
+    DEFAULT_CONTEXT.to_string()
+}
+
+/// How the daemon turns an app checkout into an artifact.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct AppRuntimeManifest {
-    /// Directory to package, relative to the workdir. Unused by `container`,
-    /// which ships an image rather than an archive.
+pub struct AppBuildSpec {
+    pub kind: String,
+    #[serde(default = "default_output")]
     pub output: String,
-    /// Interpreter family, or `container`. The deployment maps this to a
-    /// runtime layer and a binary; an unknown value is the control plane's to
-    /// reject, not the daemon's — it is the side that knows which layers exist.
-    pub runtime: String,
-    /// Entry path inside the packaged directory. Unused by `container`: the
-    /// image's own `CMD`/`ENTRYPOINT` is its entry.
-    pub entry: String,
-    /// Port the app listens on. For `container` this is what the deployment
-    /// tells Function Compute to send requests to, so it has to match what the
-    /// image actually listens on — the image's `EXPOSE` is documentation and
-    /// nothing reads it.
-    pub port: u16,
-    /// `container`: the Dockerfile, relative to the workdir.
+    #[serde(default)]
+    pub command: Option<String>,
+    #[serde(default = "default_dockerfile")]
     pub dockerfile: String,
-    /// `container`: the build context, relative to the workdir.
+    #[serde(default = "default_context")]
     pub context: String,
-    /// `container`: a path the app answers 200 on, used as the function's
-    /// health check. Absent means the deployment's default check.
-    #[serde(skip_serializing_if = "Option::is_none")]
+}
+
+/// How the control plane starts the built artifact in Function Compute.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AppStartSpec {
+    #[serde(default)]
+    pub fc_runtime: Option<String>,
+    #[serde(default)]
+    pub command: Option<Vec<String>>,
+    #[serde(default)]
+    pub args: Option<Vec<String>>,
+    pub port: u16,
+    #[serde(default)]
+    pub layers: Option<Vec<String>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub health_check_path: Option<String>,
 }
 
-/// Whether this manifest asks for an image rather than a code archive.
-pub const CONTAINER_RUNTIME: &str = "container";
-
-impl AppRuntimeManifest {
-    pub fn is_container(&self) -> bool {
-        self.runtime == CONTAINER_RUNTIME
-    }
-}
-
-impl Default for AppRuntimeManifest {
-    fn default() -> Self {
-        Self {
-            output: ".output".to_string(),
-            runtime: "node".to_string(),
-            entry: "server/index.mjs".to_string(),
-            port: 9000,
-            dockerfile: "Dockerfile".to_string(),
-            context: ".".to_string(),
-            health_check_path: None,
-        }
-    }
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AppDeclaration {
+    pub build: AppBuildSpec,
+    pub start: AppStartSpec,
 }
 
 /// The declaration file, at the app's root. Named for the brand's config file
@@ -346,99 +344,73 @@ impl Default for AppRuntimeManifest {
 /// a second convention.
 const MANIFEST_FILE: &str = "teamclu.app.json";
 
-/// What an app that declares no runtime is.
-///
-/// A node build needs a `package.json` — it is the file `pnpm install` reads,
-/// and without one there is no build to run. So an app without one is not a
-/// node app that happens to be broken; it is an app built some other way, and
-/// the only other way this daemon has is an image.
-///
-/// This exists because only the three built-in templates ever write
-/// `teamclu.app.json`. An **imported** repo gets no template and therefore no
-/// declaration, so every Django / Go / Rust checkout read as `node` and had
-/// `pnpm install` run at it — the failure was then "no package.json", which is
-/// true and says nothing about the actual problem.
-///
-/// The workdir has to exist for the answer to mean anything. When it does not
-/// this cannot tell the two apart, so it keeps the historical default; callers
-/// that need to know have `workdirExists` on the manifest endpoint.
-fn inferred_runtime(workdir: &Path) -> String {
-    if !workdir.is_dir() || workdir.join("package.json").is_file() {
-        AppRuntimeManifest::default().runtime
-    } else {
-        CONTAINER_RUNTIME.to_string()
-    }
-}
-
-/// Read the app's declaration, falling back to what the checkout itself says.
-///
-/// A malformed file is a warning, not a failure: the defaults still describe a
-/// deployable app, and refusing to build because a hint file has a typo would
-/// be a worse trade than deploying what the app actually produced.
-pub fn read_runtime_manifest(workdir: &Path) -> AppRuntimeManifest {
+/// Read and validate the required app declaration. There are deliberately no
+/// checkout-derived defaults: missing, malformed, and legacy declarations stop
+/// the deploy so the repository remains the single source of truth.
+pub fn read_app_declaration(workdir: &Path) -> anyhow::Result<AppDeclaration> {
     let path = workdir.join(MANIFEST_FILE);
-    let Ok(text) = std::fs::read_to_string(&path) else {
-        return AppRuntimeManifest {
-            runtime: inferred_runtime(workdir),
-            ..Default::default()
-        };
+    let text = match std::fs::read_to_string(&path) {
+        Ok(text) => text,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            anyhow::bail!("{ERR_MISSING_MANIFEST}")
+        }
+        Err(e) => anyhow::bail!("could not read {}: {e}", path.display()),
     };
-    match serde_json::from_str::<PartialManifest>(&text) {
-        Ok(partial) => partial.resolve(workdir),
-        Err(e) => {
-            tracing::warn!(path = %path.display(), error = %e, "ignoring unreadable app manifest");
-            AppRuntimeManifest {
-                runtime: inferred_runtime(workdir),
-                ..Default::default()
-            }
+    let value: serde_json::Value =
+        serde_json::from_str(&text).map_err(|e| anyhow::anyhow!("invalid {MANIFEST_FILE}: {e}"))?;
+    let object = value
+        .as_object()
+        .ok_or_else(|| anyhow::anyhow!("{MANIFEST_FILE} must be a JSON object with build+start"))?;
+    if object.contains_key("runtime") || object.contains_key("entry") {
+        anyhow::bail!("{ERR_LEGACY_MANIFEST}");
+    }
+
+    let mut declaration: AppDeclaration = serde_json::from_value(value)
+        .map_err(|e| anyhow::anyhow!("invalid {MANIFEST_FILE} build+start declaration: {e}"))?;
+    declaration.build.kind = declaration.build.kind.trim().to_string();
+    if !VALID_BUILD_KINDS.contains(&declaration.build.kind.as_str()) {
+        anyhow::bail!(
+            "{MANIFEST_FILE} has invalid build.kind {:?}; expected one of {}",
+            declaration.build.kind,
+            VALID_BUILD_KINDS.join(", ")
+        );
+    }
+    for (name, path) in [
+        ("build.output", &declaration.build.output),
+        ("build.dockerfile", &declaration.build.dockerfile),
+        ("build.context", &declaration.build.context),
+    ] {
+        if !is_inside_workdir(path) {
+            anyhow::bail!("{MANIFEST_FILE} {name} must stay inside the workdir");
         }
     }
-}
-
-/// Every field optional, so a file that names only what it changes is valid.
-#[derive(Debug, Default, Deserialize)]
-#[serde(rename_all = "camelCase")]
-struct PartialManifest {
-    output: Option<String>,
-    runtime: Option<String>,
-    entry: Option<String>,
-    port: Option<u16>,
-    dockerfile: Option<String>,
-    context: Option<String>,
-    health_check_path: Option<String>,
-}
-
-impl PartialManifest {
-    /// `workdir` only decides the runtime, and only when the file does not: an
-    /// explicit `"runtime"` always wins, including an explicit `"node"` on an
-    /// app whose `package.json` is somewhere this cannot see.
-    fn resolve(self, workdir: &Path) -> AppRuntimeManifest {
-        let d = AppRuntimeManifest::default();
-        let pick = |v: Option<String>, fallback: String| {
-            v.map(|s| s.trim().to_string())
-                .filter(|s| !s.is_empty())
-                .unwrap_or(fallback)
-        };
-        AppRuntimeManifest {
-            output: pick(self.output, d.output),
-            runtime: pick(self.runtime, inferred_runtime(workdir)),
-            entry: pick(self.entry, d.entry),
-            port: self.port.filter(|p| *p > 0).unwrap_or(d.port),
-            // A path that climbs out of the workdir is dropped rather than
-            // refused: the file is a hint, and the defaults still describe a
-            // deployable app. Refusing would let a typo in an optional field
-            // stop a deploy that has nothing else wrong with it.
-            dockerfile: pick(
-                self.dockerfile.filter(|p| is_inside_workdir(p)),
-                d.dockerfile,
-            ),
-            context: pick(self.context.filter(|p| is_inside_workdir(p)), d.context),
-            health_check_path: self
-                .health_check_path
-                .map(|s| s.trim().to_string())
-                .filter(|s| s.starts_with('/')),
+    if declaration.start.port == 0 {
+        anyhow::bail!("{MANIFEST_FILE} start.port must be between 1 and 65535");
+    }
+    if declaration.build.kind != "container" {
+        let runtime_present = declaration
+            .start
+            .fc_runtime
+            .as_deref()
+            .is_some_and(|value| !value.trim().is_empty());
+        let command_present = declaration.start.command.as_ref().is_some_and(|command| {
+            !command.is_empty() && command.iter().all(|part| !part.trim().is_empty())
+        });
+        if !runtime_present || !command_present {
+            anyhow::bail!(
+                "{MANIFEST_FILE} code apps require non-empty start.fcRuntime and start.command"
+            );
         }
     }
+    if declaration
+        .start
+        .health_check_path
+        .as_deref()
+        .is_some_and(|path| !path.starts_with('/'))
+    {
+        anyhow::bail!("{MANIFEST_FILE} start.healthCheckPath must start with '/'");
+    }
+    Ok(declaration)
 }
 
 /// Whether a manifest-declared relative path stays under the workdir.
@@ -555,7 +527,7 @@ pub struct BuildOutput {
     /// What the app declared about how it is run. Reported so the control plane
     /// can start the function the way the app expects instead of the one way it
     /// used to assume.
-    pub manifest: AppRuntimeManifest,
+    pub declaration: AppDeclaration,
     /// Set only when the deploy published pending work and so built a commit
     /// the caller did not know about. The caller must finalize with this one:
     /// recording the sha it started with would name a commit that is not what
@@ -584,16 +556,18 @@ pub fn build_artifact(
     if let Some(ctx) = git {
         git_commit_sha = prepare_git_build(workdir, ctx)?;
     }
-    let manifest = read_runtime_manifest(workdir);
+    let declaration = read_app_declaration(workdir)?;
     // Neither of the two things a build can start from. Checked here rather
     // than inside each branch because this app has no code of *either* kind:
     // the container branch would report a missing registry (the control plane's
     // problem, not the user's) and the node branch a missing package.json,
     // neither of which says the app was never given any files.
-    if !workdir.join("package.json").is_file() && !workdir.join(&manifest.dockerfile).is_file() {
+    if !workdir.join("package.json").is_file()
+        && !workdir.join(&declaration.build.dockerfile).is_file()
+    {
         anyhow::bail!("{ERR_NO_CODE}");
     }
-    if manifest.is_container() {
+    if declaration.build.kind == "container" {
         let minted = push.ok_or_else(|| anyhow::anyhow!("{ERR_NO_PUSH_TARGET}"))?;
         // `git_commit_sha` is set only when the build published work the client
         // did not know about, which is exactly when the minted tag is stale.
@@ -607,11 +581,11 @@ pub fn build_artifact(
             username: minted.username,
             password: minted.password,
         };
-        build_image(workdir, &manifest, &target)?;
+        build_image(workdir, &declaration.build, &target)?;
         return Ok(BuildOutput {
             product: BuildProduct::Image(target.image.to_string()),
             git_commit_sha,
-            manifest,
+            declaration,
         });
     }
     run_with_timeout(
@@ -629,12 +603,12 @@ pub fn build_artifact(
         ERR_BUILD_TIMEOUT,
     )?;
 
-    let output_dir = workdir.join(&manifest.output);
+    let output_dir = workdir.join(&declaration.build.output);
     if !output_dir.is_dir() || !output_dir_has_files(&output_dir) {
         // Name what was looked for. The message used to say only ".output/",
         // which is unhelpful precisely when an app builds somewhere else — the
         // case this whole manifest exists for.
-        anyhow::bail!("{ERR_OUTPUT_MISSING}: {}", manifest.output);
+        anyhow::bail!("{ERR_OUTPUT_MISSING}: {}", declaration.build.output);
     }
 
     let bytes = zip_dir(&output_dir)?;
@@ -647,7 +621,7 @@ pub fn build_artifact(
     Ok(BuildOutput {
         product: BuildProduct::Archive(bytes),
         git_commit_sha,
-        manifest,
+        declaration,
     })
 }
 
@@ -659,12 +633,12 @@ pub fn build_artifact(
 /// lets each have what it needs — see [`push_image`].
 fn build_image(
     workdir: &Path,
-    manifest: &AppRuntimeManifest,
+    build: &AppBuildSpec,
     target: &ImagePushTarget<'_>,
 ) -> anyhow::Result<()> {
-    let dockerfile = workdir.join(&manifest.dockerfile);
+    let dockerfile = workdir.join(&build.dockerfile);
     if !dockerfile.is_file() {
-        anyhow::bail!("{ERR_NO_DOCKERFILE}: {}", manifest.dockerfile);
+        anyhow::bail!("{ERR_NO_DOCKERFILE}: {}", build.dockerfile);
     }
     run_docker(
         &[
@@ -673,12 +647,12 @@ fn build_image(
             "--platform",
             FC_PLATFORM,
             "--file",
-            &manifest.dockerfile,
+            &build.dockerfile,
             "--tag",
             target.image,
             // Into the local image store, which is what `docker push` reads.
             "--load",
-            &manifest.context,
+            &build.context,
         ],
         workdir,
         None,
@@ -878,92 +852,142 @@ mod tests {
         tmp
     }
 
-    #[test]
-    fn an_app_with_no_manifest_gets_the_built_in_contract() {
-        // The file is optional on purpose: every app deployed before it existed
-        // must keep deploying with no change.
-        let tmp = node_checkout();
-        assert_eq!(
-            read_runtime_manifest(tmp.path()),
-            AppRuntimeManifest::default()
-        );
+    fn write_container_declaration(
+        workdir: &Path,
+        dockerfile: &str,
+        health_check_path: Option<&str>,
+    ) {
+        std::fs::write(
+            workdir.join(MANIFEST_FILE),
+            serde_json::json!({
+                "build": {
+                    "kind": "container",
+                    "output": ".output",
+                    "dockerfile": dockerfile,
+                    "context": "."
+                },
+                "start": {
+                    "port": 5000,
+                    "healthCheckPath": health_check_path
+                }
+            })
+            .to_string(),
+        )
+        .unwrap();
     }
 
     #[test]
-    fn an_app_with_no_package_json_is_a_container_app() {
-        // Only the three built-in templates write a manifest, so an imported
-        // Django / Go / Rust repo declares nothing — and used to be read as
-        // `node`, which put `pnpm install` in front of a checkout that has no
-        // package.json to install. What it does have is a Dockerfile.
+    fn an_app_with_no_manifest_is_refused() {
+        let tmp = node_checkout();
+        let err = read_app_declaration(tmp.path()).unwrap_err().to_string();
+        assert_eq!(err, ERR_MISSING_MANIFEST);
+    }
+
+    #[test]
+    fn an_app_with_no_package_json_is_not_inferred_as_container() {
         let tmp = tempfile::tempdir().unwrap();
         std::fs::write(tmp.path().join("Dockerfile"), "FROM scratch\n").unwrap();
-        assert!(read_runtime_manifest(tmp.path()).is_container());
+        assert!(read_app_declaration(tmp.path()).is_err());
     }
 
     #[test]
-    fn an_explicit_runtime_still_wins_over_the_checkout() {
-        // The inference is a fallback, not an override: an app that says `node`
-        // keeps meaning it, wherever its package.json lives.
-        let tmp = tempfile::tempdir().unwrap();
-        std::fs::write(tmp.path().join(MANIFEST_FILE), r#"{"runtime":"node"}"#).unwrap();
-        assert_eq!(read_runtime_manifest(tmp.path()).runtime, "node");
-    }
-
-    #[test]
-    fn a_workdir_that_is_not_there_keeps_the_historical_default() {
-        // Nothing to read means nothing to infer from — and the manifest
-        // endpoint reports `workdirExists` for callers that need to care.
-        let tmp = tempfile::tempdir().unwrap();
-        let missing = tmp.path().join("not-cloned-here");
-        assert_eq!(read_runtime_manifest(&missing).runtime, "node");
-    }
-
-    #[test]
-    fn a_manifest_names_only_what_it_changes() {
-        // The failure this was written for: an app that builds to `dist/` and
-        // starts `dist/index.js`. It should not have to restate the port.
-        let tmp = node_checkout();
-        std::fs::write(
-            tmp.path().join(MANIFEST_FILE),
-            r#"{"output":"dist","entry":"index.js"}"#,
-        )
-        .unwrap();
-
-        let m = read_runtime_manifest(tmp.path());
-        assert_eq!(m.output, "dist");
-        assert_eq!(m.entry, "index.js");
-        assert_eq!(m.runtime, "node", "unstated fields keep the default");
-        assert_eq!(m.port, 9000);
-    }
-
-    #[test]
-    fn a_broken_manifest_does_not_stop_a_deploy() {
-        // Defaults still describe a deployable app. Refusing to build because a
-        // hint file has a typo is a worse trade than building what the app
-        // actually produced.
+    fn a_broken_manifest_is_refused() {
         let tmp = node_checkout();
         std::fs::write(tmp.path().join(MANIFEST_FILE), "{not json").unwrap();
-        assert_eq!(
-            read_runtime_manifest(tmp.path()),
-            AppRuntimeManifest::default()
-        );
+        assert!(read_app_declaration(tmp.path()).is_err());
+    }
 
+    #[test]
+    fn a_legacy_manifest_is_refused_with_migration_guidance() {
+        let tmp = node_checkout();
         std::fs::write(
             tmp.path().join(MANIFEST_FILE),
-            r#"{"output":"  ","port":0}"#,
+            r#"{"runtime":"node","entry":"server/index.mjs"}"#,
         )
         .unwrap();
-        let m = read_runtime_manifest(tmp.path());
-        assert_eq!(m.output, ".output", "an empty value is not a value");
-        assert_eq!(m.port, 9000);
+        let err = read_app_declaration(tmp.path()).unwrap_err().to_string();
+        assert!(
+            err.contains("legacy") && err.contains("build+start"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn legacy_fields_are_refused_even_alongside_build_and_start() {
+        let tmp = node_checkout();
+        std::fs::write(
+            tmp.path().join(MANIFEST_FILE),
+            r#"{
+                "runtime":"node",
+                "build":{"kind":"node","output":".output","command":null,"dockerfile":"Dockerfile","context":"."},
+                "start":{"fcRuntime":"custom.debian10","command":["node"],"args":["server/index.mjs"],"port":9000}
+            }"#,
+        )
+        .unwrap();
+        assert_eq!(
+            read_app_declaration(tmp.path()).unwrap_err().to_string(),
+            ERR_LEGACY_MANIFEST
+        );
+    }
+
+    #[test]
+    fn a_valid_node_declaration_is_read_with_camel_case_fields() {
+        let tmp = node_checkout();
+        std::fs::write(
+            tmp.path().join(MANIFEST_FILE),
+            r#"{
+                "build":{"kind":"node","output":"dist","command":null},
+                "start":{
+                    "fcRuntime":"custom.debian12",
+                    "command":["node"],
+                    "args":["index.js"],
+                    "port":9000,
+                    "layers":[],
+                    "healthCheckPath":"/health"
+                }
+            }"#,
+        )
+        .unwrap();
+
+        let declaration = read_app_declaration(tmp.path()).unwrap();
+        assert_eq!(declaration.build.kind, "node");
+        assert_eq!(declaration.build.output, "dist");
+        assert_eq!(declaration.build.dockerfile, "Dockerfile");
+        assert_eq!(declaration.build.context, ".");
+        assert_eq!(
+            declaration.start.fc_runtime.as_deref(),
+            Some("custom.debian12")
+        );
+        assert_eq!(declaration.start.command, Some(vec!["node".to_string()]));
+        assert_eq!(
+            declaration.start.health_check_path.as_deref(),
+            Some("/health")
+        );
+        let wire = serde_json::to_value(&declaration).unwrap();
+        assert_eq!(wire["start"]["fcRuntime"], "custom.debian12");
+        assert_eq!(wire["start"]["healthCheckPath"], "/health");
+        assert!(wire["start"].get("fc_runtime").is_none());
+    }
+
+    #[test]
+    fn an_unknown_build_kind_is_refused() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(
+            tmp.path().join(MANIFEST_FILE),
+            r#"{
+                "build":{"kind":"ruby","output":".","command":null,"dockerfile":"Dockerfile","context":"."},
+                "start":{"fcRuntime":"custom.debian12","command":["ruby"],"args":["app.rb"],"port":9000}
+            }"#,
+        )
+        .unwrap();
+        let err = read_app_declaration(tmp.path()).unwrap_err().to_string();
+        assert!(err.contains("ruby"), "{err}");
     }
 
     #[test]
     fn an_app_with_neither_package_json_nor_dockerfile_says_so() {
-        // The empty-app failure. It reads as a container app (no package.json),
-        // and "no Dockerfile" would send the user to write one for an app whose
-        // real problem is that it was never given any code.
         let tmp = tempfile::tempdir().unwrap();
+        write_container_declaration(tmp.path(), "Dockerfile", None);
         let err = match build_artifact(tmp.path(), None, None) {
             Err(e) => e.to_string(),
             Ok(_) => panic!("an app with no code must not build"),
@@ -974,46 +998,39 @@ mod tests {
     #[test]
     fn a_container_app_declares_its_dockerfile_and_port() {
         let tmp = tempfile::tempdir().unwrap();
-        std::fs::write(
-            tmp.path().join(MANIFEST_FILE),
-            r#"{"runtime":"container","port":5000,"dockerfile":"deploy/Dockerfile","healthCheckPath":"/api/health"}"#,
-        )
-        .unwrap();
+        write_container_declaration(tmp.path(), "deploy/Dockerfile", Some("/api/health"));
 
-        let m = read_runtime_manifest(tmp.path());
-        assert!(m.is_container());
-        assert_eq!(m.port, 5000);
-        assert_eq!(m.dockerfile, "deploy/Dockerfile");
-        assert_eq!(m.context, ".", "unstated context is the checkout root");
-        assert_eq!(m.health_check_path.as_deref(), Some("/api/health"));
+        let declaration = read_app_declaration(tmp.path()).unwrap();
+        assert_eq!(declaration.build.kind, "container");
+        assert_eq!(declaration.start.port, 5000);
+        assert_eq!(declaration.build.dockerfile, "deploy/Dockerfile");
+        assert_eq!(declaration.build.context, ".");
+        assert_eq!(
+            declaration.start.health_check_path.as_deref(),
+            Some("/api/health")
+        );
     }
 
     #[test]
-    fn a_manifest_path_that_climbs_out_of_the_checkout_is_ignored() {
-        // These are handed to `docker` as `--file` and as the build context. A
-        // path out of the workdir would build a directory that is not the app;
-        // the default still describes a buildable one, so it wins.
+    fn a_declaration_path_that_climbs_out_of_the_checkout_is_refused() {
         let tmp = tempfile::tempdir().unwrap();
         std::fs::write(
             tmp.path().join(MANIFEST_FILE),
-            r#"{"runtime":"container","dockerfile":"../../etc/Dockerfile","context":"/etc"}"#,
+            r#"{
+                "build":{"kind":"container","output":".output","dockerfile":"../../etc/Dockerfile","context":"/etc"},
+                "start":{"port":9000}
+            }"#,
         )
         .unwrap();
 
-        let m = read_runtime_manifest(tmp.path());
-        assert_eq!(m.dockerfile, "Dockerfile");
-        assert_eq!(m.context, ".");
+        assert!(read_app_declaration(tmp.path()).is_err());
     }
 
     #[test]
     fn a_health_check_path_must_be_a_path() {
         let tmp = tempfile::tempdir().unwrap();
-        std::fs::write(
-            tmp.path().join(MANIFEST_FILE),
-            r#"{"runtime":"container","healthCheckPath":"api/health"}"#,
-        )
-        .unwrap();
-        assert_eq!(read_runtime_manifest(tmp.path()).health_check_path, None);
+        write_container_declaration(tmp.path(), "Dockerfile", Some("api/health"));
+        assert!(read_app_declaration(tmp.path()).is_err());
     }
 
     #[test]
@@ -1021,7 +1038,7 @@ mod tests {
         // Not a build failure in the app: the control plane decides which
         // handle a deploy carries, and this one carried none.
         let tmp = tempfile::tempdir().unwrap();
-        std::fs::write(tmp.path().join(MANIFEST_FILE), r#"{"runtime":"container"}"#).unwrap();
+        write_container_declaration(tmp.path(), "Dockerfile", None);
         std::fs::write(tmp.path().join("Dockerfile"), "FROM scratch\n").unwrap();
 
         // Matched rather than `unwrap_err`, which would need `BuildOutput` to
@@ -1075,12 +1092,8 @@ mod tests {
     #[test]
     fn a_container_app_without_a_dockerfile_says_which_file_is_missing() {
         let tmp = tempfile::tempdir().unwrap();
-        std::fs::write(
-            tmp.path().join(MANIFEST_FILE),
-            r#"{"runtime":"container","dockerfile":"deploy/Dockerfile"}"#,
-        )
-        .unwrap();
-        let manifest = read_runtime_manifest(tmp.path());
+        write_container_declaration(tmp.path(), "deploy/Dockerfile", None);
+        let declaration = read_app_declaration(tmp.path()).unwrap();
         let target = ImagePushTarget {
             image: "registry.example.com/ns/app:sha",
             registry: "registry.example.com",
@@ -1088,7 +1101,7 @@ mod tests {
             password: "p",
         };
 
-        let err = build_image(tmp.path(), &manifest, &target)
+        let err = build_image(tmp.path(), &declaration.build, &target)
             .unwrap_err()
             .to_string();
         assert!(err.starts_with(ERR_NO_DOCKERFILE), "{err}");

--- a/apps/daemon/src/sync/app_templates.rs
+++ b/apps/daemon/src/sync/app_templates.rs
@@ -178,6 +178,32 @@ mod tests {
                 "{t:?}: committed lockfile"
             );
             assert!(root.join("AGENTS.md").is_file(), "{t:?}: AGENTS.md");
+            assert!(
+                root.join("teamclu.app.json").is_file(),
+                "{t:?}: teamclu.app.json"
+            );
+        }
+    }
+
+    #[test]
+    fn seeded_manifest_passes_read_app_declaration() {
+        for t in [AppType::StaticWeb, AppType::Slides, AppType::DataApp] {
+            let tmp = seed(t);
+            let declaration =
+                crate::sync::app_build::read_app_declaration(tmp.path()).unwrap_or_else(|e| {
+                    panic!("{t:?}: seeded teamclu.app.json must parse: {e}")
+                });
+            assert_eq!(declaration.build.kind, "node");
+            assert_eq!(declaration.build.output, ".output");
+            assert_eq!(
+                declaration.start.command,
+                Some(vec!["/opt/nodejs20/bin/node".to_string()])
+            );
+            assert_eq!(
+                declaration.start.args,
+                Some(vec!["server/index.mjs".to_string()])
+            );
+            assert_eq!(declaration.start.port, 9000);
         }
     }
 

--- a/apps/daemon/tests/http_apps.rs
+++ b/apps/daemon/tests/http_apps.rs
@@ -145,7 +145,12 @@ async fn test_app_inner(backend: Option<Arc<dyn Backend>>) -> (TestApp, tempfile
 
 /// Files every compiled-in template ships (see `sync::app_templates`).
 fn assert_seeded_checkout(workdir: &std::path::Path) {
-    for rel in ["package.json", "pnpm-lock.yaml", "AGENTS.md"] {
+    for rel in [
+        "package.json",
+        "pnpm-lock.yaml",
+        "AGENTS.md",
+        "teamclu.app.json",
+    ] {
         assert!(
             workdir.join(rel).is_file(),
             "{rel} missing from seeded checkout"

--- a/apps/desktop/src/commands/introspect_api/apps.rs
+++ b/apps/desktop/src/commands/introspect_api/apps.rs
@@ -1188,7 +1188,7 @@ async fn finish_app_deploy(
     // actually pushed. This path used to send neither, so an agent-driven
     // deploy of an app with its own declaration silently finalized on the
     // built-in contract while the same deploy from the UI honoured it.
-    finalize_body["runtime"] = declaration.clone();
+    finalize_body["declaration"] = declaration.clone();
     if let Some(image) = row_str(&build, "image") {
         finalize_body["image"] = json!(image);
     }

--- a/apps/desktop/src/commands/introspect_api/apps.rs
+++ b/apps/desktop/src/commands/introspect_api/apps.rs
@@ -725,10 +725,10 @@ async fn app_status(api: &AppApi, row: &Value) -> Value {
     out["git_managed"] = json!(is_gitea_managed(row));
     out["custom_domain"] = f("customDomain");
     out["custom_domain_verified"] = json!(row_str(row, "customDomainVerifiedAt").is_some());
-    // What the last deploy recorded, next to what the checkout says now: the
-    // row's `runtime` is written by deploy from the declaration, so the two
-    // disagree exactly when the declaration changed since.
-    out["deployed_runtime"] = f("runtime");
+    // What the last successful deploy recorded, next to what the checkout
+    // declares now. These disagree exactly when the declaration changed since.
+    out["deployed_build_kind"] = f("runtime");
+    out["deployed_start_spec"] = f("startSpec");
 
     let app_id = row_str(row, "id").unwrap_or_default().to_string();
     let team_id = row_str(row, "teamId").unwrap_or_default().to_string();
@@ -737,10 +737,11 @@ async fn app_status(api: &AppApi, row: &Value) -> Value {
         out["workdir"] = json!(workdir);
         out["device_name"] = json!(device);
     }
-    if let Some(manifest) = daemon_app_manifest(&app_id, &team_id).await {
-        out["declared_runtime"] = json!({
-            "manifest": manifest,
-            "note": "Read from teamclu.app.json in the checkout (or inferred from it). It is not a setting: edit that file and deploy to change how the app is built and started.",
+    if let Ok(declaration) = daemon_app_declaration(&app_id, &team_id).await {
+        out["checkout_declaration"] = json!({
+            "build": declaration.get("build").cloned().unwrap_or(Value::Null),
+            "start": declaration.get("start").cloned().unwrap_or(Value::Null),
+            "note": "Read from the required build + start blocks in teamclu.app.json. This is a hard-cut contract: legacy declaration shapes are rejected. Edit that file and deploy to change how the app is built and started.",
         });
     }
 
@@ -1022,12 +1023,8 @@ fn redact_deploy_secrets(reason: &str) -> String {
     out
 }
 
-/// What the app's checkout declares about how it is built.
-///
-/// Best-effort: a daemon that cannot answer leaves the deploy on the contract
-/// every app had before declarations existed, which is what an older daemon
-/// would have done anyway.
-async fn daemon_app_manifest(app_id: &str, team_id: &str) -> Option<Value> {
+/// The checkout's required build-and-start declaration.
+async fn daemon_app_declaration(app_id: &str, team_id: &str) -> Result<Value, String> {
     use crate::daemon_client::{self as daemon, RequestSpec, NO_BODY};
     let path = format!("/v1/apps/{}/manifest", urlencoding::encode(app_id));
     let query = format!("?teamId={}", urlencoding::encode(team_id));
@@ -1038,18 +1035,10 @@ async fn daemon_app_manifest(app_id: &str, team_id: &str) -> Option<Value> {
         NO_BODY,
     )
     .await
-    .ok()?;
-    out.get("manifest").cloned()
-}
-
-fn manifest_runtime(manifest: Option<&Value>) -> String {
-    manifest
-        .and_then(|m| m.get("runtime"))
-        .and_then(|x| x.as_str())
-        .map(str::trim)
-        .filter(|s| !s.is_empty())
-        .unwrap_or("node")
-        .to_string()
+    .map_err(|e| format!("Could not read the app's build + start declaration: {e}"))?;
+    out.get("declaration")
+        .cloned()
+        .ok_or_else(|| "The daemon returned no build + start declaration.".to_string())
 }
 
 /// Kick the local daemon's build-and-upload leg.
@@ -1138,7 +1127,6 @@ async fn finish_app_deploy(
     git_commit_sha: Option<String>,
     deploy_token: &str,
     handle: &DeployHandle,
-    manifest: Option<&Value>,
 ) -> Result<Value, String> {
     let credential = if via_gitea {
         Some(mint_git_credential(api, app_id).await?)
@@ -1181,6 +1169,9 @@ async fn finish_app_deploy(
         return_git_credential(api, app_id, cred.deploy_key_id).await;
     }
     let build = build?;
+    let declaration = build
+        .get("declaration")
+        .ok_or("The daemon build response did not include the build + start declaration.")?;
 
     // What the daemon built, not what we asked for: a deploy publishes work the
     // agent left uncommitted, so HEAD can sit past the sha read off Gitea before
@@ -1197,9 +1188,7 @@ async fn finish_app_deploy(
     // actually pushed. This path used to send neither, so an agent-driven
     // deploy of an app with its own declaration silently finalized on the
     // built-in contract while the same deploy from the UI honoured it.
-    if let Some(manifest) = manifest {
-        finalize_body["runtime"] = manifest.clone();
-    }
+    finalize_body["runtime"] = declaration.clone();
     if let Some(image) = row_str(&build, "image") {
         finalize_body["image"] = json!(image);
     }
@@ -1255,8 +1244,10 @@ async fn run_app_deploy(api: &AppApi, row: &Value) -> Result<Value, String> {
     // Read before the deploy is minted, not after: a container app is handed a
     // registry to push to and every other app a presigned URL to upload to, and
     // only the machine holding the checkout can say which this is.
-    let manifest = daemon_app_manifest(&app_id, &team_id).await;
-    let mut start_body = json!({ "runtime": manifest_runtime(manifest.as_ref()) });
+    let declaration = daemon_app_declaration(&app_id, &team_id).await?;
+    let build_kind = row_str(&declaration["build"], "kind")
+        .ok_or("The daemon's app declaration has no build.kind.")?;
+    let mut start_body = json!({ "runtime": build_kind });
     if let Some(sha) = &git_commit_sha {
         start_body["gitCommitSha"] = json!(sha);
     }
@@ -1295,7 +1286,6 @@ async fn run_app_deploy(api: &AppApi, row: &Value) -> Result<Value, String> {
         git_commit_sha,
         &deploy_token,
         &handle,
-        manifest.as_ref(),
     )
     .await
     {

--- a/deploy/belayo/registry/README.md
+++ b/deploy/belayo/registry/README.md
@@ -1,6 +1,6 @@
 # belayo 的镜像仓库
 
-belayo 上的容器应用（`teamclu.app.json` 里 `runtime: "container"`）要有个地方放镜像。
+belayo 上的容器应用（`teamclu.app.json` 里 `build.kind: "container"`）要有个地方放镜像。
 ACR 个人版已经无法新建、企业版按实例收费，所以跟 self-host 一样自建一个。
 
 区别只在托管方式：self-host 那份跑在盒子的 docker compose 里、由 Caddy 挡在前面

--- a/docs/openapi/teamclu-api.v1.yaml
+++ b/docs/openapi/teamclu-api.v1.yaml
@@ -5751,7 +5751,7 @@ paths:
           application/json:
             schema:
               type: object
-              required: [deployToken]
+              required: [deployToken, declaration]
               properties:
                 gitCommitSha:
                   type: string
@@ -5763,31 +5763,19 @@ paths:
                   type: string
                   format: uuid
                   description: Bearer returned by `/deploy` for this attempt. Secret — never log it.
-                runtime:
+                declaration:
                   type: object
                   description: >-
-                    How the app says it starts, read by the daemon out of the
-                    app's own `teamclu.app.json` and resolved against the
-                    built-in contract. Omitted by a client that predates the
-                    declaration, and by an app that ships none — both get the
-                    contract every app had before it existed (node,
-                    `server/index.mjs`, port 9000). `runtime` here is the
-                    interpreter family, NOT the `runtime` column on the app
-                    (`node` vs `container`); a value this deployment has no
-                    layer for is a 400, because the function would otherwise be
-                    created unable to boot.
-                  required: [runtime, entry, port]
+                    The daemon-validated build and start declaration read from
+                    the app's required `teamclu.app.json`. The control plane
+                    persists `build.kind` and `start`, then configures Function
+                    Compute without deriving either from the checkout.
+                  required: [build, start]
                   properties:
-                    runtime:
-                      type: string
-                      enum: [node]
-                    entry:
-                      type: string
-                      description: Path inside the unpacked artifact.
-                    port:
-                      type: integer
-                      minimum: 1
-                      maximum: 65535
+                    build:
+                      $ref: "#/components/schemas/AppBuildSpec"
+                    start:
+                      $ref: "#/components/schemas/AppStartSpec"
       responses:
         "200":
           description: The app, now live.
@@ -7619,13 +7607,55 @@ components:
         Deploy lifecycle, orthogonal to `provisionStatus` (which tracks the repo
         and its seeding). `null` means the app has never been deployed.
       enum: [not_deployed, awaiting_build, building, deploying, live, deploy_error]
-    AppRuntime:
+    AppBuildKind:
       type: string
       description: |
-        FC runtime for the deployed artifact. Phase 1 supports `node` only;
-        `container` is reserved for bring-your-own-image deploys.
-      enum: [node, container]
+        How the app artifact is built. This is persisted in `apps.runtime`;
+        Function Compute's runtime is declared separately in `start.fcRuntime`.
+      enum: [node, python, go, php, java, container]
       default: node
+    AppBuildSpec:
+      type: object
+      required: [kind, output]
+      properties:
+        kind:
+          $ref: "#/components/schemas/AppBuildKind"
+        output:
+          type: string
+          description: Relative artifact output path inside the checkout.
+        command:
+          type: string
+          description: Optional shell build command.
+        dockerfile:
+          type: string
+          description: Relative Dockerfile path for container builds.
+        context:
+          type: string
+          description: Relative Docker build context.
+    AppStartSpec:
+      type: object
+      required: [port]
+      properties:
+        fcRuntime:
+          type: string
+          description: Function Compute runtime for non-container builds.
+        command:
+          type: array
+          items: { type: string }
+        args:
+          type: array
+          items: { type: string }
+        port:
+          type: integer
+          minimum: 1
+          maximum: 65535
+        layers:
+          type: array
+          items: { type: string }
+          description: Function Compute layer ARNs; an empty list disables defaults.
+        healthCheckPath:
+          type: string
+          pattern: "^/"
     AppAuthMode:
       type: string
       description: |
@@ -7682,7 +7712,13 @@ components:
             HEAD commit SHA on the app's Gitea repo at last successful deploy;
             null before the first deploy completes.
         runtime:
-          $ref: "#/components/schemas/AppRuntime"
+          $ref: "#/components/schemas/AppBuildKind"
+          description: Build kind persisted from the last successful declaration.
+        startSpec:
+          oneOf:
+            - $ref: "#/components/schemas/AppStartSpec"
+            - type: "null"
+          description: Start configuration persisted from the last successful declaration.
         authMode:
           $ref: "#/components/schemas/AppAuthMode"
         authAudience:

--- a/docs/specs/2026-09-11-fc-runtime-passthrough-design.md
+++ b/docs/specs/2026-09-11-fc-runtime-passthrough-design.md
@@ -1,0 +1,244 @@
+# FC Custom Runtime passthrough — design
+
+**Date:** 2026-09-11  
+**Status:** draft (awaiting review)  
+**Scope:** Align TeamClu app deploy start contract with Alibaba Cloud Function Compute (FC) 2023-03-30 Custom Runtime / Custom Container APIs. Split build from start. Hard-cut the old `runtime` + `entry` declaration.
+
+## 1. Problem
+
+Today an app declares:
+
+```json
+{ "runtime": "node" | "container", "entry": "server/index.mjs", "port": 9000 }
+```
+
+The control plane then invents the FC start command (`command: ["/opt/nodejs20/bin/node"]`, `args: [entry]`) and hardcodes `runtime: "custom.debian10"` plus the Nodejs20 layer. That is a private dialect:
+
+- It cannot express what the FC console calls「启动命令」/「监听端口」directly.
+- Adding Python / Go / PHP / Java means growing our translator table, not letting the app state FC’s own fields.
+- `runtime` currently means both **how to build** (pnpm vs docker) and **how to start** (node vs container).
+
+FC’s real surface for custom runtimes is small and stable:
+
+| FC field | Role |
+|---|---|
+| `runtime` | `custom` / `custom.debian10` / `custom.debian11` / `custom.debian12` / `custom-container` |
+| `customRuntimeConfig.command` | `string[]` |
+| `customRuntimeConfig.args` | `string[]` |
+| `customRuntimeConfig.port` | listen port |
+| `customRuntimeConfig.healthCheckConfig` | optional |
+| `layers` | ARN list |
+| `customContainerConfig` | image (+ optional command/args/port) for `custom-container` |
+
+Console modes (默认 / 命令 / Bash 脚本 / 数组) are UI sugar over `command` + `args`.
+
+## 2. Goals / non-goals
+
+**Goals**
+
+1. `teamclu.app.json` start block is a near-passthrough of FC Custom Runtime config.
+2. Build and start are separate declarations.
+3. First-wave build kinds: `node` / `python` / `go` / `php` / `java` / `container`.
+4. Hard cut: old `runtime` + `entry` shape is rejected; no dual-read period.
+
+**Non-goals**
+
+- FC console-parity UI picker (language → Debian → framework). Intent lives in the repo; Agent edits the file.
+- Built-in FC runtimes (`nodejs20`, `python3.10`, …) — those are handler-based and refuse `customRuntimeConfig`.
+- Auto-rewriting existing customer repos.
+- Shipping every console “stack” (ThinkPHP, Swoole, …) as a first-class build kind.
+
+## 3. Decisions (locked)
+
+| # | Decision | Choice |
+|---|---|---|
+| D1 | Alignment depth | Passthrough of FC start fields |
+| D2 | Old shape | Hard cut (reject; Agent/migration rewrites) |
+| D3 | Build vs start | Orthogonal: `build` + `start` |
+| D4 | Build kinds (v1) | `node` / `python` / `go` / `php` / `java` / `container` |
+| D5 | Schema shape | Nested `build` + `start` (not a flat CreateFunction mirror, not presets) |
+
+## 4. `teamclu.app.json` contract
+
+Product fields (`title`, `auth`, …) stay. Top-level `runtime` / `entry` are removed.
+
+```json
+{
+  "title": "notes",
+  "auth": { "mode": "none" },
+  "build": {
+    "kind": "python",
+    "output": ".",
+    "command": null
+  },
+  "start": {
+    "fcRuntime": "custom.debian12",
+    "command": ["python3"],
+    "args": ["app.py"],
+    "port": 9000,
+    "layers": [],
+    "healthCheckPath": "/health"
+  }
+}
+```
+
+### 4.1 `build` (daemon only)
+
+| Field | Rule |
+|---|---|
+| `kind` | Required: `node` \| `python` \| `go` \| `php` \| `java` \| `container` |
+| `output` | Code-package root relative to checkout. Unused for `container`. |
+| `command` | Optional override of the kind’s default build steps (single shell string). |
+| `dockerfile` / `context` | `container` only; must stay inside the workdir. |
+
+### 4.2 `start` (almost verbatim to FC)
+
+| Field | Maps to |
+|---|---|
+| `fcRuntime` | CreateFunction `runtime`. For `build.kind === "container"`, platform forces `custom-container` (field may be omitted). Allowed for code apps: `custom` \| `custom.debian10` \| `custom.debian11` \| `custom.debian12`. |
+| `command` / `args` | `customRuntimeConfig.command` / `.args` (array mode). Required for non-container (non-empty `command`). Optional for container (image ENTRYPOINT/CMD wins when omitted). |
+| `port` | `customRuntimeConfig.port` or container port. Integer 1–65535. |
+| `layers` | Function `layers`. **Omitted** → platform default layers for `build.kind` (if any). **Explicit `[]`** → no layers. Non-empty → those ARNs only (must look like FC layer ARNs). |
+| `healthCheckPath` | Optional; path must start with `/` → `healthCheckConfig.httpGetUrl` (with platform defaults for delay/period/thresholds, same spirit as today’s container health check). |
+
+### 4.3 Hard-cut validation
+
+- Presence of legacy `runtime` / `entry` (or only the old shape) → **refuse build**, error names the file and fields and points at this contract.
+- Missing file, or missing `build.kind` / required `start` fields → **refuse deploy**. No inference from `package.json` / Dockerfile for runtime family (that inference was a migration crutch and fights the hard cut).
+- Malformed JSON → refuse build (same as today’s auth parsing severity for this file once start/build are required).
+
+## 5. Daemon build table
+
+Build produces an artifact only. Start command is never invented here.
+
+| `kind` | Default steps | Product | Preconditions |
+|---|---|---|---|
+| `node` | `pnpm install --frozen-lockfile` then `pnpm build` (or `build.command`) | zip(`output`, default `.output`) | `package.json` |
+| `python` | If `requirements.txt`: `pip install -r requirements.txt -t <output>`; else skip install | zip(`output`, default `.`) | `requirements.txt` / `pyproject.toml` / declared entry path exists |
+| `go` | `CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o <output>/main .` (or override) | zip(`output`) | `go.mod` |
+| `php` | If `composer.json`: `composer install --no-dev`; else skip | zip(`output`, default `.`) | `composer.json` or declared entry |
+| `java` | Maven wrapper or Gradle by lockfile (or override) | zip(`output` under conventional `target` / `build/libs`) | `pom.xml` / `build.gradle*` |
+| `container` | Existing `docker build` + registry push | image reference | `dockerfile` present |
+
+Rules:
+
+1. Honor `build.kind`; do not branch on “has package.json ⇒ node”.
+2. Non-empty `build.command` replaces the kind’s default steps (still cwd = workdir, still timed out).
+3. Failure messages name `kind` and the missing file.
+4. Report the resolved `{ build, start }` with the build result so finalize does not re-guess.
+
+### 5.1 Template default `start` (editable)
+
+| kind | `fcRuntime` | Default layers (when `layers` omitted) | Default `command` + `args` | `port` |
+|---|---|---|---|---|
+| node | `custom.debian10` | official Nodejs20 (pinned version, region-substituted ARN) | `["/opt/nodejs20/bin/node"]` + `["server/index.mjs"]` | 9000 |
+| python | `custom.debian10` | official Python310 | `["python3"]` + `["app.py"]` | 9000 |
+| go | `custom.debian10` | official Go1 | `["./main"]` + `[]` | 9000 |
+| php | `custom.debian10` | official PHP81-Debian10 | template-chosen PHP serve command as arrays | 9000 |
+| java | `custom.debian10` | official Java17 | `["java"]` + `["-jar", "app.jar"]` (paths match build output) | 9000 |
+| container | `custom-container` | none | omit | declared or 9000 |
+
+Layer ARNs stay pinned (immutable layer versions), same rationale as today’s Nodejs20 pin.
+
+## 6. Control plane → FC
+
+On finalize:
+
+1. Accept the daemon’s resolved `{ build, start }` (+ archive object key or image).
+2. Validate (§4); do not translate `entry` into a binary anymore.
+3. Assemble CreateFunction / UpdateFunction:
+
+```text
+runtime               ← start.fcRuntime
+                        (force custom-container when build.kind = container)
+customRuntimeConfig   ← { command, args, port, healthCheckConfig? }
+                        (code apps only)
+layers                ← resolveLayers(start.layers, build.kind)
+customContainerConfig ← image + port (+ optional command/args)
+code                  ← OSS location for archive apps; absent for container
+```
+
+4. Validation failure → HTTP 400, no partial function update.
+5. Re-send full runtime shape on every update (same reason as today: old functions must heal on redeploy).
+
+`parseAppRuntimeSpec` / `RUNTIME_BINARIES` / `isSupportedRuntime("node"|"container")` are replaced by parsers for `build` + `start`. `assertDeployAllowed` checks `build.kind` against the six allowed kinds.
+
+## 7. Data model
+
+| Column | New meaning |
+|---|---|
+| `amux.apps.runtime` | Stores **`build.kind`** (`node` \| `python` \| `go` \| `php` \| `java` \| `container`). List/filter only. |
+| `amux.apps.start_spec` (new, jsonb, nullable) | Snapshot of `start` from last successful deploy. Control plane read-only; source of truth remains the repo file. |
+
+Migration:
+
+- Widen `apps_runtime_check` to the six kinds.
+- Existing rows keep `node` / `container` (still valid kinds); `start_spec` starts null until next successful deploy.
+- No backfill of `start_spec` from guesses.
+
+OpenAPI: expand `AppRuntime` enum; finalize body carries `build` + `start` instead of `{ runtime, entry, port }`.
+
+Clients (desktop, daemon local API, control panel copy) stop documenting `entry`; show `build.kind` + read-only `start_spec` / checkout file.
+
+## 8. Migration / rollout
+
+| Target | Action |
+|---|---|
+| Built-in templates | Rewrite once to `build` + `start`; delete legacy fields; update `AGENTS.md`. |
+| Existing Gitea apps | Do **not** rewrite. Next deploy fails closed with a pointed error until Agent (or human) updates `teamclu.app.json`. |
+| DB | Constraint widen + `start_spec` column; no forced redeploy. |
+| Tests | Replace old `parseAppRuntimeSpec` cases; add regression: legacy shape → 400. |
+
+Rollout order: schema + FC client + daemon parser/build table + templates + OpenAPI/clients. Prefer one PR train that cannot deploy an old-shaped template after merge.
+
+## 9. Error handling
+
+| Case | Behavior |
+|---|---|
+| Legacy `runtime`/`entry` present | Build refused; message cites fields and new contract |
+| Missing `teamclu.app.json` | Deploy refused (no silent node default) |
+| `start.layers` omitted vs `[]` | Omitted = kind defaults; `[]` = no layers |
+| Unsupported `fcRuntime` | Finalize 400 |
+| `build.kind=container` without image on finalize | 400 (unchanged intent) |
+| Build precondition missing (e.g. no `go.mod`) | Build error names kind + file |
+
+## 10. Testing
+
+1. New node template deploy: function is `custom.debian10`, Node layer attached, `command`/`args`/`port` match file.
+2. Python kind with `command: ["python3"]`, `args: ["app.py"]` boots.
+3. Legacy `{ runtime, entry }` checkout fails with readable error.
+4. Container path unchanged: no layers, no code zip, image-based config.
+5. List API `runtime` still filterable; value equals `build.kind`.
+6. Explicit `layers: []` on node does not attach Nodejs20 (escape hatch for debian-builtin interpreters).
+7. UpdateFunction on redeploy refreshes command/layers/port (regression against “code-only update leaves broken start”).
+
+## 11. Rejected alternatives
+
+| Alternative | Why rejected |
+|---|---|
+| Preset names (`python3.12-web`) expanded at deploy | Reintroduces a dialect; fights “align with FC” |
+| Flat CreateFunction-shaped root | Mixes build + start; half the fields nonsense for container |
+| Dual-read old+new forever | Per product choice: hard cut |
+| Infer kind from package.json when file missing | Undermines hard cut; imported repos must declare |
+| Built-in FC runtimes | Incompatible with `customRuntimeConfig` |
+
+## 12. Acceptance checklist
+
+- [ ] Templates ship valid `build` + `start` only.
+- [ ] Daemon build table implements six kinds with override `build.command`.
+- [ ] FC ensure/update uses passthrough `start` (no `RUNTIME_BINARIES` translator).
+- [ ] `amux.apps.runtime` = `build.kind`; `start_spec` written on successful finalize.
+- [ ] Legacy declaration fails closed.
+- [ ] OpenAPI + client types updated; control panel does not edit start/build (repo is source of truth).
+
+## 13. Relation to prior specs
+
+- [2026-08-27 apps-config-in-code](./2026-08-27-apps-config-in-code-design.md) sketched a placeholder `build: { command, outdir }` that deploy did not fully consume. This spec **replaces** that placeholder with `build.kind` + optional `build.command` + `build.output`, and adds required `start`.
+- [2026-08-27 apps-self-serve-gitea-fc](./2026-08-27-apps-self-serve-gitea-fc-design.md) introduced `amux.apps.runtime` as `node|container`. Column kept; enum and meaning become `build.kind`.
+- Control-panel rule from [2026-09-10](./2026-09-10-app-control-panel-design.md) still holds: runtime/start are not editable in the panel; they are pushed from the repo on deploy.
+
+## 14. Follow-ups (out of this spec)
+
+- Richer template pack per language (Flask / Express / Spring) — still just files, not new platform kinds.
+- debian12 as default once regional availability covers our deploy region.
+- Optional control-plane “diff expected start vs live FC getFunction” diagnostics.

--- a/packages/app/src/lib/apps/__tests__/app-list-helpers.test.ts
+++ b/packages/app/src/lib/apps/__tests__/app-list-helpers.test.ts
@@ -107,13 +107,6 @@ describe('deployDisabledReason', () => {
     expect(deployDisabledReason({ authMode: 'third' })).toBe('apps.deployDisabledThird')
     expect(deployDisabledReason({ authMode: 'none' })).toBeNull()
   })
-
-  test('a container app that already deployed can deploy again', () => {
-    // The row says `container` only because a deploy wrote it, so blocking on
-    // it disabled the button on exactly the apps that had just proved it works.
-    const deployed = { authMode: 'none', runtime: 'container' } as const
-    expect(deployDisabledReason(deployed)).toBeNull()
-  })
 })
 
 describe('showsPublicBadge', () => {

--- a/packages/app/src/lib/apps/app-list-helpers.ts
+++ b/packages/app/src/lib/apps/app-list-helpers.ts
@@ -10,14 +10,8 @@ export function canReseed(status: string): boolean {
 
 /**
  * i18n key when deploy is blocked by auth policy, or null when allowed.
- *
- * `runtime` is deliberately not consulted. It used to block `container`, back
- * when nothing could build an image — but the row only says `container` once a
- * deploy has written it, so the gate let the first deploy through and then
- * disabled the button for every one after it. An app that had just shipped read
- * as "not supported". Whether a runtime can deploy is the control plane's
- * answer (it knows which registries and layers exist), and it gives it by
- * refusing `startDeploy`; a list helper cannot know it.
+ * Build compatibility belongs to the build-and-start control plane, not a
+ * helper that only has the last successful deployment snapshot.
  */
 export function deployDisabledReason(
   app: Pick<AppRow, 'authMode'>,

--- a/packages/app/src/lib/backend/types.ts
+++ b/packages/app/src/lib/backend/types.ts
@@ -964,7 +964,29 @@ export interface WorkspacesBackend {
   }): Promise<DaemonWorkspaceBackendRow>;
 }
 
-type AppRuntime = "node" | "container";
+export type AppBuildKind = "node" | "python" | "go" | "php" | "java" | "container";
+
+export interface AppBuildSpec {
+  kind: AppBuildKind;
+  output: string;
+  command?: string;
+  dockerfile?: string;
+  context?: string;
+}
+
+export interface AppStartSpec {
+  fcRuntime?: string;
+  command?: string[];
+  args?: string[];
+  port: number;
+  layers?: string[];
+  healthCheckPath?: string;
+}
+
+export interface AppDeployDeclaration {
+  build: AppBuildSpec;
+  start: AppStartSpec;
+}
 
 export type AppAuthMode = "none" | "platform" | "third";
 
@@ -1137,7 +1159,10 @@ export interface AppRow {
   gitAuthKind: string | null;
   /** HEAD SHA at last successful deploy; null before first deploy completes. */
   gitCommitSha: string | null;
-  runtime: AppRuntime;
+  /** Build kind persisted from the last successful deploy declaration. */
+  runtime: AppBuildKind;
+  /** Start configuration persisted from the last successful deploy declaration. */
+  startSpec: AppStartSpec | null;
   authMode: AppAuthMode;
   authAudience: AppAuthAudience;
   authScope: AppAuthScope;
@@ -1392,9 +1417,8 @@ export interface AppsBackend {
     input: {
       gitCommitSha?: string;
       deployToken: string;
-      /** The app's declared start contract, from `teamclu.app.json`. A
-       *  container app declares no entry — its image's ENTRYPOINT is one. */
-      runtime?: { runtime: string; entry: string; port: number; healthCheckPath?: string };
+      /** The daemon-validated build and start contract from `teamclu.app.json`. */
+      declaration: AppDeployDeclaration;
       /** The image a container build pushed. Required for one, refused for
        *  anything else — see the control plane's parseDeployedImage. */
       image?: string;

--- a/packages/app/src/lib/daemon/daemon-local-client.ts
+++ b/packages/app/src/lib/daemon/daemon-local-client.ts
@@ -14,7 +14,7 @@ import { normalizeDaemonEnvActivationDiagnostics } from '@/lib/diagnostics/env-d
 import { useAuthStore } from '@/stores/auth-store'
 import { isTauri, openExternalUrl } from '@/lib/utils'
 import { textToBase64Url } from '@/lib/base64'
-import type { AppBuildKind } from '@/lib/backend/types'
+import type { AppDeployDeclaration } from '@/lib/backend/types'
 
 // ─── Workspace ID encoding ────────────────────────────────────────────────────
 
@@ -1045,29 +1045,6 @@ export interface BuildAppResult {
    * the presigned URL instead.
    */
   image: string | null
-}
-
-/**
- * What an app declares about how it is built and run (`teamclu.app.json`),
- * validated by the daemon.
- *
- */
-export interface AppDeployDeclaration {
-  build: {
-    kind: AppBuildKind
-    output: string
-    command?: string
-    dockerfile?: string
-    context?: string
-  }
-  start: {
-    fcRuntime?: string
-    command?: string[]
-    args?: string[]
-    port: number
-    layers?: string[]
-    healthCheckPath?: string
-  }
 }
 
 /**

--- a/packages/app/src/lib/daemon/daemon-local-client.ts
+++ b/packages/app/src/lib/daemon/daemon-local-client.ts
@@ -14,6 +14,7 @@ import { normalizeDaemonEnvActivationDiagnostics } from '@/lib/diagnostics/env-d
 import { useAuthStore } from '@/stores/auth-store'
 import { isTauri, openExternalUrl } from '@/lib/utils'
 import { textToBase64Url } from '@/lib/base64'
+import type { AppBuildKind } from '@/lib/backend/types'
 
 // ─── Workspace ID encoding ────────────────────────────────────────────────────
 
@@ -1034,14 +1035,13 @@ export interface BuildAppResult {
    */
   gitCommitSha: string | null
   /**
-   * What the app declared about how it starts (`teamclu.app.json`), resolved by
-   * the daemon against the built-in contract. Handed to finalize so the
-   * function is started the way the app expects.
+   * The validated build and start declaration from `teamclu.app.json`. Handed
+   * to finalize so the function is built and started the way the app expects.
    */
-  runtime: AppRuntimeDeclaration | null
+  declaration: AppDeployDeclaration | null
   /**
-   * The image this build pushed, for an app that declares `runtime:
-   * "container"`. Null for every other app — that one uploaded an archive to
+   * The image this build pushed, for an app whose `build.kind` is
+   * `"container"`. Null for every other app — that one uploaded an archive to
    * the presigned URL instead.
    */
   image: string | null
@@ -1049,16 +1049,25 @@ export interface BuildAppResult {
 
 /**
  * What an app declares about how it is built and run (`teamclu.app.json`),
- * resolved by the daemon against the built-in contract.
+ * validated by the daemon.
  *
- * `entry` is empty for a container app: the image's own ENTRYPOINT is its
- * entry, and there is nothing for us to name.
  */
-export interface AppRuntimeDeclaration {
-  runtime: string
-  entry: string
-  port: number
-  healthCheckPath?: string
+export interface AppDeployDeclaration {
+  build: {
+    kind: AppBuildKind
+    output: string
+    command?: string
+    dockerfile?: string
+    context?: string
+  }
+  start: {
+    fcRuntime?: string
+    command?: string[]
+    args?: string[]
+    port: number
+    layers?: string[]
+    healthCheckPath?: string
+  }
 }
 
 /**
@@ -1122,23 +1131,23 @@ interface DaemonAppWorkdirInfo {
  *
  * Asked before the deploy is minted, because the answer decides which kind of
  * handle the control plane hands back: a container app pushes an image, every
- * other app uploads an archive. Null when the daemon cannot say — the deploy
- * then takes the contract every app had before declarations existed.
+ * other app uploads an archive. Null when the daemon cannot say; callers must
+ * stop before minting a deploy with the wrong destination.
  */
 export async function daemonAppManifest(
   appId: string,
   teamId?: string | null,
-): Promise<AppRuntimeDeclaration | null> {
+): Promise<AppDeployDeclaration | null> {
   try {
     const query = teamId?.trim() ? `?teamId=${encodeURIComponent(teamId.trim())}` : ''
-    const result = await daemonFetch<{ manifest?: AppRuntimeDeclaration }>(
+    const result = await daemonFetch<{ declaration?: AppDeployDeclaration }>(
       `/v1/apps/${encodeURIComponent(appId)}/manifest${query}`,
     )
     if (!result.ok) {
       console.warn('[daemon-local-client] app manifest unavailable (non-fatal):', result.error)
       return null
     }
-    return result.data?.manifest ?? null
+    return result.data?.declaration ?? null
   } catch (err) {
     console.warn('[daemon-local-client] app manifest unavailable:', err)
     return null
@@ -1302,12 +1311,7 @@ export async function buildDaemonApp(
       status: string
       gitCommitSha?: string
       image?: string
-      manifest?: {
-        runtime?: string
-        entry?: string
-        port?: number
-        healthCheckPath?: string
-      }
+      declaration?: AppDeployDeclaration
     }>('/v1/apps/build', {
       method: 'POST',
       body: JSON.stringify({
@@ -1321,34 +1325,23 @@ export async function buildDaemonApp(
       }),
     })
     if (result.ok) {
-      const m = result.data?.manifest
       return {
         outcome: "built",
         error: null,
         gitCommitSha: result.data?.gitCommitSha?.trim() || null,
-        // A container app states no entry, so requiring one here would drop the
-        // whole declaration — including the port FC has to send requests to.
-        runtime:
-          m?.runtime && m.port
-            ? {
-                runtime: m.runtime,
-                entry: m.entry ?? "",
-                port: m.port,
-                ...(m.healthCheckPath ? { healthCheckPath: m.healthCheckPath } : {}),
-              }
-            : null,
+        declaration: result.data?.declaration ?? null,
         image: result.data?.image?.trim() || null,
       }
     }
     if (result.status === 0) {
       console.warn('[daemon-local-client] app build unreachable (non-fatal):', result.error)
-      return { outcome: "unreachable", error: null, gitCommitSha: null, runtime: null, image: null }
+      return { outcome: "unreachable", error: null, gitCommitSha: null, declaration: null, image: null }
     }
     console.warn('[daemon-local-client] app build failed:', result.error)
-    return { outcome: "failed", error: result.error ?? null, gitCommitSha: null, runtime: null, image: null }
+    return { outcome: "failed", error: result.error ?? null, gitCommitSha: null, declaration: null, image: null }
   } catch (err) {
     console.warn('[daemon-local-client] app build unavailable:', err)
-    return { outcome: "unreachable", error: null, gitCommitSha: null, runtime: null, image: null }
+    return { outcome: "unreachable", error: null, gitCommitSha: null, declaration: null, image: null }
   }
 }
 

--- a/packages/app/src/stores/apps-store.test.ts
+++ b/packages/app/src/stores/apps-store.test.ts
@@ -90,13 +90,23 @@ const seedResult = (
   over: { workdir?: string | null; error?: string | null } = {},
 ) => ({ outcome, workdir: null, error: null, ...over });
 
+const defaultDeclaration = {
+  build: { kind: "node", output: ".output" },
+  start: {
+    fcRuntime: "custom.debian10",
+    command: ["/opt/nodejs20/bin/node"],
+    args: ["server/index.mjs"],
+    port: 9000,
+  },
+};
+
 const buildResult = (
   outcome: "built" | "failed" | "unreachable",
   error: string | null = null,
   gitCommitSha: string | null = null,
-  runtime: { runtime: string; entry: string; port: number } | null = null,
+  declaration: typeof defaultDeclaration | null = defaultDeclaration,
   image: string | null = null,
-) => ({ outcome, error, gitCommitSha, runtime, image });
+) => ({ outcome, error, gitCommitSha, declaration, image });
 
 const gitCred = {
   remoteUrl: "git@gitea:team/app-1.git",
@@ -118,6 +128,7 @@ const appRow = (over = {}) => ({
   gitAuthKind: null,
   gitCommitSha: null,
   runtime: "node" as const,
+  startSpec: null,
   authMode: "none" as const,
   oauthClientId: null,
   provisionStatus: "pending",
@@ -816,9 +827,7 @@ describe("apps-store deploy", () => {
     });
     mocks.getGitHead.mockResolvedValue({ sha: "abc1234567890" });
     mocks.getGitCredential.mockResolvedValue(gitCred);
-    // An app that declares nothing: the daemon reports the built-in contract,
-    // which is what every app deployed before declarations existed gets.
-    mocks.daemonAppManifest.mockResolvedValue(null);
+    mocks.daemonAppManifest.mockResolvedValue(defaultDeclaration);
     mocks.getDaemonEnvActivationDiagnostics.mockResolvedValue({
       workspace_has_active_turn: false,
     });
@@ -838,12 +847,11 @@ describe("apps-store deploy", () => {
     // The whole point of the container path: no OSS upload handle is minted,
     // the daemon is handed a registry instead, and the image it pushed is what
     // the function is pointed at.
-    mocks.daemonAppManifest.mockResolvedValue({
-      runtime: "container",
-      entry: "",
-      port: 5000,
-      healthCheckPath: "/api/health",
-    });
+    const declaration = {
+      build: { kind: "container", output: ".", dockerfile: "Dockerfile", context: "." },
+      start: { port: 5000, healthCheckPath: "/api/health" },
+    };
+    mocks.daemonAppManifest.mockResolvedValue(declaration);
     const image = {
       reference: "registry.cn-shenzhen.aliyuncs.com/tc/tc-app-app-1:abc1234567890",
       registry: "registry.cn-shenzhen.aliyuncs.com",
@@ -858,7 +866,7 @@ describe("apps-store deploy", () => {
       gitCommitSha: "abc1234567890",
     });
     mocks.buildDaemonApp.mockResolvedValueOnce(
-      buildResult("built", null, null, { runtime: "container", entry: "", port: 5000 }, image.reference),
+      buildResult("built", null, null, declaration, image.reference),
     );
     mocks.finalizeDeploy.mockResolvedValueOnce({
       ...readyApp(),
@@ -880,7 +888,7 @@ describe("apps-store deploy", () => {
     );
     expect(mocks.finalizeDeploy).toHaveBeenCalledWith("app-1", {
       gitCommitSha: "abc1234567890",
-      runtime: { runtime: "container", entry: "", port: 5000 },
+      declaration,
       image: image.reference,
       deployToken: "tok-1",
     });
@@ -905,7 +913,10 @@ describe("apps-store deploy", () => {
     await useAppsStore.getState().deploy("app-1");
 
     expect(mocks.getGitHead).toHaveBeenCalledWith("app-1");
-    expect(mocks.deployApp).toHaveBeenCalledWith("app-1", { gitCommitSha: "abc1234567890" });
+    expect(mocks.deployApp).toHaveBeenCalledWith("app-1", {
+      gitCommitSha: "abc1234567890",
+      runtime: "node",
+    });
     expect(mocks.daemonAppManifest).toHaveBeenCalledWith("app-1", "team-1");
     expect(mocks.getGitCredential).toHaveBeenCalledWith("app-1");
     expect(mocks.buildDaemonApp).toHaveBeenCalledWith("app-1", "team-1", {
@@ -917,6 +928,7 @@ describe("apps-store deploy", () => {
     });
     expect(mocks.finalizeDeploy).toHaveBeenCalledWith("app-1", {
       gitCommitSha: "abc1234567890",
+      declaration: defaultDeclaration,
       deployToken: "tok-1",
     });
     expect(mocks.updateAppDeployStatus).not.toHaveBeenCalled();
@@ -954,6 +966,7 @@ describe("apps-store deploy", () => {
     );
     expect(mocks.finalizeDeploy).toHaveBeenCalledWith("app-1", {
       gitCommitSha: "def4567890123",
+      declaration: defaultDeclaration,
       deployToken: "tok-1",
     });
   });
@@ -969,16 +982,18 @@ describe("apps-store deploy", () => {
       deployToken: "tok-1",
       gitCommitSha: "abc1234567890",
     });
-    mocks.buildDaemonApp.mockResolvedValueOnce(
-      buildResult("built", null, null, { runtime: "node", entry: "index.js", port: 8080 }),
-    );
+    const declaration = {
+      build: { kind: "node", output: "dist" },
+      start: { fcRuntime: "custom.debian12", command: ["node"], args: ["index.js"], port: 8080 },
+    };
+    mocks.buildDaemonApp.mockResolvedValueOnce(buildResult("built", null, null, declaration));
     mocks.finalizeDeploy.mockResolvedValueOnce({ ...readyApp(), fcStatus: "live" });
     const { useAppsStore } = await import("./apps-store");
     await useAppsStore.getState().deploy("app-1");
 
     expect(mocks.finalizeDeploy).toHaveBeenCalledWith(
       "app-1",
-      expect.objectContaining({ runtime: { runtime: "node", entry: "index.js", port: 8080 } }),
+      expect.objectContaining({ declaration }),
     );
   });
 
@@ -1158,7 +1173,7 @@ describe("apps-store deploy", () => {
 
     expect(mocks.getGitHead).not.toHaveBeenCalled();
     expect(mocks.getGitCredential).not.toHaveBeenCalled();
-    expect(mocks.deployApp).toHaveBeenCalledWith("app-1", {});
+    expect(mocks.deployApp).toHaveBeenCalledWith("app-1", { runtime: "node" });
     expect(mocks.buildDaemonApp).toHaveBeenCalledWith("app-1", "team-1", {
       gitCommitSha: undefined,
       gitRemoteUrl: undefined,
@@ -1166,7 +1181,10 @@ describe("apps-store deploy", () => {
       presignedPut: "https://oss/put?sig=x",
       image: undefined,
     });
-    expect(mocks.finalizeDeploy).toHaveBeenCalledWith("app-1", { deployToken: "tok-1" });
+    expect(mocks.finalizeDeploy).toHaveBeenCalledWith("app-1", {
+      declaration: defaultDeclaration,
+      deployToken: "tok-1",
+    });
     expect(useAppsStore.getState().items[0]).toMatchObject({ fcStatus: "live" });
   });
 

--- a/packages/app/src/stores/apps-store.ts
+++ b/packages/app/src/stores/apps-store.ts
@@ -781,9 +781,12 @@ export const useAppsStore = create<AppsState>((set, get) => ({
       // presigned URL to upload to, and only the machine holding the checkout
       // can say which this is.
       const declared = await daemonAppManifest(appId, app.teamId);
+      if (!declared) {
+        throw new Error("amuxd did not return the app declaration");
+      }
       const started = await getBackend().apps.deployApp(appId, {
         ...(gitCommitSha ? { gitCommitSha } : {}),
-        ...(declared?.runtime ? { runtime: declared.runtime } : {}),
+        runtime: declared.build.kind,
       });
       mergeRow(set, started);
 
@@ -825,6 +828,9 @@ export const useAppsStore = create<AppsState>((set, get) => ({
         await toastError("部署失败：构建未完成", reason);
         return;
       }
+      if (!build.declaration) {
+        throw new Error("amuxd build response did not include declaration");
+      }
 
       // No success toast. It showed `fcEndpoint` — the raw FC function URL —
       // which is not the address the product hands out (that is the app's
@@ -842,7 +848,7 @@ export const useAppsStore = create<AppsState>((set, get) => ({
         // How the app says it starts. The control plane used to assume one
         // answer for every app; this is the app's own, read off its
         // declaration by the daemon that just built it.
-        ...(build.runtime ? { runtime: build.runtime } : {}),
+        declaration: build.declaration,
         // The image that build actually pushed. A container app has no code
         // object, so finalizing without it would point the function at whatever
         // the previous deploy left in OSS.

--- a/services/fc/src/index.ts
+++ b/services/fc/src/index.ts
@@ -218,7 +218,7 @@ function makeDeployDeps() {
     startDeploy: (a: {
       appId: string;
       region: string;
-      runtime?: string;
+      buildKind?: string;
       gitCommitSha?: string | null;
     }) =>
       startDeployImpl(

--- a/services/fc/src/lib/provisioning/app-deploy.ts
+++ b/services/fc/src/lib/provisioning/app-deploy.ts
@@ -440,7 +440,10 @@ export async function finalizeDeploy(deps: FinalizeDeps, input: FinalizeInput): 
     );
   }
 
-  const env: Record<string, string> = { PORT: "9000", NODE_ENV: "production" };
+  const env: Record<string, string> = { NODE_ENV: "production" };
+  if (input.declaration) {
+    env.PORT = String(input.declaration.start.port);
+  }
 
   if (needsDatabase(input.appType)) {
     const appsAdminUrl = deps.appsAdminUrl ?? readAppsAdminUrl();

--- a/services/fc/src/lib/provisioning/app-deploy.ts
+++ b/services/fc/src/lib/provisioning/app-deploy.ts
@@ -7,12 +7,13 @@ import {
   resolveAppConnectionString,
 } from "./app-postgres.js";
 import {
-  isContainerRuntime,
-  isSupportedRuntime,
   readAppsFcVpcConfig,
-  SUPPORTED_RUNTIMES,
-  type AppRuntimeSpec,
 } from "./fc-client.js";
+import {
+  BUILD_KINDS,
+  isContainerKind,
+  type AppDeployDeclaration,
+} from "./app-runtime-spec.js";
 import { ApiError } from "../http-utils.js";
 import { needsDatabase } from "../validation/app-type.js";
 
@@ -47,83 +48,6 @@ export function parseOptionalGitCommitSha(raw: unknown): string | null {
 }
 
 /**
- * Validate what the daemon reported the app declared about starting itself.
- *
- * Rejected rather than defaulted when a field is present but wrong: a bad entry
- * path or port produces a function that cannot boot, and an opaque instance
- * failure minutes later is a much worse answer than a 400 here. Absent means
- * the contract every app had before declarations existed.
- *
- * Note this `runtime` is the interpreter family (`node`), NOT `apps.runtime`
- * (`node` vs `container`) — different column, different question.
- */
-export function parseAppRuntimeSpec(raw: unknown): AppRuntimeSpec | undefined {
-  if (raw === undefined || raw === null) return undefined;
-  if (typeof raw !== "object") {
-    throw new ApiError(400, "validation_failed", "runtime must be an object");
-  }
-  const r = raw as Record<string, unknown>;
-  const runtime = typeof r.runtime === "string" ? r.runtime.trim() : "";
-  const entry = typeof r.entry === "string" ? r.entry.trim() : "";
-  const port = typeof r.port === "number" ? r.port : Number.NaN;
-  const container = isContainerRuntime(runtime);
-  // A container app has no entry to state: the image's own ENTRYPOINT is it.
-  if (!runtime || (!entry && !container)) {
-    throw new ApiError(400, "validation_failed", "runtime.runtime and runtime.entry are required");
-  }
-  if (!isSupportedRuntime(runtime)) {
-    throw new ApiError(
-      400,
-      "unsupported_runtime",
-      `runtime "${runtime}" is not available on this deployment (have: ${SUPPORTED_RUNTIMES.join(", ")})`,
-    );
-  }
-  // An absolute or climbing path escapes the unpacked artifact, and the entry
-  // is joined against it by the runtime, not by us.
-  if (entry && (entry.startsWith("/") || entry.split("/").includes(".."))) {
-    throw new ApiError(400, "validation_failed", "runtime.entry must be a path inside the artifact");
-  }
-  if (!Number.isInteger(port) || port < 1 || port > 65535) {
-    throw new ApiError(400, "validation_failed", "runtime.port must be a TCP port");
-  }
-  const healthCheckPath =
-    typeof r.healthCheckPath === "string" ? r.healthCheckPath.trim() : "";
-  if (healthCheckPath && !healthCheckPath.startsWith("/")) {
-    throw new ApiError(400, "validation_failed", "runtime.healthCheckPath must start with /");
-  }
-  return {
-    runtime,
-    entry,
-    port,
-    ...(healthCheckPath ? { healthCheckPath } : {}),
-  };
-}
-
-/**
- * The runtime a deploy says it is building, from the client's hint.
- *
- * Only the family, not the whole spec: at this point the daemon has read the
- * declaration but built nothing, and the rest of it (entry, port) is checked
- * at finalize against what was actually produced.
- */
-export function parseDeclaredRuntime(raw: unknown): string | undefined {
-  if (raw === undefined || raw === null || raw === "") return undefined;
-  if (typeof raw !== "string") {
-    throw new ApiError(400, "validation_failed", "runtime must be a string");
-  }
-  const runtime = raw.trim();
-  if (!runtime) return undefined;
-  if (!isSupportedRuntime(runtime)) {
-    throw new ApiError(
-      400,
-      "unsupported_runtime",
-      `runtime "${runtime}" is not available on this deployment (have: ${SUPPORTED_RUNTIMES.join(", ")})`,
-    );
-  }
-  return runtime;
-}
-
-/**
  * The image reference a container deploy finished with.
  *
  * Required for a container app and refused for any other: an archive deploy
@@ -132,10 +56,10 @@ export function parseDeclaredRuntime(raw: unknown): string | undefined {
  */
 export function parseDeployedImage(
   raw: unknown,
-  spec: AppRuntimeSpec | undefined,
+  declaration: AppDeployDeclaration,
 ): string | undefined {
   const image = typeof raw === "string" ? raw.trim() : "";
-  if (!isContainerRuntime(spec?.runtime)) {
+  if (!isContainerKind(declaration.build.kind)) {
     if (image) {
       throw new ApiError(400, "validation_failed", "image is only accepted for a container runtime");
     }
@@ -181,11 +105,11 @@ function runtimeOf(row: DeployGateRow): string {
  */
 export function assertDeployAllowed(row: DeployGateRow): void {
   const runtime = runtimeOf(row);
-  if (!isSupportedRuntime(runtime)) {
+  if (!(BUILD_KINDS as readonly string[]).includes(runtime)) {
     throw new ApiError(
       409,
       "unsupported_runtime",
-      `runtime "${runtime}" is not available on this deployment (have: ${SUPPORTED_RUNTIMES.join(", ")})`,
+      `runtime "${runtime}" is not available on this deployment (have: ${BUILD_KINDS.join(", ")})`,
     );
   }
   const authMode = authModeOf(row);
@@ -346,11 +270,10 @@ export interface StartDeployInput {
    *  that predates this, which then gets the `tc-app-<uuid>` shape. */
   slug?: string | null;
   /**
-   * What the app's checkout declares, read by the daemon before the deploy is
-   * minted. Absent means the built-in contract, which is what every client
-   * older than container support sends.
+   * Build kind read by the daemon before the deploy is minted. It determines
+   * whether the build receives an archive upload or image-push handle.
    */
-  runtime?: string;
+  buildKind?: string;
   gitCommitSha?: string | null;
 }
 export interface StartDeployResult {
@@ -379,7 +302,7 @@ export async function startDeploy(deps: StartDeployDeps, input: StartDeployInput
     fcFunctionName: appFunctionName(input.appId, input.slug),
     fcRegion: input.region,
   };
-  if (isContainerRuntime(input.runtime)) {
+  if (isContainerKind(input.buildKind ?? "")) {
     if (!deps.mintImagePush) {
       throw new ApiError(
         503,
@@ -421,7 +344,7 @@ export interface FinalizeDeps {
       a: {
         ossObjectName: string;
         env: Record<string, string>;
-        runtime?: AppRuntimeSpec;
+        declaration?: AppDeployDeclaration;
         image?: string;
       },
     ) => Promise<void>;
@@ -469,10 +392,10 @@ export interface FinalizeInput {
    */
   userEnv?: Record<string, string>;
   /**
-   * What the app declared about how it starts, reported by the daemon that
-   * built it. Absent → the contract every app had before declarations existed.
+   * The daemon-validated build and start declaration. The FC client rejects an
+   * absent value rather than inventing a Node start command.
    */
-  runtime?: AppRuntimeSpec;
+  declaration?: AppDeployDeclaration;
   /**
    * The image the build pushed, for a `container` app. Required for one:
    * there is no code object for that deploy, so a finalize without it would
@@ -585,7 +508,7 @@ export async function finalizeDeploy(deps: FinalizeDeps, input: FinalizeInput): 
   await deps.fcOps.ensureFunction(input.fcFunctionName, {
     ossObjectName: input.ossObjectName,
     env,
-    runtime: input.runtime,
+    declaration: input.declaration,
     image: input.image,
   });
   // The trigger URL is still created: it is what the function is reachable on

--- a/services/fc/src/lib/provisioning/app-deploy.ts
+++ b/services/fc/src/lib/provisioning/app-deploy.ts
@@ -485,6 +485,23 @@ export interface FinalizeInput {
 // have always imported it from here.
 export { needsDatabase };
 
+// build+start declaration parsers — call sites migrate here before Task 2/3.
+export {
+  BUILD_KINDS,
+  CONTAINER_RUNTIME_FC,
+  FC_CODE_RUNTIMES,
+  defaultLayersForKind,
+  isContainerKind,
+  layerArn,
+  parseAppDeployDeclaration,
+  parseDeclaredBuildKind,
+  resolveLayers,
+  type AppBuildKind,
+  type AppBuildSpec,
+  type AppDeployDeclaration,
+  type AppStartSpec,
+} from "./app-runtime-spec.js";
+
 export async function finalizeDeploy(deps: FinalizeDeps, input: FinalizeInput): Promise<{ fcEndpoint: string }> {
   // First, before anything is provisioned. `parseDeployedImage` has already
   // checked that an image is present iff the runtime is `container`, but not

--- a/services/fc/src/lib/provisioning/app-runtime-spec.ts
+++ b/services/fc/src/lib/provisioning/app-runtime-spec.ts
@@ -57,9 +57,13 @@ export const CONTAINER_RUNTIME_FC = "custom-container";
 const LAYER_VERSIONS: Record<Exclude<AppBuildKind, "container">, { name: string; version: number }> = {
   node: { name: "Nodejs20", version: 3 },
   python: { name: "Python310", version: 3 },
+  // Alibaba's official catalog marks Go1 and PHP81-Debian10 compatible with
+  // custom.debian10, not the newer Debian custom runtimes.
   go: { name: "Go1", version: 1 },
   php: { name: "PHP81-Debian10", version: 1 },
-  java: { name: "Java17", version: 1 },
+  // Alibaba FC official public-layer catalog (ListLayers --official), Java17
+  // version 3. Catalog/docs: https://help.aliyun.com/en/functioncompute/fc/user-guide/configure-common-layers-for-a-function-1
+  java: { name: "Java17", version: 3 },
 };
 
 const OFFICIAL_LAYER_ARN =

--- a/services/fc/src/lib/provisioning/app-runtime-spec.ts
+++ b/services/fc/src/lib/provisioning/app-runtime-spec.ts
@@ -113,8 +113,8 @@ function requireObject(raw: unknown, label: string): Record<string, unknown> {
 }
 
 function rejectLegacyShape(raw: Record<string, unknown>): void {
-  const hasRuntime = typeof raw.runtime === "string";
-  const hasEntry = typeof raw.entry === "string";
+  const hasRuntime = Object.prototype.hasOwnProperty.call(raw, "runtime");
+  const hasEntry = Object.prototype.hasOwnProperty.call(raw, "entry");
   if (hasRuntime || hasEntry) {
     throw new ApiError(
       400,
@@ -209,11 +209,11 @@ function parseStart(build: AppBuildSpec, raw: unknown): AppStartSpec {
       );
     }
     const command = parseStringArray(s.command, "start.command", { required: false });
-    const args = parseStringArray(s.args, "start.args", { required: false }) ?? [];
+    const args = parseStringArray(s.args, "start.args", { required: false });
     return {
       ...(fcRuntimeRaw ? { fcRuntime: fcRuntimeRaw } : {}),
       ...(command ? { command } : {}),
-      args,
+      ...(args ? { args } : {}),
       port,
       ...(layers !== undefined ? { layers } : {}),
       ...(healthCheckPath ? { healthCheckPath } : {}),

--- a/services/fc/src/lib/provisioning/app-runtime-spec.ts
+++ b/services/fc/src/lib/provisioning/app-runtime-spec.ts
@@ -1,0 +1,277 @@
+import { ApiError } from "../http-utils.js";
+
+export type AppBuildKind =
+  | "node"
+  | "python"
+  | "go"
+  | "php"
+  | "java"
+  | "container";
+
+export const BUILD_KINDS: readonly AppBuildKind[] = [
+  "node",
+  "python",
+  "go",
+  "php",
+  "java",
+  "container",
+];
+
+export interface AppBuildSpec {
+  kind: AppBuildKind;
+  output: string;
+  command?: string;
+  dockerfile?: string;
+  context?: string;
+}
+
+export interface AppStartSpec {
+  /** FC `runtime`. Required unless kind is container (then forced to custom-container). */
+  fcRuntime?: string;
+  command?: string[];
+  args?: string[];
+  port: number;
+  /**
+   * `undefined` = apply kind defaults.
+   * `[]` = attach no layers.
+   * non-empty = exactly these ARNs.
+   */
+  layers?: string[];
+  healthCheckPath?: string;
+}
+
+export interface AppDeployDeclaration {
+  build: AppBuildSpec;
+  start: AppStartSpec;
+}
+
+export const FC_CODE_RUNTIMES: readonly string[] = [
+  "custom",
+  "custom.debian10",
+  "custom.debian11",
+  "custom.debian12",
+];
+
+export const CONTAINER_RUNTIME_FC = "custom-container";
+
+const LAYER_VERSIONS: Record<Exclude<AppBuildKind, "container">, { name: string; version: number }> = {
+  node: { name: "Nodejs20", version: 3 },
+  python: { name: "Python310", version: 3 },
+  go: { name: "Go1", version: 1 },
+  php: { name: "PHP81-Debian10", version: 1 },
+  java: { name: "Java17", version: 1 },
+};
+
+const OFFICIAL_LAYER_ARN =
+  /^acs:fc:[a-z0-9-]+:official:layers\/[A-Za-z0-9._-]+\/versions\/\d+$/;
+const ACCOUNT_LAYER_ARN =
+  /^acs:fc:[a-z0-9-]+:\d+:layers\/[A-Za-z0-9._-]+\/versions\/\d+$/;
+
+export function isContainerKind(kind: string): boolean {
+  return kind === "container";
+}
+
+export function layerArn(region: string, name: string, version: number): string {
+  return `acs:fc:${region}:official:layers/${name}/versions/${version}`;
+}
+
+export function defaultLayersForKind(region: string, kind: AppBuildKind): string[] {
+  if (isContainerKind(kind)) return [];
+  const pin = LAYER_VERSIONS[kind];
+  return [layerArn(region, pin.name, pin.version)];
+}
+
+export function resolveLayers(
+  region: string,
+  kind: AppBuildKind,
+  layers: string[] | undefined,
+): string[] {
+  if (layers === undefined) return defaultLayersForKind(region, kind);
+  if (layers.length === 0) return [];
+  for (const arn of layers) {
+    if (!isValidLayerArn(arn)) {
+      throw new ApiError(400, "validation_failed", `start.layers contains an invalid layer ARN: ${arn}`);
+    }
+  }
+  return [...layers];
+}
+
+function isValidLayerArn(arn: string): boolean {
+  const trimmed = arn.trim();
+  return OFFICIAL_LAYER_ARN.test(trimmed) || ACCOUNT_LAYER_ARN.test(trimmed);
+}
+
+function isBuildKind(raw: string): raw is AppBuildKind {
+  return (BUILD_KINDS as readonly string[]).includes(raw);
+}
+
+function requireObject(raw: unknown, label: string): Record<string, unknown> {
+  if (raw === null || typeof raw !== "object" || Array.isArray(raw)) {
+    throw new ApiError(400, "validation_failed", `${label} must be an object`);
+  }
+  return raw as Record<string, unknown>;
+}
+
+function rejectLegacyShape(raw: Record<string, unknown>): void {
+  const hasRuntime = typeof raw.runtime === "string";
+  const hasEntry = typeof raw.entry === "string";
+  if (hasRuntime || hasEntry) {
+    throw new ApiError(
+      400,
+      "validation_failed",
+      "teamclu.app.json uses the legacy runtime/entry shape — replace with build + start (see FC runtime passthrough contract)",
+    );
+  }
+}
+
+function parseStringArray(raw: unknown, label: string, { required }: { required: boolean }): string[] | undefined {
+  if (raw === undefined) {
+    if (required) {
+      throw new ApiError(400, "validation_failed", `${label} is required`);
+    }
+    return undefined;
+  }
+  if (!Array.isArray(raw)) {
+    throw new ApiError(400, "validation_failed", `${label} must be an array of strings`);
+  }
+  const out: string[] = [];
+  for (const item of raw) {
+    if (typeof item !== "string" || !item.trim()) {
+      throw new ApiError(400, "validation_failed", `${label} must be an array of non-empty strings`);
+    }
+    out.push(item);
+  }
+  return out;
+}
+
+function parsePort(raw: unknown): number {
+  const port = typeof raw === "number" ? raw : Number.NaN;
+  if (!Number.isInteger(port) || port < 1 || port > 65535) {
+    throw new ApiError(400, "validation_failed", "start.port must be a TCP port between 1 and 65535");
+  }
+  return port;
+}
+
+function parseBuild(raw: unknown): AppBuildSpec {
+  const b = requireObject(raw, "build");
+  const kindRaw = typeof b.kind === "string" ? b.kind.trim() : "";
+  if (!kindRaw || !isBuildKind(kindRaw)) {
+    throw new ApiError(
+      400,
+      "validation_failed",
+      `build.kind must be one of: ${BUILD_KINDS.join(", ")}`,
+    );
+  }
+  const container = isContainerKind(kindRaw);
+  const outputDefault = kindRaw === "node" ? ".output" : ".";
+  const output =
+    typeof b.output === "string" && b.output.trim()
+      ? b.output.trim()
+      : outputDefault;
+  const command =
+    typeof b.command === "string" && b.command.trim() ? b.command.trim() : undefined;
+  if (container) {
+    const dockerfile =
+      typeof b.dockerfile === "string" && b.dockerfile.trim()
+        ? b.dockerfile.trim()
+        : "Dockerfile";
+    const context =
+      typeof b.context === "string" && b.context.trim() ? b.context.trim() : ".";
+    return { kind: kindRaw, output, command, dockerfile, context };
+  }
+  return { kind: kindRaw, output, command };
+}
+
+function parseStart(build: AppBuildSpec, raw: unknown): AppStartSpec {
+  const s = requireObject(raw, "start");
+  const port = parsePort(s.port);
+  const healthCheckPath =
+    typeof s.healthCheckPath === "string" ? s.healthCheckPath.trim() : "";
+  if (healthCheckPath && !healthCheckPath.startsWith("/")) {
+    throw new ApiError(400, "validation_failed", "start.healthCheckPath must start with /");
+  }
+
+  let layers: string[] | undefined;
+  if (s.layers !== undefined) {
+    layers = parseStringArray(s.layers, "start.layers", { required: true }) ?? [];
+    resolveLayers("", build.kind, layers);
+  }
+
+  const container = isContainerKind(build.kind);
+  const fcRuntimeRaw = typeof s.fcRuntime === "string" ? s.fcRuntime.trim() : "";
+
+  if (container) {
+    if (fcRuntimeRaw && fcRuntimeRaw !== CONTAINER_RUNTIME_FC) {
+      throw new ApiError(
+        400,
+        "validation_failed",
+        `start.fcRuntime for container must be "${CONTAINER_RUNTIME_FC}" when set`,
+      );
+    }
+    const command = parseStringArray(s.command, "start.command", { required: false });
+    const args = parseStringArray(s.args, "start.args", { required: false }) ?? [];
+    return {
+      ...(fcRuntimeRaw ? { fcRuntime: fcRuntimeRaw } : {}),
+      ...(command ? { command } : {}),
+      args,
+      port,
+      ...(layers !== undefined ? { layers } : {}),
+      ...(healthCheckPath ? { healthCheckPath } : {}),
+    };
+  }
+
+  if (!fcRuntimeRaw) {
+    throw new ApiError(400, "validation_failed", "start.fcRuntime is required for non-container apps");
+  }
+  if (!(FC_CODE_RUNTIMES as readonly string[]).includes(fcRuntimeRaw)) {
+    throw new ApiError(
+      400,
+      "validation_failed",
+      `start.fcRuntime must be one of: ${FC_CODE_RUNTIMES.join(", ")}`,
+    );
+  }
+  const command = parseStringArray(s.command, "start.command", { required: true }) ?? [];
+  if (command.length === 0) {
+    throw new ApiError(400, "validation_failed", "start.command must be a non-empty array for non-container apps");
+  }
+  const args = parseStringArray(s.args, "start.args", { required: false }) ?? [];
+  return {
+    fcRuntime: fcRuntimeRaw,
+    command,
+    args,
+    port,
+    ...(layers !== undefined ? { layers } : {}),
+    ...(healthCheckPath ? { healthCheckPath } : {}),
+  };
+}
+
+export function parseAppDeployDeclaration(raw: unknown): AppDeployDeclaration {
+  const root = requireObject(raw, "teamclu.app.json");
+  rejectLegacyShape(root);
+  if (root.build === undefined) {
+    throw new ApiError(400, "validation_failed", "build is required in teamclu.app.json");
+  }
+  if (root.start === undefined) {
+    throw new ApiError(400, "validation_failed", "start is required in teamclu.app.json");
+  }
+  const build = parseBuild(root.build);
+  const start = parseStart(build, root.start);
+  return { build, start };
+}
+
+export function parseDeclaredBuildKind(raw: unknown): AppBuildKind | undefined {
+  if (raw === undefined || raw === null || raw === "") return undefined;
+  if (typeof raw !== "string") {
+    throw new ApiError(400, "validation_failed", "build.kind must be a string");
+  }
+  const kind = raw.trim();
+  if (!kind) return undefined;
+  if (!isBuildKind(kind)) {
+    throw new ApiError(
+      400,
+      "validation_failed",
+      `build.kind must be one of: ${BUILD_KINDS.join(", ")}`,
+    );
+  }
+  return kind;
+}

--- a/services/fc/src/lib/provisioning/fc-client.ts
+++ b/services/fc/src/lib/provisioning/fc-client.ts
@@ -3,7 +3,12 @@ import { Config } from "@alicloud/openapi-client";
 import { appsRegion, type AppsOssProfile } from "./apps-oss.js";
 import { imageForPull } from "./apps-registry.js";
 import { ApiError } from "../http-utils.js";
-import { layerArn as officialLayerArn } from "./app-runtime-spec.js";
+import {
+  isContainerKind,
+  resolveLayers,
+  type AppDeployDeclaration,
+  type AppStartSpec,
+} from "./app-runtime-spec.js";
 
 type FcClientInstance = InstanceType<typeof FcClient.default>;
 
@@ -123,8 +128,8 @@ export interface FcOpsConfig {
 export interface EnsureFunctionArgs {
   ossObjectName: string;
   env: Record<string, string>;
-  /** What the app declared about how it is started. Absent → the built-in Node contract. */
-  runtime?: AppRuntimeSpec;
+  /** The daemon-validated build and start declaration. Required at runtime. */
+  declaration?: AppDeployDeclaration;
   /**
    * The image to run, for a `container` app. Already in the registry: the
    * daemon pushed it before finalize was called, so there is no code object
@@ -174,78 +179,6 @@ function functionNetworkInput(vpc: AppsFcVpcConfig | undefined) {
 }
 
 /**
- * The custom runtime image ships NO node at all — not merely one that is off
- * PATH. `command: ["node"]` therefore failed EVERY deploy at instance start
- * with `CAFileNotFound: the file node is not exist`, and `/bin/sh -c 'exec
- * node …'` failed the same way with `exec: node: not found` (exit 127). The
- * standard `nodejs20` runtime is not an escape either: it rejects a startup
- * command outright (`customRuntimeConfig not supported for non-custom
- * runtime`), because it is handler-based.
- *
- * What works is the official Node.js layer. It mounts under `/opt/nodejs20`
- * and does NOT extend PATH (verified in a live instance: PATH is still
- * `/usr/local/sbin:…:/bin`), so the start command must name the binary by
- * absolute path.
- *
- * The version is pinned rather than floating: a layer version is immutable, so
- * pinning is what keeps a redeploy of an untouched app from silently changing
- * its Node runtime underneath it.
- */
-export const NODE_BIN = "/opt/nodejs20/bin/node";
-
-/** The runtimes this deployment can actually start, and what starts them. */
-const RUNTIME_BINARIES: Record<string, string> = { node: NODE_BIN };
-
-/**
- * The app ships its own image instead of code for one of our layers.
- *
- * Not in RUNTIME_BINARIES: there is no interpreter to name, because the image
- * brings its own. It is a supported runtime all the same.
- */
-export const CONTAINER_RUNTIME = "container";
-
-/** An app's declared start contract, already validated against RUNTIME_BINARIES. */
-export interface AppRuntimeSpec {
-  runtime: string;
-  entry: string;
-  port: number;
-  /** `container` only: a path the app answers 200 on. */
-  healthCheckPath?: string;
-}
-
-export function isContainerRuntime(runtime: string | undefined): boolean {
-  return runtime === CONTAINER_RUNTIME;
-}
-
-export function isSupportedRuntime(runtime: string): boolean {
-  return isContainerRuntime(runtime) || Object.hasOwn(RUNTIME_BINARIES, runtime);
-}
-
-export const SUPPORTED_RUNTIMES = [...Object.keys(RUNTIME_BINARIES), CONTAINER_RUNTIME];
-
-/**
- * The start command, from what the app declared or from the contract every app
- * had before declarations existed.
- *
- * The interpreter comes from a table, never from the app: the runtime image
- * ships no interpreter at all, so a binary reaches the instance only if a
- * matching layer was attached. An app naming `python3` would start a function
- * that cannot boot, and the failure would surface as an opaque instance error.
- */
-function startCommand(spec: AppRuntimeSpec | undefined) {
-  const resolved: AppRuntimeSpec = spec ?? { runtime: "node", entry: "server/index.mjs", port: 9000 };
-  const bin = RUNTIME_BINARIES[resolved.runtime];
-  if (!bin) {
-    throw new ApiError(
-      400,
-      "unsupported_runtime",
-      `runtime "${resolved.runtime}" is not available on this deployment (have: ${SUPPORTED_RUNTIMES.join(", ")})`,
-    );
-  }
-  return new $fc.CustomRuntimeConfig({ command: [bin], args: [resolved.entry], port: resolved.port });
-}
-
-/**
  * The container half of the same question: what starts this app.
  *
  * Nothing about the process is named here — the image's own `ENTRYPOINT` and
@@ -256,14 +189,15 @@ function startCommand(spec: AppRuntimeSpec | undefined) {
  */
 function containerConfig(
   image: string,
-  spec: AppRuntimeSpec | undefined,
+  start: AppStartSpec,
   auth: FcOpsConfig["registryAuth"],
 ) {
-  const port = spec?.port ?? 9000;
-  const healthCheckPath = spec?.healthCheckPath?.trim();
+  const healthCheckPath = start.healthCheckPath?.trim();
   return new $fc.CustomContainerConfig({
     image: imageForPull(image, auth?.host),
-    port,
+    port: start.port,
+    ...(start.command ? { command: start.command } : {}),
+    ...(start.args ? { args: start.args } : {}),
     // A private registry that is not ACR is reached with a plain login, which
     // is what `registryConfig` exists for. Read-only where the deployment
     // configured a separate pull user: this credential lives in the function's
@@ -307,7 +241,11 @@ function containerConfig(
  * first image it was ever given.
  */
 function runtimeInput(cfg: FcOpsConfig, args: EnsureFunctionArgs, codeLocation: (n: string) => any) {
-  if (isContainerRuntime(args.runtime?.runtime)) {
+  const declaration = args.declaration;
+  if (!declaration) {
+    throw new ApiError(400, "validation_failed", "declaration (build+start) is required");
+  }
+  if (isContainerKind(declaration.build.kind)) {
     if (!args.image) {
       throw new ApiError(
         400,
@@ -320,19 +258,32 @@ function runtimeInput(cfg: FcOpsConfig, args: EnsureFunctionArgs, codeLocation: 
     // mounted into someone's Python image.
     return {
       runtime: "custom-container",
-      customContainerConfig: containerConfig(args.image, args.runtime, cfg.registryAuth),
+      customContainerConfig: containerConfig(args.image, declaration.start, cfg.registryAuth),
     };
   }
+  const healthCheckPath = declaration.start.healthCheckPath?.trim();
   return {
-    runtime: "custom.debian10",
-    layers: [nodejsLayerArn(cfg.region)],
-    customRuntimeConfig: startCommand(args.runtime),
+    runtime: declaration.start.fcRuntime,
+    layers: resolveLayers(cfg.region, declaration.build.kind, declaration.start.layers),
+    customRuntimeConfig: new $fc.CustomRuntimeConfig({
+      command: declaration.start.command,
+      args: declaration.start.args ?? [],
+      port: declaration.start.port,
+      ...(healthCheckPath
+        ? {
+            healthCheckConfig: new $fc.CustomHealthCheckConfig({
+              httpGetUrl: healthCheckPath,
+              initialDelaySeconds: 10,
+              periodSeconds: 5,
+              timeoutSeconds: 3,
+              failureThreshold: 6,
+              successThreshold: 1,
+            }),
+          }
+        : {}),
+    }),
     code: codeLocation(args.ossObjectName),
   };
-}
-
-export function nodejsLayerArn(region: string): string {
-  return officialLayerArn(region, "Nodejs20", 3);
 }
 
 function isNotFound(e: any): boolean {

--- a/services/fc/src/lib/provisioning/fc-client.ts
+++ b/services/fc/src/lib/provisioning/fc-client.ts
@@ -3,6 +3,7 @@ import { Config } from "@alicloud/openapi-client";
 import { appsRegion, type AppsOssProfile } from "./apps-oss.js";
 import { imageForPull } from "./apps-registry.js";
 import { ApiError } from "../http-utils.js";
+import { layerArn as officialLayerArn } from "./app-runtime-spec.js";
 
 type FcClientInstance = InstanceType<typeof FcClient.default>;
 
@@ -331,7 +332,7 @@ function runtimeInput(cfg: FcOpsConfig, args: EnsureFunctionArgs, codeLocation: 
 }
 
 export function nodejsLayerArn(region: string): string {
-  return `acs:fc:${region}:official:layers/Nodejs20/versions/3`;
+  return officialLayerArn(region, "Nodejs20", 3);
 }
 
 function isNotFound(e: any): boolean {

--- a/services/fc/src/lib/supabase-repo.ts
+++ b/services/fc/src/lib/supabase-repo.ts
@@ -4016,10 +4016,10 @@ export function createSupabaseBusinessRepository(options) {
 
     async finalizeDeploy(
       appId: string,
-      input: { gitCommitSha?: string; deployToken: string; runtime?: unknown; image?: unknown },
+      input: { gitCommitSha?: string; deployToken: string; declaration?: unknown; image?: unknown },
     ) {
       const gitCommitSha = parseOptionalGitCommitSha(input?.gitCommitSha);
-      const declaration = parseAppDeployDeclaration(input?.runtime);
+      const declaration = parseAppDeployDeclaration(input?.declaration);
       const deployToken = parseDeployToken(input?.deployToken);
       // Visibility gate. RLS on amux.apps returns nothing when the app is not
       // visible to the caller → surface null so the route 404s.

--- a/services/fc/src/lib/supabase-repo.ts
+++ b/services/fc/src/lib/supabase-repo.ts
@@ -4097,6 +4097,7 @@ export function createSupabaseBusinessRepository(options) {
             // What is now running, as opposed to what the deploy set out to
             // build. They differ when an app's declaration changed mid-deploy.
             runtime: declaration.build.kind,
+            start_spec: declaration.start,
             // The function that just went live carries this auth_mode's env.
             // Recording it here is what lets `authModePendingRedeploy` clear —
             // and what makes the pending state a property of the row rather

--- a/services/fc/src/lib/supabase-repo.ts
+++ b/services/fc/src/lib/supabase-repo.ts
@@ -59,8 +59,8 @@ import {
   checkDeployInProgress,
   deployUnavailable,
   needsDatabase,
-  parseAppRuntimeSpec,
-  parseDeclaredRuntime,
+  parseAppDeployDeclaration,
+  parseDeclaredBuildKind,
   parseDeployedImage,
   parseDeployToken,
   parseOptionalGitCommitSha,
@@ -3922,7 +3922,7 @@ export function createSupabaseBusinessRepository(options) {
       // deploy. It decides which handle this deploy carries — an OSS upload or
       // a registry to push an image to — so it has to arrive here, not at
       // finalize where the rest of the declaration does.
-      const declaredRuntime = parseDeclaredRuntime(input?.runtime);
+      const declaredBuildKind = parseDeclaredBuildKind(input?.runtime);
       // Visibility + readiness gate. RLS on amux.apps returns nothing when the
       // app is not visible to the caller → surface null so the route 404s.
       const { data: existing, error: selErr } = await supabase
@@ -3961,7 +3961,7 @@ export function createSupabaseBusinessRepository(options) {
         const r = await startDeploy({
           appId,
           region: process.env.REGION || "cn-hangzhou",
-          runtime: declaredRuntime,
+          buildKind: declaredBuildKind,
           gitCommitSha,
           // Only consulted when a function is first minted, so an app that has
           // already deployed keeps the name stored on its row.
@@ -3980,7 +3980,7 @@ export function createSupabaseBusinessRepository(options) {
             // The column records what this deployment is building, which until
             // now nothing ever wrote — it sat at its default while the guard
             // beside it refused every value but that default.
-            ...(declaredRuntime ? { runtime: declaredRuntime } : {}),
+            ...(declaredBuildKind ? { runtime: declaredBuildKind } : {}),
             updated_at: deployStartedAt,
           })
           .eq("id", appId)
@@ -4019,7 +4019,7 @@ export function createSupabaseBusinessRepository(options) {
       input: { gitCommitSha?: string; deployToken: string; runtime?: unknown; image?: unknown },
     ) {
       const gitCommitSha = parseOptionalGitCommitSha(input?.gitCommitSha);
-      const runtimeSpec = parseAppRuntimeSpec(input?.runtime);
+      const declaration = parseAppDeployDeclaration(input?.runtime);
       const deployToken = parseDeployToken(input?.deployToken);
       // Visibility gate. RLS on amux.apps returns nothing when the app is not
       // visible to the caller → surface null so the route 404s.
@@ -4081,13 +4081,12 @@ export function createSupabaseBusinessRepository(options) {
           platformAuthEnv,
           storageEnv,
           userEnv,
-          // What the daemon read out of the app's own declaration. Absent for a
-          // client that predates it, which is the contract every app had before.
-          runtime: runtimeSpec,
+          // What the daemon read out of the app's own declaration.
+          declaration,
           // The image that build pushed. A container app has no code object,
           // so without this the function would be pointed at whatever the
           // previous deploy happened to leave in OSS.
-          image: parseDeployedImage(input?.image, runtimeSpec),
+          image: parseDeployedImage(input?.image, declaration),
         });
         const { data: row, error: updErr } = await supabase
           .from("apps")
@@ -4097,7 +4096,7 @@ export function createSupabaseBusinessRepository(options) {
             ...(gitCommitSha ? { git_commit_sha: gitCommitSha } : {}),
             // What is now running, as opposed to what the deploy set out to
             // build. They differ when an app's declaration changed mid-deploy.
-            ...(runtimeSpec ? { runtime: runtimeSpec.runtime } : {}),
+            runtime: declaration.build.kind,
             // The function that just went live carries this auth_mode's env.
             // Recording it here is what lets `authModePendingRedeploy` clear —
             // and what makes the pending state a property of the row rather

--- a/services/fc/src/lib/supabase-repo/shared.ts
+++ b/services/fc/src/lib/supabase-repo/shared.ts
@@ -105,7 +105,7 @@ export function mapDefaultAgentError(error: any) {
 // the client contract. Selecting it keeps finalizeDeploy and the data browser
 // from needing a second round trip.
 export const APP_COLUMNS =
-  "id, team_id, org_id, created_by_actor_id, name, slug, type, visibility, workspace_id, git_remote_url, git_auth_kind, git_commit_sha, runtime, auth_mode, auth_audience, auth_scope, auth_rules, deployed_auth_mode, deployed_type, env_updated_at, env_deployed_at, oauth_client_id, provision_status, fc_status, fc_endpoint, fc_function_name, fc_region, created_at, updated_at";
+  "id, team_id, org_id, created_by_actor_id, name, slug, type, visibility, workspace_id, git_remote_url, git_auth_kind, git_commit_sha, runtime, start_spec, auth_mode, auth_audience, auth_scope, auth_rules, deployed_auth_mode, deployed_type, env_updated_at, env_deployed_at, oauth_client_id, provision_status, fc_status, fc_endpoint, fc_function_name, fc_region, created_at, updated_at";
 
 export function slugify(name: string): string {
   return (
@@ -141,6 +141,7 @@ export function mapApp(r: any) {
     gitAuthKind: r.git_auth_kind ?? null,
     gitCommitSha: r.git_commit_sha ?? null,
     runtime: r.runtime ?? "node",
+    startSpec: r.start_spec ?? null,
     authMode: r.auth_mode ?? "none",
     // Unset reads as the strict value everywhere, matching the column default:
     // a row that predates the column must not appear more open than it is.

--- a/services/fc/test/app-v1.test.ts
+++ b/services/fc/test/app-v1.test.ts
@@ -1,4 +1,4 @@
-import { parseAppRuntimeSpec } from "../src/lib/provisioning/app-deploy.js";
+import { parseAppDeployDeclaration } from "../src/lib/provisioning/app-deploy.js";
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { createApp } from "../src/app.js";
@@ -32,38 +32,34 @@ test("missing bearer on /v1/teams -> 401", async () => {
   assert.equal(res.status, 401);
 });
 
-test("parseAppRuntimeSpec: absent keeps the contract every app had before", () => {
-  assert.equal(parseAppRuntimeSpec(undefined), undefined);
-  assert.equal(parseAppRuntimeSpec(null), undefined);
+test("parseAppDeployDeclaration: a declaration is required", () => {
+  assert.throws(() => parseAppDeployDeclaration(undefined), /must be an object/);
+  assert.throws(() => parseAppDeployDeclaration(null), /must be an object/);
 });
 
-test("parseAppRuntimeSpec: a declared start is taken as declared", () => {
-  assert.deepEqual(parseAppRuntimeSpec({ runtime: "node", entry: "index.js", port: 8080 }), {
-    runtime: "node",
-    entry: "index.js",
-    port: 8080,
+test("parseAppDeployDeclaration: build and start are taken as declared", () => {
+  assert.deepEqual(parseAppDeployDeclaration({
+    build: { kind: "python", output: "." },
+    start: { fcRuntime: "custom.debian12", command: ["python3"], args: ["app.py"], port: 8080 },
+  }), {
+    build: { kind: "python", output: ".", command: undefined },
+    start: { fcRuntime: "custom.debian12", command: ["python3"], args: ["app.py"], port: 8080 },
   });
 });
 
-test("parseAppRuntimeSpec: refuses what would produce a function that cannot boot", () => {
-  // The runtime image ships no interpreter; a binary reaches the instance only
-  // if a matching layer was attached, so an unknown runtime is a 400 here
-  // rather than an opaque instance failure minutes later.
+test("parseAppDeployDeclaration: refuses the legacy runtime and entry shape", () => {
   assert.throws(
-    () => parseAppRuntimeSpec({ runtime: "python", entry: "app.py", port: 9000 }),
-    /not available on this deployment/,
+    () => parseAppDeployDeclaration({ runtime: "node", entry: "server/index.mjs", port: 9000 }),
+    /legacy runtime\/entry shape/,
   );
-  // The entry is joined against the unpacked artifact by the runtime, not by us.
+});
+
+test("parseAppDeployDeclaration: refuses invalid start configuration", () => {
   assert.throws(
-    () => parseAppRuntimeSpec({ runtime: "node", entry: "/etc/passwd", port: 9000 }),
-    /inside the artifact/,
-  );
-  assert.throws(
-    () => parseAppRuntimeSpec({ runtime: "node", entry: "../x.js", port: 9000 }),
-    /inside the artifact/,
-  );
-  assert.throws(
-    () => parseAppRuntimeSpec({ runtime: "node", entry: "index.js", port: 0 }),
+    () => parseAppDeployDeclaration({
+      build: { kind: "node" },
+      start: { fcRuntime: "custom.debian10", command: ["/opt/nodejs20/bin/node"], args: ["index.js"], port: 0 },
+    }),
     /TCP port/,
   );
 });

--- a/services/fc/test/provisioning/app-deploy.test.ts
+++ b/services/fc/test/provisioning/app-deploy.test.ts
@@ -40,7 +40,7 @@ test("finalizeDeploy provisions the org DB + schema, then sets code + env togeth
   const orgId = "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee";
   const declaration = {
     build: { kind: "python" as const, output: "." },
-    start: { fcRuntime: "custom.debian12", command: ["python3"], args: ["app.py"], port: 9000 },
+    start: { fcRuntime: "custom.debian12", command: ["python3"], args: ["app.py"], port: 8088 },
   };
   const out = await finalizeDeploy(
     {
@@ -80,7 +80,7 @@ test("finalizeDeploy provisions the org DB + schema, then sets code + env togeth
   const [, name, args] = ensure;
   assert.equal(name, "tc-app-3f1c9a2e-0000-4000-8000-000000000abc");
   assert.equal(args.ossObjectName, "apps/3f1c9a2e-0000-4000-8000-000000000abc/code.zip");
-  assert.equal(args.env.PORT, "9000");
+  assert.equal(args.env.PORT, "8088");
   assert.match(args.env.DATABASE_URL, /tc_org_/);
   assert.match(args.env.DATABASE_URL, /pw-fixed/);
   assert.deepEqual(args.declaration, declaration);
@@ -244,7 +244,22 @@ test("a static app deploys with no database at all", async () => {
           ensureHttpTrigger: async () => "https://fn.example.fcapp.run",
         },
       } as any,
-      { appId: "app-1", slug: "demo", appType, fcFunctionName: "tc-app-1", ossObjectName: "apps/app-1/code.zip" },
+      {
+        appId: "app-1",
+        slug: "demo",
+        appType,
+        fcFunctionName: "tc-app-1",
+        ossObjectName: "apps/app-1/code.zip",
+        declaration: {
+          build: { kind: "node", output: ".output" },
+          start: {
+            fcRuntime: "custom.debian10",
+            command: ["/opt/nodejs20/bin/node"],
+            args: ["server/index.mjs"],
+            port: 9000,
+          },
+        },
+      },
     );
     assert.deepEqual(out, { fcEndpoint: "https://fn.example.fcapp.run" });
   }

--- a/services/fc/test/provisioning/app-deploy.test.ts
+++ b/services/fc/test/provisioning/app-deploy.test.ts
@@ -7,7 +7,7 @@ import {
   checkDeployInProgress,
   isStaleDeploy,
   parseOptionalGitCommitSha,
-  parseAppRuntimeSpec,
+  parseAppDeployDeclaration,
   parseDeployedImage,
   assertDeployAllowed,
   STALE_DEPLOY_MS,
@@ -38,6 +38,10 @@ test("startDeploy does NOT touch FC — the code object does not exist yet", asy
 test("finalizeDeploy provisions the org DB + schema, then sets code + env together", async () => {
   const calls: any[] = [];
   const orgId = "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee";
+  const declaration = {
+    build: { kind: "python" as const, output: "." },
+    start: { fcRuntime: "custom.debian12", command: ["python3"], args: ["app.py"], port: 9000 },
+  };
   const out = await finalizeDeploy(
     {
       appsAdminUrl: "postgres://host:5432/postgres",
@@ -63,6 +67,7 @@ test("finalizeDeploy provisions the org DB + schema, then sets code + env togeth
       appType: "data_app",
       fcFunctionName: "tc-app-3f1c9a2e-0000-4000-8000-000000000abc",
       ossObjectName: "apps/3f1c9a2e-0000-4000-8000-000000000abc/code.zip",
+      declaration,
     },
   );
   assert.deepEqual(out, { fcEndpoint: "https://fn.example.fcapp.run" });
@@ -78,6 +83,7 @@ test("finalizeDeploy provisions the org DB + schema, then sets code + env togeth
   assert.equal(args.env.PORT, "9000");
   assert.match(args.env.DATABASE_URL, /tc_org_/);
   assert.match(args.env.DATABASE_URL, /pw-fixed/);
+  assert.deepEqual(args.declaration, declaration);
   assert.equal(calls.at(-1)[0], "trigger");
 });
 
@@ -477,7 +483,7 @@ test("a container app is minted a registry to push to, not an upload URL", async
         };
       },
     },
-    { appId: "app-1", region: "cn-shenzhen", runtime: "container", gitCommitSha: "abc1234" },
+    { appId: "app-1", region: "cn-shenzhen", buildKind: "container", gitCommitSha: "abc1234" },
   );
   assert.deepEqual(minted, { appId: "app-1", sha: "abc1234" });
   assert.equal(out.presignedPut, undefined);
@@ -496,7 +502,7 @@ test("a container deploy on a deployment with no registry names the variable", a
           mintUploadUrl: async () => "https://oss.example/put",
           imagePushUnavailable: "APPS_REGISTRY_HOST is not set",
         },
-        { appId: "app-1", region: "cn-shenzhen", runtime: "container" },
+        { appId: "app-1", region: "cn-shenzhen", buildKind: "container" },
       ),
     (e: any) => {
       assert.equal(e.statusCode ?? e.status, 503);
@@ -516,35 +522,45 @@ test("an app that declares nothing still gets the upload handle", async () => {
   assert.equal(out.image, undefined);
 });
 
-test("a container app declares no entry, and a code app may not send an image", () => {
-  const spec = parseAppRuntimeSpec({ runtime: "container", port: 5000, healthCheckPath: "/api/health" });
-  assert.deepEqual(spec, { runtime: "container", entry: "", port: 5000, healthCheckPath: "/api/health" });
+test("a container declaration has no entry, and a code app may not send an image", () => {
+  const spec = parseAppDeployDeclaration({
+    build: { kind: "container" },
+    start: { port: 5000, healthCheckPath: "/api/health" },
+  });
+  assert.equal(spec.build.kind, "container");
+  assert.equal(spec.start.healthCheckPath, "/api/health");
 
   // The image belongs to the runtime that has one. Accepting it for an archive
   // deploy would let a client point the function at an unrelated build.
   assert.equal(parseDeployedImage("registry/ns/app:sha", spec), "registry/ns/app:sha");
   assert.throws(() => parseDeployedImage("", spec), /must finalize with its image/);
-  const node = parseAppRuntimeSpec({ runtime: "node", entry: "server/index.mjs", port: 9000 });
+  const node = parseAppDeployDeclaration({
+    build: { kind: "node", output: ".output" },
+    start: {
+      fcRuntime: "custom.debian10",
+      command: ["/opt/nodejs20/bin/node"],
+      args: ["server/index.mjs"],
+      port: 9000,
+    },
+  });
   assert.equal(parseDeployedImage(undefined, node), undefined);
   assert.throws(() => parseDeployedImage("registry/ns/app:sha", node), /only accepted for a container/);
 });
 
 test("a health check path that is not a path is refused", () => {
   assert.throws(
-    () => parseAppRuntimeSpec({ runtime: "container", port: 5000, healthCheckPath: "api/health" }),
+    () => parseAppDeployDeclaration({
+      build: { kind: "container" },
+      start: { port: 5000, healthCheckPath: "api/health" },
+    }),
     /healthCheckPath must start with/,
   );
 });
 
-test("the deploy gate no longer refuses a container app outright", () => {
-  // It used to 409 every runtime but node, which is what stood between a
-  // Python app and a deploy. Whether THIS deployment can build one is decided
-  // where the registry config is known.
+test("the deploy gate accepts every declared build kind", () => {
   assertDeployAllowed({ id: "app-1", slug: "notes", runtime: "container", authMode: "none" });
-  assert.throws(
-    () => assertDeployAllowed({ id: "app-1", slug: "notes", runtime: "python", authMode: "none" }),
-    /not available on this deployment/,
-  );
+  assertDeployAllowed({ id: "app-1", slug: "notes", runtime: "python", authMode: "none" });
+  assert.throws(() => assertDeployAllowed({ id: "app-1", slug: "notes", runtime: "ruby", authMode: "none" }), /not available/);
 });
 
 test("finalizeDeploy refuses an image outside the app's own repository", async () => {

--- a/services/fc/test/provisioning/app-runtime-spec.test.ts
+++ b/services/fc/test/provisioning/app-runtime-spec.test.ts
@@ -1,0 +1,73 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  parseAppDeployDeclaration,
+  resolveLayers,
+  defaultLayersForKind,
+  layerArn,
+} from "../../src/lib/provisioning/app-runtime-spec.js";
+
+test("parse: accepts build+start for node", () => {
+  const d = parseAppDeployDeclaration({
+    build: { kind: "node", output: ".output" },
+    start: {
+      fcRuntime: "custom.debian10",
+      command: ["/opt/nodejs20/bin/node"],
+      args: ["server/index.mjs"],
+      port: 9000,
+    },
+  });
+  assert.equal(d.build.kind, "node");
+  assert.deepEqual(d.start.command, ["/opt/nodejs20/bin/node"]);
+  assert.equal(d.start.layers, undefined);
+});
+
+test("parse: refuses legacy runtime/entry shape", () => {
+  assert.throws(
+    () =>
+      parseAppDeployDeclaration({
+        runtime: "node",
+        entry: "server/index.mjs",
+        port: 9000,
+      }),
+    (e: any) => /legacy|runtime\.entry|teamclu\.app\.json/i.test(String(e?.message ?? e)),
+  );
+});
+
+test("parse: container may omit command; forces no required fcRuntime", () => {
+  const d = parseAppDeployDeclaration({
+    build: { kind: "container", dockerfile: "Dockerfile", context: "." },
+    start: { port: 5000, healthCheckPath: "/api/health" },
+  });
+  assert.equal(d.build.kind, "container");
+  assert.equal(d.start.port, 5000);
+});
+
+test("parse: non-container requires non-empty command array", () => {
+  assert.throws(() =>
+    parseAppDeployDeclaration({
+      build: { kind: "python", output: "." },
+      start: { fcRuntime: "custom.debian10", command: [], args: ["app.py"], port: 9000 },
+    }),
+  );
+});
+
+test("parse: healthCheckPath must start with /", () => {
+  assert.throws(() =>
+    parseAppDeployDeclaration({
+      build: { kind: "container" },
+      start: { port: 9000, healthCheckPath: "health" },
+    }),
+  );
+});
+
+test("resolveLayers: omitted uses defaults; [] uses none", () => {
+  const region = "cn-shenzhen";
+  assert.ok(defaultLayersForKind(region, "node").length >= 1);
+  assert.deepEqual(resolveLayers(region, "node", undefined), defaultLayersForKind(region, "node"));
+  assert.deepEqual(resolveLayers(region, "node", []), []);
+  assert.deepEqual(
+    resolveLayers(region, "node", [layerArn(region, "Python310", 1)]),
+    [layerArn(region, "Python310", 1)],
+  );
+});

--- a/services/fc/test/provisioning/app-runtime-spec.test.ts
+++ b/services/fc/test/provisioning/app-runtime-spec.test.ts
@@ -22,6 +22,26 @@ test("parse: accepts build+start for node", () => {
   assert.equal(d.start.layers, undefined);
 });
 
+test("parse: build output defaults match the daemon build table", () => {
+  for (const [kind, output] of [
+    ["node", ".output"],
+    ["python", "."],
+    ["go", "."],
+    ["php", "."],
+    ["java", "."],
+  ] as const) {
+    const d = parseAppDeployDeclaration({
+      build: { kind },
+      start: {
+        fcRuntime: "custom.debian10",
+        command: ["run"],
+        port: 9000,
+      },
+    });
+    assert.equal(d.build.output, output, kind);
+  }
+});
+
 test("parse: refuses legacy runtime/entry shape", () => {
   for (const legacy of [{ runtime: null }, { entry: { path: "server/index.mjs" } }]) {
     assert.throws(
@@ -78,4 +98,7 @@ test("resolveLayers: omitted uses defaults; [] uses none", () => {
     resolveLayers(region, "node", [layerArn(region, "Python310", 1)]),
     [layerArn(region, "Python310", 1)],
   );
+  assert.deepEqual(defaultLayersForKind(region, "java"), [
+    layerArn(region, "Java17", 3),
+  ]);
 });

--- a/services/fc/test/provisioning/app-runtime-spec.test.ts
+++ b/services/fc/test/provisioning/app-runtime-spec.test.ts
@@ -23,24 +23,32 @@ test("parse: accepts build+start for node", () => {
 });
 
 test("parse: refuses legacy runtime/entry shape", () => {
-  assert.throws(
-    () =>
-      parseAppDeployDeclaration({
-        runtime: "node",
-        entry: "server/index.mjs",
-        port: 9000,
-      }),
-    (e: any) => /legacy|runtime\.entry|teamclu\.app\.json/i.test(String(e?.message ?? e)),
-  );
+  for (const legacy of [{ runtime: null }, { entry: { path: "server/index.mjs" } }]) {
+    assert.throws(
+      () =>
+        parseAppDeployDeclaration({
+          ...legacy,
+          build: { kind: "node" },
+          start: {
+            fcRuntime: "custom.debian10",
+            command: ["node"],
+            port: 9000,
+          },
+        }),
+      (e: any) => /legacy|runtime\.entry|teamclu\.app\.json/i.test(String(e?.message ?? e)),
+    );
+  }
 });
 
-test("parse: container may omit command; forces no required fcRuntime", () => {
+test("parse: omitted container command and args stay undefined", () => {
   const d = parseAppDeployDeclaration({
     build: { kind: "container", dockerfile: "Dockerfile", context: "." },
     start: { port: 5000, healthCheckPath: "/api/health" },
   });
   assert.equal(d.build.kind, "container");
   assert.equal(d.start.port, 5000);
+  assert.equal(d.start.command, undefined);
+  assert.equal(d.start.args, undefined);
 });
 
 test("parse: non-container requires non-empty command array", () => {

--- a/services/fc/test/provisioning/fc-client.test.ts
+++ b/services/fc/test/provisioning/fc-client.test.ts
@@ -1,6 +1,17 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { makeFcOps, fcEndpoint, accountIdFromRoleArn, NODE_BIN, nodejsLayerArn, readAppsFcVpcConfig } from "../../src/lib/provisioning/fc-client.js";
+import { makeFcOps, fcEndpoint, accountIdFromRoleArn, readAppsFcVpcConfig } from "../../src/lib/provisioning/fc-client.js";
+import { defaultLayersForKind } from "../../src/lib/provisioning/app-runtime-spec.js";
+
+const NODE_DECL = {
+  build: { kind: "node" as const, output: ".output" },
+  start: {
+    fcRuntime: "custom.debian10",
+    command: ["/opt/nodejs20/bin/node"],
+    args: ["server/index.mjs"],
+    port: 9000,
+  },
+};
 
 function fakeClient(overrides: Record<string, any> = {}) {
   const calls: any[] = [];
@@ -19,7 +30,7 @@ test("ensureFunction creates when GetFunction 404s", async () => {
   const notFound = Object.assign(new Error("not found"), { statusCode: 404, code: "FunctionNotFound" });
   const { client, calls } = fakeClient({ getFunction: async () => { throw notFound; } });
   const ops = makeFcOps(client as any, { bucket: "b", role: "acs:ram::1:role/fc", region: "cn-shenzhen" });
-  await ops.ensureFunction("tc-app-1", { ossObjectName: "apps/1/code.zip", env: { PORT: "9000" } });
+  await ops.ensureFunction("tc-app-1", { declaration: NODE_DECL, ossObjectName: "apps/1/code.zip", env: { PORT: "9000" } });
   assert.ok(calls.some((c) => c[0] === "createFunction"));
   assert.ok(!calls.some((c) => c[0] === "updateFunction"));
 });
@@ -27,43 +38,51 @@ test("ensureFunction creates when GetFunction 404s", async () => {
 test("ensureFunction updates code when the function already exists", async () => {
   const { client, calls } = fakeClient();
   const ops = makeFcOps(client as any, { bucket: "b", role: "acs:ram::1:role/fc", region: "cn-shenzhen" });
-  await ops.ensureFunction("tc-app-1", { ossObjectName: "apps/1/code.zip", env: { PORT: "9000" } });
+  await ops.ensureFunction("tc-app-1", { declaration: NODE_DECL, ossObjectName: "apps/1/code.zip", env: { PORT: "9000" } });
   assert.ok(calls.some((c) => c[0] === "updateFunction"));
   assert.ok(!calls.some((c) => c[0] === "createFunction"));
 });
 
-test("ensureFunction points the custom runtime at the artifact's own layout", async () => {
-  // The daemon zips the CONTENTS of `.output`, so the entry is `server/index.mjs`.
-  // A `.output/` prefix here names a path that never exists in the package and
-  // the function silently fails to boot.
+test("ensureFunction passes the declared FC runtime and start config through on create", async () => {
   const notFound = Object.assign(new Error("not found"), { statusCode: 404, code: "FunctionNotFound" });
   const { client, calls } = fakeClient({ getFunction: async () => { throw notFound; } });
   const ops = makeFcOps(client as any, { bucket: "b", role: "acs:ram::1:role/fc", region: "cn-shenzhen" });
-  await ops.ensureFunction("tc-app-1", { ossObjectName: "apps/1/code.zip", env: { PORT: "9000" } });
-  const create = calls.find((c) => c[0] === "createFunction");
-  const runtimeCfg = create[1].body.customRuntimeConfig;
-  assert.deepEqual(runtimeCfg.args, ["server/index.mjs"]);
-  assert.equal(runtimeCfg.port, 9000);
-});
-
-test("ensureFunction starts node from the layer, by absolute path", async () => {
-  // The custom runtime image has no node — a bare "node" (and even
-  // `/bin/sh -c 'exec node …'`) dies at instance start with exit 127. The
-  // official layer supplies one under /opt and does not touch PATH.
-  const notFound = Object.assign(new Error("not found"), { statusCode: 404, code: "FunctionNotFound" });
-  const { client, calls } = fakeClient({ getFunction: async () => { throw notFound; } });
-  const ops = makeFcOps(client as any, { bucket: "b", role: "acs:ram::1:role/fc", region: "cn-shenzhen" });
-  await ops.ensureFunction("tc-app-1", { ossObjectName: "apps/1/code.zip", env: { PORT: "9000" } });
+  await ops.ensureFunction("tc-app-1", { declaration: NODE_DECL, ossObjectName: "apps/1/code.zip", env: { PORT: "9000" } });
   const create = calls.find((c) => c[0] === "createFunction")[1].body;
-  assert.deepEqual(create.customRuntimeConfig.command, [NODE_BIN]);
-  assert.match(NODE_BIN, /^\//, "must be an absolute path, not a PATH lookup");
-  assert.deepEqual(create.layers, ["acs:fc:cn-shenzhen:official:layers/Nodejs20/versions/3"]);
+  assert.equal(create.runtime, NODE_DECL.start.fcRuntime);
+  assert.deepEqual(create.customRuntimeConfig.command, NODE_DECL.start.command);
+  assert.deepEqual(create.customRuntimeConfig.args, NODE_DECL.start.args);
+  assert.equal(create.customRuntimeConfig.port, NODE_DECL.start.port);
+  assert.deepEqual(create.layers, defaultLayersForKind("cn-shenzhen", "node"));
 });
 
-test("nodejsLayerArn is region-scoped", () => {
-  // A layer ARN names its region; the function's region is the apps region, so
-  // borrowing another region's ARN makes CreateFunction fail on a valid config.
-  assert.equal(nodejsLayerArn("cn-hangzhou"), "acs:fc:cn-hangzhou:official:layers/Nodejs20/versions/3");
+test("an explicit empty layers list suppresses the kind's default layer", async () => {
+  const notFound = Object.assign(new Error("not found"), { statusCode: 404, code: "FunctionNotFound" });
+  const { client, calls } = fakeClient({ getFunction: async () => { throw notFound; } });
+  const ops = makeFcOps(client as any, { bucket: "b", role: "acs:ram::1:role/fc", region: "cn-shenzhen" });
+  await ops.ensureFunction("tc-app-1", {
+    declaration: { ...NODE_DECL, start: { ...NODE_DECL.start, layers: [] } },
+    ossObjectName: "apps/1/code.zip",
+    env: {},
+  });
+  const create = calls.find((c) => c[0] === "createFunction")[1].body;
+  assert.deepEqual(create.layers, []);
+});
+
+test("a python declaration gets the Python layer and its declared command", async () => {
+  const notFound = Object.assign(new Error("not found"), { statusCode: 404, code: "FunctionNotFound" });
+  const { client, calls } = fakeClient({ getFunction: async () => { throw notFound; } });
+  const ops = makeFcOps(client as any, { bucket: "b", role: "acs:ram::1:role/fc", region: "cn-shenzhen" });
+  const declaration = {
+    build: { kind: "python" as const, output: "." },
+    start: { fcRuntime: "custom.debian12", command: ["python3"], args: ["app.py"], port: 8080 },
+  };
+  await ops.ensureFunction("tc-app-1", { declaration, ossObjectName: "apps/1/code.zip", env: {} });
+  const create = calls.find((c) => c[0] === "createFunction")[1].body;
+  assert.equal(create.runtime, "custom.debian12");
+  assert.deepEqual(create.customRuntimeConfig.command, ["python3"]);
+  assert.deepEqual(create.customRuntimeConfig.args, ["app.py"]);
+  assert.deepEqual(create.layers, defaultLayersForKind("cn-shenzhen", "python"));
 });
 
 test("ensureFunction re-sends the layer and start command on the update path", async () => {
@@ -72,11 +91,23 @@ test("ensureFunction re-sends the layer and start command on the update path", a
   // the user tries — the update has to repair the config, not just the code.
   const { client, calls } = fakeClient();
   const ops = makeFcOps(client as any, { bucket: "b", role: "acs:ram::1:role/fc", region: "cn-shenzhen" });
-  await ops.ensureFunction("tc-app-1", { ossObjectName: "apps/1/code.zip", env: { PORT: "9000" } });
+  const declaration = {
+    ...NODE_DECL,
+    start: {
+      fcRuntime: "custom.debian12",
+      command: ["/bin/sh"],
+      args: ["start-server"],
+      port: 8081,
+      layers: [],
+    },
+  };
+  await ops.ensureFunction("tc-app-1", { declaration, ossObjectName: "apps/1/code.zip", env: { PORT: "8081" } });
   const upd = calls.find((c) => c[0] === "updateFunction")[2].body;
-  assert.deepEqual(upd.customRuntimeConfig.command, [NODE_BIN]);
-  assert.deepEqual(upd.customRuntimeConfig.args, ["server/index.mjs"]);
-  assert.deepEqual(upd.layers, ["acs:fc:cn-shenzhen:official:layers/Nodejs20/versions/3"]);
+  assert.equal(upd.runtime, "custom.debian12");
+  assert.deepEqual(upd.customRuntimeConfig.command, ["/bin/sh"]);
+  assert.deepEqual(upd.customRuntimeConfig.args, ["start-server"]);
+  assert.equal(upd.customRuntimeConfig.port, 8081);
+  assert.deepEqual(upd.layers, []);
 });
 
 test("ensureFunction re-sends environmentVariables on the update path", async () => {
@@ -85,6 +116,7 @@ test("ensureFunction re-sends environmentVariables on the update path", async ()
   const { client, calls } = fakeClient();
   const ops = makeFcOps(client as any, { bucket: "b", role: "acs:ram::1:role/fc", region: "cn-shenzhen" });
   await ops.ensureFunction("tc-app-1", {
+    declaration: NODE_DECL,
     ossObjectName: "apps/1/code.zip",
     env: { PORT: "9000", DATABASE_URL: "postgres://app_x:new-pw@h/teamclu_apps" },
   });
@@ -98,7 +130,7 @@ test("ensureFunction attaches VPC config on create and update when configured", 
   const { client, calls } = fakeClient({ getFunction: async () => { throw notFound; } });
   const vpc = { vpcId: "vpc-apps", vSwitchIds: ["vsw-apps"], securityGroupId: "sg-apps" };
   const ops = makeFcOps(client as any, { bucket: "b", role: "acs:ram::1:role/fc", region: "cn-shenzhen", vpc });
-  await ops.ensureFunction("tc-app-1", { ossObjectName: "apps/1/code.zip", env: { PORT: "9000" } });
+  await ops.ensureFunction("tc-app-1", { declaration: NODE_DECL, ossObjectName: "apps/1/code.zip", env: { PORT: "9000" } });
   const create = calls.find((c) => c[0] === "createFunction")[1].body;
   assert.equal(create.vpcConfig.vpcId, "vpc-apps");
   assert.deepEqual(create.vpcConfig.vSwitchIds, ["vsw-apps"]);
@@ -107,7 +139,7 @@ test("ensureFunction attaches VPC config on create and update when configured", 
 
   const { client: existing, calls: updateCalls } = fakeClient();
   const ops2 = makeFcOps(existing as any, { bucket: "b", role: "acs:ram::1:role/fc", region: "cn-shenzhen", vpc });
-  await ops2.ensureFunction("tc-app-1", { ossObjectName: "apps/1/code.zip", env: { PORT: "9000" } });
+  await ops2.ensureFunction("tc-app-1", { declaration: NODE_DECL, ossObjectName: "apps/1/code.zip", env: { PORT: "9000" } });
   const upd = updateCalls.find((c) => c[0] === "updateFunction")[2].body;
   assert.equal(upd.vpcConfig.vpcId, "vpc-apps");
 });
@@ -248,7 +280,7 @@ test("a new function is created with its log config", async () => {
   const notFound = Object.assign(new Error("not found"), { statusCode: 404, code: "FunctionNotFound" });
   const { client, calls } = fakeClient({ getFunction: async () => { throw notFound; } });
   const ops = makeFcOps(client as any, { bucket: "b", role: undefined, region: "cn-shenzhen", logs: () => LOGS });
-  await ops.ensureFunction("tc-app-1", { ossObjectName: "apps/1/code.zip", env: {} });
+  await ops.ensureFunction("tc-app-1", { declaration: NODE_DECL, ossObjectName: "apps/1/code.zip", env: {} });
   const create = calls.find((c) => c[0] === "createFunction")[1].body;
   assert.equal(create.logConfig.project, "teamclu-apps-1");
   assert.equal(create.logConfig.logstore, "app-logs");
@@ -264,7 +296,7 @@ test("an existing function gets its log config re-sent on every update", async (
   // VPC config were both fixed for.
   const { client, calls } = fakeClient();
   const ops = makeFcOps(client as any, { bucket: "b", role: undefined, region: "cn-shenzhen", logs: () => LOGS });
-  await ops.ensureFunction("tc-app-1", { ossObjectName: "apps/1/code.zip", env: {} });
+  await ops.ensureFunction("tc-app-1", { declaration: NODE_DECL, ossObjectName: "apps/1/code.zip", env: {} });
   const update = calls.find((c) => c[0] === "updateFunction")[2].body;
   assert.equal(update.logConfig.project, "teamclu-apps-1");
   assert.equal(update.logConfig.logstore, "app-logs");
@@ -276,14 +308,17 @@ test("a deployment with no usable log store deploys without a log config", async
   // up" into "this app cannot deploy at all".
   const { client, calls } = fakeClient();
   const ops = makeFcOps(client as any, { bucket: "b", role: undefined, region: "cn-shenzhen", logs: () => undefined });
-  await ops.ensureFunction("tc-app-1", { ossObjectName: "apps/1/code.zip", env: {} });
+  await ops.ensureFunction("tc-app-1", { declaration: NODE_DECL, ossObjectName: "apps/1/code.zip", env: {} });
   const update = calls.find((c) => c[0] === "updateFunction")[2].body;
   assert.equal(update.logConfig, undefined);
 });
 
 // --- Container apps
 
-const CONTAINER = { runtime: "container", entry: "", port: 5000 };
+const CONTAINER = {
+  build: { kind: "container" as const, output: ".", dockerfile: "Dockerfile", context: "." },
+  start: { args: [], port: 5000 },
+};
 
 test("a container app runs its own image, with no layer and no code object", async () => {
   // Sending either alongside customContainerConfig is how a Node layer ends up
@@ -295,7 +330,7 @@ test("a container app runs its own image, with no layer and no code object", asy
   await ops.ensureFunction("tc-app-1", {
     ossObjectName: "apps/1/code.zip",
     env: { PORT: "5000" },
-    runtime: CONTAINER,
+    declaration: CONTAINER,
     image: "registry.cn-shenzhen.aliyuncs.com/ns/tc-app-1:abc1234",
   });
   const create = calls.find((c) => c[0] === "createFunction")[1].body;
@@ -316,7 +351,7 @@ test("a redeploy re-sends the image, not just the environment", async () => {
   await ops.ensureFunction("tc-app-1", {
     ossObjectName: "apps/1/code.zip",
     env: {},
-    runtime: CONTAINER,
+    declaration: CONTAINER,
     image: "registry/ns/tc-app-1:second",
   });
   const update = calls.find((c) => c[0] === "updateFunction")[2].body;
@@ -332,7 +367,7 @@ test("a container app with a declared health path gets a check that survives a c
   await ops.ensureFunction("tc-app-1", {
     ossObjectName: "apps/1/code.zip",
     env: {},
-    runtime: { ...CONTAINER, healthCheckPath: "/api/health" },
+    declaration: { ...CONTAINER, start: { ...CONTAINER.start, healthCheckPath: "/api/health" } },
     image: "registry/ns/tc-app-1:abc",
   });
   const cfg = calls.find((c) => c[0] === "createFunction")[1].body.customContainerConfig;
@@ -347,7 +382,16 @@ test("a container app cannot be finalized without the image the build pushed", a
   const { client } = fakeClient();
   const ops = makeFcOps(client as any, { bucket: "b", role: "acs:ram::1:role/fc", region: "cn-shenzhen" });
   await assert.rejects(
-    () => ops.ensureFunction("tc-app-1", { ossObjectName: "apps/1/code.zip", env: {}, runtime: CONTAINER }),
+    () => ops.ensureFunction("tc-app-1", { ossObjectName: "apps/1/code.zip", env: {}, declaration: CONTAINER }),
     /must be finalized with the image/,
+  );
+});
+
+test("a declaration is required instead of silently defaulting to node", async () => {
+  const { client } = fakeClient();
+  const ops = makeFcOps(client as any, { bucket: "b", role: "acs:ram::1:role/fc", region: "cn-shenzhen" });
+  await assert.rejects(
+    () => ops.ensureFunction("tc-app-1", { ossObjectName: "apps/1/code.zip", env: {} }),
+    /declaration \(build\+start\) is required/,
   );
 });

--- a/services/fc/test/provisioning/fc-client.test.ts
+++ b/services/fc/test/provisioning/fc-client.test.ts
@@ -317,7 +317,7 @@ test("a deployment with no usable log store deploys without a log config", async
 
 const CONTAINER = {
   build: { kind: "container" as const, output: ".", dockerfile: "Dockerfile", context: "." },
-  start: { args: [], port: 5000 },
+  start: { port: 5000 },
 };
 
 test("a container app runs its own image, with no layer and no code object", async () => {
@@ -337,6 +337,8 @@ test("a container app runs its own image, with no layer and no code object", asy
   assert.equal(create.runtime, "custom-container");
   assert.equal(create.customContainerConfig.image, "registry.cn-shenzhen.aliyuncs.com/ns/tc-app-1:abc1234");
   assert.equal(create.customContainerConfig.port, 5000);
+  assert.equal(create.customContainerConfig.command, undefined);
+  assert.equal(create.customContainerConfig.args, undefined);
   assert.equal(create.layers, undefined);
   assert.equal(create.code, undefined);
   assert.equal(create.customRuntimeConfig, undefined);

--- a/services/fc/test/supabase-repo.test.ts
+++ b/services/fc/test/supabase-repo.test.ts
@@ -1655,6 +1655,7 @@ const APP_ROW = {
   git_remote_url: null,
   git_commit_sha: null,
   runtime: "node",
+  start_spec: { command: ["node"], args: ["server.js"], port: 3000 },
   auth_mode: "none",
   oauth_client_id: null,
   provision_status: "pending",
@@ -1682,7 +1683,7 @@ test("apps: mapApp exposes exactly the canonical keys", async () => {
     "fcStatus", "fcEndpoint", "fcFunctionName", "fcRegion",
     "gitAuthKind", "gitCommitSha", "gitRemoteUrl", "id", "name", "oauthClientId",
     "provisionStatus", "publicUrl",
-    "runtime", "slug", "teamId", "type", "updatedAt", "visibility", "workspaceId",
+    "runtime", "slug", "startSpec", "teamId", "type", "updatedAt", "visibility", "workspaceId",
   ].sort());
   assert.equal(items[0].authMode, "none");
   // A row with no auth columns reads as the STRICT values, never the open ones.
@@ -1690,6 +1691,7 @@ test("apps: mapApp exposes exactly the canonical keys", async () => {
   assert.equal(items[0].authScope, "all");
   assert.deepEqual(items[0].authRules, []);
   assert.equal(items[0].runtime, "node");
+  assert.deepEqual(items[0].startSpec, APP_ROW.start_spec);
   assert.equal(items[0].gitCommitSha, null);
   assert.equal(items[0].oauthClientId, null);
   // Null unless the deployment sets an apps domain — this suite sets none.
@@ -2926,8 +2928,9 @@ test("apps: finalizeDeploy rejects 503 when finalizeDeploy dep missing", async (
 });
 
 test("apps: finalizeDeploy on awaiting_build app returns live + fcEndpoint", async () => {
+  const calls: any[] = [];
   const repo = appsRepo(
-    appsSupabase({ seed: { apps: [{ ...APP_ROW, provision_status: "ready" }] } }),
+    appsSupabase({ seed: { apps: [{ ...APP_ROW, provision_status: "ready" }] }, calls }),
     {
       startDeploy: async () => ({
         fcFunctionName: "tc-app-1", fcRegion: "cn-hangzhou",
@@ -2945,6 +2948,9 @@ test("apps: finalizeDeploy on awaiting_build app returns live + fcEndpoint", asy
   assert.equal(result.fcStatus, "live");
   assert.equal(result.fcEndpoint, "https://x.fcapp.run");
   assert.equal(result.gitCommitSha, APP_SHA);
+  const liveUpdate = calls.find((c) => c.table === "apps" && c.op === "update" && c.row?.fc_status === "live");
+  assert.equal(liveUpdate?.row.runtime, APP_DECLARATION.build.kind);
+  assert.deepEqual(liveUpdate?.row.start_spec, APP_DECLARATION.start);
 });
 
 test("apps: finalizeDeploy pins apps.org_id on the first success", async () => {

--- a/services/fc/test/supabase-repo.test.ts
+++ b/services/fc/test/supabase-repo.test.ts
@@ -2744,7 +2744,7 @@ const APP_DECLARATION = {
 const appFinalize = (deployToken: string) => ({
   gitCommitSha: APP_SHA,
   deployToken,
-  runtime: APP_DECLARATION,
+  declaration: APP_DECLARATION,
 });
 
 test("apps: deployApp method is present", async () => {

--- a/services/fc/test/supabase-repo.test.ts
+++ b/services/fc/test/supabase-repo.test.ts
@@ -2730,6 +2730,20 @@ test("apps: a type-only PATCH tolerates a stale provisionStatus riding along", a
 
 const APP_SHA = "abc1234";
 const APP_DEPLOY = { gitCommitSha: APP_SHA };
+const APP_DECLARATION = {
+  build: { kind: "node", output: ".output" },
+  start: {
+    fcRuntime: "custom.debian10",
+    command: ["/opt/nodejs20/bin/node"],
+    args: ["server/index.mjs"],
+    port: 9000,
+  },
+};
+const appFinalize = (deployToken: string) => ({
+  gitCommitSha: APP_SHA,
+  deployToken,
+  runtime: APP_DECLARATION,
+});
 
 test("apps: deployApp method is present", async () => {
   const repo = appsRepo(appsSupabase({}));
@@ -2865,7 +2879,7 @@ test("apps: finalizeDeploy returns null when RLS hides the app", async () => {
   const repo = appsRepo(appsSupabase({ seed: { apps: [] } }), {
     finalizeDeploy: async () => { throw new Error("should not be called"); },
   });
-  assert.equal(await repo.finalizeDeploy("app-1", { gitCommitSha: APP_SHA, deployToken: "tok" }), null);
+  assert.equal(await repo.finalizeDeploy("app-1", appFinalize("tok")), null);
 });
 
 test("apps: finalizeDeploy rejects 409 when app has no function", async () => {
@@ -2874,7 +2888,7 @@ test("apps: finalizeDeploy rejects 409 when app has no function", async () => {
     { finalizeDeploy: async () => { throw new Error("should not be called"); } },
   );
   await assert.rejects(
-    () => repo.finalizeDeploy("app-1", { gitCommitSha: APP_SHA, deployToken: "tok" }),
+    () => repo.finalizeDeploy("app-1", appFinalize("tok")),
     (err: any) => err?.code === "not_deploying" && err?.statusCode === 409,
   );
 });
@@ -2885,7 +2899,7 @@ test("apps: finalizeDeploy rejects 409 on illegal fc_status transition", async (
     { finalizeDeploy: async () => { throw new Error("should not be called"); } },
   );
   await assert.rejects(
-    () => repo.finalizeDeploy("app-1", { gitCommitSha: APP_SHA, deployToken: "tok" }),
+    () => repo.finalizeDeploy("app-1", appFinalize("tok")),
     (err: any) => err?.code === "invalid_deploy_state" && err?.statusCode === 409,
   );
 });
@@ -2896,7 +2910,7 @@ test("apps: finalizeDeploy rejects 409 when deployToken mismatches", async () =>
     { finalizeDeploy: async () => { throw new Error("should not be called"); } },
   );
   await assert.rejects(
-    () => repo.finalizeDeploy("app-1", { gitCommitSha: APP_SHA, deployToken: "bad" }),
+    () => repo.finalizeDeploy("app-1", appFinalize("bad")),
     (err: any) => err?.code === "deploy_token_mismatch" && err?.statusCode === 409,
   );
 });
@@ -2906,7 +2920,7 @@ test("apps: finalizeDeploy rejects 503 when finalizeDeploy dep missing", async (
     appsSupabase({ seed: { apps: [{ ...APP_ROW, fc_function_name: "tc-app-1", fc_status: "awaiting_build", deploy_token: "tok" }] } }),
   );
   await assert.rejects(
-    () => repo.finalizeDeploy("app-1", { gitCommitSha: APP_SHA, deployToken: "tok" }),
+    () => repo.finalizeDeploy("app-1", appFinalize("tok")),
     (err: any) => err?.code === "deploy_unavailable" && err?.statusCode === 503,
   );
 });
@@ -2927,7 +2941,7 @@ test("apps: finalizeDeploy on awaiting_build app returns live + fcEndpoint", asy
     },
   );
   const started = await repo.deployApp("app-1", APP_DEPLOY);
-  const result = await repo.finalizeDeploy("app-1", { gitCommitSha: APP_SHA, deployToken: started.deployToken });
+  const result = await repo.finalizeDeploy("app-1", appFinalize(started.deployToken));
   assert.equal(result.fcStatus, "live");
   assert.equal(result.fcEndpoint, "https://x.fcapp.run");
   assert.equal(result.gitCommitSha, APP_SHA);
@@ -2953,7 +2967,7 @@ test("apps: finalizeDeploy pins apps.org_id on the first success", async () => {
     },
   );
   const started = await repo.deployApp("app-1", APP_DEPLOY);
-  await repo.finalizeDeploy("app-1", { gitCommitSha: APP_SHA, deployToken: started.deployToken });
+  await repo.finalizeDeploy("app-1", appFinalize(started.deployToken));
 
   assert.equal(seen[0].orgId, "org-old", "first finalize derives the org from the team");
   const upd = calls.filter((c) => c.table === "apps" && c.op === "update" && c.row?.fc_status === "live");
@@ -2985,7 +2999,7 @@ test("apps: finalizeDeploy deploys to the stored org even after teams.oid change
     },
   );
   const started = await repo.deployApp("app-1", APP_DEPLOY);
-  await repo.finalizeDeploy("app-1", { gitCommitSha: APP_SHA, deployToken: started.deployToken });
+  await repo.finalizeDeploy("app-1", appFinalize(started.deployToken));
 
   assert.equal(seen.length, 1);
   assert.equal(seen[0].orgId, "org-old", "provision must target the database the data is already in");
@@ -3012,7 +3026,7 @@ test("apps: finalizeDeploy leaves org_id null for a static app", async () => {
     },
   );
   const started = await repo.deployApp("app-1", APP_DEPLOY);
-  await repo.finalizeDeploy("app-1", { gitCommitSha: APP_SHA, deployToken: started.deployToken });
+  await repo.finalizeDeploy("app-1", appFinalize(started.deployToken));
 
   const upd = calls.filter((c) => c.table === "apps" && c.op === "update" && c.row?.fc_status === "live");
   assert.equal(upd.length, 1);
@@ -3045,7 +3059,7 @@ test("apps: finalizeDeploy stamps deployed_type with the type it deployed", asyn
   assert.equal((await repo.getApp("app-1"))?.typePendingRedeploy, true);
 
   const started = await repo.deployApp("app-1", APP_DEPLOY);
-  const result = await repo.finalizeDeploy("app-1", { gitCommitSha: APP_SHA, deployToken: started.deployToken });
+  const result = await repo.finalizeDeploy("app-1", appFinalize(started.deployToken));
 
   assert.equal(seen[0].appType, "slides");
   const upd = calls.filter((c) => c.table === "apps" && c.op === "update" && c.row?.fc_status === "live");
@@ -3075,7 +3089,7 @@ test("apps: a type change that lands mid-finalize stays pending", async () => {
     },
   );
   const started = await repo.deployApp("app-1", APP_DEPLOY);
-  const result = await repo.finalizeDeploy("app-1", { gitCommitSha: APP_SHA, deployToken: started.deployToken });
+  const result = await repo.finalizeDeploy("app-1", appFinalize(started.deployToken));
 
   assert.equal(result.type, "data_app");
   assert.equal(result.fcStatus, "live");
@@ -3095,7 +3109,7 @@ test("apps: finalizeDeploy wraps finalize failure as 502", async () => {
   );
   const started = await repo.deployApp("app-1", APP_DEPLOY);
   await assert.rejects(
-    () => repo.finalizeDeploy("app-1", { gitCommitSha: APP_SHA, deployToken: started.deployToken }),
+    () => repo.finalizeDeploy("app-1", appFinalize(started.deployToken)),
     (err: any) => err?.code === "finalize_failed" && err?.statusCode === 502,
   );
 });

--- a/services/supabase/migrations/20260911010000_apps_start_spec.sql
+++ b/services/supabase/migrations/20260911010000_apps_start_spec.sql
@@ -1,0 +1,19 @@
+-- amux.apps.runtime becomes build.kind; start_spec snapshots the last
+-- successfully deployed start declaration.
+alter table amux.apps
+  drop constraint if exists apps_runtime_check;
+
+alter table amux.apps
+  add constraint apps_runtime_check
+  check (runtime in ('node', 'python', 'go', 'php', 'java', 'container'));
+
+alter table amux.apps
+  add column if not exists start_spec jsonb;
+
+comment on column amux.apps.runtime is
+  'build.kind from teamclu.app.json at last successful deploy (node|python|go|php|java|container)';
+
+comment on column amux.apps.start_spec is
+  'Snapshot of start{} from teamclu.app.json at last successful deploy; repo file remains source of truth';
+
+notify pgrst, 'reload schema';

--- a/services/supabase/tests/001_schema_shape.sql
+++ b/services/supabase/tests/001_schema_shape.sql
@@ -28,7 +28,7 @@ exception
 end;
 $$;
 
-select plan(66);
+select plan(69);
 
 select has_schema('amux', 'amux schema exists');
 
@@ -45,6 +45,22 @@ select has_table('amux', 'idea_external_refs',  'idea_external_refs exists');
 select has_table('amux', 'sessions',            'sessions exists');
 select has_table('amux', 'session_participants','session_participants exists');
 select has_table('amux', 'messages',            'messages exists');
+
+select has_column('amux', 'apps', 'start_spec',
+                  'apps.start_spec exists');
+select col_type_is('amux', 'apps', 'start_spec', 'jsonb',
+                   'apps.start_spec is jsonb');
+select ok(
+  (
+    select pg_get_constraintdef(oid) like all (
+      array['%node%', '%python%', '%go%', '%php%', '%java%', '%container%']
+    )
+      from pg_constraint
+     where conrelid = 'amux.apps'::regclass
+       and conname = 'apps_runtime_check'
+  ),
+  'apps_runtime_check admits every supported build kind'
+);
 
 select col_type_is('amux', 'actors', 'last_active_at', 'timestamp with time zone',
                    'actors.last_active_at is timestamptz');

--- a/templates/slides/AGENTS.md
+++ b/templates/slides/AGENTS.md
@@ -32,6 +32,14 @@ reveal 自带的全部主题（black、white、league、solarized 等）。
   `pnpm install --frozen-lockfile`；曾经有依赖用 caret 范围，上游一次发布就把所有
   app 的构建打挂了。
 
+## 部署声明（`teamclu.app.json`）
+
+仓根 `teamclu.app.json` 声明**怎么构建、怎么启动**，平台按其中的 `build` + `start` 部署到 FC Custom Runtime：
+
+- 改 `build.kind` / `start.command` / `start.port` 以匹配 FC Custom Runtime（本模板默认 Node：`build.kind: "node"`，`start.command: ["/opt/nodejs20/bin/node"]`，`args: ["server/index.mjs"]`，`port: 9000`）。
+- **不要用**旧字段 `runtime` / `entry` —— 缺 `build` + `start` 或仍带 legacy 字段时部署会被拒。
+- 改完 **commit + push**，再让用户在控制面部署。
+
 ## 怎么上线
 
 部署按 **Gitea 远端 commit** 构建。改完幻灯片后：

--- a/templates/slides/teamclu.app.json
+++ b/templates/slides/teamclu.app.json
@@ -1,0 +1,14 @@
+{
+  "title": "{{APP_NAME}}",
+  "auth": { "mode": "none" },
+  "build": {
+    "kind": "node",
+    "output": ".output"
+  },
+  "start": {
+    "fcRuntime": "custom.debian10",
+    "command": ["/opt/nodejs20/bin/node"],
+    "args": ["server/index.mjs"],
+    "port": 9000
+  }
+}

--- a/templates/static-web/AGENTS.md
+++ b/templates/static-web/AGENTS.md
@@ -61,6 +61,14 @@ async function storageCredentials() {
   `pnpm install --frozen-lockfile`；曾经有一次依赖用了 caret 范围，上游发了个新版本
   就把所有 app 的构建打挂了。
 
+## 部署声明（`teamclu.app.json`）
+
+仓根 `teamclu.app.json` 声明**怎么构建、怎么启动**，平台按其中的 `build` + `start` 部署到 FC Custom Runtime：
+
+- 改 `build.kind` / `start.command` / `start.port` 以匹配 FC Custom Runtime（本模板默认 Node：`build.kind: "node"`，`start.command: ["/opt/nodejs20/bin/node"]`，`args: ["server/index.mjs"]`，`port: 9000`）。
+- **不要用**旧字段 `runtime` / `entry` —— 缺 `build` + `start` 或仍带 legacy 字段时部署会被拒。
+- 改完 **commit + push**，再让用户在控制面部署。
+
 ## 怎么上线
 
 部署按 **Gitea 远端 commit** 构建，不是按本机未保存的文件。改完代码后：

--- a/templates/static-web/teamclu.app.json
+++ b/templates/static-web/teamclu.app.json
@@ -1,0 +1,14 @@
+{
+  "title": "{{APP_NAME}}",
+  "auth": { "mode": "none" },
+  "build": {
+    "kind": "node",
+    "output": ".output"
+  },
+  "start": {
+    "fcRuntime": "custom.debian10",
+    "command": ["/opt/nodejs20/bin/node"],
+    "args": ["server/index.mjs"],
+    "port": 9000
+  }
+}

--- a/templates/tanstack-postgres/AGENTS.md
+++ b/templates/tanstack-postgres/AGENTS.md
@@ -67,6 +67,14 @@ async function storageCredentials() {
   上游发了一版删掉了模板引用的入口，所有 app 的构建当场全挂。加依赖时也请写精确版本
   并更新锁文件。
 
+## 部署声明（`teamclu.app.json`）
+
+仓根 `teamclu.app.json` 声明**怎么构建、怎么启动**，平台按其中的 `build` + `start` 部署到 FC Custom Runtime：
+
+- 改 `build.kind` / `start.command` / `start.port` 以匹配 FC Custom Runtime（本模板默认 Node：`build.kind: "node"`，`start.command: ["/opt/nodejs20/bin/node"]`，`args: ["server/index.mjs"]`，`port: 9000`）。
+- **不要用**旧字段 `runtime` / `entry` —— 缺 `build` + `start` 或仍带 legacy 字段时部署会被拒。
+- 改完 **commit + push**，再让用户在控制面部署。
+
 ## 怎么上线
 
 部署按 **Gitea 远端 commit** 构建，不是本机未保存的文件。改完代码后：

--- a/templates/tanstack-postgres/teamclu.app.json
+++ b/templates/tanstack-postgres/teamclu.app.json
@@ -1,0 +1,14 @@
+{
+  "title": "{{APP_NAME}}",
+  "auth": { "mode": "none" },
+  "build": {
+    "kind": "node",
+    "output": ".output"
+  },
+  "start": {
+    "fcRuntime": "custom.debian10",
+    "command": ["/opt/nodejs20/bin/node"],
+    "args": ["server/index.mjs"],
+    "port": 9000
+  }
+}


### PR DESCRIPTION
## Summary
- Hard-cut app deploy from legacy `runtime`/`entry` to FC-aligned `build` + `start` in `teamclu.app.json` (near-passthrough of CustomRuntimeConfig / custom-container).
- Daemon builds by `build.kind` (`node` / `python` / `go` / `php` / `java` / `container`); Cloud API maps `start` into CreateFunction/UpdateFunction; `amux.apps.runtime` stores build kind and `start_spec` snapshots last successful start.
- Templates ship the new declaration; existing apps without it fail closed on next deploy with an error that includes an example JSON.

## Migration

### Database (automatic on self-host deploy)
Migration `services/supabase/migrations/20260911010000_apps_start_spec.sql`:
- Widens `amux.apps.runtime` check to `node | python | go | php | java | container` (column now means **`build.kind`**).
- Adds nullable `amux.apps.start_spec` (jsonb). Filled only on the next **successful** finalize; no backfill.
- Existing rows stay `node` / `container` — still valid. Live sites keep running until someone redeploys.

### Existing app checkouts (manual — hard cut)
**This branch does not rewrite customer repos.** After merge, any deploy whose checkout lacks a valid `teamclu.app.json` (or still has top-level `runtime` / `entry`) **fails at build** with a pointed error + example.

What to do per app:
1. At the app repo root, add or replace `teamclu.app.json`.
2. Commit + push, then redeploy from the control panel / introspect.

**Typical node app** (matches current templates; adjust `args` / `output` to the real artifact):

```json
{
  "title": "your-app-name",
  "auth": { "mode": "none" },
  "build": { "kind": "node", "output": ".output" },
  "start": {
    "fcRuntime": "custom.debian10",
    "command": ["/opt/nodejs20/bin/node"],
    "args": ["server/index.mjs"],
    "port": 9000
  }
}
```

**Container app:**

```json
{
  "title": "your-app-name",
  "auth": { "mode": "none" },
  "build": { "kind": "container", "dockerfile": "Dockerfile", "context": "." },
  "start": { "port": 9000 }
}
```

(`start.command` / `args` optional — image ENTRYPOINT/CMD wins when omitted.)

**Do not keep** top-level `"runtime"` / `"entry"` — presence is rejected even next to a valid `build`+`start`.

**Reseed** still overwrites the checkout with the template (including the new file). Prefer editing the existing repo unless the app was never customized.

### Operator checklist after merge
- [ ] Confirm migration applied (`start_spec` column + widened check).
- [ ] For each app that must keep deploying: ensure HEAD has `build`+`start` before the next deploy.
- [ ] New apps from templates are fine — they seed the file automatically.
- [ ] Spec: `docs/specs/2026-09-11-fc-runtime-passthrough-design.md`.

## Test plan
- [ ] `cd services/fc && pnpm exec tsx --test test/provisioning/app-runtime-spec.test.ts test/provisioning/fc-client.test.ts test/provisioning/app-deploy.test.ts`
- [ ] `pnpm --filter @teamclu/app exec vitest run src/stores/apps-store.test.ts src/lib/apps`
- [ ] `pnpm rust:check` and focused amuxd app_build / app_templates tests
- [ ] Apply migration `20260911010000_apps_start_spec.sql` (or deploy path) and confirm `start_spec` + widened runtime check
- [ ] Seed a new template app → deploy → confirm FC function gets declared `command`/`args`/`port`/layers
- [ ] Confirm an old checkout without `teamclu.app.json` fails deploy with the example error message
- [ ] Container app still deploys image-only (no layers / no code zip)