### PR TITLE
perf(dev): speed up tauri:dev by not forcing amuxd every launch

### DIFF
--- a/apps/desktop/crates/teamclu-introspect/src/main.rs
+++ b/apps/desktop/crates/teamclu-introspect/src/main.rs
@@ -27,7 +27,11 @@ use std::io::{BufRead, BufReader, Write};
 #[derive(Parser, Debug)]
 #[command(
     name = "teamclu-introspect",
-    about = "TeamClu MCP introspection server"
+    about = "TeamClu MCP introspection server",
+    // ensure-*-sidecar probes `--version`; without this clap rejects the flag
+    // (exit 2), readExecutableVersion returns null, and every tauri:dev pays
+    // a cargo rebuild of a binary whose sources did not change.
+    version
 )]
 struct Args {
     /// Path to the TeamClu workspace directory

--- a/scripts/lib/dev-flags.js
+++ b/scripts/lib/dev-flags.js
@@ -7,7 +7,7 @@
  * Usage:
  *   pnpm tauri:dev -- --skip-setup
  *   pnpm tauri:dev -- --skip-daemon-onboarding
- *   pnpm tauri:dev -- --no-force-amuxd
+ *   pnpm tauri:dev -- --force-amuxd
  *   pnpm tauri:dev -- --force-introspect
  *   pnpm tauri:dev:daemon
  *   pnpm tauri:dev:introspect
@@ -17,8 +17,8 @@
  *          --skip-amuxd / --no-rebuild-amuxd → --no-force-amuxd
  *          --rebuild-introspect → --force-introspect
  * Env fallbacks: TEAMCLU_SKIP_SETUP=1, TEAMCLU_SKIP_DAEMON_ONBOARDING=1,
- *                TEAMCLU_FORCE_AMUXD_SIDECAR=0 (dev opts out of the forced
- *                amuxd rebuild), TEAMCLU_FORCE_INTROSPECT_SIDECAR=1
+ *                TEAMCLU_FORCE_AMUXD_SIDECAR=1 (opt in to a forced amuxd
+ *                rebuild), TEAMCLU_FORCE_INTROSPECT_SIDECAR=1
  *
  * @param {string[]} argv
  * @param {NodeJS.ProcessEnv} env mutated in place
@@ -36,13 +36,14 @@ function applyDevSkipFlags(argv, env, opts) {
   let skipDaemonOnboarding =
     env.TEAMCLU_SKIP_DAEMON_ONBOARDING === "1" ||
     env.VITE_TEAMCLU_SKIP_DAEMON_ONBOARDING === "true";
-  // Dev rebuilds amuxd every run. The bundled sidecar is a *snapshot* of
-  // target/debug/amuxd, and the version-equality check that guards the normal
-  // path never fires during development (Cargo.toml keeps the same version
-  // across daemon edits), so a daemon change stays invisible to the running app
-  // until it is re-staged. Opt out with --no-force-amuxd when iterating on the
-  // frontend and the extra cargo build is pure latency.
-  let forceAmuxd = env.TEAMCLU_FORCE_AMUXD_SIDECAR !== "0";
+  // Default off: every forced amuxd rebuild costs tens of seconds even when
+  // warm, and ensure-amuxd-sidecar already rebuilds when daemon sources /
+  // Cargo.lock are newer than the staged binary. Opt in with --force-amuxd
+  // (or `pnpm tauri:dev:daemon`) when you need a guaranteed restage — e.g.
+  // recovering a corrupted sidecar, or after a change the mtime walk missed.
+  let forceAmuxd =
+    env.TEAMCLU_FORCE_AMUXD_SIDECAR === "1" ||
+    env.TEAMCLU_FORCE_AMUXD_SIDECAR === "true";
   let forceIntrospect =
     env.TEAMCLU_FORCE_INTROSPECT_SIDECAR === "1" ||
     env.TEAMCLU_FORCE_INTROSPECT_SIDECAR === "true";

--- a/scripts/lib/dev-flags.test.js
+++ b/scripts/lib/dev-flags.test.js
@@ -5,15 +5,30 @@ const { applyDevSkipFlags } = require("./dev-flags");
 
 const silent = { log: () => {} };
 
-test("dev forces an amuxd sidecar rebuild by default", () => {
+test("dev does not force an amuxd sidecar rebuild by default", () => {
   const env = {};
   const argv = applyDevSkipFlags(["dev"], env, silent);
+  assert.deepEqual(argv, ["dev"]);
+  assert.equal(env.TEAMCLU_FORCE_AMUXD_SIDECAR, "0");
+});
+
+test("--force-amuxd opts in and is stripped from argv", () => {
+  const env = {};
+  const argv = applyDevSkipFlags(["dev", "--force-amuxd"], env, silent);
   assert.deepEqual(argv, ["dev"]);
   assert.equal(env.TEAMCLU_FORCE_AMUXD_SIDECAR, "1");
 });
 
+test("--rebuild-daemon and --rebuild-amuxd alias --force-amuxd", () => {
+  for (const flag of ["--rebuild-daemon", "--rebuild-amuxd"]) {
+    const env = {};
+    assert.deepEqual(applyDevSkipFlags(["dev", flag], env, silent), ["dev"]);
+    assert.equal(env.TEAMCLU_FORCE_AMUXD_SIDECAR, "1", flag);
+  }
+});
+
 test("--no-force-amuxd opts out and is stripped from argv", () => {
-  const env = {};
+  const env = { TEAMCLU_FORCE_AMUXD_SIDECAR: "1" };
   const argv = applyDevSkipFlags(["dev", "--no-force-amuxd"], env, silent);
   assert.deepEqual(argv, ["dev"]);
   assert.equal(env.TEAMCLU_FORCE_AMUXD_SIDECAR, "0");
@@ -21,7 +36,7 @@ test("--no-force-amuxd opts out and is stripped from argv", () => {
 
 test("--skip-amuxd and --no-rebuild-amuxd alias --no-force-amuxd", () => {
   for (const flag of ["--skip-amuxd", "--no-rebuild-amuxd"]) {
-    const env = {};
+    const env = { TEAMCLU_FORCE_AMUXD_SIDECAR: "1" };
     assert.deepEqual(applyDevSkipFlags(["dev", flag], env, silent), ["dev"]);
     assert.equal(env.TEAMCLU_FORCE_AMUXD_SIDECAR, "0", flag);
   }
@@ -33,7 +48,13 @@ test("an explicit opt-out beats an inherited TEAMCLU_FORCE_AMUXD_SIDECAR=1", () 
   assert.equal(env.TEAMCLU_FORCE_AMUXD_SIDECAR, "0");
 });
 
-test("TEAMCLU_FORCE_AMUXD_SIDECAR=0 opts out without a flag", () => {
+test("TEAMCLU_FORCE_AMUXD_SIDECAR=1 opts in without a flag", () => {
+  const env = { TEAMCLU_FORCE_AMUXD_SIDECAR: "1" };
+  applyDevSkipFlags(["dev"], env, silent);
+  assert.equal(env.TEAMCLU_FORCE_AMUXD_SIDECAR, "1");
+});
+
+test("TEAMCLU_FORCE_AMUXD_SIDECAR=0 stays off without a flag", () => {
   const env = { TEAMCLU_FORCE_AMUXD_SIDECAR: "0" };
   applyDevSkipFlags(["dev"], env, silent);
   assert.equal(env.TEAMCLU_FORCE_AMUXD_SIDECAR, "0");
@@ -57,5 +78,5 @@ test("other dev flags still parse alongside the amuxd default", () => {
   assert.equal(env.VITE_TEAMCLU_SKIP_SETUP, "true");
   assert.equal(env.VITE_TEAMCLU_SKIP_DAEMON_ONBOARDING, "true");
   assert.equal(env.TEAMCLU_FORCE_INTROSPECT_SIDECAR, "1");
-  assert.equal(env.TEAMCLU_FORCE_AMUXD_SIDECAR, "1");
+  assert.equal(env.TEAMCLU_FORCE_AMUXD_SIDECAR, "0");
 });

--- a/scripts/lib/dev-timing.js
+++ b/scripts/lib/dev-timing.js
@@ -1,0 +1,42 @@
+"use strict";
+
+/**
+ * Lightweight wall-clock phase timer for tauri:dev prelude scripts.
+ * Prints one line per mark: phase delta + running total since create.
+ */
+
+function formatDuration(ms) {
+  if (!Number.isFinite(ms) || ms < 0) return "0ms";
+  if (ms < 1000) return `${Math.round(ms)}ms`;
+  return `${(ms / 1000).toFixed(1)}s`;
+}
+
+/**
+ * @param {{ prefix?: string, log?: (msg: string) => void, now?: () => number }} [opts]
+ */
+function createPhaseTimer(opts = {}) {
+  const prefix = opts.prefix ?? "[timing]";
+  const log = opts.log ?? console.log;
+  const now = opts.now ?? Date.now;
+  const t0 = now();
+  let last = t0;
+
+  return {
+    /** @param {string} name */
+    mark(name) {
+      const t = now();
+      const phaseMs = t - last;
+      const totalMs = t - t0;
+      last = t;
+      log(
+        `${prefix} timing: ${name} ${formatDuration(phaseMs)} (total ${formatDuration(totalMs)})`,
+      );
+      return { phaseMs, totalMs };
+    },
+    elapsedMs() {
+      return now() - t0;
+    },
+  };
+}
+
+module.exports = { createPhaseTimer, formatDuration };

--- a/scripts/lib/dev-timing.test.js
+++ b/scripts/lib/dev-timing.test.js
@@ -1,0 +1,37 @@
+const assert = require("node:assert/strict");
+const { test } = require("node:test");
+
+const { createPhaseTimer, formatDuration } = require("./dev-timing");
+
+test("formatDuration uses ms under one second and s above", () => {
+  assert.equal(formatDuration(0), "0ms");
+  assert.equal(formatDuration(42), "42ms");
+  assert.equal(formatDuration(999), "999ms");
+  assert.equal(formatDuration(1000), "1.0s");
+  assert.equal(formatDuration(14200), "14.2s");
+});
+
+test("createPhaseTimer marks phase delta and running total", () => {
+  const lines = [];
+  let clock = 1_000;
+  const timer = createPhaseTimer({
+    prefix: "[test]",
+    log: (msg) => lines.push(msg),
+    now: () => clock,
+  });
+
+  clock = 1_250;
+  const a = timer.mark("introspect");
+  assert.equal(a.phaseMs, 250);
+  assert.equal(a.totalMs, 250);
+
+  clock = 14_000;
+  const b = timer.mark("amuxd");
+  assert.equal(b.phaseMs, 12_750);
+  assert.equal(b.totalMs, 13_000);
+
+  assert.deepEqual(lines, [
+    "[test] timing: introspect 250ms (total 250ms)",
+    "[test] timing: amuxd 12.8s (total 13.0s)",
+  ]);
+});

--- a/scripts/tauri-cli.js
+++ b/scripts/tauri-cli.js
@@ -7,11 +7,13 @@ const { createRustBuildEnv } = require("./rust-build-env");
 const { ensureTeamcluIntrospectSidecar } = require("./ensure-introspect-sidecar");
 const { ensureAmuxdSidecar } = require("./ensure-amuxd-sidecar");
 const { applyDevSkipFlags } = require("./lib/dev-flags");
+const { createPhaseTimer } = require("./lib/dev-timing");
 const { platform } = process;
 
 let args = process.argv.slice(2);
 const isWindows = platform === "win32";
 const sub = args[0];
+const timing = createPhaseTimer({ prefix: "[tauri-cli]" });
 
 // On Windows, dev/build must use --no-default-features to avoid wmi/windows-core conflict (p2p/iroh).
 // Strip any --features p2p so the broken dependency is not pulled in.
@@ -36,8 +38,13 @@ if (isWindows && (sub === "dev" || sub === "build")) {
 
 const env = createRustBuildEnv(process.env, __dirname);
 args = applyDevSkipFlags(args, env);
+timing.mark("flags+env");
+
 ensureTeamcluIntrospectSidecar(env, { logPrefix: "[tauri-cli]" });
+timing.mark("ensure-introspect");
+
 ensureAmuxdSidecar(env, { logPrefix: "[tauri-cli]" });
+timing.mark("ensure-amuxd");
 
 const desktopDir = path.resolve(__dirname, "..", "apps", "desktop");
 const child = spawn("pnpm", ["exec", "tauri", ...args], {
@@ -46,4 +53,5 @@ const child = spawn("pnpm", ["exec", "tauri", ...args], {
   env,
   cwd: desktopDir,
 });
+timing.mark(`spawn tauri ${sub ?? "?"} (vite+cargo follow)`);
 child.on("exit", (code) => process.exit(code ?? 0));

--- a/scripts/update-tauri-config.js
+++ b/scripts/update-tauri-config.js
@@ -4,7 +4,9 @@ const fs = require('fs');
 const path = require('path');
 const { applyNameToTauriConf, resolveLogoPlan, applyIdentityToTauriConf } = require('./lib/branding');
 const { execFileSync } = require('child_process');
+const { createPhaseTimer } = require('./lib/dev-timing');
 
+const timing = createPhaseTimer({ prefix: '[update-tauri-config]' });
 const rootDir = path.resolve(__dirname, '..');
 const tauriConfPath = path.join(rootDir, 'apps/desktop', 'tauri.conf.json');
 
@@ -132,3 +134,5 @@ if (updated) {
 } else {
   console.log('⚠ No updater configuration found in build.config.json');
 }
+
+timing.mark('done');


### PR DESCRIPTION
## Summary
- Stop forcing an amuxd sidecar rebuild on every `pnpm tauri:dev`; rely on `ensure-amuxd-sidecar` mtime checks, and opt in with `--force-amuxd` / `TEAMCLU_FORCE_AMUXD_SIDECAR=1` when a guaranteed restage is needed.
- Teach `teamclu-introspect` clap `--version` so sidecar probes stop failing and triggering needless cargo rebuilds.
- Add lightweight phase timing in the tauri:dev prelude (`flags+env` → introspect → amuxd → spawn) to make remaining startup cost visible.

## Test plan
- [ ] `node --test scripts/lib/dev-flags.test.js scripts/lib/dev-timing.test.js`
- [ ] Warm `pnpm tauri:dev` without daemon source changes — confirm amuxd is not force-rebuilt and timing lines print
- [ ] Change a daemon source file, then `pnpm tauri:dev` — confirm amuxd rebuilds via mtime
- [ ] `pnpm tauri:dev -- --force-amuxd` (or `pnpm tauri:dev:daemon`) — confirm forced rebuild still works
- [ ] Confirm introspect sidecar no longer rebuilds solely because `--version` was rejected


Made with [Cursor](https://cursor.com)