### PR TITLE
fix(gateway): SeaTalk 出站按 4000 字节分片切断中文导致 panic，回复静默丢失

### DIFF
--- a/crates/teamclu-gateway/src/seatalk.rs
+++ b/crates/teamclu-gateway/src/seatalk.rs
@@ -1,9 +1,10 @@
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use futures_util::{SinkExt, StreamExt};
+use futures_util::{FutureExt, SinkExt, StreamExt};
 use serde::Deserialize;
 use serde_json::json;
+use std::panic::AssertUnwindSafe;
 use tokio::sync::{oneshot, RwLock};
 use tokio_tungstenite::{connect_async, tungstenite::Message as WsMessage};
 
@@ -211,6 +212,9 @@ pub struct SeaTalkGateway {
     shutdown_tx: Arc<RwLock<Option<oneshot::Sender<()>>>>,
     status: Arc<RwLock<SeaTalkGatewayStatusResponse>>,
     is_running: Arc<RwLock<bool>>,
+    /// Background gateway task. Status reporting checks liveness so a panicked
+    /// task cannot keep reporting `Connected`.
+    task_handle: Arc<RwLock<Option<tokio::task::JoinHandle<()>>>>,
     processed_events: Arc<RwLock<ProcessedMessageTracker>>,
     inbound_sink: Arc<RwLock<Option<Arc<dyn crate::driver::InboundSink>>>>,
 }
@@ -233,6 +237,7 @@ impl SeaTalkGateway {
             shutdown_tx: Arc::new(RwLock::new(None)),
             status: Arc::new(RwLock::new(SeaTalkGatewayStatusResponse::default())),
             is_running: Arc::new(RwLock::new(false)),
+            task_handle: Arc::new(RwLock::new(None)),
             processed_events: Arc::new(RwLock::new(ProcessedMessageTracker::new(
                 MAX_PROCESSED_MESSAGES,
             ))),
@@ -256,7 +261,24 @@ impl SeaTalkGateway {
     }
 
     pub async fn get_status(&self) -> SeaTalkGatewayStatusResponse {
-        self.status.read().await.clone()
+        let mut status = self.status.read().await.clone();
+        let task_dead = self
+            .task_handle
+            .read()
+            .await
+            .as_ref()
+            .is_some_and(|h| h.is_finished());
+        let claims_live = matches!(
+            status.status,
+            SeaTalkGatewayStatus::Connected | SeaTalkGatewayStatus::Connecting
+        );
+        if claims_live && task_dead {
+            status.status = SeaTalkGatewayStatus::Error;
+            if status.error_message.is_none() {
+                status.error_message = Some("gateway task exited unexpectedly".to_string());
+            }
+        }
+        status
     }
 
     /// Proactive DM send for cron / MCP `send` (HTTP OpenAPI, no WS required).
@@ -315,15 +337,27 @@ impl SeaTalkGateway {
         *self.shutdown_tx.write().await = Some(shutdown_tx);
 
         let gateway = self.clone();
-        tokio::spawn(async move {
-            if let Err(e) = gateway.run_gateway_loop(shutdown_rx).await {
-                eprintln!("[SeaTalk] Gateway error: {e}");
-                let mut status = gateway.status.write().await;
-                status.status = SeaTalkGatewayStatus::Error;
-                status.error_message = Some(e);
+        let handle = tokio::spawn(async move {
+            let run = AssertUnwindSafe(gateway.run_gateway_loop(shutdown_rx));
+            match run.catch_unwind().await {
+                Ok(Ok(())) => {}
+                Ok(Err(e)) => {
+                    eprintln!("[SeaTalk] Gateway error: {e}");
+                    let mut status = gateway.status.write().await;
+                    status.status = SeaTalkGatewayStatus::Error;
+                    status.error_message = Some(e);
+                }
+                Err(panic_payload) => {
+                    let msg = panic_message(&panic_payload);
+                    eprintln!("[SeaTalk] Gateway task panicked: {msg}");
+                    let mut status = gateway.status.write().await;
+                    status.status = SeaTalkGatewayStatus::Error;
+                    status.error_message = Some(format!("gateway task panicked: {msg}"));
+                }
             }
             *gateway.is_running.write().await = false;
         });
+        *self.task_handle.write().await = Some(handle);
 
         Ok(())
     }
@@ -362,7 +396,20 @@ impl SeaTalkGateway {
                     println!("[SeaTalk] Gateway shutting down");
                     return Ok(());
                 }
-                result = self.connect_websocket(&ctx) => {
+                result = async {
+                    match AssertUnwindSafe(self.connect_websocket(&ctx))
+                        .catch_unwind()
+                        .await
+                    {
+                        Ok(r) => r,
+                        Err(panic_payload) => {
+                            Err(format!(
+                                "WebSocket session panicked: {}",
+                                panic_message(&panic_payload)
+                            ))
+                        }
+                    }
+                } => {
                     match result {
                         Ok(()) => {
                             backoff = INITIAL_BACKOFF_MS;
@@ -478,7 +525,10 @@ impl SeaTalkGateway {
                             if let Some(data) = env.data.clone() {
                                 let preview = data.to_string();
                                 let preview = if preview.len() > 500 {
-                                    format!("{}…", &preview[..500])
+                                    format!(
+                                        "{}…",
+                                        truncate_utf8_bytes(&preview, 500)
+                                    )
                                 } else {
                                     preview
                                 };
@@ -1043,26 +1093,81 @@ fn strip_leading_mentions(text: &str) -> String {
     rest.trim().to_string()
 }
 
+/// Largest index `<= index` that still sits on a UTF-8 character boundary.
+fn floor_char_boundary(text: &str, index: usize) -> usize {
+    if index >= text.len() {
+        return text.len();
+    }
+    let mut i = index;
+    while i > 0 && !text.is_char_boundary(i) {
+        i -= 1;
+    }
+    i
+}
+
+/// Truncate to at most `max_bytes` without splitting a character.
+fn truncate_utf8_bytes(text: &str, max_bytes: usize) -> &str {
+    if text.len() <= max_bytes {
+        text
+    } else {
+        &text[..floor_char_boundary(text, max_bytes)]
+    }
+}
+
+/// Split SeaTalk outbound text into chunks of at most `limit` bytes, preferring
+/// to break after a `\n` inside the window.
+///
+/// `TEXT_CHUNK_LIMIT` is a byte cap and 4000 is not a multiple of 3, so a naive
+/// `&text[start..start + limit]` lands mid-character on CJK (3 bytes) or emoji
+/// (4 bytes) and panics — which used to kill the gateway task and drop the
+/// whole reply. Every cut must back off to a character boundary.
 fn chunk_text(text: &str, limit: usize) -> Vec<String> {
     if text.len() <= limit {
         return vec![text.to_string()];
     }
+
     let mut chunks = Vec::new();
     let mut start = 0;
     while start < text.len() {
-        let end = (start + limit).min(text.len());
-        let split_at = if end == text.len() {
-            end
-        } else {
-            text[start..end]
-                .rfind('\n')
-                .map(|i| start + i + 1)
-                .unwrap_or(end)
-        };
+        let remaining = text.len() - start;
+        if remaining <= limit {
+            chunks.push(text[start..].to_string());
+            break;
+        }
+
+        let hard_end = floor_char_boundary(text, start + limit);
+        if hard_end <= start {
+            // A single character is wider than the limit; emit it alone rather
+            // than looping forever.
+            let ch_end = text[start..]
+                .chars()
+                .next()
+                .map(|c| start + c.len_utf8())
+                .unwrap_or(text.len());
+            chunks.push(text[start..ch_end].to_string());
+            start = ch_end;
+            continue;
+        }
+
+        let split_at = text[start..hard_end]
+            .rfind('\n')
+            .map(|i| start + i + 1)
+            .filter(|&i| i > start)
+            .unwrap_or(hard_end);
         chunks.push(text[start..split_at].to_string());
         start = split_at;
     }
     chunks
+}
+
+fn panic_message(payload: &Box<dyn std::any::Any + Send>) -> String {
+    if let Some(s) = payload.downcast_ref::<&str>() {
+        (*s).to_string()
+    } else if let Some(s) = payload.downcast_ref::<String>() {
+        s.clone()
+    } else {
+        "unknown panic".to_string()
+    }
 }
 
 impl Clone for SeaTalkGateway {
@@ -1077,6 +1182,7 @@ impl Clone for SeaTalkGateway {
             shutdown_tx: Arc::clone(&self.shutdown_tx),
             status: Arc::clone(&self.status),
             is_running: Arc::clone(&self.is_running),
+            task_handle: Arc::clone(&self.task_handle),
             processed_events: Arc::clone(&self.processed_events),
             inbound_sink: Arc::clone(&self.inbound_sink),
         }
@@ -1422,6 +1528,46 @@ mod tests {
             let msg = build_text_message(&chunk, Some("tB"));
             assert_eq!(msg["thread_id"], json!("tB"));
         }
+    }
+
+    #[test]
+    fn outbound_chunks_survive_cjk_at_byte_limit() {
+        // TEXT_CHUNK_LIMIT=4000 is not a multiple of 3; naive byte slicing panics.
+        let long = "中".repeat(2000); // 6000 bytes
+        let chunks = chunk_text(&long, TEXT_CHUNK_LIMIT);
+        assert!(chunks.len() > 1);
+        assert!(chunks.iter().all(|c| c.len() <= TEXT_CHUNK_LIMIT));
+        assert_eq!(chunks.concat(), long);
+    }
+
+    #[test]
+    fn outbound_chunks_survive_emoji_at_byte_limit() {
+        let long = "😀".repeat(1500); // 6000 bytes, 4 bytes each
+        let chunks = chunk_text(&long, TEXT_CHUNK_LIMIT);
+        assert!(chunks.iter().all(|c| c.len() <= TEXT_CHUNK_LIMIT));
+        assert_eq!(chunks.concat(), long);
+    }
+
+    #[test]
+    fn outbound_chunks_prefer_newline_breaks() {
+        let text = format!("{}\n{}", "中".repeat(1000), "文".repeat(1000));
+        let chunks = chunk_text(&text, TEXT_CHUNK_LIMIT);
+        assert_eq!(chunks.len(), 2);
+        assert!(chunks[0].ends_with('\n'));
+        assert_eq!(chunks.concat(), text);
+    }
+
+    #[test]
+    fn short_outbound_text_is_not_split() {
+        assert_eq!(chunk_text("短回复", TEXT_CHUNK_LIMIT), vec!["短回复"]);
+    }
+
+    #[test]
+    fn event_preview_truncate_survives_cjk_at_500() {
+        let preview = "中".repeat(200); // 600 bytes
+        let cut = truncate_utf8_bytes(&preview, 500);
+        assert!(cut.len() <= 500);
+        assert!(preview.starts_with(cut));
     }
 
     #[test]


### PR DESCRIPTION
## Description

修复 SeaTalk 出站长回复丢失。Agent 生成的回复写进了会话（桌面端能看到 4,825 字全文），但 SeaTalk 侧完全没收到，且网关状态仍显示 `Connected`——看起来像"入站没收到"，实际是**出站分片 panic 后静默死亡**。

根因在 `crates/teamclu-gateway/src/seatalk.rs`：

```rust
let end = (start + limit).min(text.len());   // limit = TEXT_CHUNK_LIMIT = 4000（字节）
text[start..end]                              // 4000 不是 3 的倍数 → 切进中文中间 → panic
```

- `TEXT_CHUNK_LIMIT = 4000` 是**字节**上限，而一个中文字符占 3 字节（emoji 4 字节）。`4000 % 3 != 0`，4,825 字的中文回复切第二片时必然落在字符中间，`&str` 索引直接 panic。
- panic 发生在网关任务的 async 循环里，没有 `catch_unwind`，任务直接死掉；`is_running` 没复位，`get_status()` 继续报 `Connected`，外层也没有重连。用户侧表现为"没有任何回复"，而且现有长回复不会自动重试。
- 同一文件里 500 字节的事件日志预览 `&preview[..500]` 有同样的隐患。

本 PR **只改 `seatalk.rs` 一个文件**（其他渠道的同类写法未动，见 Additional Notes）。

## Related Issue

Fixes #(issue) — 暂无对应 issue，来自线上排查（`amuxd.managed.log` 里 `chunk_text` 的 panic 栈）。

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## 改动

1. **分片按 UTF-8 边界切**：新增 `floor_char_boundary`，`chunk_text` 先回退到字符边界，再优先在窗口内的 `\n` 处断开。单个字符比 `limit` 还宽时让它单独成片，避免死循环。4,825 字中文回复现在切 2 片。
2. **日志预览安全截断**：新增 `truncate_utf8_bytes`，500 字节事件预览不再可能 panic。
3. **网关 panic 后自愈**：任务改为 `catch_unwind` + 保存 `JoinHandle`；panic 记录成 `status = Error` 并复位 `is_running`；`get_status()` 检测到任务已死（`is_finished()`）时不再谎报 `Connected`；外层重连循环按退避重连。

## 测试

```
cargo test -p teamclu-gateway --lib       # 175 passed; 0 failed
cargo clippy -p teamclu-gateway --lib     # 无新增警告
cargo check -p teamclu-gateway --all-targets
cargo check -p amuxd                      # daemon 消费者编译通过
```

新增 5 个用例：

- `outbound_chunks_survive_cjk_at_byte_limit` — 6000 字节中文在 4000 上限处分片，还原线上 crash 场景
- `outbound_chunks_survive_emoji_at_byte_limit` — 4 字节字符
- `outbound_chunks_prefer_newline_breaks` — 有换行时优先在换行处断开
- `short_outbound_text_is_not_split` — 短回复走原有单条路径
- `event_preview_truncate_survives_cjk_at_500`

## Additional Notes

**仍未修，需要单独决策：发送失败重试。**

`send_group_text` / `send_single_text` 目前是：

```rust
for chunk in chunk_text(text, TEXT_CHUNK_LIMIT) {
    self.api_call(..., true).await?;   // 任一片失败 → 后续分片全部丢弃
}
```

`api_call` 的 `retry` 只处理 `code == 100`（token 过期刷新一次），网络错误和其他错误码不重试。所以本 PR 之后的语义是：**不会再 panic，但第 2 片失败时用户会收到"半条回复"，且没有提示、不会重发**（比静默全丢好，但不是必达）。

建议的后续方向（欢迎在这个 PR 里讨论，我按结论另开 PR）：片级重试 + 指数退避，超过上限后在会话里补一条可见的失败提示。

**范围说明**：排查时发现其他渠道有同类裸切写法，但按 review 要求本 PR 不扩散改动：

- `discord.rs::split_message`：单行超长时 `remaining.split_at(max_len)`，同样会在 CJK 中间 panic（真实隐患，未修）
- `feishu.rs` / `lib.rs`：日志预览 `&s[..min(n)]` 同类写法（仅日志，未修）
- `wecom.rs` / `wecom_delivery.rs`：已有自己的 `is_char_boundary` 回退实现，不 panic（未修）
