### PR TITLE
fix(api): 修掉 OpenAPI 里 5 个悬空 $ref —— openapi:types 一直跑不通

### DIFF
--- a/docs/openapi/teamclu-api.v1.yaml
+++ b/docs/openapi/teamclu-api.v1.yaml
@@ -2358,7 +2358,7 @@ paths:
           description: Registry moved since the publisher loaded it (`stale_team_skill_base`).
           content:
             application/json:
-              schema: { $ref: "#/components/schemas/Error" }
+              schema: { $ref: "#/components/schemas/ErrorEnvelope" }
   /v1/teams/{teamId}/skills/{slug}/versions/{version}:
     get:
       operationId: getTeamSkillVersion
@@ -2428,7 +2428,7 @@ paths:
           description: Package blob is not uploaded yet (`blob_missing`).
           content:
             application/json:
-              schema: { $ref: "#/components/schemas/Error" }
+              schema: { $ref: "#/components/schemas/ErrorEnvelope" }
   /v1/teams/{teamId}/skills/{slug}/versions/{version}/revert:
     post:
       operationId: revertTeamSkillVersion
@@ -2488,7 +2488,7 @@ paths:
             latest (`conflict`).
           content:
             application/json:
-              schema: { $ref: "#/components/schemas/Error" }
+              schema: { $ref: "#/components/schemas/ErrorEnvelope" }
   /v1/teams/{teamId}/skills/{slug}/install:
     put:
       operationId: installTeamSkill
@@ -7161,8 +7161,7 @@ components:
       in: path
       required: true
       schema:
-        type: string
-        pattern: "^[a-z0-9][a-z0-9-]{1,63}$"
+        $ref: "#/components/schemas/TeamSkillSlug"
     TeamMcpServerName:
       name: name
       in: path
@@ -7286,6 +7285,14 @@ components:
           schema:
             $ref: "#/components/schemas/ErrorEnvelope"
   schemas:
+    TeamSkillSlug:
+      type: string
+      pattern: "^[a-z0-9][a-z0-9-]{1,63}$"
+      description: >-
+        Skill identifier inside a team registry. Mirrors
+        `TEAM_SKILL_SLUG_RE` in the FC repository layer — lowercase
+        alphanumerics and hyphens, never leading with a hyphen, 2 to 64
+        characters.
     TeamSkillCategory:
       type: string
       description: >
@@ -7422,7 +7429,7 @@ components:
       type: object
       required: [slug, summary, category, changelog, contentHash]
       properties:
-        slug: { type: string, pattern: "^[a-z0-9][a-z0-9-]{1,63}$" }
+        slug: { $ref: "#/components/schemas/TeamSkillSlug" }
         summary: { type: string, maxLength: 200 }
         category: { $ref: "#/components/schemas/TeamSkillCategory" }
         whenToUse: { type: string }


### PR DESCRIPTION
## 问题

`npm run openapi:types` 在 main 上从来没成功过，`redocly lint` 一直挂着 5 个 `no-unresolved-refs`。契约生成类型这条链路等于一直是断的。

## 成因

| 引用 | 位置 | 实际情况 |
|---|---|---|
| `#/components/schemas/Error` | 三个 skills 版本相关的 409 | 文档里叫 `ErrorEnvelope`（`components/responses/Error` 用的正是它） |
| `#/components/schemas/TeamSkillSlug` | marketplace 详情的路径参数、adopt 请求体的 `slug` | 这个名字只存在于 `components/parameters/` 下 |

## 改动

- **409**：只改 schema 指向。这三处各带一条比通用错误更具体的 description（如 `stale_team_skill_base`），整块换成 `responses/Error` 会把它丢掉。
- **`TeamSkillSlug`**：补上 schema。adopt 请求体那处要的确实是 schema 而非 parameter，所以补 schema 是唯一能同时修好两处的做法。正则没有另写，取自 FC 仓储层的 `TEAM_SKILL_SLUG_RE`（`services/fc/src/lib/supabase-repo.ts`）。
- **去重**：同一个正则原本内联在 `parameters/TeamSkillSlug` 和 `TeamSkillPublish.slug` 两处，一并指向新 schema。几份副本各自漂移正是这类 bug 的成因；不收拢的话，这次修复本身就会再添一份。

纯契约修复，无语义变化。只动 `docs/openapi/`，不在 self-host 部署的触发路径上。

## 验证

在**与当前 origin/main 合并后的树**上跑的（main 这两天有 3 个 commit 动过这个文件）：

- `redocly lint`：5 errors → **0**（10 warnings 为既有基线，未变）
- `openapi:types`：**首次能生成**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011eBW7QD9TNSNjT1uBbKJ6F
