### PR TITLE
fix(daemon): drop session index.toml; Cloud list + MQTT two-phase restore

### DIFF
--- a/apps/daemon/src/backend/cloud_api/mod.rs
+++ b/apps/daemon/src/backend/cloud_api/mod.rs
@@ -1272,6 +1272,37 @@ impl Backend for CloudApiBackend {
         })
     }
 
+    async fn list_actor_session_ids(
+        &self,
+        team_id: &str,
+        cursor: Option<&str>,
+        limit: u32,
+    ) -> BackendResult<(Vec<String>, Option<String>)> {
+        #[derive(serde::Deserialize)]
+        struct ListItem {
+            id: String,
+        }
+        #[derive(serde::Deserialize)]
+        struct Page {
+            items: Vec<ListItem>,
+            #[serde(rename = "nextCursor", default)]
+            next_cursor: Option<String>,
+        }
+        let limit = limit.clamp(1, 100);
+        // Offline catch-up only needs human/collab threads — not cron job sessions.
+        let mut path = format!("/v1/sessions?teamId={team_id}&limit={limit}&kind=regular");
+        if let Some(cursor) = cursor.filter(|c| !c.is_empty()) {
+            path.push_str("&cursor=");
+            path.push_str(cursor);
+        }
+        let page: Page = self.get(&path).await?;
+        let ids = page.items.into_iter().map(|row| row.id).collect();
+        let next = page
+            .next_cursor
+            .filter(|cursor| !cursor.is_empty());
+        Ok((ids, next))
+    }
+
     async fn messages_after_cursor(
         &self,
         session_id: &str,

--- a/apps/daemon/src/backend/deferred.rs
+++ b/apps/daemon/src/backend/deferred.rs
@@ -341,6 +341,17 @@ impl Backend for DeferredBackend {
             .await
     }
 
+    async fn list_actor_session_ids(
+        &self,
+        team_id: &str,
+        cursor: Option<&str>,
+        limit: u32,
+    ) -> BackendResult<(Vec<String>, Option<String>)> {
+        self.inner()?
+            .list_actor_session_ids(team_id, cursor, limit)
+            .await
+    }
+
     async fn get_session_roster(
         &self,
         session_id: &str,

--- a/apps/daemon/src/backend/mock.rs
+++ b/apps/daemon/src/backend/mock.rs
@@ -488,6 +488,23 @@ impl Backend for MockBackend {
             })
     }
 
+    async fn list_actor_session_ids(
+        &self,
+        _team_id: &str,
+        _cursor: Option<&str>,
+        _limit: u32,
+    ) -> BackendResult<(Vec<String>, Option<String>)> {
+        let ids = self
+            .state
+            .lock()
+            .unwrap()
+            .sessions
+            .keys()
+            .cloned()
+            .collect();
+        Ok((ids, None))
+    }
+
     async fn get_actors_by_ids(&self, ids: &[String]) -> BackendResult<Vec<ActorDirectoryRow>> {
         let st = self.state.lock().unwrap();
         // Unseeded ids are simply absent, matching the real directory: it

--- a/apps/daemon/src/backend/mod.rs
+++ b/apps/daemon/src/backend/mod.rs
@@ -494,6 +494,16 @@ pub trait Backend: Send + Sync {
         session_id: &str,
     ) -> BackendResult<BackendSessionAndParticipants>;
 
+    /// Paginated session ids for the calling actor (`GET /v1/sessions?kind=regular`).
+    /// Excludes archived and cron sessions server-side; used for offline catch-up
+    /// scans instead of a local on-disk session index.
+    async fn list_actor_session_ids(
+        &self,
+        team_id: &str,
+        cursor: Option<&str>,
+        limit: u32,
+    ) -> BackendResult<(Vec<String>, Option<String>)>;
+
     /// Display names for seated session participants via
     /// `GET /v1/sessions/{sessionId}/roster`.
     async fn get_session_roster(&self, session_id: &str) -> BackendResult<SessionRoster>;

--- a/apps/daemon/src/daemon/server.rs
+++ b/apps/daemon/src/daemon/server.rs
@@ -919,14 +919,14 @@ impl DaemonServer {
                 return Err("stale MQTT generation after runtime subscription".to_string());
             }
             if let Some(tc) = &mut self.teamclu {
-                if let Err(e) = tc.subscribe_all().await {
+                if let Err(e) = tc.subscribe_team_topics().await {
                     warn!(
                         context,
                         error = %e,
-                        "teamclu subscribe failed after CONNACK, reconnecting"
+                        "teamclu team-topic subscribe failed after CONNACK, reconnecting"
                     );
                     mark_mqtt_connected(&self.mqtt_connected_flag, false);
-                    return Err(format!("teamclu subscription failed: {e}"));
+                    return Err(format!("teamclu team-topic subscription failed: {e}"));
                 }
             }
             // Optional: ACL for sync/+ may lag token rotation (Task 6). Never
@@ -1025,6 +1025,36 @@ impl DaemonServer {
             return Err("stale MQTT generation before readiness".to_string());
         }
         Ok(())
+    }
+
+    /// Phase-2 MQTT restore: team topics (when the CONNACK path skipped them)
+    /// and tracked session/live subscriptions. Failures are logged only —
+    /// they must not tear down the MQTT worker.
+    async fn restore_mqtt_session_live_subscriptions(&mut self) {
+        let Some(tc) = &mut self.teamclu else {
+            return;
+        };
+        if let Err(e) = tc.subscribe_team_topics().await {
+            warn!(
+                error = %e,
+                "MQTT phase-2: team topic subscribe failed; session live restore skipped"
+            );
+            return;
+        }
+        match tc.resubscribe_tracked_live_sessions().await {
+            Ok(()) => {
+                info!(
+                    live_session_count = tc.tracked_live_session_count(),
+                    "MQTT phase-2: restored tracked session/live subscriptions"
+                );
+            }
+            Err(e) => {
+                warn!(
+                    error = %e,
+                    "MQTT phase-2: session/live subscribe failed; will retry on next reconnect"
+                );
+            }
+        }
     }
 
     /// Run the daemon. When `shutdown` resolves, the inner loop exits
@@ -1871,6 +1901,7 @@ impl DaemonServer {
 
             // ── 4. Subscribe and announce ──
             info!(actor_id = %self.config.actor.id, "MQTT connected, listening for commands");
+            self.restore_mqtt_session_live_subscriptions().await;
 
             if first_connect {
                 // Drain messages that landed in the cloud backend while the daemon
@@ -2079,6 +2110,7 @@ impl DaemonServer {
                                         .await
                                 {
                                     info!(generation, "MQTT generation readiness acknowledged");
+                                    self.restore_mqtt_session_live_subscriptions().await;
                                 } else {
                                     warn!(generation, "MQTT state restore failed; requesting generation rebuild");
                                     mqtt_supervisor
@@ -2605,17 +2637,49 @@ impl DaemonServer {
     /// branching logic (no prior row → skip, only self-authored unread →
     /// skip, already-running runtime → skip, etc.) without booting a real
     /// ACP backend.
-    pub(crate) async fn plan_auto_restart_offline_sessions(&self) -> Vec<OfflineRestartPlan> {
-        let session_ids: Vec<String> = match self.teamclu.as_ref() {
-            Some(tc) => tc.membership_session_ids(),
-            None => return Vec::new(),
+    async fn list_all_actor_session_ids(&self) -> Vec<String> {
+        let team_id = match self.config.team_id.as_deref() {
+            Some(team_id) if !team_id.is_empty() => team_id,
+            _ => return Vec::new(),
         };
+        let mut session_ids = Vec::new();
+        let mut cursor: Option<String> = None;
+        loop {
+            let (page, next) = match self
+                .backend
+                .list_actor_session_ids(team_id, cursor.as_deref(), 50)
+                .await
+            {
+                Ok(page) => page,
+                Err(e) => {
+                    warn!(
+                        ?e,
+                        team_id,
+                        "list_all_actor_session_ids: Cloud session list failed"
+                    );
+                    break;
+                }
+            };
+            session_ids.extend(page);
+            cursor = next.filter(|c| !c.is_empty());
+            if cursor.is_none() {
+                break;
+            }
+        }
+        session_ids
+    }
+
+    pub(crate) async fn plan_auto_restart_offline_sessions(&self) -> Vec<OfflineRestartPlan> {
+        if self.teamclu.is_none() {
+            return Vec::new();
+        }
+        let session_ids = self.list_all_actor_session_ids().await;
         if session_ids.is_empty() {
             return Vec::new();
         }
         info!(
             count = session_ids.len(),
-            "plan_auto_restart_offline_sessions: scanning membership sessions for offline messages"
+            "plan_auto_restart_offline_sessions: scanning Cloud regular sessions for offline messages"
         );
 
         let mut plan = Vec::new();
@@ -4059,12 +4123,9 @@ pub(crate) mod tests {
 
     #[tokio::test]
     pub(crate) async fn auto_restart_offline_sessions_is_noop_without_membership() {
-        // The default test fixture has no teamclu memberships (no
-        // sessions.toml entries the actor is a participant in), so the
-        // method must return early before touching the Cloud API. A real
-        // request would fail because `test_cloud_api()` points at
-        // http://localhost with no server running, so a successful return
-        // here implies the early-exit guard fired.
+        // The default test fixture has no Cloud session list mock, so
+        // `list_actor_session_ids` fails and offline restart scans zero
+        // sessions without spawning runtimes.
         let mut fixture = test_server();
         fixture.server.auto_restart_offline_sessions().await;
         // No runtimes added beyond the fixture's seeded "session-1".
@@ -4618,7 +4679,45 @@ pub(crate) mod tests {
         })
     }
 
-    pub(crate) async fn add_membership(fixture: &mut TestServer, session_id: &str) {
+    pub(crate) async fn mock_actor_session_list(
+        srv: &MockServer,
+        team_id: &str,
+        session_ids: &[&str],
+    ) {
+        let items: Vec<serde_json::Value> = session_ids
+            .iter()
+            .map(|session_id| {
+                serde_json::json!({
+                    "id": session_id,
+                    "teamId": team_id,
+                    "title": session_id,
+                    "mode": "collab",
+                    "ideaId": null,
+                    "lastMessageAt": null,
+                    "lastMessagePreview": null,
+                    "hasUnread": false,
+                    "createdAt": "2026-09-10T00:00:00Z",
+                    "updatedAt": "2026-09-10T00:00:00Z",
+                })
+            })
+            .collect();
+        Mock::given(method("GET"))
+            .and(path("/v1/sessions"))
+            .and(query_param("teamId", team_id))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "items": items,
+                "nextCursor": null,
+            })))
+            .mount(srv)
+            .await;
+    }
+
+    pub(crate) async fn add_membership(
+        srv: &MockServer,
+        fixture: &mut TestServer,
+        session_id: &str,
+    ) {
+        mock_actor_session_list(srv, "team-test", &[session_id]).await;
         let tc = fixture.server.teamclu.as_mut().expect("teamclu set");
         tc.insert_session_from_backend_for_test(
             session_id,
@@ -4644,7 +4743,7 @@ pub(crate) mod tests {
             .await;
 
         let mut fixture = test_server_with_cloud_api(test_cloud_api_with_url(srv.uri()));
-        add_membership(&mut fixture, "sess-no-row").await;
+        add_membership(&srv, &mut fixture, "sess-no-row").await;
 
         let plan = fixture.server.plan_auto_restart_offline_sessions().await;
         assert!(plan.is_empty(), "no prior row should produce empty plan");
@@ -4661,7 +4760,7 @@ pub(crate) mod tests {
         mock_messages_response(&srv, "sess-empty", serde_json::json!([])).await;
 
         let mut fixture = test_server_with_cloud_api(test_cloud_api_with_url(srv.uri()));
-        add_membership(&mut fixture, "sess-empty").await;
+        add_membership(&srv, &mut fixture, "sess-empty").await;
 
         let plan = fixture.server.plan_auto_restart_offline_sessions().await;
         assert!(
@@ -4696,7 +4795,7 @@ pub(crate) mod tests {
         .await;
 
         let mut fixture = test_server_with_cloud_api(test_cloud_api_with_url(srv.uri()));
-        add_membership(&mut fixture, "sess-self").await;
+        add_membership(&srv, &mut fixture, "sess-self").await;
 
         let plan = fixture.server.plan_auto_restart_offline_sessions().await;
         assert!(
@@ -4758,7 +4857,7 @@ pub(crate) mod tests {
         mock_session_detail(&srv, "sess-mention", serde_json::json!({})).await;
 
         let mut fixture = test_server_with_cloud_api(test_cloud_api_with_url(srv.uri()));
-        add_membership(&mut fixture, "sess-mention").await;
+        add_membership(&srv, &mut fixture, "sess-mention").await;
 
         let plan = fixture.server.plan_auto_restart_offline_sessions().await;
         assert_eq!(plan.len(), 1, "one session should need restart");
@@ -4804,7 +4903,7 @@ pub(crate) mod tests {
         .await;
 
         let mut fixture = test_server_with_cloud_api(test_cloud_api_with_url(srv.uri()));
-        add_membership(&mut fixture, "sess-thread").await;
+        add_membership(&srv, &mut fixture, "sess-thread").await;
 
         let plan = fixture.server.plan_auto_restart_offline_sessions().await;
         assert_eq!(plan.len(), 1);
@@ -4841,7 +4940,7 @@ pub(crate) mod tests {
         .await;
 
         let mut fixture = test_server_with_cloud_api(test_cloud_api_with_url(srv.uri()));
-        add_membership(&mut fixture, "session-1").await;
+        add_membership(&srv, &mut fixture, "session-1").await;
 
         let plan = fixture.server.plan_auto_restart_offline_sessions().await;
         assert!(
@@ -5081,7 +5180,7 @@ pub(crate) mod tests {
         .await;
 
         let mut fixture = test_server_with_cloud_api(test_cloud_api_with_url(srv.uri()));
-        add_membership(&mut fixture, "sess-answered").await;
+        add_membership(&srv, &mut fixture, "sess-answered").await;
 
         let plan = fixture.server.plan_auto_restart_offline_sessions().await;
         assert!(

--- a/apps/daemon/src/daemon/server/rpc.rs
+++ b/apps/daemon/src/daemon/server/rpc.rs
@@ -453,14 +453,6 @@ impl DaemonServer {
                             session_id = %r.session_id,
                             "FetchSession: failed to cache cloud session locally"
                         );
-                        return RpcResponse {
-                            request_id: request.request_id.clone(),
-                            success: false,
-                            error: format!("failed to cache session: {err}"),
-                            requester_client_id: String::new(),
-                            requester_actor_id: String::new(),
-                            result: None,
-                        };
                     }
                     if let Some(info) = tc.sessions.to_proto_session_info(&r.session_id) {
                         return RpcResponse {

--- a/apps/daemon/src/daemon/server/rpc.rs
+++ b/apps/daemon/src/daemon/server/rpc.rs
@@ -415,6 +415,86 @@ impl DaemonServer {
         Ok(response.encode_to_vec())
     }
 
+    pub(crate) async fn handle_fetch_session_rpc(
+        &mut self,
+        request: &crate::proto::teamclu::RpcRequest,
+        r: &crate::proto::teamclu::FetchSessionRequest,
+    ) -> crate::proto::teamclu::RpcResponse {
+        use crate::proto::teamclu::RpcResponse;
+
+        if let Some(tc) = self.teamclu.as_ref() {
+            if let Some(info) = tc.sessions.to_proto_session_info(&r.session_id) {
+                return RpcResponse {
+                    request_id: request.request_id.clone(),
+                    success: true,
+                    error: String::new(),
+                    requester_client_id: String::new(),
+                    requester_actor_id: String::new(),
+                    result: Some(crate::proto::teamclu::rpc_response::Result::SessionInfo(
+                        info,
+                    )),
+                };
+            }
+        }
+
+        match self
+            .backend
+            .fetch_session_with_participants(&r.session_id)
+            .await
+        {
+            Ok(snap) => {
+                if let Some(tc) = &mut self.teamclu {
+                    if let Err(err) = tc
+                        .insert_session_from_backend(&snap.session, &snap.participants)
+                        .await
+                    {
+                        warn!(
+                            ?err,
+                            session_id = %r.session_id,
+                            "FetchSession: failed to cache cloud session locally"
+                        );
+                        return RpcResponse {
+                            request_id: request.request_id.clone(),
+                            success: false,
+                            error: format!("failed to cache session: {err}"),
+                            requester_client_id: String::new(),
+                            requester_actor_id: String::new(),
+                            result: None,
+                        };
+                    }
+                    if let Some(info) = tc.sessions.to_proto_session_info(&r.session_id) {
+                        return RpcResponse {
+                            request_id: request.request_id.clone(),
+                            success: true,
+                            error: String::new(),
+                            requester_client_id: String::new(),
+                            requester_actor_id: String::new(),
+                            result: Some(
+                                crate::proto::teamclu::rpc_response::Result::SessionInfo(info),
+                            ),
+                        };
+                    }
+                }
+                RpcResponse {
+                    request_id: request.request_id.clone(),
+                    success: false,
+                    error: "session_manager not initialized".to_string(),
+                    requester_client_id: String::new(),
+                    requester_actor_id: String::new(),
+                    result: None,
+                }
+            }
+            Err(err) => RpcResponse {
+                request_id: request.request_id.clone(),
+                success: false,
+                error: format!("session {} not found: {err}", r.session_id),
+                requester_client_id: String::new(),
+                requester_actor_id: String::new(),
+                result: None,
+            },
+        }
+    }
+
     /// Transport-agnostic RPC method dispatch shared by the MQTT `rpc/req`
     /// path and the local HTTP `/v1/rpc` path.
     pub(crate) async fn dispatch_rpc_request(
@@ -424,9 +504,9 @@ impl DaemonServer {
         use crate::proto::teamclu::{rpc_request::Method, RpcResponse};
 
         match &request.method {
+            Some(Method::FetchSession(r)) => self.handle_fetch_session_rpc(&request, r).await,
             // ─── Session/idea methods — delegate to SessionManager ───
             Some(Method::CreateSession(_))
-            | Some(Method::FetchSession(_))
             | Some(Method::FetchSessionMessages(_))
             | Some(Method::JoinSession(_))
             | Some(Method::AddParticipant(_))

--- a/apps/daemon/src/daemon/server/runtime_lifecycle.rs
+++ b/apps/daemon/src/daemon/server/runtime_lifecycle.rs
@@ -500,8 +500,8 @@ impl DaemonServer {
         }
 
         // If iOS handed us a cloud session_id, pull the row + participants
-        // so we (a) populate the teamclu cache that `agents_to_activate`
-        // reads, and (b) subscribe to `session/{sid}/live` so inbound
+        // so we (a) populate the in-memory teamclu session cache, and (b)
+        // subscribe to `session/{sid}/live` so inbound
         // `message.created` events from iOS actually reach us.
         // iOS creates these sessions directly in the cloud backend, so this is the
         // only place the daemon learns about them.

--- a/apps/daemon/src/teamclu/session_manager.rs
+++ b/apps/daemon/src/teamclu/session_manager.rs
@@ -75,7 +75,6 @@ pub struct SessionManager {
     #[allow(dead_code)]
     rpc_server: RpcServer,
     pub(crate) sessions: TeamcluSessionStore,
-    sessions_path: PathBuf,
     pub(crate) config_dir: PathBuf,
     config_actor_id: String,
     team_id: String,
@@ -106,19 +105,13 @@ impl SessionManager {
             team_id.to_string(),
             config_actor_id.to_string(),
         );
-        // Before the first read: sessions/messages/ideas written by a
-        // pre-rebrand daemon live one directory over.
-        let sessions_path = TeamcluSessionStore::default_path(&config_dir);
-        let sessions = TeamcluSessionStore::load(&sessions_path)?;
-
         Ok(Self {
             topics,
             client,
             live_publisher,
             notify_publisher,
             rpc_server,
-            sessions,
-            sessions_path,
+            sessions: TeamcluSessionStore::default(),
             config_dir,
             config_actor_id: config_actor_id.to_string(),
             team_id: team_id.to_string(),
@@ -155,21 +148,29 @@ impl SessionManager {
         self.live_publisher.set_local_tee(tx);
     }
 
-    /// Subscribe to all relevant teamclu topics.
-    pub async fn subscribe_all(&mut self) -> crate::error::Result<()> {
+    /// Team-scoped MQTT topics (RPC + notify). Must complete before marking
+    /// MQTT ready — session/{id}/live is restored separately.
+    pub async fn subscribe_team_topics(&mut self) -> crate::error::Result<()> {
         for topic in self.base_subscription_topics() {
             self.client
                 .subscribe(&topic, DeliveryGuarantee::AtLeastOnce)
                 .await?;
         }
-        // MQTT uses clean sessions, so a reconnect drops broker-side
-        // session/live subscriptions even though this in-memory set still
-        // contains them. Force `refresh_membership_subscriptions` to reissue
-        // every live SUBSCRIBE after `DaemonServer` calls `subscribe_all()`.
-        self.subscribed_live_sessions.clear();
-        self.refresh_membership_subscriptions().await?;
-
         Ok(())
+    }
+
+    /// Re-SUB `session/{id}/live` for sessions this process was already
+    /// tracking. Safe to run outside the CONNACK restore deadline.
+    pub async fn resubscribe_tracked_live_sessions(&mut self) -> crate::error::Result<()> {
+        let tracked: Vec<String> = self.subscribed_live_sessions.iter().cloned().collect();
+        self.subscribed_live_sessions.clear();
+        self.apply_membership_sessions(tracked).await
+    }
+
+    /// Subscribe to all relevant teamclu topics (team + tracked live).
+    pub async fn subscribe_all(&mut self) -> crate::error::Result<()> {
+        self.subscribe_team_topics().await?;
+        self.resubscribe_tracked_live_sessions().await
     }
 
     /// Handle a pre-parsed RPC request. Only dispatches session/idea-scoped methods.
@@ -191,9 +192,6 @@ impl SessionManager {
             Some(teamclu::rpc_request::Method::CreateSession(r)) => {
                 self.handle_create_session(&request, r, primary_agent_id)
                     .await
-            }
-            Some(teamclu::rpc_request::Method::FetchSession(r)) => {
-                self.handle_fetch_session(&request, r).await
             }
             Some(teamclu::rpc_request::Method::FetchSessionMessages(r)) => {
                 self.handle_fetch_session_messages(&request, r).await
@@ -265,11 +263,8 @@ impl SessionManager {
         };
 
         self.sessions.upsert(session);
-        if let Err(e) = self.sessions.save(&self.sessions_path) {
-            warn!("handle_create_session: failed to save sessions: {}", e);
-        }
 
-        if let Err(e) = self.refresh_membership_subscriptions().await {
+        if let Err(e) = self.ensure_session_live_subscription(&session_id).await {
             warn!(
                 session_id = %session_id,
                 "handle_create_session: failed to refresh membership subscriptions: {}",
@@ -287,31 +282,6 @@ impl SessionManager {
             requester_client_id: String::new(),
             requester_actor_id: String::new(),
             result: session_info.map(|s| teamclu::rpc_response::Result::SessionInfo(s)),
-        }
-    }
-
-    async fn handle_fetch_session(
-        &self,
-        req: &RpcRequest,
-        r: teamclu::FetchSessionRequest,
-    ) -> RpcResponse {
-        match self.sessions.to_proto_session_info(&r.session_id) {
-            Some(info) => RpcResponse {
-                request_id: req.request_id.clone(),
-                success: true,
-                error: String::new(),
-                requester_client_id: String::new(),
-                requester_actor_id: String::new(),
-                result: Some(teamclu::rpc_response::Result::SessionInfo(info)),
-            },
-            None => RpcResponse {
-                request_id: req.request_id.clone(),
-                success: false,
-                error: format!("session {} not found", r.session_id),
-                requester_client_id: String::new(),
-                requester_actor_id: String::new(),
-                result: None,
-            },
         }
     }
 
@@ -411,13 +381,10 @@ impl SessionManager {
             }
         }
 
-        if let Err(e) = self.sessions.save(&self.sessions_path) {
-            warn!("handle_join_session: failed to save sessions: {}", e);
-        }
-        if let Err(e) = self.refresh_membership_subscriptions().await {
+        if let Err(e) = self.ensure_session_live_subscription(&r.session_id).await {
             warn!(
                 session_id = %r.session_id,
-                "handle_join_session: failed to refresh membership subscriptions: {}",
+                "handle_join_session: failed to subscribe session live: {}",
                 e
             );
         }
@@ -515,13 +482,10 @@ impl SessionManager {
             }
         }
 
-        if let Err(e) = self.sessions.save(&self.sessions_path) {
-            warn!("handle_add_participant: failed to save sessions: {}", e);
-        }
-        if let Err(e) = self.refresh_membership_subscriptions().await {
+        if let Err(e) = self.ensure_session_live_subscription(&r.session_id).await {
             warn!(
                 session_id = %r.session_id,
-                "handle_add_participant: failed to refresh membership subscriptions: {}",
+                "handle_add_participant: failed to subscribe session live: {}",
                 e
             );
         }
@@ -591,13 +555,10 @@ impl SessionManager {
             }
         };
 
-        if let Err(e) = self.sessions.save(&self.sessions_path) {
-            warn!("handle_remove_participant: failed to save sessions: {}", e);
-        }
         if let Err(e) = self.refresh_membership_subscriptions().await {
             warn!(
                 session_id = %r.session_id,
-                "handle_remove_participant: failed to refresh membership subscriptions: {}",
+                "handle_remove_participant: failed to refresh live subscriptions: {}",
                 e
             );
         }
@@ -643,9 +604,9 @@ impl SessionManager {
         }
     }
 
-    /// Synthesise a local `StoredSession` from a backend fetch, populate
-    /// participants, and trigger a `refresh_membership_subscriptions` so the
-    /// daemon subscribes to `session/{sid}/live` if it is a participant.
+    /// Synthesise an in-memory `StoredSession` from a backend fetch and
+    /// subscribe to `session/{sid}/live` when the local daemon actor is a
+    /// participant.
     ///
     /// iOS creates collab sessions by writing directly to the remote backend
     /// `sessions`/`session_participants`; the daemon only learns about them
@@ -656,10 +617,7 @@ impl SessionManager {
     /// `session_participants` doesn't carry an explicit actor_type. We stamp
     /// the local daemon actor as `personal_agent` (which it is — the daemon
     /// owns the device's primary agent), and other participants as
-    /// `unknown` until a richer source of truth is wired through. This is
-    /// load-bearing for `agents_to_activate`, which only routes messages to
-    /// participants whose stored actor_type is `personal_agent` or
-    /// `role_agent`.
+    /// `unknown` until a richer source of truth is wired through.
     pub async fn insert_session_from_backend(
         &mut self,
         session: &crate::backend::BackendSessionRow,
@@ -695,15 +653,17 @@ impl SessionManager {
             primary_agent_id: session.primary_agent_id.clone().unwrap_or_default(),
         };
 
+        let session_id = session.id.clone();
+        let is_local_participant = local_actor_id.is_some_and(|actor_id| {
+            participants
+                .iter()
+                .any(|participant| participant.actor_id == actor_id)
+        });
         self.sessions.upsert(stored);
-        if let Err(e) = self.sessions.save(&self.sessions_path) {
-            warn!(
-                "insert_session_from_backend: failed to save sessions: {}",
-                e
-            );
-        }
 
-        self.refresh_membership_subscriptions().await?;
+        if is_local_participant {
+            self.ensure_session_live_subscription(&session_id).await?;
+        }
         info!(
             session_id = %session.id,
             "inserted backend-sourced session into teamclu cache"
@@ -1126,36 +1086,6 @@ impl SessionManager {
         Ok(())
     }
 
-    /// Returns the agent actor_ids that should receive this message.
-    ///
-    /// If there's only one agent in the session, all messages are relevant.
-    /// Otherwise, only agents that are explicitly mentioned.
-    #[allow(dead_code)]
-    pub fn agents_to_activate(&self, session_id: &str, message: &teamclu::Message) -> Vec<String> {
-        let session = match self.sessions.find_by_id(session_id) {
-            Some(s) => s,
-            None => return vec![],
-        };
-
-        let agents: Vec<String> = session
-            .participants
-            .iter()
-            .filter(|p| p.actor_type == "personal_agent" || p.actor_type == "role_agent")
-            .map(|p| p.actor_id.clone())
-            .collect();
-
-        if agents.len() == 1 {
-            // Only one agent — all messages activate it
-            return agents;
-        }
-
-        // Multiple agents — only activate those mentioned
-        agents
-            .into_iter()
-            .filter(|actor_id| message.mentions.contains(actor_id))
-            .collect()
-    }
-
     /// Returns the agent actor_ids that should be activated for a idea event.
     ///
     /// - Claimed → activate the claiming agent
@@ -1197,20 +1127,8 @@ impl SessionManager {
         }
     }
 
-    /// Get session_ids where this agent participates.
-    #[allow(dead_code)]
-    pub fn sessions_for_agent(&self, agent_actor_id: &str) -> Vec<String> {
-        self.sessions
-            .sessions
-            .iter()
-            .filter(|s| s.participants.iter().any(|p| p.actor_id == agent_actor_id))
-            .map(|s| s.session_id.clone())
-            .collect()
-    }
-
     /// Fan-out wrapper around `LivePublisher::publish_acp_event` for a single
-    /// session. Mirrors the `publish_agent_message` indirection so server.rs
-    /// can stay decoupled from the LivePublisher type.
+    /// session so server.rs can stay decoupled from the LivePublisher type.
     pub async fn publish_agent_acp_event(
         &self,
         session_id: &str,
@@ -1234,37 +1152,6 @@ impl SessionManager {
 
     /// Publish an agent's output as a session message.
     ///
-    /// `model` is the model id the agent was running on when it produced this
-    /// reply (looked up from `RuntimeManager.current_model` by the caller).
-    /// Pass an empty string for legacy / unknown.
-    #[allow(dead_code)]
-    pub async fn publish_agent_message(
-        &self,
-        session_id: &str,
-        agent_actor_id: &str,
-        content: &str,
-        model: &str,
-    ) {
-        let msg = teamclu::Message {
-            message_id: Uuid::new_v4().to_string()[..8].to_string(),
-            session_id: session_id.to_string(),
-            sender_actor_id: agent_actor_id.to_string(),
-            kind: teamclu::MessageKind::Text as i32,
-            content: content.to_string(),
-            created_at: Utc::now().timestamp(),
-            model: model.to_string(),
-            ..Default::default()
-        };
-        let envelope = teamclu::SessionMessageEnvelope {
-            message: Some(msg),
-            mention_actor_ids: vec![],
-        };
-        let _ = self
-            .live_publisher
-            .publish_message(session_id, agent_actor_id, &envelope)
-            .await;
-    }
-
     /// Emit one logical agent message: append to local TOML, publish to
     /// session/live as `message.created`, and (if `persist_backend`) write
     /// to backend `messages`.
@@ -1457,14 +1344,6 @@ pub struct SessionMessageWrite<'a> {
 }
 
 impl SessionManager {
-    #[allow(dead_code)]
-    pub async fn ensure_session_subscription(
-        &mut self,
-        _session_id: &str,
-    ) -> crate::error::Result<()> {
-        self.refresh_membership_subscriptions().await
-    }
-
     /// Subscribe to `session/{sid}/live` when attaching a runtime. Unlike
     /// `refresh_membership_subscriptions`, this does not depend on the local
     /// participant cache being complete — a race where the backend fetch omits
@@ -1485,8 +1364,8 @@ impl SessionManager {
     }
 
     pub async fn refresh_membership_subscriptions(&mut self) -> crate::error::Result<()> {
-        self.apply_membership_sessions(self.membership_session_ids())
-            .await
+        let tracked: Vec<String> = self.subscribed_live_sessions.iter().cloned().collect();
+        self.apply_membership_sessions(tracked).await
     }
 
     pub async fn apply_membership_sessions(
@@ -1521,7 +1400,11 @@ impl SessionManager {
         Ok(())
     }
 
-    #[allow(dead_code)]
+    pub fn tracked_live_session_count(&self) -> usize {
+        self.subscribed_live_sessions.len()
+    }
+
+    #[cfg(test)]
     pub fn subscribed_live_sessions(&self) -> Vec<String> {
         self.subscribed_live_sessions.iter().cloned().collect()
     }
@@ -1593,23 +1476,6 @@ impl SessionManager {
 
     fn live_session_topic(&self, session_id: &str) -> String {
         self.topics.session_live(session_id)
-    }
-
-    pub fn membership_session_ids(&self) -> Vec<String> {
-        let local_actor_id = self.actor_id.as_deref();
-        self.sessions
-            .sessions
-            .iter()
-            .filter(|session| {
-                local_actor_id.is_some_and(|actor_id| {
-                    session
-                        .participants
-                        .iter()
-                        .any(|participant| participant.actor_id == actor_id)
-                })
-            })
-            .map(|session| session.session_id.clone())
-            .collect()
     }
 
     async fn request_recent_session_events(&self, _session_id: &str) -> crate::error::Result<()> {
@@ -1735,126 +1601,6 @@ mod tests {
         }
     }
 
-    fn make_agent_participant(actor_id: &str) -> StoredParticipant {
-        StoredParticipant {
-            actor_id: actor_id.to_string(),
-            actor_type: "personal_agent".to_string(),
-            display_name: actor_id.to_string(),
-            joined_at: Utc::now(),
-        }
-    }
-
-    fn make_human_participant(actor_id: &str) -> StoredParticipant {
-        StoredParticipant {
-            actor_id: actor_id.to_string(),
-            actor_type: "human".to_string(),
-            display_name: actor_id.to_string(),
-            joined_at: Utc::now(),
-        }
-    }
-
-    fn make_message(session_id: &str, mentions: Vec<String>) -> teamclu::Message {
-        teamclu::Message {
-            message_id: "msg1".to_string(),
-            session_id: session_id.to_string(),
-            sender_actor_id: "human1".to_string(),
-            kind: teamclu::MessageKind::Text as i32,
-            content: "hello".to_string(),
-            created_at: Utc::now().timestamp(),
-            mentions,
-            ..Default::default()
-        }
-    }
-
-    // --- agents_to_activate tests ---
-
-    #[test]
-    fn test_agents_to_activate_no_session() {
-        let tmp = TempDir::new().unwrap();
-        let sm = dummy_session_manager(tmp.path());
-        let msg = make_message("nonexistent", vec![]);
-        let result = sm.agents_to_activate("nonexistent", &msg);
-        assert!(result.is_empty());
-    }
-
-    #[test]
-    fn test_agents_to_activate_session_no_agents() {
-        let tmp = TempDir::new().unwrap();
-        let mut sm = dummy_session_manager(tmp.path());
-
-        let mut session = make_session("s1");
-        session.participants.push(make_human_participant("human1"));
-        sm.sessions.upsert(session);
-
-        let msg = make_message("s1", vec![]);
-        let result = sm.agents_to_activate("s1", &msg);
-        assert!(result.is_empty());
-    }
-
-    #[test]
-    fn test_agents_to_activate_sole_agent_gets_all_messages() {
-        let tmp = TempDir::new().unwrap();
-        let mut sm = dummy_session_manager(tmp.path());
-
-        let mut session = make_session("s1");
-        session.participants.push(make_human_participant("human1"));
-        session.participants.push(make_agent_participant("agent1"));
-        sm.sessions.upsert(session);
-
-        // No mentions — sole agent still receives it
-        let msg = make_message("s1", vec![]);
-        let result = sm.agents_to_activate("s1", &msg);
-        assert_eq!(result, vec!["agent1".to_string()]);
-    }
-
-    #[test]
-    fn test_agents_to_activate_two_agents_mentioned_one() {
-        let tmp = TempDir::new().unwrap();
-        let mut sm = dummy_session_manager(tmp.path());
-
-        let mut session = make_session("s1");
-        session.participants.push(make_agent_participant("agent1"));
-        session.participants.push(make_agent_participant("agent2"));
-        sm.sessions.upsert(session);
-
-        let msg = make_message("s1", vec!["agent1".to_string()]);
-        let result = sm.agents_to_activate("s1", &msg);
-        assert_eq!(result, vec!["agent1".to_string()]);
-    }
-
-    #[test]
-    fn test_agents_to_activate_two_agents_no_mention_returns_empty() {
-        let tmp = TempDir::new().unwrap();
-        let mut sm = dummy_session_manager(tmp.path());
-
-        let mut session = make_session("s1");
-        session.participants.push(make_agent_participant("agent1"));
-        session.participants.push(make_agent_participant("agent2"));
-        sm.sessions.upsert(session);
-
-        let msg = make_message("s1", vec![]);
-        let result = sm.agents_to_activate("s1", &msg);
-        assert!(result.is_empty());
-    }
-
-    #[test]
-    fn test_agents_to_activate_sender_is_agent_still_returned() {
-        // Filtering out the sender happens in server.rs, not here.
-        // The method should still return the agent even if they sent the message.
-        let tmp = TempDir::new().unwrap();
-        let mut sm = dummy_session_manager(tmp.path());
-
-        let mut session = make_session("s1");
-        session.participants.push(make_agent_participant("agent1"));
-        sm.sessions.upsert(session);
-
-        let mut msg = make_message("s1", vec![]);
-        msg.sender_actor_id = "agent1".to_string();
-
-        let result = sm.agents_to_activate("s1", &msg);
-        assert_eq!(result, vec!["agent1".to_string()]);
-    }
-
     #[test]
     fn test_membership_refresh_targets_only_include_requester() {
         let tmp = TempDir::new().unwrap();
@@ -1890,18 +1636,6 @@ mod tests {
         (tmp, sm)
     }
 
-    fn test_message(sender_actor_id: &str, session_id: &str, content: &str) -> teamclu::Message {
-        teamclu::Message {
-            message_id: "msg-test".to_string(),
-            session_id: session_id.to_string(),
-            sender_actor_id: sender_actor_id.to_string(),
-            kind: teamclu::MessageKind::Text as i32,
-            content: content.to_string(),
-            created_at: Utc::now().timestamp(),
-            ..Default::default()
-        }
-    }
-
     #[tokio::test]
     async fn test_ensure_session_live_subscription_subscribes_without_membership_refresh() {
         let tmp = TempDir::new().unwrap();
@@ -1935,10 +1669,6 @@ mod tests {
             subs.contains(&"sess-1".to_string()),
             "expected sess-1 to be subscribed; got {subs:?}"
         );
-
-        let msg = test_message("user-1", "sess-1", "hello");
-        let activated = sm.agents_to_activate("sess-1", &msg);
-        assert_eq!(activated, vec!["daemon-actor-1".to_string()]);
     }
 
     #[tokio::test]
@@ -1961,7 +1691,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_refresh_membership_subscriptions_uses_local_actor_truth() {
+    async fn test_refresh_membership_subscriptions_reapplies_tracked_live_set() {
         let tmp = TempDir::new().unwrap();
         let (client, _eventloop) =
             rumqttc::AsyncClient::new(rumqttc::MqttOptions::new("test", "localhost", 1883), 10);
@@ -1976,24 +1706,16 @@ mod tests {
         .unwrap();
         sm.skip_live_subscription_io = true;
 
-        let mut joined = make_session("joined");
-        joined.participants.push(make_human_participant("member-a"));
-
-        let mut unrelated = make_session("unrelated");
-        unrelated
-            .participants
-            .push(make_human_participant("someone-else"));
-
-        sm.sessions.upsert(joined);
-        sm.sessions.upsert(unrelated);
-
+        sm.apply_membership_sessions(vec!["joined".to_string()])
+            .await
+            .unwrap();
         sm.refresh_membership_subscriptions().await.unwrap();
 
         assert_eq!(sm.subscribed_live_sessions(), vec!["joined".to_string()]);
     }
 
     #[tokio::test]
-    async fn test_subscribe_all_rebuilds_live_set_from_membership_truth() {
+    async fn test_subscribe_all_rebuilds_broker_live_subs_from_tracked_set() {
         let tmp = TempDir::new().unwrap();
         let (client, _eventloop) =
             rumqttc::AsyncClient::new(rumqttc::MqttOptions::new("test", "localhost", 1883), 10);
@@ -2008,11 +1730,9 @@ mod tests {
         .unwrap();
         sm.skip_live_subscription_io = true;
 
-        let mut joined = make_session("joined");
-        joined.participants.push(make_human_participant("member-a"));
-
-        sm.sessions.upsert(joined);
-
+        sm.apply_membership_sessions(vec!["joined".to_string()])
+            .await
+            .unwrap();
         sm.subscribe_all().await.unwrap();
 
         assert_eq!(sm.subscribed_live_sessions(), vec!["joined".to_string()]);
@@ -2034,17 +1754,13 @@ mod tests {
         .unwrap();
         sm.skip_live_subscription_io = true;
 
-        let mut joined = make_session("joined");
-        joined.participants.push(make_human_participant("member-a"));
-
-        sm.sessions.upsert(joined);
+        sm.apply_membership_sessions(vec!["joined".to_string()])
+            .await
+            .unwrap();
         sm.subscribe_all().await.unwrap();
         assert_eq!(sm.subscribed_live_sessions(), vec!["joined".to_string()]);
 
-        let mut unrelated = make_session("replacement");
-        sm.sessions.sessions.clear();
-        sm.sessions.upsert(unrelated);
-
+        sm.apply_membership_sessions(vec![]).await.unwrap();
         sm.subscribe_all().await.unwrap();
 
         assert!(sm.subscribed_live_sessions().is_empty());
@@ -2218,44 +1934,6 @@ mod tests {
         };
 
         let result = sm.agents_to_activate_for_idea("s1", &event);
-        assert!(result.is_empty());
-    }
-
-    // --- sessions_for_agent tests ---
-
-    #[test]
-    fn test_sessions_for_agent_in_two_sessions() {
-        let tmp = TempDir::new().unwrap();
-        let mut sm = dummy_session_manager(tmp.path());
-
-        let mut s1 = make_session("s1");
-        s1.participants.push(make_agent_participant("agent1"));
-        sm.sessions.upsert(s1);
-
-        let mut s2 = make_session("s2");
-        s2.participants.push(make_agent_participant("agent1"));
-        sm.sessions.upsert(s2);
-
-        // s3 does not have agent1
-        let mut s3 = make_session("s3");
-        s3.participants.push(make_agent_participant("agent2"));
-        sm.sessions.upsert(s3);
-
-        let mut result = sm.sessions_for_agent("agent1");
-        result.sort();
-        assert_eq!(result, vec!["s1".to_string(), "s2".to_string()]);
-    }
-
-    #[test]
-    fn test_sessions_for_agent_not_in_any_session() {
-        let tmp = TempDir::new().unwrap();
-        let mut sm = dummy_session_manager(tmp.path());
-
-        let mut s1 = make_session("s1");
-        s1.participants.push(make_agent_participant("agent2"));
-        sm.sessions.upsert(s1);
-
-        let result = sm.sessions_for_agent("agent1");
         assert!(result.is_empty());
     }
 

--- a/apps/daemon/src/teamclu/session_manager.rs
+++ b/apps/daemon/src/teamclu/session_manager.rs
@@ -662,7 +662,13 @@ impl SessionManager {
         self.sessions.upsert(stored);
 
         if is_local_participant {
-            self.ensure_session_live_subscription(&session_id).await?;
+            if let Err(e) = self.ensure_session_live_subscription(&session_id).await {
+                warn!(
+                    session_id = %session_id,
+                    err = %e,
+                    "insert_session_from_backend: ensure_session_live_subscription failed"
+                );
+            }
         }
         info!(
             session_id = %session.id,
@@ -1363,9 +1369,28 @@ impl SessionManager {
         Ok(())
     }
 
+    /// Reconcile `session/{id}/live` subs with the local participant cache
+    /// (e.g. after RemoveParticipant). Does not replay the old tracked set.
     pub async fn refresh_membership_subscriptions(&mut self) -> crate::error::Result<()> {
-        let tracked: Vec<String> = self.subscribed_live_sessions.iter().cloned().collect();
-        self.apply_membership_sessions(tracked).await
+        let desired = self.live_session_ids_from_local_membership();
+        self.apply_membership_sessions(desired).await
+    }
+
+    fn live_session_ids_from_local_membership(&self) -> Vec<String> {
+        let Some(actor_id) = self.actor_id.as_deref() else {
+            return Vec::new();
+        };
+        self.sessions
+            .sessions
+            .iter()
+            .filter(|session| {
+                session
+                    .participants
+                    .iter()
+                    .any(|participant| participant.actor_id == actor_id)
+            })
+            .map(|session| session.session_id.clone())
+            .collect()
     }
 
     pub async fn apply_membership_sessions(
@@ -1691,27 +1716,44 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_refresh_membership_subscriptions_reapplies_tracked_live_set() {
-        let tmp = TempDir::new().unwrap();
-        let (client, _eventloop) =
-            rumqttc::AsyncClient::new(rumqttc::MqttOptions::new("test", "localhost", 1883), 10);
-        let client: Arc<dyn MessagePublisher> = Arc::new(client);
-        let mut sm = SessionManager::new(
-            client,
-            "team1",
-            "dev-a",
-            Some("member-a".to_string()),
-            tmp.path().to_path_buf(),
-        )
-        .unwrap();
-        sm.skip_live_subscription_io = true;
+    async fn test_refresh_membership_subscriptions_matches_local_participant_cache() {
+        let (_tmp, mut sm) = make_test_session_manager_with_actor("member-a");
 
-        sm.apply_membership_sessions(vec!["joined".to_string()])
-            .await
-            .unwrap();
+        sm.insert_session_from_backend_for_test(
+            "joined",
+            "team1",
+            None,
+            &[("member-a", "member"), ("other", "member")],
+        )
+        .await
+        .unwrap();
         sm.refresh_membership_subscriptions().await.unwrap();
 
         assert_eq!(sm.subscribed_live_sessions(), vec!["joined".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn test_refresh_membership_subscriptions_unsubscribes_after_local_remove() {
+        let (_tmp, mut sm) = make_test_session_manager_with_actor("member-a");
+
+        sm.insert_session_from_backend_for_test(
+            "sess-left",
+            "team1",
+            None,
+            &[("member-a", "member"), ("other", "member")],
+        )
+        .await
+        .unwrap();
+        assert_eq!(sm.subscribed_live_sessions(), vec!["sess-left".to_string()]);
+
+        sm.sessions
+            .find_by_id_mut("sess-left")
+            .unwrap()
+            .participants
+            .retain(|p| p.actor_id != "member-a");
+        sm.refresh_membership_subscriptions().await.unwrap();
+
+        assert!(sm.subscribed_live_sessions().is_empty());
     }
 
     #[tokio::test]

--- a/apps/daemon/src/teamclu/session_store.rs
+++ b/apps/daemon/src/teamclu/session_store.rs
@@ -1,9 +1,12 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
-use std::path::{Path, PathBuf};
 
 use crate::proto::teamclu;
 
+/// In-memory session metadata cache for the daemon process.
+///
+/// There is no on-disk index (`index.toml` was removed): Cloud API is the source
+/// of truth; this store only holds rows the running daemon has touched.
 #[derive(Debug, Default, Serialize, Deserialize)]
 pub struct TeamcluSessionStore {
     #[serde(default)]
@@ -39,34 +42,6 @@ pub struct StoredParticipant {
 }
 
 impl TeamcluSessionStore {
-    pub fn default_path(base_dir: &Path) -> PathBuf {
-        crate::config::layout::team_state_dir_in(base_dir, &crate::config::layout::active_team())
-            .join("sessions")
-            .join("index.toml")
-    }
-
-    pub fn load(path: &Path) -> crate::error::Result<Self> {
-        if !path.exists() {
-            return Ok(Self::default());
-        }
-        let content = std::fs::read_to_string(path).map_err(|e| {
-            crate::error::AmuxError::Config(format!("read {}: {}", path.display(), e))
-        })?;
-        toml::from_str(&content).map_err(|e| {
-            crate::error::AmuxError::Config(format!("parse {}: {}", path.display(), e))
-        })
-    }
-
-    pub fn save(&self, path: &Path) -> crate::error::Result<()> {
-        if let Some(parent) = path.parent() {
-            std::fs::create_dir_all(parent)?;
-        }
-        let content = toml::to_string_pretty(self)
-            .map_err(|e| crate::error::AmuxError::Config(e.to_string()))?;
-        std::fs::write(path, content)?;
-        Ok(())
-    }
-
     pub fn upsert(&mut self, session: StoredSession) {
         if let Some(existing) = self
             .sessions
@@ -141,7 +116,6 @@ fn actor_type_to_proto(s: &str) -> teamclu::ActorType {
 mod tests {
     use super::*;
     use chrono::Utc;
-    use tempfile::TempDir;
 
     fn make_session(id: &str, _session_type: &str) -> StoredSession {
         StoredSession {
@@ -202,28 +176,6 @@ mod tests {
         assert!(store.remove("s1"));
         assert_eq!(store.sessions.len(), 1);
         assert!(!store.remove("s1")); // already removed
-    }
-
-    #[test]
-    fn test_save_and_load() {
-        let tmp = TempDir::new().unwrap();
-        let path = tmp.path().join("sessions.toml");
-
-        let mut store = TeamcluSessionStore::default();
-        store.upsert(make_session("s1", "collab"));
-        store.save(&path).unwrap();
-
-        let loaded = TeamcluSessionStore::load(&path).unwrap();
-        assert_eq!(loaded.sessions.len(), 1);
-        assert_eq!(loaded.sessions[0].session_id, "s1");
-    }
-
-    #[test]
-    fn test_load_nonexistent_returns_default() {
-        let tmp = TempDir::new().unwrap();
-        let path = tmp.path().join("nonexistent.toml");
-        let store = TeamcluSessionStore::load(&path).unwrap();
-        assert!(store.sessions.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Remove on-disk `index.toml` session membership index; daemon session cache is in-memory only, with live MQTT subs tracked in `subscribed_live_sessions`.
- Offline auto-restart plans sessions via paginated Cloud `GET /v1/sessions?kind=regular`; MQTT reconnect uses phase 1 (team topics) + phase 2 (restore tracked live subs).
- `FetchSession` RPC falls back to Cloud and caches locally; live subscribe failures are warn-only; `RemoveParticipant` reconciles live subs from local participant membership (unsub after leave).

## Test plan

- [ ] Cold-start daemon: no `index.toml` read/write under teamclu config; MQTT reconnect completes without 15s restore timeout loops.
- [ ] Open session not in local cache: `FetchSession` returns `SessionInfo` from Cloud when MQTT live sub is flaky.
- [ ] Leave a session: daemon unsubscribes `session/{id}/live` for local actor.
- [ ] `pnpm rust:check` / `cargo test -p amuxd test_refresh_membership` (daemon session_manager tests)


Made with [Cursor](https://cursor.com)