### PR TITLE
fix(team-share): keep MCP probes when a slow refresh lands last

### DIFF
--- a/packages/app/src/stores/__tests__/team-share-mcp-probe-race.test.ts
+++ b/packages/app/src/stores/__tests__/team-share-mcp-probe-race.test.ts
@@ -1,0 +1,99 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+const { getDaemonMcpTools, manageAgentCapability, listTeamMcpServers } = vi.hoisted(() => ({
+  getDaemonMcpTools: vi.fn(),
+  manageAgentCapability: vi.fn(),
+  listTeamMcpServers: vi.fn(),
+}))
+
+vi.mock('@/lib/utils', () => ({ isTauri: () => true }))
+vi.mock('@/lib/workspace/effective-workspace', () => ({
+  effectiveWorkspacePath: async () => '/Users/me/project',
+}))
+vi.mock('@/lib/backend/provider', () => ({
+  getBackend: () => ({
+    teamMcp: { listTeamMcpServers },
+    actors: { createAgentManagementGrant: async () => ({ grant: 'g', nonce: 'n' }) },
+  }),
+}))
+vi.mock('@/lib/daemon/teamclu-rpc', () => ({ manageAgentCapability }))
+vi.mock('@/lib/agent/agent-device-reachability', () => ({
+  resolveAgentDevicePresenceSync: () => 'online',
+}))
+vi.mock('@tauri-apps/api/core', () => ({ invoke: vi.fn(async () => null) }))
+vi.mock('@/lib/daemon/local-daemon-identity', () => ({
+  getKnownLocalDaemonActorId: () => 'actor-1',
+}))
+vi.mock('@/lib/daemon/daemon-local-client', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/daemon/daemon-local-client')>()
+  return { ...actual, getDaemonMcpTools }
+})
+
+import { useTeamShareBrowserStore } from '../team-share-browser'
+import { useCurrentTeamStore } from '../current-team'
+
+const store = () => useTeamShareBrowserStore.getState()
+
+/** One built-in server, the shape the daemon's `mcp:list` inventory returns. */
+function inventory() {
+  return {
+    mcpServers: [
+      {
+        id: 'teamclu-introspect',
+        name: 'teamclu-introspect',
+        transport: 'stdio',
+        source: 'builtin',
+        configStatus: 'installed',
+        commandOrUrl: '/Applications/TeamClu.app/Contents/MacOS/teamclu-introspect',
+        configuredEnvKeys: [],
+        configuredHeaderKeys: [],
+      },
+    ],
+  }
+}
+
+describe('a slow MCP refresh that does not probe must not drop a probe', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    useCurrentTeamStore.setState({ team: { id: 'team-1' } } as never)
+    useTeamShareBrowserStore.setState({
+      subjectActorId: 'actor-1',
+      mcp: { items: [], loading: false, loaded: false, error: null },
+    })
+    manageAgentCapability.mockResolvedValue(inventory())
+    getDaemonMcpTools.mockResolvedValue({
+      'teamclu-introspect': {
+        probe_status: 'ready',
+        tools: ['get_my_capabilities', 'manage_mcp'],
+        error: null,
+        probed_at: '2026-09-11T00:00:00Z',
+      },
+    })
+  })
+
+  test('keeps the tools when a non-probing refresh resolves last', async () => {
+    // The no-tools load (`loadCounts` on a team/workspace switch) starts first
+    // and its catalog fetch is slow; the probing load that opens the pane
+    // finishes first. Its late `set` used to restore the unprobed rows it
+    // snapshotted at start — every server went back to "Idle · 0 tools".
+    let calls = 0
+    listTeamMcpServers.mockImplementation(async () => {
+      calls += 1
+      if (calls === 1) await new Promise((resolve) => setTimeout(resolve, 50))
+      return []
+    })
+
+    const slowNoTools = store().loadSection('mcp', { force: true })
+    await new Promise((resolve) => setTimeout(resolve, 5))
+    const fastProbing = store().loadSection('mcp', { force: true, withTools: true })
+    await Promise.all([slowNoTools, fastProbing])
+
+    expect(store().mcp.items).toHaveLength(1)
+    expect(store().mcp.items[0]).toMatchObject({
+      id: 'teamclu-introspect',
+      kind: 'builtin',
+      probeStatus: 'ready',
+      tools: ['get_my_capabilities', 'manage_mcp'],
+    })
+  })
+})

--- a/packages/app/src/stores/team-share-browser.ts
+++ b/packages/app/src/stores/team-share-browser.ts
@@ -2228,7 +2228,22 @@ export const useTeamShareBrowserStore = create<TeamShareBrowserState>((set, get)
           get().mcp.items,
           get().subjectActorId ?? undefined,
         )
-        set({ mcp: { items, loading: false, loaded: true, error: null } })
+        // `listTeamMcp` merges the probes it saw when THIS call started, which
+        // is stale whenever a probing load landed while this one was in flight.
+        // A refresh that does not probe (`loadCounts` on a team/workspace
+        // switch, `createMcp`) routinely outlives the probing load that opened
+        // the pane, and its late `set` then put every probed server back to
+        // "Idle · 0 tools" — with nothing left to re-probe, until the user
+        // clicked Re-sync. Merge against the live rows at write time instead.
+        set((s) => ({
+          mcp: {
+            ...s.mcp,
+            items: preserveMcpProbes(items, s.mcp.items),
+            loading: false,
+            loaded: true,
+            error: null,
+          },
+        }))
         if (opts?.withTools) await get().loadMcpTools()
       }
     } catch (e) {


### PR DESCRIPTION
## Summary

Fixes #1371.

A refresh that does **not** probe (`loadCounts` on a team / workspace switch, `createMcp`) calls `listTeamMcp` with the rows it saw when it started, then `set`s the result unconditionally. When that call is slower than the probing load that opened the MCP pane, its late write restores the unprobed snapshot taken at start — every server flips back to **“Idle · 0 tools”** and stays there, because the MCP list only re-probes on section change, so nothing fixes it until the user clicks **Re-sync**.

This is the remaining cause after #1324 (which fixed the `setSubjectActor` → `withTools` path). #1385 was closed as a duplicate of that same fix.

Fix: merge against the live rows at write time (`preserveMcpProbes(items, s.mcp.items)`) so a non-probing refresh keeps any probe that landed while it was in flight.

## Before / after (same race, non-probing refresh resolves last)

| | Before | After |
| --- | --- | --- |
| probing load finishes | `ready/8, ready/29, skipped, ready/21` | same |
| slow non-probing load lands last | **`unknown/0` ×4** (the reported symptom) | `ready/8, ready/29, skipped, ready/21` |

Reproduced live on the dev app by stalling the first `listTeamMcpServers` call 15s via tauri-mcp `execute_js`; with the fix the same race keeps the probes.

## Test plan

- [x] New regression test `packages/app/src/stores/__tests__/team-share-mcp-probe-race.test.ts` — fails on unmodified code (`probeStatus: unknown`, `tools: []`), passes with the fix
- [x] `pnpm typecheck` clean
- [x] `pnpm vitest run src/stores/__tests__/team-share src/lib/__tests__/daemon-mcp-tools.test.ts` — 14 files / 60 tests pass
- [x] eslint clean on both changed files
- [x] Manually verified in the running `pnpm tauri:dev` via a controlled race (see table)
- Note: 3 pre-existing failures in `src/stores` (`session-pins`, `acp-debug-store`) reproduce on clean `main` — unrelated.

## Out of scope (noticed while debugging)

The RPC path sets `enabled: item.configStatus === 'installed'`, which is always true, so a server disabled in the daemon (`playwright` on this machine) still renders with the toggle on. Separate issue.
