### PR TITLE
feat(knowledge): review session drafts before they enter the vault

### DIFF
--- a/apps/daemon/assets/knowledge-templates/mcp-manifest.json
+++ b/apps/daemon/assets/knowledge-templates/mcp-manifest.json
@@ -47,8 +47,24 @@
       "maps_to": { "action": "write" }
     },
     {
+      "name": "knowledge_propose",
+      "description": "Draft a conclusion from this conversation for human review. Writes a pending candidate on this device only — it does NOT enter the team knowledge vault. Tell the user a review tab will open; do not say the page is saved or shared. 把对话结论提交为本机审稿草稿，不会写入团队知识库。告知用户将打开审稿页，不要说已经保存或已共享。 Never call knowledge_write / knowledge_salvage / knowledge_create for this; those skip review.",
+      "inputSchema": {
+        "type": "object",
+        "required": ["title", "content"],
+        "properties": {
+          "title": { "type": "string" },
+          "content": { "type": "string", "description": "Markdown body of the proposed page / 拟写入的正文" },
+          "suggestedPath": { "type": "string", "description": "Vault-relative path suggestion, e.g. 20-domains/payments/对账口径.md" },
+          "session_id": { "type": "string" },
+          "source": { "type": "string", "description": "Use 'agent-propose' when calling from a session" }
+        }
+      },
+      "maps_to": { "action": "propose" }
+    },
+    {
       "name": "knowledge_salvage",
-      "description": "Capture a conclusion from the current conversation into the vault as a salvage draft (00-salvage/<date>-<slug>.md with provenance frontmatter). Use when the user says something is worth keeping. 把对话中值得固化的结论存入知识库（打捞草稿）。 If the reply carries teamSync:\"not-syncing\", the page was saved on this device only and is not reaching the team — say so rather than reporting it as shared. 若返回 teamSync:\"not-syncing\"，说明只存在本机、没有同步给团队，要如实告知，不要说成已共享。",
+      "description": "Legacy: writes a page straight into knowledge/00-salvage/, which syncs to the team without review. Prefer knowledge_propose. 遗留：直接写入 knowledge/00-salvage/ 并同步，没有审稿。请改用 knowledge_propose。",
       "inputSchema": {
         "type": "object",
         "required": ["title", "content"],

--- a/apps/daemon/src/daemon/server.rs
+++ b/apps/daemon/src/daemon/server.rs
@@ -50,7 +50,7 @@ mod app_git_credential;
 mod channels;
 mod command_executor;
 mod cron;
-mod knowledge;
+pub(crate) mod knowledge;
 mod messaging;
 mod peers_workspaces;
 mod remote_tools;
@@ -357,8 +357,9 @@ pub(crate) enum SockCommand {
         payload: serde_json::Value,
         reply_tx: oneshot::Sender<String>,
     },
-    /// Knowledge-base MCP tools (scaffold / create / search) from the
-    /// agent-facing MCP bridge. Pure vault file ops on the active team.
+    /// Knowledge-base tools (scaffold / create / search / propose / publish)
+    /// from the MCP bridge and the desktop review tab. Vault writes stay in
+    /// `shared/knowledge/`; `propose` writes the local inbox under `state/`.
     Knowledge {
         payload: serde_json::Value,
         reply_tx: oneshot::Sender<String>,

--- a/apps/daemon/src/daemon/server/knowledge.rs
+++ b/apps/daemon/src/daemon/server/knowledge.rs
@@ -12,13 +12,19 @@
 //! - `create`        — create one page from a template (adr / runbook / domain-index / page)
 //! - `write`         — write or edit a page (overwrite, path-locked to the vault)
 //! - `salvage`       — capture a conversation conclusion into a vault page
+//!   (legacy; writes `00-salvage/` which syncs. New product path is `propose`)
+//! - `propose`       — draft a session conclusion into the local inbox (not vault)
+//! - `inbox_list` / `inbox_get` / `inbox_discard` — review-inbox bookkeeping
+//! - `publish`       — write a pending candidate into the vault (desktop only)
 //! - `search`        — substring search across the vault, no index (see `search.rs`)
 //! - `manifest_get`  — read knowledge.manifest.yaml
 //! - `manifest_set`  — update manifest fields (visibility change needs confirm:true)
 //! - `health`        — freshness / coverage stats
 //!
-//! All writes are confined to the active team's `shared/knowledge/` root;
-//! path traversal outside the vault is rejected.
+//! Vault writes (`create` / `write` / `salvage` / `publish`) stay inside the
+//! active team's `shared/knowledge/` root. `propose` writes
+//! `state/knowledge-inbox/` instead — see
+//! docs/specs/2026-09-11-session-knowledge-review-design.md.
 
 use std::path::{Path, PathBuf};
 
@@ -40,13 +46,14 @@ const MAX_SALVAGE_SUFFIX: usize = 50;
 const STALE_DAYS_RUNBOOK: i64 = 90;
 const STALE_DAYS_UPDATED: i64 = 90;
 
+pub(crate) mod inbox;
 mod search;
 
-fn err(code: &str, message: impl Into<String>) -> String {
+pub(super) fn err(code: &str, message: impl Into<String>) -> String {
     json!({ "ok": false, "error": message.into(), "errorCode": code }).to_string()
 }
 
-fn ok(result: Value) -> String {
+pub(super) fn ok(result: Value) -> String {
     json!({ "ok": true, "result": result }).to_string()
 }
 
@@ -80,7 +87,7 @@ fn stale_index_root(team_id: &str) -> PathBuf {
 
 /// Resolve a caller-supplied relative path against the vault root, rejecting
 /// anything that escapes it.
-fn resolve_in_vault(root: &Path, rel: &str) -> Result<PathBuf, String> {
+pub(super) fn resolve_in_vault(root: &Path, rel: &str) -> Result<PathBuf, String> {
     let rel = rel.trim();
     if rel.is_empty() {
         return Err(err("invalid_path", "path is required"));
@@ -161,7 +168,7 @@ fn with_team_sync(mut body: serde_json::Map<String, Value>, note: Option<(&str, 
     Value::Object(body)
 }
 
-fn str_field<'a>(payload: &'a Value, key: &str) -> Option<&'a str> {
+pub(super) fn str_field<'a>(payload: &'a Value, key: &str) -> Option<&'a str> {
     payload
         .get(key)
         .and_then(Value::as_str)
@@ -194,14 +201,20 @@ fn handle_knowledge_inner(payload: Value) -> String {
     // only for the actions that write — `search` and `health` have nothing to
     // say about whether a page reaches the team.
     let blocked = match action {
-        "create" | "write" | "salvage" => LocalSyncState::peek_forbidden(&team_id),
+        "create" | "write" | "salvage" | "publish" => LocalSyncState::peek_forbidden(&team_id),
         _ => ForbiddenPaths::default(),
     };
+    let inbox = inbox::inbox_dir(&team_id);
     match action {
         "scaffold" => knowledge_scaffold(&root, &payload),
         "create" => knowledge_create(&root, &payload, &blocked),
         "write" => knowledge_write(&root, &payload, &blocked),
         "salvage" => knowledge_salvage(&root, &payload, &blocked),
+        "propose" => inbox::propose(&team_id, &inbox, &payload),
+        "inbox_list" => inbox::inbox_list(&inbox),
+        "inbox_get" => inbox::inbox_get(&inbox, &payload),
+        "inbox_discard" => inbox::inbox_discard(&inbox, &payload),
+        "publish" => inbox::publish(&inbox, &root, &payload, &blocked),
         "search" => search::search(&root, &stale_index_root(&team_id), &payload),
         "manifest_get" => manifest_get(&root),
         "manifest_set" => manifest_set(&root, &payload),
@@ -210,7 +223,8 @@ fn handle_knowledge_inner(payload: Value) -> String {
             "unknown_action",
             format!(
                 "unknown knowledge action '{other}'; expected \
-                 scaffold|create|write|salvage|search|manifest_get|manifest_set|health"
+                 scaffold|create|write|salvage|propose|inbox_list|inbox_get|\
+                 inbox_discard|publish|search|manifest_get|manifest_set|health"
             ),
         ),
     }
@@ -285,7 +299,7 @@ fn page_body(
     Ok(raw.replace("{{TITLE}}", title).replace("{{DATE}}", today))
 }
 
-fn create_or_write(
+pub(super) fn create_or_write(
     root: &Path,
     payload: &Value,
     overwrite: bool,

--- a/apps/daemon/src/daemon/server/knowledge/inbox.rs
+++ b/apps/daemon/src/daemon/server/knowledge/inbox.rs
@@ -1,0 +1,477 @@
+//! Session-to-knowledge review inbox.
+//!
+//! Candidates live under `teams/<id>/state/knowledge-inbox/`, which is
+//! daemon-private and never synced. `propose` writes here. `publish` is the
+//! only action that creates a vault page — and only the desktop review tab
+//! should call it (see docs/specs/2026-09-11-session-knowledge-review-design.md).
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use uuid::Uuid;
+
+use crate::config::knowledge_scaffold::today_iso;
+use crate::config::layout;
+use crate::sync::oss::state::ForbiddenPaths;
+
+use super::{create_or_write, err, ok, resolve_in_vault, str_field};
+
+const INBOX_DIR: &str = "knowledge-inbox";
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub(super) enum CandidateSource {
+    SessionHeader,
+    AgentPropose,
+    Message,
+    Unknown,
+}
+
+impl CandidateSource {
+    fn parse(raw: Option<&str>) -> Self {
+        match raw.unwrap_or("unknown") {
+            "session-header" => Self::SessionHeader,
+            "agent-propose" => Self::AgentPropose,
+            "message" => Self::Message,
+            _ => Self::Unknown,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub(super) enum CandidateStatus {
+    Pending,
+    Published,
+    Discarded,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct KnowledgeCandidate {
+    pub id: String,
+    pub team_id: String,
+    pub session_id: String,
+    pub title: String,
+    pub body: String,
+    #[serde(default)]
+    pub suggested_path: String,
+    pub source: CandidateSource,
+    pub created_at: String,
+    pub status: CandidateStatus,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub published_path: Option<String>,
+}
+
+pub(crate) fn inbox_dir(team_id: &str) -> PathBuf {
+    layout::team_state_dir(team_id).join(INBOX_DIR)
+}
+
+fn candidate_path(dir: &Path, id: &str) -> Result<PathBuf, String> {
+    if id.is_empty()
+        || id.contains(['/', '\\', '.'])
+        || id.chars().any(|c| !(c.is_ascii_alphanumeric() || c == '-'))
+    {
+        return Err(err("invalid_id", "id must be a uuid-like token"));
+    }
+    Ok(dir.join(format!("{id}.json")))
+}
+
+fn read_candidate(dir: &Path, id: &str) -> Result<KnowledgeCandidate, String> {
+    let path = candidate_path(dir, id)?;
+    let raw = fs::read_to_string(&path)
+        .map_err(|_| err("not_found", format!("candidate '{id}' not found")))?;
+    serde_json::from_str(&raw).map_err(|e| err("corrupt", format!("candidate '{id}' is unreadable: {e}")))
+}
+
+fn write_candidate(dir: &Path, candidate: &KnowledgeCandidate) -> Result<(), String> {
+    if let Err(e) = fs::create_dir_all(dir) {
+        return Err(err(
+            "write_failed",
+            format!("creating inbox dir failed: {e}"),
+        ));
+    }
+    let path = candidate_path(dir, &candidate.id)?;
+    let raw = serde_json::to_string_pretty(candidate)
+        .map_err(|e| err("write_failed", format!("serialize failed: {e}")))?;
+    fs::write(&path, raw).map_err(|e| err("write_failed", format!("inbox write failed: {e}")))
+}
+
+fn candidate_json(c: &KnowledgeCandidate) -> Value {
+    serde_json::to_value(c).unwrap_or(Value::Null)
+}
+
+/// `propose` — create a pending candidate. Does not touch the vault.
+pub(crate) fn propose(team_id: &str, inbox: &Path, payload: &Value) -> String {
+    let Some(body) = str_field(payload, "content").or_else(|| str_field(payload, "body")) else {
+        return err("invalid_content", "content is required for propose");
+    };
+    let title = str_field(payload, "title").unwrap_or("untitled");
+    let suggested_path = str_field(payload, "suggestedPath")
+        .or_else(|| str_field(payload, "suggested_path"))
+        .unwrap_or("")
+        .to_string();
+    if !suggested_path.is_empty() {
+        if let Err(e) = resolve_in_vault(Path::new("/vault"), &suggested_path) {
+            return e;
+        }
+    }
+    let candidate = KnowledgeCandidate {
+        id: Uuid::new_v4().to_string(),
+        team_id: team_id.to_string(),
+        session_id: str_field(payload, "sessionId")
+            .or_else(|| str_field(payload, "session_id"))
+            .unwrap_or("")
+            .to_string(),
+        title: title.to_string(),
+        body: body.to_string(),
+        suggested_path,
+        source: CandidateSource::parse(str_field(payload, "source")),
+        created_at: chrono::Utc::now().to_rfc3339(),
+        status: CandidateStatus::Pending,
+        published_path: None,
+    };
+    match write_candidate(inbox, &candidate) {
+        Ok(()) => ok(candidate_json(&candidate)),
+        Err(e) => e,
+    }
+}
+
+/// Pending candidates, newest first. Published / discarded stay out of the
+/// review badge.
+pub(crate) fn inbox_list(inbox: &Path) -> String {
+    let Ok(entries) = fs::read_dir(inbox) else {
+        return ok(json!({ "items": [] }));
+    };
+    let mut items: Vec<KnowledgeCandidate> = entries
+        .filter_map(|e| e.ok())
+        .filter(|e| e.path().extension().and_then(|s| s.to_str()) == Some("json"))
+        .filter_map(|e| fs::read_to_string(e.path()).ok())
+        .filter_map(|raw| serde_json::from_str::<KnowledgeCandidate>(&raw).ok())
+        .filter(|c| c.status == CandidateStatus::Pending)
+        .collect();
+    items.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+    ok(json!({
+        "items": items.iter().map(candidate_json).collect::<Vec<_>>(),
+    }))
+}
+
+pub(crate) fn inbox_get(inbox: &Path, payload: &Value) -> String {
+    let Some(id) = str_field(payload, "id") else {
+        return err("invalid_id", "id is required");
+    };
+    match read_candidate(inbox, id) {
+        Ok(c) => ok(candidate_json(&c)),
+        Err(e) => e,
+    }
+}
+
+pub(crate) fn inbox_discard(inbox: &Path, payload: &Value) -> String {
+    let Some(id) = str_field(payload, "id") else {
+        return err("invalid_id", "id is required");
+    };
+    let path = match candidate_path(inbox, id) {
+        Ok(p) => p,
+        Err(e) => return e,
+    };
+    match fs::remove_file(&path) {
+        Ok(()) => ok(json!({ "id": id, "status": "discarded" })),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            err("not_found", format!("candidate '{id}' not found"))
+        }
+        Err(e) => err("write_failed", format!("discard failed: {e}")),
+    }
+}
+
+fn with_md(path: &str) -> String {
+    let trimmed = path.trim().trim_start_matches('/');
+    match Path::new(trimmed).extension() {
+        Some(_) => trimmed.to_string(),
+        None => format!("{trimmed}.md"),
+    }
+}
+
+fn published_page(session_id: &str, title: &str, body: &str) -> String {
+    let today = today_iso();
+    format!(
+        "---\ntype: page\nsource: session\nsession-id: {session_id}\nreviewed: {today}\n---\n\n# {title}\n\n{body}\n"
+    )
+}
+
+/// `publish` — write the candidate into the vault. Desktop review tab only.
+pub(crate) fn publish(
+    inbox: &Path,
+    vault: &Path,
+    payload: &Value,
+    blocked: &ForbiddenPaths,
+) -> String {
+    let Some(id) = str_field(payload, "id") else {
+        return err("invalid_id", "id is required");
+    };
+    let mut candidate = match read_candidate(inbox, id) {
+        Ok(c) => c,
+        Err(e) => return e,
+    };
+    if candidate.status != CandidateStatus::Pending {
+        return err(
+            "not_pending",
+            format!("candidate '{id}' is {:?}, not pending", candidate.status),
+        );
+    }
+    let title = str_field(payload, "title").unwrap_or(candidate.title.as_str());
+    let body = str_field(payload, "content")
+        .or_else(|| str_field(payload, "body"))
+        .unwrap_or(candidate.body.as_str());
+    let path_raw = str_field(payload, "path")
+        .or_else(|| {
+            if candidate.suggested_path.is_empty() {
+                None
+            } else {
+                Some(candidate.suggested_path.as_str())
+            }
+        })
+        .unwrap_or("");
+    if path_raw.is_empty() {
+        return err("invalid_path", "path is required (relative to the vault)");
+    }
+    let path = with_md(path_raw);
+    let overwrite = payload
+        .get("overwrite")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    let page = published_page(&candidate.session_id, title, body);
+    let write_payload = json!({
+        "path": path,
+        "title": title,
+        "content": page,
+    });
+    let reply = create_or_write(vault, &write_payload, overwrite, blocked);
+    let parsed: Value = match serde_json::from_str(&reply) {
+        Ok(v) => v,
+        Err(_) => return reply,
+    };
+    if parsed.get("ok") != Some(&Value::Bool(true)) {
+        return reply;
+    }
+    let published_path = parsed
+        .pointer("/result/path")
+        .and_then(Value::as_str)
+        .unwrap_or(&path)
+        .to_string();
+    candidate.title = title.to_string();
+    candidate.body = body.to_string();
+    candidate.status = CandidateStatus::Published;
+    candidate.published_path = Some(published_path.clone());
+    // Vault write already landed. Inbox bookkeeping is secondary — the
+    // reviewer can see the open editor either way.
+    let _ = write_candidate(inbox, &candidate);
+    let mut result = parsed
+        .get("result")
+        .cloned()
+        .unwrap_or_else(|| json!({ "path": published_path }));
+    if let Some(obj) = result.as_object_mut() {
+        obj.insert("id".into(), Value::String(candidate.id.clone()));
+        obj.insert("status".into(), Value::String("published".into()));
+    }
+    ok(result)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sync::oss::state::ForbiddenPath;
+
+    fn tmp_pair() -> (tempfile::TempDir, PathBuf, PathBuf) {
+        let tmp = tempfile::tempdir().unwrap();
+        let inbox = tmp.path().join("inbox");
+        let vault = tmp.path().join("vault");
+        fs::create_dir_all(&inbox).unwrap();
+        fs::create_dir_all(&vault).unwrap();
+        (tmp, inbox, vault)
+    }
+
+    fn parse(reply: &str) -> Value {
+        serde_json::from_str(reply).unwrap()
+    }
+
+    #[test]
+    fn propose_does_not_touch_the_vault() {
+        let (_tmp, inbox, vault) = tmp_pair();
+        let reply = propose(
+            "team-1",
+            &inbox,
+            &json!({
+                "title": "对账口径",
+                "content": "以渠道单号为准",
+                "sessionId": "sess-1",
+                "source": "agent-propose",
+                "suggestedPath": "20-domains/payments/对账口径",
+            }),
+        );
+        let v = parse(&reply);
+        assert_eq!(v["ok"], true, "{v}");
+        assert_eq!(v["result"]["status"], "pending");
+        assert_eq!(v["result"]["sessionId"], "sess-1");
+        assert_eq!(v["result"]["suggestedPath"], "20-domains/payments/对账口径");
+        assert!(v["result"]["id"].as_str().unwrap().contains('-'));
+
+        let vault_files: Vec<_> = fs::read_dir(&vault).unwrap().collect();
+        assert!(vault_files.is_empty(), "propose must not write the vault");
+        assert_eq!(fs::read_dir(&inbox).unwrap().count(), 1);
+    }
+
+    #[test]
+    fn propose_rejects_a_path_that_escapes_the_vault() {
+        let (_tmp, inbox, vault) = tmp_pair();
+        let reply = propose(
+            "team-1",
+            &inbox,
+            &json!({
+                "title": "x",
+                "content": "y",
+                "suggestedPath": "../outside.md",
+            }),
+        );
+        let v = parse(&reply);
+        assert_eq!(v["ok"], false, "{v}");
+        assert_eq!(v["errorCode"], "invalid_path");
+        assert!(vault.read_dir().unwrap().next().is_none());
+        assert!(inbox.read_dir().unwrap().next().is_none());
+    }
+
+    #[test]
+    fn publish_writes_frontmatter_and_leaves_inbox_published() {
+        let (_tmp, inbox, vault) = tmp_pair();
+        let proposed = parse(&propose(
+            "team-1",
+            &inbox,
+            &json!({
+                "title": "对账口径",
+                "content": "以渠道单号为准",
+                "sessionId": "sess-9",
+                "suggestedPath": "20-domains/payments/对账口径",
+            }),
+        ));
+        let id = proposed["result"]["id"].as_str().unwrap();
+        let reply = publish(
+            &inbox,
+            &vault,
+            &json!({ "id": id }),
+            &ForbiddenPaths::default(),
+        );
+        let v = parse(&reply);
+        assert_eq!(v["ok"], true, "{v}");
+        assert_eq!(v["result"]["path"], "20-domains/payments/对账口径.md");
+        assert_eq!(v["result"]["status"], "published");
+
+        let raw = fs::read_to_string(vault.join("20-domains/payments/对账口径.md")).unwrap();
+        assert!(raw.contains("type: page"));
+        assert!(raw.contains("source: session"));
+        assert!(raw.contains("session-id: sess-9"));
+        assert!(raw.contains("reviewed:"));
+        assert!(raw.contains("# 对账口径"));
+        assert!(raw.contains("以渠道单号为准"));
+
+        let listed = parse(&inbox_list(&inbox));
+        assert_eq!(listed["result"]["items"].as_array().unwrap().len(), 0);
+
+        let got = parse(&inbox_get(&inbox, &json!({ "id": id })));
+        assert_eq!(got["result"]["status"], "published");
+        assert_eq!(
+            got["result"]["publishedPath"],
+            "20-domains/payments/对账口径.md"
+        );
+    }
+
+    #[test]
+    fn publish_refuses_overwrite_unless_asked() {
+        let (_tmp, inbox, vault) = tmp_pair();
+        fs::create_dir_all(vault.join("20-domains")).unwrap();
+        fs::write(vault.join("20-domains/keep.md"), b"original").unwrap();
+        let proposed = parse(&propose(
+            "team-1",
+            &inbox,
+            &json!({
+                "title": "keep",
+                "content": "new",
+                "suggestedPath": "20-domains/keep.md",
+            }),
+        ));
+        let id = proposed["result"]["id"].as_str().unwrap();
+        let refused = parse(&publish(
+            &inbox,
+            &vault,
+            &json!({ "id": id, "path": "20-domains/keep.md" }),
+            &ForbiddenPaths::default(),
+        ));
+        assert_eq!(refused["ok"], false, "{refused}");
+        assert_eq!(refused["errorCode"], "already_exists");
+        assert_eq!(
+            fs::read_to_string(vault.join("20-domains/keep.md")).unwrap(),
+            "original"
+        );
+
+        let overwritten = parse(&publish(
+            &inbox,
+            &vault,
+            &json!({ "id": id, "path": "20-domains/keep.md", "overwrite": true }),
+            &ForbiddenPaths::default(),
+        ));
+        assert_eq!(overwritten["ok"], true, "{overwritten}");
+        let raw = fs::read_to_string(vault.join("20-domains/keep.md")).unwrap();
+        assert!(raw.contains("new"));
+        assert!(!raw.contains("original"));
+    }
+
+    #[test]
+    fn discard_deletes_the_candidate_and_not_the_vault() {
+        let (_tmp, inbox, vault) = tmp_pair();
+        fs::write(vault.join("existing.md"), b"stay").unwrap();
+        let proposed = parse(&propose(
+            "team-1",
+            &inbox,
+            &json!({ "title": "t", "content": "c" }),
+        ));
+        let id = proposed["result"]["id"].as_str().unwrap();
+        let reply = parse(&inbox_discard(&inbox, &json!({ "id": id })));
+        assert_eq!(reply["ok"], true, "{reply}");
+        assert!(inbox_get(&inbox, &json!({ "id": id })).contains("not_found"));
+        assert_eq!(fs::read_to_string(vault.join("existing.md")).unwrap(), "stay");
+    }
+
+    #[test]
+    fn publish_of_a_refused_directory_still_writes_locally_and_says_not_syncing() {
+        let (_tmp, inbox, vault) = tmp_pair();
+        let proposed = parse(&propose(
+            "team-1",
+            &inbox,
+            &json!({
+                "title": "hr",
+                "content": "secret",
+                "suggestedPath": "hr/note.md",
+            }),
+        ));
+        let id = proposed["result"]["id"].as_str().unwrap();
+        let blocked = ForbiddenPaths::from_entries([(
+            "knowledge/hr/salary.md".to_string(),
+            ForbiddenPath {
+                last_tried_at: std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .map(|d| d.as_secs())
+                    .unwrap_or(0),
+                reason: "not accessible".into(),
+            },
+        )]);
+        let v = parse(&publish(
+            &inbox,
+            &vault,
+            &json!({ "id": id }),
+            &blocked,
+        ));
+        assert_eq!(v["ok"], true, "{v}");
+        assert_eq!(v["result"]["teamSync"], "not-syncing");
+        assert!(vault.join("hr/note.md").exists());
+    }
+}

--- a/apps/daemon/src/http/knowledge_inbox.rs
+++ b/apps/daemon/src/http/knowledge_inbox.rs
@@ -1,0 +1,187 @@
+//! Desktop HTTP for the session→knowledge review inbox.
+//!
+//! Same handlers as the control-socket `cmd: knowledge` actions (`propose`,
+//! `inbox_*`, `publish`). The review tab talks HTTP; the session agent, once
+//! wired, still uses the socket / MCP tool. Neither path writes the vault
+//! until `publish`.
+
+use axum::{
+    extract::Path,
+    Json,
+};
+use serde::Deserialize;
+use serde_json::{json, Value};
+
+use crate::config::global_team_store::sync_content_root;
+use crate::config::layout;
+use crate::daemon::server::knowledge::inbox;
+use crate::sync::oss::state::LocalSyncState;
+
+use super::auth::{require_scope, Principal};
+use super::errors::{ErrorCode, HttpError};
+
+fn active_team_id() -> Result<String, HttpError> {
+    let team_id = layout::active_team();
+    if team_id == layout::UNCLAIMED_TEAM {
+        return Err(HttpError::validation(
+            "daemon is not onboarded to a team; knowledge inbox is team-scoped",
+        ));
+    }
+    Ok(team_id)
+}
+
+fn vault_root(team_id: &str) -> std::path::PathBuf {
+    sync_content_root(team_id).join("knowledge")
+}
+
+fn map_inbox_error(code: &str, message: &str) -> HttpError {
+    match code {
+        "not_found" => HttpError::not_found(message.to_string()),
+        "already_exists" => HttpError::new(ErrorCode::Conflict, message.to_string()),
+        "no_team" | "not_pending" | "invalid_id" | "invalid_path" | "invalid_content"
+        | "corrupt" => HttpError::validation(message.to_string()),
+        _ => HttpError::internal(message.to_string()),
+    }
+}
+
+fn inbox_reply(raw: String) -> Result<Json<Value>, HttpError> {
+    let v: Value = serde_json::from_str(&raw).map_err(|e| HttpError::internal(e.to_string()))?;
+    if v.get("ok") == Some(&Value::Bool(true)) {
+        return Ok(Json(v.get("result").cloned().unwrap_or(Value::Null)));
+    }
+    let code = v.get("errorCode").and_then(Value::as_str).unwrap_or("internal");
+    let message = v
+        .get("error")
+        .and_then(Value::as_str)
+        .unwrap_or("knowledge inbox failed");
+    Err(map_inbox_error(code, message))
+}
+
+/// `GET /v1/knowledge/inbox`
+pub async fn list_inbox(principal: Principal) -> Result<Json<Value>, HttpError> {
+    require_scope(&principal, "workspace:read")?;
+    let team_id = active_team_id()?;
+    inbox_reply(inbox::inbox_list(&inbox::inbox_dir(&team_id)))
+}
+
+/// `GET /v1/knowledge/inbox/:id`
+pub async fn get_inbox(
+    principal: Principal,
+    Path(id): Path<String>,
+) -> Result<Json<Value>, HttpError> {
+    require_scope(&principal, "workspace:read")?;
+    let team_id = active_team_id()?;
+    inbox_reply(inbox::inbox_get(
+        &inbox::inbox_dir(&team_id),
+        &json!({ "id": id }),
+    ))
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ProposeBody {
+    pub title: Option<String>,
+    pub content: Option<String>,
+    pub body: Option<String>,
+    pub suggested_path: Option<String>,
+    pub session_id: Option<String>,
+    pub source: Option<String>,
+}
+
+/// `POST /v1/knowledge/inbox`
+pub async fn propose_inbox(
+    principal: Principal,
+    Json(body): Json<ProposeBody>,
+) -> Result<Json<Value>, HttpError> {
+    require_scope(&principal, "workspace:write")?;
+    let team_id = active_team_id()?;
+    let mut payload = serde_json::Map::new();
+    if let Some(title) = body.title {
+        payload.insert("title".into(), Value::String(title));
+    }
+    if let Some(content) = body.content.or(body.body) {
+        payload.insert("content".into(), Value::String(content));
+    }
+    if let Some(path) = body.suggested_path {
+        payload.insert("suggestedPath".into(), Value::String(path));
+    }
+    if let Some(session_id) = body.session_id {
+        payload.insert("sessionId".into(), Value::String(session_id));
+    }
+    payload.insert(
+        "source".into(),
+        Value::String(body.source.unwrap_or_else(|| "session-header".into())),
+    );
+    inbox_reply(inbox::propose(&team_id, &inbox::inbox_dir(&team_id), &Value::Object(payload)))
+}
+
+/// `DELETE /v1/knowledge/inbox/:id`
+pub async fn discard_inbox(
+    principal: Principal,
+    Path(id): Path<String>,
+) -> Result<Json<Value>, HttpError> {
+    require_scope(&principal, "workspace:write")?;
+    let team_id = active_team_id()?;
+    inbox_reply(inbox::inbox_discard(
+        &inbox::inbox_dir(&team_id),
+        &json!({ "id": id }),
+    ))
+}
+
+#[derive(Debug, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct PublishBody {
+    pub title: Option<String>,
+    pub content: Option<String>,
+    pub body: Option<String>,
+    pub path: Option<String>,
+    #[serde(default)]
+    pub overwrite: bool,
+}
+
+/// `POST /v1/knowledge/inbox/:id/publish`
+pub async fn publish_inbox(
+    principal: Principal,
+    Path(id): Path<String>,
+    Json(body): Json<PublishBody>,
+) -> Result<Json<Value>, HttpError> {
+    require_scope(&principal, "workspace:write")?;
+    let team_id = active_team_id()?;
+    let mut payload = serde_json::Map::new();
+    payload.insert("id".into(), Value::String(id));
+    if let Some(title) = body.title {
+        payload.insert("title".into(), Value::String(title));
+    }
+    if let Some(content) = body.content.or(body.body) {
+        payload.insert("content".into(), Value::String(content));
+    }
+    if let Some(path) = body.path {
+        payload.insert("path".into(), Value::String(path));
+    }
+    payload.insert("overwrite".into(), Value::Bool(body.overwrite));
+    let blocked = LocalSyncState::peek_forbidden(&team_id);
+    inbox_reply(inbox::publish(
+        &inbox::inbox_dir(&team_id),
+        &vault_root(&team_id),
+        &Value::Object(payload),
+        &blocked,
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::map_inbox_error;
+    use crate::http::errors::ErrorCode;
+
+    #[test]
+    fn already_exists_is_a_conflict_not_a_validation_miss() {
+        let err = map_inbox_error("already_exists", "exists");
+        assert_eq!(err.code, ErrorCode::Conflict);
+    }
+
+    #[test]
+    fn missing_candidate_is_not_found() {
+        let err = map_inbox_error("not_found", "gone");
+        assert_eq!(err.code, ErrorCode::NotFound);
+    }
+}

--- a/apps/daemon/src/http/mod.rs
+++ b/apps/daemon/src/http/mod.rs
@@ -33,6 +33,7 @@ pub mod config;
 pub mod cors;
 pub mod errors;
 pub mod events;
+pub mod knowledge_inbox;
 pub mod limit;
 pub mod live_events;
 pub mod live_ingest;

--- a/apps/daemon/src/http/routes.rs
+++ b/apps/daemon/src/http/routes.rs
@@ -17,6 +17,7 @@ use super::apps;
 use super::auth;
 use super::config;
 use super::limit::{body_limit_layer, rate_limit_layer};
+use super::knowledge_inbox;
 use super::live_events;
 use super::live_ingest;
 use super::observ::request_id_layer;
@@ -277,6 +278,15 @@ pub fn build(state: HttpState) -> Router {
         )
         // Team-share: materialize the global dir + workspace symlink on demand
         // (called by the app right after enabling/joining team-share).
+        .route("/v1/knowledge/inbox", get(knowledge_inbox::list_inbox).post(knowledge_inbox::propose_inbox))
+        .route(
+            "/v1/knowledge/inbox/:id",
+            get(knowledge_inbox::get_inbox).delete(knowledge_inbox::discard_inbox),
+        )
+        .route(
+            "/v1/knowledge/inbox/:id/publish",
+            post(knowledge_inbox::publish_inbox),
+        )
         .route("/v1/team/link", post(team::link_team_workspace))
         .route("/v1/team/unlink", post(team::unlink_team_workspace))
         // Daemon-owned team sync: desktop triggers sync + reads status over loopback.

--- a/docs/specs/2026-09-11-session-knowledge-review-design.md
+++ b/docs/specs/2026-09-11-session-knowledge-review-design.md
@@ -1,0 +1,110 @@
+# 会话结论审稿后写入知识库
+
+- **Date**: 2026-09-11
+- **Status**: APPROVED — slices 1–3 landed (`propose`/`publish`, review tab, header button). Slice 4 (block agent writes to `team-knowledge/`) is not in yet
+- **Scope**: Desktop + amuxd。会话里整理结论 → 本机审稿 → 确认后写入团队 `knowledge/` vault
+- **Non-scope**: 全员审批、每日自动打捞、「等待我」、iOS / Expo 写入、Ideas 打通、复用冲突解决页
+- **Related**: ADR-0008、`docs/plans/2026-08-31-team-knowledge-base-program.md`、`docs/architecture/obsidian-compatible-knowledge.md`、`docs/specs/2026-09-01-team-sync-two-roots-design.md`、`apps/daemon/src/daemon/server/knowledge.rs`
+
+---
+
+## 0. 一句话
+
+Agent 只能起草。人改完、选好路径、点写入，这篇东西才进入知识库。确认前 vault / Obsidian / 同步 / RAG 都看不见它。
+
+## 1. 为什么现有 salvage 不够
+
+`knowledge_salvage` 把草稿写到 `knowledge/00-salvage/`。那是同步前缀里的正式路径，一落盘就进团队 vault。聊天是过程，知识库是共识（ADR-0008）；未审摘要不能当共识。
+
+`00-salvage/` 继续留给已经写进去的历史文件，**不再作为这条产品路径的草稿篮**。
+
+## 2. 决策
+
+| # | 决定 | 理由 |
+|---|---|---|
+| D1 | 审稿人是作者本人，在本机完成 | 一 user 一 team 一台 Desktop；不是全员审批 |
+| D2 | 草稿放 `teams/<id>/state/knowledge-inbox/` | `state/` 本来就不进同步 |
+| D3 | 确认后走现有写磁盘 + fs watcher | 和知识库里手建页同一条路 |
+| D4 | 会话 agent 只暴露 `propose`，不暴露 `write` / `salvage` / `publish` | 否则审稿是摆设 |
+| D5 | 普通 `write`/`edit` 落到 `team-knowledge/**` 必须拒绝或改写成 propose | 只靠 prompt 挡不住 |
+| D6 | 不做 Ideas / 冲突解决复用 | 存储模型和语义都错 |
+
+## 3. 信息流
+
+```
+会话（顶栏「整理到知识库」或对 agent 说「存知识库」）
+        │
+        ▼
+   knowledge_propose → state/knowledge-inbox/<id>.json
+        │
+        ▼
+   审稿 native tab（改标题 / 正文 / 落点）
+        │
+        ├── 丢弃 → 删 candidate
+        ├── 稍后 → 留在 inbox；知识库列「待写入 · N」
+        └── 写入 → knowledge_publish → knowledge/<path>.md → 打开编辑器
+```
+
+## 4. Candidate
+
+```ts
+type KnowledgeCandidate = {
+  id: string
+  teamId: string
+  sessionId: string
+  title: string
+  body: string
+  suggestedPath: string     // vault 相对，可空
+  source: "session-header" | "agent-propose" | "message" | "unknown"
+  createdAt: string         // ISO-8601
+  status: "pending" | "published" | "discarded"
+  publishedPath?: string
+}
+```
+
+写入 vault 时由 publish 盖 frontmatter（正文以 `---` 开头则整页原样写入的规则不用于这条路径；publish 自己拼页）：
+
+```yaml
+---
+type: page
+source: session
+session-id: <sessionId>
+reviewed: YYYY-MM-DD
+---
+```
+
+## 5. Daemon 动作
+
+控制套接字仍是 `{ "cmd": "knowledge", "action": ... }`。
+
+| action | 谁可调 | 写 vault？ |
+|---|---|---|
+| `propose` | 会话 agent + 桌面 | 否 |
+| `inbox_list` / `inbox_get` / `inbox_discard` | 桌面 | 否 |
+| `publish` | **仅桌面审稿页** | 是 |
+| `search` | 会话 agent（只读，已有） | 否 |
+| `write` / `create` / `salvage` | 会话里不暴露 | salvage 历史行为不变，不当产品入口 |
+
+`publish` 规则：路径锁在 vault 内；无扩展名补 `.md`；目标已存在且 `overwrite != true` 则拒绝；成功后 candidate 标 `published`。
+
+## 6. UI（后续切片）
+
+- 会话顶栏，和「导出完整会话记录」并排：「整理到知识库」
+- 新 native tab `knowledge-review:<id>`：来源会话、标题、知识库路径选择器、Markdown 正文、写入 / 稍后 / 丢弃
+- 知识库第二列「待写入 · N」
+- 不在文件树里画草稿
+
+## 7. 切片
+
+1. inbox + `propose` / `inbox_*` / `publish` ——确认前 vault 无新文件
+2. 审稿 tab + 「待写入」
+3. 会话顶栏入口（本机从消息拼草稿；模型摘要仍可走 `knowledge_propose`）
+4. 接上 `knowledge_propose`，并拦住对 `team-knowledge/` 的 write
+
+## 8. 验收
+
+- propose 之后 `knowledge/` 下没有新文件，其他成员同步不到
+- publish 后指定路径出现带 `session-id` + `reviewed` 的 `.md`
+- 目标已存在且未覆盖 → 不写
+- discard / 稍后 → vault 无变化
+- agent 对 `team-knowledge/foo.md` 调用 write → 失败或变成 propose（切片 4）

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -13,6 +13,7 @@ import { BookOpen, ChevronLeft, X, PanelRightClose, Loader2, RotateCw, MessageSq
 import { DiagnoseSessionButton } from "@/components/chat/DiagnoseSessionButton";
 import { SessionShareButton } from "@/components/chat/SessionShareButton";
 import { ExportPiTranscriptButton } from "@/components/chat/ExportPiTranscriptButton";
+import { SaveToKnowledgeButton } from "@/components/chat/SaveToKnowledgeButton";
 import { RefreshSkillsHeaderButton } from "@/components/chat/RefreshSkillsHeaderButton";
 import { useWorkspaceInit } from "@/hooks/use-workspace-init";
 import { useChannelGatewayInit } from "@/hooks/use-channel-gateway-init";
@@ -638,6 +639,7 @@ function AppContent() {
             )}
             {activeSession && <SessionShareButton sessionId={activeSession.id} />}
             {activeSession && <ExportPiTranscriptButton sessionId={activeSession.id} />}
+            {activeSession && <SaveToKnowledgeButton sessionId={activeSession.id} />}
             {activeSession && <DiagnoseSessionButton sessionId={activeSession.id} />}
 
             {/* Panel tabs - right side of header */}

--- a/packages/app/src/components/chat/SaveToKnowledgeButton.tsx
+++ b/packages/app/src/components/chat/SaveToKnowledgeButton.tsx
@@ -1,0 +1,34 @@
+import { useState } from 'react'
+import { BookmarkPlus, Loader2 } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+import { toast } from 'sonner'
+import { proposeSessionToKnowledge } from '@/lib/knowledge/propose-from-session'
+
+export function SaveToKnowledgeButton({ sessionId }: { sessionId: string }) {
+  const { t } = useTranslation()
+  const [busy, setBusy] = useState(false)
+
+  return (
+    <button
+      type="button"
+      data-testid="save-to-knowledge-button"
+      disabled={busy}
+      onClick={() => {
+        if (busy) return
+        setBusy(true)
+        void proposeSessionToKnowledge(sessionId)
+          .then(() => {
+            toast.success(t('knowledgeReview.opened', '已打开审稿页，确认后才会写入知识库'))
+          })
+          .catch((err) => {
+            toast.error(err instanceof Error ? err.message : String(err))
+          })
+          .finally(() => setBusy(false))
+      }}
+      className="shrink-0 rounded-md p-1 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground disabled:opacity-40"
+      title={t('knowledgeReview.headerAction', '整理到知识库')}
+    >
+      {busy ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <BookmarkPlus className="h-3.5 w-3.5" />}
+    </button>
+  )
+}

--- a/packages/app/src/components/chat/__tests__/SaveToKnowledgeButton.test.tsx
+++ b/packages/app/src/components/chat/__tests__/SaveToKnowledgeButton.test.tsx
@@ -1,0 +1,43 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { SaveToKnowledgeButton } from '../SaveToKnowledgeButton'
+
+const proposeSessionToKnowledge = vi.fn()
+const toastSuccess = vi.fn()
+const toastError = vi.fn()
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (_key: string, fallback?: string) => fallback ?? _key }),
+}))
+
+vi.mock('sonner', () => ({
+  toast: {
+    success: (...args: unknown[]) => toastSuccess(...args),
+    error: (...args: unknown[]) => toastError(...args),
+  },
+}))
+
+vi.mock('@/lib/knowledge/propose-from-session', () => ({
+  proposeSessionToKnowledge: (...args: unknown[]) => proposeSessionToKnowledge(...args),
+}))
+
+describe('SaveToKnowledgeButton', () => {
+  it('opens a review draft for the current session', async () => {
+    proposeSessionToKnowledge.mockResolvedValue('cand-1')
+    render(<SaveToKnowledgeButton sessionId="sess-9" />)
+    fireEvent.click(screen.getByRole('button', { name: '整理到知识库' }))
+    await waitFor(() => {
+      expect(proposeSessionToKnowledge).toHaveBeenCalledWith('sess-9')
+      expect(toastSuccess).toHaveBeenCalled()
+    })
+  })
+
+  it('toasts on failure', async () => {
+    proposeSessionToKnowledge.mockRejectedValue(new Error('daemon down'))
+    render(<SaveToKnowledgeButton sessionId="sess-9" />)
+    fireEvent.click(screen.getByRole('button', { name: '整理到知识库' }))
+    await waitFor(() => {
+      expect(toastError).toHaveBeenCalled()
+    })
+  })
+})

--- a/packages/app/src/components/main-content/NativeContent.tsx
+++ b/packages/app/src/components/main-content/NativeContent.tsx
@@ -6,6 +6,7 @@ import { PaneLoading } from "@/components/ui/pane-loading"
 import {
   decodeCloudVersionTarget,
   decodeKnowledgeConflictTarget,
+  decodeKnowledgeReviewTarget,
   decodeTeamShareTarget,
   decodeVersionHistoryTarget,
 } from "@/lib/tabs/teamshare-target"
@@ -39,6 +40,10 @@ const KnowledgeConflictResolver = lazyNamed(
 const KnowledgeCloudVersion = lazyNamed(
   () => import("@/components/teamshare/KnowledgeCloudVersion"),
   "KnowledgeCloudVersion",
+)
+const KnowledgeReviewTab = lazyNamed(
+  () => import("@/components/teamshare/KnowledgeReviewTab"),
+  "KnowledgeReviewTab",
 )
 const TeamShareTabContent = lazyNamed(
   () => import("@/components/teamshare/TeamShareTabContent"),
@@ -144,6 +149,9 @@ function resolveNativeBody(target: string) {
 
   const cloudPath = decodeCloudVersionTarget(target)
   if (cloudPath) return <KnowledgeCloudVersion path={cloudPath} />
+
+  const reviewId = decodeKnowledgeReviewTarget(target)
+  if (reviewId) return <KnowledgeReviewTab candidateId={reviewId} />
 
   const versionPath = decodeVersionHistoryTarget(target)
   if (versionPath !== undefined) {

--- a/packages/app/src/components/responsive/NarrowChatHeader.tsx
+++ b/packages/app/src/components/responsive/NarrowChatHeader.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { SquarePen, SlidersHorizontal, List, MoreHorizontal, Settings, Loader2, LifeBuoy, Download } from 'lucide-react'
+import { SquarePen, SlidersHorizontal, List, MoreHorizontal, Settings, Loader2, LifeBuoy, Download, BookmarkPlus } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { Button } from '@/components/ui/button'
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/components/ui/sheet'
@@ -24,6 +24,7 @@ import {
   exportTranscriptErrorMessage,
   savePiTranscript,
 } from '@/lib/session/pi-transcript-export'
+import { proposeSessionToKnowledge } from '@/lib/knowledge/propose-from-session'
 
 export function NarrowChatHeader() {
   const { t } = useTranslation()
@@ -156,6 +157,23 @@ export function NarrowChatHeader() {
                   >
                     <Download className="mr-2 h-4 w-4" />
                     {t('chat.exportTranscript', '导出完整会话记录')}
+                  </DropdownMenuItem>
+                ) : null}
+                {activeSessionId ? (
+                  <DropdownMenuItem
+                    onSelect={() => {
+                      setMoreOpen(false)
+                      void proposeSessionToKnowledge(activeSessionId)
+                        .then(() => {
+                          toast.success(t('knowledgeReview.opened', '已打开审稿页，确认后才会写入知识库'))
+                        })
+                        .catch((err) => {
+                          toast.error(err instanceof Error ? err.message : String(err))
+                        })
+                    }}
+                  >
+                    <BookmarkPlus className="mr-2 h-4 w-4" />
+                    {t('knowledgeReview.headerAction', '整理到知识库')}
                   </DropdownMenuItem>
                 ) : null}
                 {activeSessionId ? (

--- a/packages/app/src/components/sidebar/TeamShareListColumn.tsx
+++ b/packages/app/src/components/sidebar/TeamShareListColumn.tsx
@@ -75,6 +75,7 @@ import { getKnownLocalDaemonActorId } from '@/lib/daemon/local-daemon-identity'
 import { encodeWorkspaceId, notifyDaemonSkillsChanged } from '@/lib/daemon/daemon-local-client'
 import { SkillScanPaths } from './SkillScanPaths'
 import { KnowledgeSyncFooter } from '@/components/teamshare/KnowledgeSyncFooter'
+import { KnowledgeInboxStrip } from '@/components/teamshare/KnowledgeInboxStrip'
 import { useTeamConflictsStore } from '@/stores/team-conflicts'
 import { ObsidianIcon } from '@/components/workspace/ObsidianIcon'
 import { useObsidianStatus } from '@/hooks/use-obsidian'
@@ -1251,6 +1252,8 @@ export function TeamShareListColumn({ section }: { section: TeamShareSection }) 
             // The whole shared root, not just knowledge/ — create / rename /
             // delete / move all come from FileBrowser's existing context menu,
             // and clicking a file opens it exactly as it does in the workspace.
+            <>
+            <KnowledgeInboxStrip />
             <FileBrowser
               variant="panel"
               rootPath={syncRoot}
@@ -1265,6 +1268,7 @@ export function TeamShareListColumn({ section }: { section: TeamShareSection }) 
                 void handleRootCreate(name)
               }}
             />
+            </>
           ) : (
             // The directory is missing locally. Sync is on regardless — this is
             // a repairable local state, so offer the repair.

--- a/packages/app/src/components/teamshare/KnowledgeInboxStrip.tsx
+++ b/packages/app/src/components/teamshare/KnowledgeInboxStrip.tsx
@@ -1,0 +1,46 @@
+import * as React from 'react'
+import { useTranslation } from 'react-i18next'
+import { Inbox } from 'lucide-react'
+
+import { cn } from '@/lib/utils'
+import { openKnowledgeReview } from '@/lib/tabs/knowledge-tabs'
+import { useKnowledgeInboxStore } from '@/stores/knowledge-inbox'
+
+export function KnowledgeInboxStrip() {
+  const { t } = useTranslation()
+  const items = useKnowledgeInboxStore((s) => s.items)
+  const load = useKnowledgeInboxStore((s) => s.load)
+
+  React.useEffect(() => {
+    void load()
+  }, [load])
+
+  if (items.length === 0) return null
+
+  return (
+    <div className="shrink-0 border-b border-border-soft px-2 py-1.5">
+      <div className="px-2 pb-1 text-[10.5px] font-semibold uppercase tracking-[0.8px] text-faint">
+        {t('knowledgeReview.pendingKicker', '待写入 · {{count}}', { count: items.length })}
+      </div>
+      <div className="flex flex-col">
+        {items.slice(0, 5).map((item) => (
+          <button
+            key={item.id}
+            type="button"
+            data-testid={`knowledge-inbox-${item.id}`}
+            onClick={() => openKnowledgeReview(item.id, item.title || t('knowledgeReview.tabLabel', '审稿'))}
+            className={cn(
+              'flex items-center gap-2 rounded-[8px] px-2 py-1.5 text-left',
+              'hover:bg-selected',
+            )}
+          >
+            <Inbox className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+            <span className="min-w-0 flex-1 truncate text-[13px] font-semibold text-foreground">
+              {item.title || t('knowledgeReview.untitled', '未命名')}
+            </span>
+          </button>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/packages/app/src/components/teamshare/KnowledgeReviewTab.tsx
+++ b/packages/app/src/components/teamshare/KnowledgeReviewTab.tsx
@@ -1,0 +1,229 @@
+import * as React from 'react'
+import { useTranslation } from 'react-i18next'
+import { toast } from 'sonner'
+import { Loader2 } from 'lucide-react'
+
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { cn } from '@/lib/utils'
+import {
+  getKnowledgeCandidate,
+  isAlreadyExistsError,
+  publishKnowledgeCandidate,
+} from '@/lib/knowledge/inbox-client'
+import type { KnowledgeCandidate } from '@/lib/knowledge/inbox-types'
+import { encodeKnowledgeReviewTarget } from '@/lib/tabs/teamshare-target'
+import { useTabsStore } from '@/stores/tabs'
+import { useKnowledgeInboxStore } from '@/stores/knowledge-inbox'
+import { useTeamShareBrowserStore } from '@/stores/team-share-browser'
+import { useWorkspaceStore } from '@/stores/workspace'
+
+function vaultAbsPath(syncRoot: string | null, rel: string): string | null {
+  if (!syncRoot) return null
+  const clean = rel.replace(/^\/+/, '')
+  return `${syncRoot.replace(/\/+$/, '')}/knowledge/${clean}`
+}
+
+export function KnowledgeReviewTab({ candidateId }: { candidateId: string }) {
+  const { t } = useTranslation()
+  const closeWhere = useTabsStore((s) => s.closeWhere)
+  const [candidate, setCandidate] = React.useState<KnowledgeCandidate | null>(null)
+  const [loadError, setLoadError] = React.useState<string | null>(null)
+  const [title, setTitle] = React.useState('')
+  const [path, setPath] = React.useState('')
+  const [body, setBody] = React.useState('')
+  const [overwrite, setOverwrite] = React.useState(false)
+  const [busy, setBusy] = React.useState<'publish' | 'discard' | null>(null)
+
+  React.useEffect(() => {
+    let cancelled = false
+    void getKnowledgeCandidate(candidateId)
+      .then((row) => {
+        if (cancelled) return
+        setCandidate(row)
+        setTitle(row.title)
+        setPath(row.suggestedPath || '')
+        setBody(row.body)
+        setLoadError(null)
+      })
+      .catch((err) => {
+        if (cancelled) return
+        setLoadError(err instanceof Error ? err.message : String(err))
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [candidateId])
+
+  const closeTab = React.useCallback(() => {
+    const target = encodeKnowledgeReviewTarget(candidateId)
+    closeWhere((tab) => tab.type === 'native' && tab.target === target)
+  }, [candidateId, closeWhere])
+
+  const onLater = () => {
+    closeTab()
+  }
+
+  const onDiscard = async () => {
+    setBusy('discard')
+    try {
+      await useKnowledgeInboxStore.getState().remove(candidateId)
+      toast.success(t('knowledgeReview.discarded', '已丢弃草稿'))
+      closeTab()
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : String(err))
+    } finally {
+      setBusy(null)
+    }
+  }
+
+  const onPublish = async () => {
+    const trimmedPath = path.trim()
+    if (!trimmedPath) {
+      toast.error(t('knowledgeReview.pathRequired', '请填写知识库路径'))
+      return
+    }
+    setBusy('publish')
+    try {
+      const result = await publishKnowledgeCandidate(candidateId, {
+        title: title.trim() || candidate?.title || 'untitled',
+        content: body,
+        path: trimmedPath,
+        overwrite,
+      })
+      await useKnowledgeInboxStore.getState().load()
+      const abs = vaultAbsPath(useTeamShareBrowserStore.getState().syncRoot, result.path)
+      if (abs) await useWorkspaceStore.getState().selectFile(abs)
+      if (result.teamSync === 'not-syncing') {
+        toast.message(
+          t('knowledgeReview.savedLocalOnly', '已写入本机，当前没有同步到团队'),
+        )
+      } else {
+        toast.success(t('knowledgeReview.published', '已写入知识库'))
+      }
+      closeTab()
+    } catch (err) {
+      if (isAlreadyExistsError(err)) {
+        setOverwrite(false)
+        toast.error(
+          t('knowledgeReview.alreadyExists', '目标已存在。勾选覆盖后再写入。'),
+        )
+      } else {
+        toast.error(err instanceof Error ? err.message : String(err))
+      }
+    } finally {
+      setBusy(null)
+    }
+  }
+
+  if (loadError) {
+    return (
+      <div className="flex h-full items-center justify-center px-8 text-center text-sm text-muted-foreground">
+        {loadError}
+      </div>
+    )
+  }
+
+  if (!candidate) {
+    return (
+      <div className="flex h-full items-center justify-center text-muted-foreground">
+        <Loader2 className="h-4 w-4 animate-spin" />
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex h-full min-h-0 flex-col bg-background">
+      <div className="border-b border-border px-6 py-4" data-tauri-drag-region>
+        <div className="text-[10.5px] font-semibold uppercase tracking-[0.8px] text-faint">
+          {t('knowledgeReview.kicker', '审稿')}
+        </div>
+        <div className="mt-1 text-[15px] font-bold text-foreground">
+          {t('knowledgeReview.title', '写入知识库前先看一遍')}
+        </div>
+        <div className="mt-1 text-[12px] text-muted-foreground">
+          {candidate.sessionId
+            ? t('knowledgeReview.fromSession', '来自会话 {{id}}', {
+                id: candidate.sessionId.slice(0, 8),
+              })
+            : t('knowledgeReview.fromUnknown', '来自本机草稿')}
+        </div>
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-auto px-6 py-4">
+        <div className="mx-auto flex max-w-2xl flex-col gap-4">
+          <label className="flex flex-col gap-1.5">
+            <span className="text-[12px] font-medium text-foreground">
+              {t('knowledgeReview.fieldTitle', '标题')}
+            </span>
+            <Input
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              className="h-9 bg-paper text-[13.5px]"
+            />
+          </label>
+          <label className="flex flex-col gap-1.5">
+            <span className="text-[12px] font-medium text-foreground">
+              {t('knowledgeReview.fieldPath', '知识库路径')}
+            </span>
+            <Input
+              value={path}
+              onChange={(e) => setPath(e.target.value)}
+              placeholder="20-domains/example.md"
+              className="h-9 bg-paper font-mono text-[12px]"
+            />
+          </label>
+          <label className="flex flex-col gap-1.5">
+            <span className="text-[12px] font-medium text-foreground">
+              {t('knowledgeReview.fieldBody', '正文')}
+            </span>
+            <textarea
+              value={body}
+              onChange={(e) => setBody(e.target.value)}
+              rows={16}
+              className={cn(
+                'w-full resize-y rounded-[8px] border border-border bg-paper',
+                'px-3 py-2.5 text-[13.5px] leading-[1.7] text-foreground',
+                'outline-none focus-visible:border-foreground/20',
+              )}
+            />
+          </label>
+          <label className="flex items-center gap-2 text-[12px] text-muted-foreground">
+            <input
+              type="checkbox"
+              checked={overwrite}
+              onChange={(e) => setOverwrite(e.target.checked)}
+            />
+            {t('knowledgeReview.overwrite', '覆盖已有页面')}
+          </label>
+        </div>
+      </div>
+
+      <div className="flex items-center justify-end gap-2 border-t border-border-soft bg-paper px-6 py-3">
+        <Button
+          type="button"
+          variant="ghost"
+          disabled={busy !== null}
+          onClick={() => void onDiscard()}
+        >
+          {t('knowledgeReview.discard', '丢弃')}
+        </Button>
+        <Button type="button" variant="ghost" disabled={busy !== null} onClick={onLater}>
+          {t('knowledgeReview.later', '稍后')}
+        </Button>
+        <Button
+          type="button"
+          disabled={busy !== null}
+          onClick={() => void onPublish()}
+          className="bg-coral text-white hover:bg-coral/90"
+        >
+          {busy === 'publish' ? (
+            <Loader2 className="h-3.5 w-3.5 animate-spin" />
+          ) : (
+            t('knowledgeReview.publish', '写入知识库')
+          )}
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/packages/app/src/lib/knowledge/__tests__/inbox-client.test.ts
+++ b/packages/app/src/lib/knowledge/__tests__/inbox-client.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest'
+import { isAlreadyExistsError } from '@/lib/knowledge/inbox-client'
+
+describe('isAlreadyExistsError', () => {
+  it('recognizes the daemon conflict wording', () => {
+    expect(isAlreadyExistsError(new Error("'x.md' already exists; refusing to overwrite"))).toBe(
+      true,
+    )
+    expect(isAlreadyExistsError(new Error('already_exists'))).toBe(true)
+    expect(isAlreadyExistsError(new Error('daemon is not connected'))).toBe(false)
+  })
+})

--- a/packages/app/src/lib/knowledge/__tests__/propose-from-session.test.ts
+++ b/packages/app/src/lib/knowledge/__tests__/propose-from-session.test.ts
@@ -1,0 +1,70 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { MessageKind } from '@/lib/proto/teamclu_pb'
+
+const proposeKnowledgeCandidate = vi.fn()
+const openKnowledgeReview = vi.fn()
+const inboxLoad = vi.fn()
+
+vi.mock('@/lib/knowledge/inbox-client', () => ({
+  proposeKnowledgeCandidate: (...args: unknown[]) => proposeKnowledgeCandidate(...args),
+}))
+
+vi.mock('@/lib/tabs/knowledge-tabs', () => ({
+  openKnowledgeReview: (...args: unknown[]) => openKnowledgeReview(...args),
+}))
+
+vi.mock('@/stores/knowledge-inbox', () => ({
+  useKnowledgeInboxStore: {
+    getState: () => ({ load: inboxLoad }),
+  },
+}))
+
+vi.mock('@/stores/session-message-store', () => ({
+  useSessionMessageStore: {
+    getState: () => ({
+      messages: {
+        'sess-1': [
+          { kind: 1, content: '以渠道单号为准', senderActorId: 'alice' },
+        ],
+      },
+    }),
+  },
+}))
+
+vi.mock('@/stores/session-store', () => ({
+  useSessionStore: { getState: () => ({ messages: {}, sessions: [] }) },
+}))
+
+vi.mock('@/stores/session-list-store', () => ({
+  useSessionListStore: {
+    getState: () => ({ rows: [{ id: 'sess-1', title: '对账口径' }] }),
+  },
+}))
+
+describe('proposeSessionToKnowledge', () => {
+  beforeEach(() => {
+    proposeKnowledgeCandidate.mockReset()
+    openKnowledgeReview.mockReset()
+    inboxLoad.mockReset()
+    inboxLoad.mockResolvedValue(undefined)
+  })
+
+  it('proposes a pending candidate and opens the review tab', async () => {
+    proposeKnowledgeCandidate.mockResolvedValue({ id: 'cand-9', title: '对账口径' })
+    const { proposeSessionToKnowledge } = await import('@/lib/knowledge/propose-from-session')
+    await proposeSessionToKnowledge('sess-1')
+    expect(proposeKnowledgeCandidate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: '对账口径',
+        sessionId: 'sess-1',
+        source: 'session-header',
+        suggestedPath: '20-domains/对账口径.md',
+      }),
+    )
+    const content = proposeKnowledgeCandidate.mock.calls[0][0].content as string
+    expect(content).toContain('以渠道单号为准')
+    expect(content).not.toContain(String(MessageKind.SYSTEM))
+    expect(openKnowledgeReview).toHaveBeenCalledWith('cand-9', '对账口径')
+    expect(inboxLoad).toHaveBeenCalled()
+  })
+})

--- a/packages/app/src/lib/knowledge/__tests__/session-knowledge-draft.test.ts
+++ b/packages/app/src/lib/knowledge/__tests__/session-knowledge-draft.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+import { MessageKind } from '@/lib/proto/teamclu_pb'
+import { draftFromSession, slugifyDraftTitle } from '@/lib/knowledge/session-knowledge-draft'
+
+describe('slugifyDraftTitle', () => {
+  it('keeps CJK and separates on space', () => {
+    expect(slugifyDraftTitle('对账口径')).toBe('对账口径')
+    expect(slugifyDraftTitle('Push 文案')).toBe('push-文案')
+  })
+
+  it('falls back when nothing remains', () => {
+    expect(slugifyDraftTitle('!!!')).toBe('note')
+  })
+})
+
+describe('draftFromSession', () => {
+  it('skips system messages and empty bodies', () => {
+    const draft = draftFromSession({
+      sessionId: 's1',
+      title: '对账口径',
+      messages: [
+        { kind: MessageKind.SYSTEM, content: 'joined', senderActorId: 'sys' },
+        { kind: MessageKind.TEXT, content: '以渠道单号为准', senderActorId: 'alice' },
+        { kind: MessageKind.TEXT, content: '   ', senderActorId: 'bob' },
+      ],
+    })
+    expect(draft.title).toBe('对账口径')
+    expect(draft.suggestedPath).toBe('20-domains/对账口径.md')
+    expect(draft.body).toContain('alice')
+    expect(draft.body).toContain('以渠道单号为准')
+    expect(draft.body).not.toContain('joined')
+  })
+
+  it('asks the reviewer to write when the thread is empty', () => {
+    const draft = draftFromSession({
+      sessionId: 's1',
+      title: '  ',
+      messages: [],
+    })
+    expect(draft.title).toBe('untitled')
+    expect(draft.body).toContain('审稿页')
+  })
+})

--- a/packages/app/src/lib/knowledge/inbox-client.ts
+++ b/packages/app/src/lib/knowledge/inbox-client.ts
@@ -1,0 +1,61 @@
+import { daemonRequest } from '@/lib/daemon/daemon-local-client'
+import type { KnowledgeCandidate, KnowledgePublishResult } from '@/lib/knowledge/inbox-types'
+
+export type ProposeKnowledgeInput = {
+  title: string
+  content: string
+  sessionId?: string
+  suggestedPath?: string
+  source?: KnowledgeCandidate['source']
+}
+
+export async function listKnowledgeInbox(): Promise<KnowledgeCandidate[]> {
+  const result = await daemonRequest<{ items?: KnowledgeCandidate[] }>('/v1/knowledge/inbox')
+  return Array.isArray(result.items) ? result.items : []
+}
+
+export async function getKnowledgeCandidate(id: string): Promise<KnowledgeCandidate> {
+  return daemonRequest<KnowledgeCandidate>(`/v1/knowledge/inbox/${encodeURIComponent(id)}`)
+}
+
+export async function proposeKnowledgeCandidate(
+  input: ProposeKnowledgeInput,
+): Promise<KnowledgeCandidate> {
+  return daemonRequest<KnowledgeCandidate>('/v1/knowledge/inbox', {
+    method: 'POST',
+    body: JSON.stringify({
+      title: input.title,
+      content: input.content,
+      sessionId: input.sessionId,
+      suggestedPath: input.suggestedPath,
+      source: input.source ?? 'session-header',
+    }),
+  })
+}
+
+export async function discardKnowledgeCandidate(id: string): Promise<void> {
+  await daemonRequest(`/v1/knowledge/inbox/${encodeURIComponent(id)}`, { method: 'DELETE' })
+}
+
+export async function publishKnowledgeCandidate(
+  id: string,
+  input: { title: string; content: string; path: string; overwrite?: boolean },
+): Promise<KnowledgePublishResult> {
+  return daemonRequest<KnowledgePublishResult>(
+    `/v1/knowledge/inbox/${encodeURIComponent(id)}/publish`,
+    {
+      method: 'POST',
+      body: JSON.stringify({
+        title: input.title,
+        content: input.content,
+        path: input.path,
+        overwrite: input.overwrite ?? false,
+      }),
+    },
+  )
+}
+
+export function isAlreadyExistsError(err: unknown): boolean {
+  const raw = err instanceof Error ? err.message : String(err)
+  return /already_exists|already exists/i.test(raw)
+}

--- a/packages/app/src/lib/knowledge/inbox-types.ts
+++ b/packages/app/src/lib/knowledge/inbox-types.ts
@@ -1,0 +1,29 @@
+export type KnowledgeCandidateSource =
+  | 'session-header'
+  | 'agent-propose'
+  | 'message'
+  | 'unknown'
+
+export type KnowledgeCandidateStatus = 'pending' | 'published' | 'discarded'
+
+export type KnowledgeCandidate = {
+  id: string
+  teamId: string
+  sessionId: string
+  title: string
+  body: string
+  suggestedPath: string
+  source: KnowledgeCandidateSource
+  createdAt: string
+  status: KnowledgeCandidateStatus
+  publishedPath?: string
+}
+
+export type KnowledgePublishResult = {
+  id?: string
+  path: string
+  status?: string
+  overwritten?: boolean
+  teamSync?: string
+  teamSyncNote?: string
+}

--- a/packages/app/src/lib/knowledge/propose-from-session.ts
+++ b/packages/app/src/lib/knowledge/propose-from-session.ts
@@ -1,0 +1,29 @@
+import { draftFromSession } from '@/lib/knowledge/session-knowledge-draft'
+import { proposeKnowledgeCandidate } from '@/lib/knowledge/inbox-client'
+import { openKnowledgeReview } from '@/lib/tabs/knowledge-tabs'
+import { useKnowledgeInboxStore } from '@/stores/knowledge-inbox'
+import { useSessionMessageStore } from '@/stores/session-message-store'
+import { useSessionListStore } from '@/stores/session-list-store'
+import { useSessionStore } from '@/stores/session-store'
+
+export async function proposeSessionToKnowledge(sessionId: string): Promise<string> {
+  const messages =
+    useSessionMessageStore.getState().messages[sessionId] ??
+    useSessionStore.getState().messages[sessionId] ??
+    []
+  const title =
+    useSessionListStore.getState().rows.find((row) => row.id === sessionId)?.title ??
+    useSessionStore.getState().sessions.find((row) => row.id === sessionId)?.title ??
+    ''
+  const draft = draftFromSession({ sessionId, title, messages })
+  const candidate = await proposeKnowledgeCandidate({
+    title: draft.title,
+    content: draft.body,
+    suggestedPath: draft.suggestedPath,
+    sessionId,
+    source: 'session-header',
+  })
+  await useKnowledgeInboxStore.getState().load()
+  openKnowledgeReview(candidate.id, candidate.title || draft.title)
+  return candidate.id
+}

--- a/packages/app/src/lib/knowledge/session-knowledge-draft.ts
+++ b/packages/app/src/lib/knowledge/session-knowledge-draft.ts
@@ -1,0 +1,62 @@
+import { MessageKind } from '@/lib/proto/teamclu_pb'
+
+const MAX_BODY_CHARS = 8000
+const MAX_TITLE_CHARS = 48
+
+export type SessionDraftMessage = {
+  content?: string
+  kind?: number
+  senderActorId?: string
+}
+
+export type SessionKnowledgeDraft = {
+  title: string
+  body: string
+  suggestedPath: string
+}
+
+/** Filename slug: keep letters of any script, collapse the rest to `-`. */
+export function slugifyDraftTitle(title: string): string {
+  let out = ''
+  for (const c of title) {
+    if (/\p{L}|\p{N}/u.test(c)) out += c.toLowerCase()
+    else if (out && !out.endsWith('-')) out += '-'
+  }
+  const trimmed = out.replace(/^-+|-+$/g, '').slice(0, MAX_TITLE_CHARS).replace(/-+$/g, '')
+  return trimmed || 'note'
+}
+
+/**
+ * A reviewable draft from the messages already on screen.
+ *
+ * This is not the model summary — it is the raw material the reviewer edits
+ * before publish. The header button uses it so "整理到知识库" works without
+ * waiting for an agent turn.
+ */
+export function draftFromSession(input: {
+  sessionId: string
+  title: string
+  messages: SessionDraftMessage[]
+}): SessionKnowledgeDraft {
+  const title = input.title.trim() || 'untitled'
+  const lines: string[] = []
+  for (const message of input.messages) {
+    if (message.kind === MessageKind.SYSTEM) continue
+    const text = (message.content ?? '').trim()
+    if (!text) continue
+    const who = (message.senderActorId ?? '').trim() || 'unknown'
+    lines.push(`### ${who}\n\n${text}`)
+  }
+  let body = lines.join('\n\n')
+  if (!body) {
+    body = '（会话里还没有可整理的正文。请在审稿页写下结论。）'
+  }
+  if (body.length > MAX_BODY_CHARS) {
+    body = `${body.slice(0, MAX_BODY_CHARS)}\n\n…`
+  }
+  return {
+    title,
+    body,
+    suggestedPath: `20-domains/${slugifyDraftTitle(title)}.md`,
+  }
+}

--- a/packages/app/src/lib/tabs/__tests__/teamshare-target.test.ts
+++ b/packages/app/src/lib/tabs/__tests__/teamshare-target.test.ts
@@ -4,6 +4,8 @@ import {
   decodeTeamShareTarget,
   encodeVersionHistoryTarget,
   decodeVersionHistoryTarget,
+  encodeKnowledgeReviewTarget,
+  decodeKnowledgeReviewTarget,
   isTeamShareOwnedTarget,
   tabSelectionForSection,
   type TeamShareTabTarget,
@@ -52,6 +54,9 @@ describe('team-share tab targets', () => {
     expect(isTeamShareOwnedTarget('version-history/x.md')).toBe(true)
     expect(isTeamShareOwnedTarget('version-history')).toBe(true)
     expect(isTeamShareOwnedTarget('/Users/me/notes.md')).toBe(false)
+    expect(isTeamShareOwnedTarget('knowledge-review/abc')).toBe(true)
+    expect(decodeKnowledgeReviewTarget(encodeKnowledgeReviewTarget('abc-1'))).toBe('abc-1')
+    expect(decodeKnowledgeReviewTarget('knowledge-cloud/x.md')).toBeUndefined()
   })
 
   test('a file inside a package keeps its skill row selected', () => {

--- a/packages/app/src/lib/tabs/knowledge-tabs.ts
+++ b/packages/app/src/lib/tabs/knowledge-tabs.ts
@@ -2,6 +2,7 @@ import { useTabsStore } from '@/stores/tabs'
 import {
   encodeKnowledgeConflictTarget,
   encodeCloudVersionTarget,
+  encodeKnowledgeReviewTarget,
 } from '@/lib/tabs/teamshare-target'
 
 /**
@@ -27,6 +28,14 @@ export function openKnowledgeConflict(path: string, label: string) {
  * see", which is the document itself, not the delta from what happens to be on
  * this disk.
  */
+export function openKnowledgeReview(id: string, label: string) {
+  useTabsStore.getState().openTab({
+    type: 'native',
+    target: encodeKnowledgeReviewTarget(id),
+    label,
+  })
+}
+
 export function openCloudVersion(path: string, label: string) {
   useTabsStore.getState().openTab({
     type: 'native',

--- a/packages/app/src/lib/tabs/teamshare-target.ts
+++ b/packages/app/src/lib/tabs/teamshare-target.ts
@@ -31,6 +31,9 @@ const KNOWLEDGE_CONFLICT = 'knowledge-conflict'
 /** The read-only "what does the cloud hold" view for one team document. */
 const CLOUD_VERSION = 'knowledge-cloud'
 
+/** Review one session→knowledge candidate before it enters the vault. */
+const KNOWLEDGE_REVIEW = 'knowledge-review'
+
 export function encodeTeamShareTarget(t: TeamShareTarget): string {
   switch (t.kind) {
     case 'skill':
@@ -126,6 +129,16 @@ export function encodeCloudVersionTarget(path: string): string {
   return `${CLOUD_VERSION}/${path}`
 }
 
+export function encodeKnowledgeReviewTarget(id: string): string {
+  return `${KNOWLEDGE_REVIEW}/${id}`
+}
+
+/** The candidate a review tab names, `undefined` when it is not one. */
+export function decodeKnowledgeReviewTarget(target: string): string | undefined {
+  if (!target.startsWith(`${KNOWLEDGE_REVIEW}/`)) return undefined
+  return target.slice(KNOWLEDGE_REVIEW.length + 1) || undefined
+}
+
 /** The document whose cloud copy a target names, `undefined` when it is not one. */
 export function decodeCloudVersionTarget(target: string): string | undefined {
   if (!target.startsWith(`${CLOUD_VERSION}/`)) return undefined
@@ -140,7 +153,8 @@ export function isTeamShareOwnedTarget(target: string): boolean {
     // A conflict belongs to the team whose tree it is in; keeping the tab open
     // across a team switch would offer a decision about another team's file.
     decodeKnowledgeConflictTarget(target) !== undefined ||
-    decodeCloudVersionTarget(target) !== undefined
+    decodeCloudVersionTarget(target) !== undefined ||
+    decodeKnowledgeReviewTarget(target) !== undefined
   )
 }
 

--- a/packages/app/src/stores/knowledge-inbox.ts
+++ b/packages/app/src/stores/knowledge-inbox.ts
@@ -1,0 +1,37 @@
+import { create } from 'zustand'
+import {
+  discardKnowledgeCandidate,
+  listKnowledgeInbox,
+} from '@/lib/knowledge/inbox-client'
+import type { KnowledgeCandidate } from '@/lib/knowledge/inbox-types'
+
+type KnowledgeInboxState = {
+  items: KnowledgeCandidate[]
+  loading: boolean
+  error: string | null
+  load: () => Promise<void>
+  remove: (id: string) => Promise<void>
+}
+
+export const useKnowledgeInboxStore = create<KnowledgeInboxState>((set, get) => ({
+  items: [],
+  loading: false,
+  error: null,
+  load: async () => {
+    if (get().loading) return
+    set({ loading: true, error: null })
+    try {
+      const items = await listKnowledgeInbox()
+      set({ items, loading: false })
+    } catch (err) {
+      set({
+        loading: false,
+        error: err instanceof Error ? err.message : String(err),
+      })
+    }
+  },
+  remove: async (id) => {
+    await discardKnowledgeCandidate(id)
+    set({ items: get().items.filter((item) => item.id !== id) })
+  },
+}))


### PR DESCRIPTION
## Description

Session conclusions should not become team knowledge until a human reviews them. This adds a local inbox + review tab: the header action (or a later `knowledge_propose` tool) stages a draft under `state/knowledge-inbox/`, which is not synced. Only **写入知识库** writes a page into `knowledge/` and lets the existing fs watcher sync it.

`knowledge_salvage` still writes `00-salvage/` (legacy). The product path is propose → review → publish.

## Related Issue

n/a

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Test plan

- [ ] Desktop: open a session → 整理到知识库 → review tab opens, `knowledge/` has no new file, teammates do not sync anything
- [ ] Edit title / body / path → 写入知识库 → page appears at that vault path with `session-id` + `reviewed` frontmatter, editor opens it
- [ ] Target already exists, overwrite unchecked → write refused
- [ ] 稍后 → vault unchanged; Knowledge column shows 待写入 · N and reopens the same tab
- [ ] 丢弃 → candidate gone, vault unchanged
- [ ] Narrow header overflow menu also offers 整理到知识库

## Additional Notes

- Spec: `docs/specs/2026-09-11-session-knowledge-review-design.md`
- Not in this PR (slice 4): wire `knowledge_propose` to in-session pi, and reject ordinary `write`/`edit` under `team-knowledge/`. Without that, asking the agent to “save to knowledge” can still bypass review.
- Rust/Tauri were not compiled locally (memory). Please rely on CI.


Made with [Cursor](https://cursor.com)