### PR TITLE
fix(team-share): probe MCP tools when selecting an Agent

### DIFF
--- a/packages/app/src/stores/__tests__/team-share-mcp-subject-refresh.test.ts
+++ b/packages/app/src/stores/__tests__/team-share-mcp-subject-refresh.test.ts
@@ -1,0 +1,69 @@
+import { describe, test, expect, beforeEach, vi } from 'vitest'
+
+// Regression test for https://github.com/different-ai-studio/teamclu/issues/1371
+//
+// Symptom: after opening the MCP panel (or switching the selected Agent), every
+// server sits at "Idle"/"Unknown" with an empty tool list until the user manually
+// clicks "Re-sync". Root cause: `setSubjectActor` reloads the mcp section with
+// `loadSection('mcp', { force: true })` — no `withTools: true` — so the probe
+// request (`getDaemonMcpTools`) never fires on the path that actually
+// establishes which Agent is selected. `loadMcpTools` only runs later, when the
+// user triggers a refresh by hand.
+
+const { createAgentManagementGrant, manageAgentCapability, listTeamMcpServers, getDaemonMcpTools } =
+  vi.hoisted(() => ({
+    createAgentManagementGrant: vi.fn(async () => ({ grant: 'grant', nonce: 'nonce' })),
+    manageAgentCapability: vi.fn(async () => ({ mcpServers: [] })),
+    listTeamMcpServers: vi.fn(async () => []),
+    getDaemonMcpTools: vi.fn(async () => ({})),
+  }))
+
+vi.mock('@/lib/utils', () => ({ isTauri: () => true }))
+vi.mock('@/lib/workspace/effective-workspace', () => ({
+  effectiveWorkspacePath: async () => '/Users/me/project',
+}))
+vi.mock('@/lib/daemon/local-daemon-identity', () => ({
+  getKnownLocalDaemonActorId: () => 'actor-1',
+  noteLocalDaemonActorId: () => {},
+}))
+vi.mock('@/lib/daemon/daemon-local-client', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/daemon/daemon-local-client')>()
+  return {
+    ...actual,
+    getDaemonMcpTools,
+    encodeWorkspaceId: (p: string) => `ws:${p}`,
+  }
+})
+vi.mock('@/lib/backend/provider', () => ({
+  getBackend: () => ({
+    actors: { createAgentManagementGrant },
+    teamMcp: { listTeamMcpServers },
+  }),
+}))
+vi.mock('@/lib/daemon/teamclu-rpc', () => ({ manageAgentCapability }))
+vi.mock('@tauri-apps/api/core', () => ({ invoke: vi.fn(async () => null) }))
+
+import { useTeamShareBrowserStore } from '../team-share-browser'
+import { useCurrentTeamStore } from '../current-team'
+
+const store = () => useTeamShareBrowserStore.getState()
+
+describe('setSubjectActor refreshes MCP tool probes', () => {
+  beforeEach(() => {
+    createAgentManagementGrant.mockClear()
+    manageAgentCapability.mockClear()
+    listTeamMcpServers.mockClear()
+    getDaemonMcpTools.mockClear()
+    useCurrentTeamStore.setState({ team: { id: 'team-1' } } as never)
+    useTeamShareBrowserStore.setState({
+      subjectActorId: null,
+      mcp: { items: [], loading: false, loaded: false, error: null },
+    })
+  })
+
+  test('selecting an Agent probes MCP tool status without a manual re-sync', async () => {
+    await store().setSubjectActor('actor-1')
+
+    expect(getDaemonMcpTools).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/app/src/stores/team-share-browser.ts
+++ b/packages/app/src/stores/team-share-browser.ts
@@ -1305,7 +1305,7 @@ export const useTeamShareBrowserStore = create<TeamShareBrowserState>((set, get)
     set({ subjectActorId: actorId, detailTarget: null })
     await Promise.all([
       get().loadSection('skills', { force: true }),
-      get().loadSection('mcp', { force: true }),
+      get().loadSection('mcp', { force: true, withTools: true }),
     ])
   },
 


### PR DESCRIPTION
## Summary
- `setSubjectActor` reloaded the MCP section via `loadSection('mcp', { force: true })` without `withTools: true`, so switching (or auto-selecting) the subject Agent never triggered `loadMcpTools`. Every server sat at "Idle"/"Unknown" with an empty tool list until the user manually clicked "Re-sync".
- Fix: pass `withTools: true` on that call, matching the 7 other mutation call sites in the same file that already do this correctly.

Fixes #1371

## Test plan
- [x] Added a regression test (`team-share-mcp-subject-refresh.test.ts`) that fails on unmodified code and passes after the fix
- [x] `pnpm typecheck` clean
- [x] Full unit suite passes (one pre-existing, unrelated `i18n-parity` failure confirmed present on clean `main`)
- [x] Manually verified in `pnpm tauri:dev`: newly installed MCP servers now show a resolved status (`Needs attention` / `Connected`) immediately, with no manual "Re-sync" click required