### PR TITLE
ci(self-host): nightly deploy instead of push-to-main

### DIFF
--- a/.github/workflows/self-host-deploy.yml
+++ b/.github/workflows/self-host-deploy.yml
@@ -1,14 +1,13 @@
 name: Self-Host Deploy
 
+# Self-host ECS no longer deploys on every merge to main. Schedule matches
+# nightly-release-oss.yml: 16:00 UTC = 00:00 Asia/Shanghai. Manual runs stay
+# available via workflow_dispatch.
+
 on:
+  schedule:
+    - cron: "0 16 * * *" # 16:00 UTC = 00:00 Asia/Shanghai
   workflow_dispatch: {}
-  push:
-    branches: [main]
-    paths:
-      - 'deploy/self-host/**'
-      - 'services/fc/**'
-      - 'services/ai-gateway/**'
-      - 'services/supabase/migrations/**'
 
 # Shared with daemon-deploy.yml deploy job — both reset /opt/teamclaw on the
 # same ECS box. Never cancel mid compose build / up.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,9 +76,9 @@ pnpm daemon:test            # Daemon tests
 pnpm ios:test:core          # AMUXCore SwiftPM tests
 pnpm ios:test               # iOS UI tests
 
-# Deploy — automatic: push to main touching deploy/self-host/**, services/fc/**,
-# services/ai-gateway/** or services/supabase/migrations/** triggers
-# self-host-deploy.yml. That covers SELF-HOST only; belayo is a separate path.
+# Deploy — self-host: nightly at 00:00 Asia/Shanghai (self-host-deploy.yml
+# schedule) or manual workflow_dispatch. No longer on push to main. Belayo is
+# a separate path.
 ```
 
 ## Architecture
@@ -299,21 +299,18 @@ The `-dev` hostnames identify the self-host test environment. Belayo's current
 topology and migration state are tracked in
 `docs/specs/2026-09-11-belayo-dokploy-target-architecture.md`.
 
-**Deploy is automatic — for self-host.** Pushing to `main` with changes under
-`deploy/self-host/**`, `services/fc/**`, `services/ai-gateway/**` or
-`services/supabase/migrations/**` triggers
-`.github/workflows/self-host-deploy.yml`, which SSHes to the box, `git pull`s,
+**Self-host deploys on a nightly schedule**, not on every merge.
+`.github/workflows/self-host-deploy.yml` runs at 00:00 Asia/Shanghai (`cron:
+0 16 * * *` UTC) and on `workflow_dispatch`. It SSHes to the box, `git pull`s,
 `docker compose build fc ai-gateway`, `docker compose up -d`, waits for both to
 report healthy, then runs `run-e2e.sh`.
 
-**belayo does not ride that workflow**, and the difference has stranded it
-before. Self-host builds the gateway from source in compose; belayo's Dokploy
-app is `sourceType: docker`, so it pulls a pre-built image from Alibaba ACR and
-a source change reaches it only when someone builds and pushes that image.
-`.github/workflows/belayo-ai-gateway.yml` now does that on the same trigger —
-before it existed, self-host moved forward on every merge while belayo silently
-stayed on an image from weeks earlier, with nothing anywhere reporting the
-drift. Database migrations are applied by the `migrate`
+**belayo does not ride that workflow.** Self-host builds the gateway from
+source in compose; belayo's Dokploy app is `sourceType: docker`, so it pulls a
+pre-built image from Alibaba ACR and a source change reaches it only when
+someone builds and pushes that image. `.github/workflows/belayo-ai-gateway.yml`
+still triggers on push to `main` under `services/ai-gateway/**` (and on
+`workflow_dispatch`). Database migrations are applied by the `migrate`
 compose service (`deploy/self-host/init/apply-migrations.sh`, tracked in
 `_selfhost.schema_migrations`, idempotent, lexical order).
 

--- a/docs/deployment/full-backend-stack.md
+++ b/docs/deployment/full-backend-stack.md
@@ -85,14 +85,12 @@ cp .env.example .env
 
 **Podman 本地访问：** Caddy `http://api.example.com:8080`，FC 直连 `http://127.0.0.1:9000`。
 
-### CI 自动部署（唯一发布路径）
+### CI 部署（夜间定时 + 手动）
 
-push 到 `main` 且改动 `deploy/self-host/**`、`services/fc/**` 或
-`services/supabase/migrations/**` 时，`.github/workflows/self-host-deploy.yml`
-自动 SSH 到 ECS：`git pull` → `docker compose build fc` → `up -d` → 等健康 →
-跑 `run-e2e.sh`。也可 `workflow_dispatch` 手动触发。
-
-> 换言之：**合入 `main` 即部署**，无需手动脚本。
+`.github/workflows/self-host-deploy.yml` 每天 00:00 Asia/Shanghai（`cron:
+0 16 * * *` UTC）跑一次，也可 `workflow_dispatch` 手动触发。合入 `main`
+不再自动部署。流程：SSH 到 ECS → `git pull` → `docker compose build fc
+ai-gateway` → `up -d` → 等健康 → 跑 `run-e2e.sh`。
 
 ---
 
@@ -216,8 +214,8 @@ docker compose build fc && docker compose up -d fc
 方式一旦只配在 env 里，一次无关的常规部署就会让登录按钮消失。放代码里则跟着版本走，
 可 review、有 git 历史。
 
-改一个开关 = 改 `feature-profiles.ts` 提 PR：self-host 合并到 main 自动部署生效，
-belayo 跟着下次手工部署生效。
+改一个开关 = 改 `feature-profiles.ts` 提 PR：self-host 等夜间部署（或手动
+`workflow_dispatch`）生效，belayo 跟着下次手工部署生效。
 
 两条不下发的规则，别绕：
 
@@ -312,7 +310,7 @@ Daemon 需要：
 | Self-host（唯一环境） | `https://api.teamclu-dev.ucar.cc` |
 | 自建的其他实例 | `https://${FC_DOMAIN}` |
 
-**发布桌面版前：** 若 Cloud API 有 breaking 变更，需先让 Cloud API + migration 部署完成（合入 `main` 即自动部署），再发客户端。见 [`docs/release/desktop.md`](../release/desktop.md)。
+**发布桌面版前：** 若 Cloud API 有 breaking 变更，需先让 Cloud API + migration 部署完成（夜间 self-host 部署或手动 `workflow_dispatch`），再发客户端。见 [`docs/release/desktop.md`](../release/desktop.md)。
 
 Web 开发可覆盖：`VITE_CLOUD_API_URL=...`
 
@@ -424,7 +422,7 @@ cd services/supabase && npm test   # pgTAP（若已配置）
 | [`deploy/self-host/README.md`](../../deploy/self-host/README.md) | Self-host 完整操作手册 |
 | [`deploy/self-host/docker-compose.yml`](../../deploy/self-host/docker-compose.yml) | 服务编排 + 环境变量权威来源 |
 | [`deploy/self-host/.env.example`](../../deploy/self-host/.env.example) | 可配置项清单 |
-| [`.github/workflows/self-host-deploy.yml`](../../.github/workflows/self-host-deploy.yml) | 自动部署流水线 |
+| [`.github/workflows/self-host-deploy.yml`](../../.github/workflows/self-host-deploy.yml) | Self-host 夜间 / 手动部署流水线 |
 | [`services/supabase/migrations/README.md`](../../services/supabase/migrations/README.md) | Migration 策略 |
 | [`docs/architecture/v2.md`](../architecture/v2.md) | 架构总览 |
 | [`docs/openapi/teamclu-api.v1.yaml`](../openapi/teamclu-api.v1.yaml) | API 契约 |


### PR DESCRIPTION
## Summary
- Remove `push`/`paths` triggers from `self-host-deploy.yml` so merges to `main` no longer auto-deploy self-host.
- Add a nightly `cron: "0 16 * * *"` (00:00 Asia/Shanghai), aligned with nightly OSS; keep `workflow_dispatch`.
- Update `CLAUDE.md` and `docs/deployment/full-backend-stack.md` to match. Belayo gateway workflow is unchanged.

## Test plan
- [ ] Confirm the PR diff only changes the `on:` block (plus docs) and leaves deploy steps intact
- [ ] After merge, verify Actions → Self-Host Deploy no longer runs on FC/gateway/migration pushes
- [ ] Optionally `workflow_dispatch` once to confirm manual path still works
- [ ] Next calendar midnight Shanghai: confirm a scheduled run appears


Made with [Cursor](https://cursor.com)