### PR TITLE
chore/gitignore-cargo-target-star

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@ dist/
 !apps/daemon/tests/fixtures/pi-host-stub/dist/
 target/
 .cargo-target/
-.cargo-target-fix/
+.cargo-target-*/
 *.tsbuildinfo
 
 # IDE


### PR DESCRIPTION
Commits:
- chore: ignore all .cargo-target-* local Cargo dirs

Opened by seahelm `/return`.