### PR TITLE
fix(webview): stop crashing on a live URL query during page load

### DIFF
--- a/apps/desktop/src/commands/webview.rs
+++ b/apps/desktop/src/commands/webview.rs
@@ -739,7 +739,13 @@ pub async fn webview_create(
 
             // A navigation away from the trusted origin (redirect, link, SSO
             // hop) must not carry the identity object with it.
-            let on_trusted_origin = webview.url().ok().map(|u| origin_key(&u)) == identity_origin;
+            //
+            // Read the URL from the load event, not `webview.url()`: that live
+            // getter round-trips into WKWebView.URL, which is nil until a
+            // navigation commits, and wry 0.55.1 unwraps it instead of
+            // returning an error — panicking the whole process on the
+            // PageLoadEvent::Started for a just-created webview.
+            let on_trusted_origin = Some(origin_key(payload.url())) == identity_origin;
             if let (Some((device_no, device_name)), true) = (&identity, on_trusted_origin) {
                 let script = build_teamclu_identity_script(device_no, device_name);
                 match payload.event() {

--- a/apps/desktop/src/commands/webview.rs
+++ b/apps/desktop/src/commands/webview.rs
@@ -942,14 +942,27 @@ pub async fn webview_navigate(
     Ok(())
 }
 
+/// `webview.url()` round-trips into the native WKWebView.URL getter, which is
+/// nil until a navigation commits. wry 0.55.1's `url_from_webview` unwraps
+/// that instead of returning an error (the same panic `webview_create`'s
+/// `on_page_load` handler avoids above by reading the load event's own URL
+/// instead) — so catch it here rather than crash the process on a webview
+/// that hasn't loaded anything yet. `WebViewToolbar.tsx` polls the commands
+/// built on this every 2s starting 2s after a webview is created, which is
+/// well within the window a slow-loading page can still be uncommitted.
+pub(crate) fn webview_url_safe<R: tauri::Runtime>(
+    webview: &tauri::Webview<R>,
+) -> Result<tauri::Url, String> {
+    std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| webview.url()))
+        .map_err(|_| "webview has not committed a navigation yet".to_string())?
+        .map_err(|e| e.to_string())
+}
+
 /// Get the current URL of the webview.
 #[tauri::command]
 pub async fn webview_get_url(app: tauri::AppHandle, label: String) -> Result<String, String> {
     if let Some(webview) = app.get_webview(&label) {
-        return webview
-            .url()
-            .map(|u| u.to_string())
-            .map_err(|e| format!("{}", e));
+        return webview_url_safe(&webview).map(|u| u.to_string());
     }
     Err("Webview not found".to_string())
 }
@@ -1033,7 +1046,7 @@ pub async fn webview_read_local_storage(
 
     // Only harvest when the webview is actually on the caller-declared host.
     let allowed = expected_host.as_deref().filter(|h| !h.is_empty());
-    match (allowed, webview.url()) {
+    match (allowed, webview_url_safe(&webview)) {
         (Some(host), Ok(url)) if url.host_str() == Some(host) => {}
         _ => return Ok(None),
     }
@@ -1147,7 +1160,7 @@ pub async fn webview_read_local_storage(
 #[tauri::command]
 pub async fn webview_get_favicon(app: tauri::AppHandle, label: String) -> Result<String, String> {
     if let Some(webview) = app.get_webview(&label) {
-        let url = webview.url().map_err(|e| format!("{}", e))?;
+        let url = webview_url_safe(&webview)?;
         if let Some(host) = url.host_str() {
             let scheme = url.scheme();
             let port = url.port().map(|p| format!(":{}", p)).unwrap_or_default();

--- a/apps/desktop/src/webview_recovery.rs
+++ b/apps/desktop/src/webview_recovery.rs
@@ -23,10 +23,12 @@ pub fn should_restart_for_probe(probe: MainWebviewProbe) -> bool {
 /// used to restart the whole app even though the main webview was healthy.
 pub fn probe_main_webview(app: &tauri::AppHandle) -> MainWebviewProbe {
     classify_main_webview_url(app.get_webview("main").map(|webview| {
-        webview.url().map(|_| ()).map_err(|err| {
-            log::error!("[WebViewRecovery] main webview URL probe failed: {err}");
-            err.to_string()
-        })
+        crate::commands::webview::webview_url_safe(&webview)
+            .map(|_| ())
+            .map_err(|err| {
+                log::error!("[WebViewRecovery] main webview URL probe failed: {err}");
+                err
+            })
     }))
 }
 


### PR DESCRIPTION
## Summary
- `webview_create`'s `on_page_load` handler called `webview.url()` to check whether a navigation stayed on the trusted origin before injecting the identity script.
- That getter round-trips into `WKWebView.URL`, which is `nil` until a navigation commits. `wry` 0.55.1's `url_from_webview` (`wkwebview/mod.rs:1349`) unwraps it instead of returning an error, so it panics the whole desktop process — observed opening an app-preview webview at a local dev URL, right after `[Webview] Created successfully` logged.
- Fix: read the URL from `payload.url()` instead — the URL Tauri already attaches to the page-load event from the navigation itself, never a live re-query of the WKWebView object, so it can't be nil.

**Follow-up from code review:** three other call sites in the same file (`webview_get_url`, `webview_read_local_storage`, `webview_get_favicon`) plus `webview_recovery.rs`'s main-webview health probe call the same panicking `webview.url()` getter and already handle a `Result`-typed error from it — but since wry panics instead of returning one, none of that error handling ever runs. This is a live path, not theoretical: `WebViewToolbar.tsx` polls `webview_get_url`/`webview_get_favicon` every 2s starting 2s after a webview is created, well within the window a slow-loading page can still have no committed navigation. Added `webview_url_safe`, a `catch_unwind` wrapper around the call (same pattern already used in `terminal/pty.rs` for isolating a third-party panic), and routed all four remaining sites through it.

## Test plan
- [x] `pnpm rust:check` clean
- [x] `pnpm rust:clippy` clean
- [x] Manually reproduced the original crash on `main` (opening a webview to a local dev URL panicked the process with `called \`Option::unwrap()\` on a \`None\` value` at `wry-0.55.1/src/wkwebview/mod.rs:1349`)
- [x] Confirmed fixed: same flow now either loads cleanly or fails closed with a clean pre-flight error, no panic
- [x] `/code-review` run on the initial commit; this PR's second commit addresses its finding