### PR TITLE
fix(daemon): fan out auth_logout so live pi children drop removed providers

### DIFF
--- a/apps/daemon/src/http/apps.rs
+++ b/apps/daemon/src/http/apps.rs
@@ -380,9 +380,8 @@ pub async fn app_manifest(
 ///
 /// Re-seeding an existing template checkout is safe: the template is written
 /// over the top, so a wrecked app can be repaired without losing the agent's
-/// other files. Re-seeding a *cloned* app is refused rather than made safe —
-/// `app_clone` will not clone over a non-empty directory, because the only
-/// thing it could do there is destroy the user's repo.
+/// other files. A cloned app with an existing checkout is already ready:
+/// `app_clone` skips the clone and leaves the directory untouched.
 pub async fn seed_app(
     principal: Principal,
     State(_state): State<HttpState>,

--- a/apps/daemon/src/runtime/pi_rpc/mod.rs
+++ b/apps/daemon/src/runtime/pi_rpc/mod.rs
@@ -469,12 +469,13 @@ struct EstablishedSession {
 /// A successful login already fans out from its `auth_login_end` host event
 /// ([`events::broadcast_auth_refresh`]), so it is deliberately absent here.
 /// What it cannot cover: a `models.json` write (custom provider added, edited
-/// or deleted) and an explicit `auth_refresh` both change the catalog every
-/// live child serves, and pi reports them as a plain command response, never
-/// as a host event. Without this, a provider added from the settings pane is
-/// invisible to new sessions too — `attach` reuses a pooled (often prewarmed)
-/// child, so its `get_available_models` still answers from the pre-add
-/// `ModelRuntime`.
+/// or deleted), a logout, and an explicit `auth_refresh` all change the
+/// catalog every live child serves, and pi reports them as a plain command
+/// response, never as a host event. Without this, a provider added from the
+/// settings pane is invisible to new sessions too — `attach` reuses a pooled
+/// (often prewarmed) child, so its `get_available_models` still answers from
+/// the pre-add `ModelRuntime` — and a provider removed there stays selectable
+/// in every chat already open (#1391).
 fn auth_command_refresh_fanout(request: &serde_json::Value) -> Option<Option<String>> {
     match request.get("type").and_then(|v| v.as_str()) {
         // Full rebuild, never a provider scope: a brand-new provider id has
@@ -486,6 +487,22 @@ fn auth_command_refresh_fanout(request: &serde_json::Value) -> Option<Option<Str
         // rest of the device learns about it the same way a login teaches
         // them, scoped to the provider when the caller named one.
         Some("auth_refresh") => Some(
+            request
+                .get("providerId")
+                .and_then(|v| v.as_str())
+                .filter(|p| !p.trim().is_empty())
+                .map(str::to_string),
+        ),
+        // A logout revokes one provider's credentials on the auth child. Every
+        // other live child's `ModelRuntime` still has that provider marked
+        // usable until told otherwise, and — unlike a login — there is no
+        // `auth_login_end` host event to carry the news, so nothing else
+        // reaches them. Scoped like `auth_refresh`: one provider disappearing,
+        // not a rebuild of the whole catalog. The request always names a
+        // provider (`pi_auth.rs`'s `logout_provider` puts it on the path), but
+        // fall through to a full refresh if that ever stops being true rather
+        // than silently dropping the fan-out.
+        Some("auth_logout") => Some(
             request
                 .get("providerId")
                 .and_then(|v| v.as_str())
@@ -1869,6 +1886,20 @@ mod tests {
     }
 
     #[test]
+    fn a_logout_fans_out_scoped_to_its_provider() {
+        let logout = serde_json::json!({"type": "auth_logout", "providerId": "kimi-coding"});
+        assert_eq!(
+            auth_command_refresh_fanout(&logout),
+            Some(Some("kimi-coding".to_string()))
+        );
+
+        // No provider named (should not happen — the HTTP handler always puts
+        // one on the path — but a full refresh is the safe fallback).
+        let bare = serde_json::json!({"type": "auth_logout"});
+        assert_eq!(auth_command_refresh_fanout(&bare), Some(None));
+    }
+
+    #[test]
     fn commands_that_do_not_change_the_catalog_do_not_fan_out() {
         // A login fans out from its `auth_login_end` host event instead.
         for ty in [
@@ -1876,7 +1907,6 @@ mod tests {
             "auth_login_cancel",
             "auth_models_get",
             "auth_list",
-            "auth_logout",
         ] {
             let req = serde_json::json!({"type": ty});
             assert_eq!(

--- a/apps/daemon/src/sync/app_clone.rs
+++ b/apps/daemon/src/sync/app_clone.rs
@@ -29,6 +29,17 @@ const CLONE_TIMEOUT: Duration = Duration::from_secs(5 * 60);
 /// mapping cannot drift from what is thrown.
 pub const ERR_CLONE_TIMEOUT: &str = "git clone timed out after 5 minutes";
 
+/// What a clone request did to its target directory.
+///
+/// A pre-existing checkout is already usable.  Treating it as a success avoids
+/// making retry/redeploy flows fail merely because their earlier clone worked.
+/// We still never write over it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CloneOutcome {
+    Cloned,
+    AlreadyPresent,
+}
+
 /// Whether `dir` has anything in it (a missing directory counts as empty).
 fn is_empty_dir(dir: &Path) -> bool {
     match std::fs::read_dir(dir) {
@@ -39,22 +50,19 @@ fn is_empty_dir(dir: &Path) -> bool {
 
 /// Clone `url` into `workdir`.
 ///
-/// Refuses a non-empty `workdir`: cloning into an app that already has files
-/// would either fail halfway or bury work the agent has already done, and the
-/// caller (app creation) only ever passes a fresh directory.
+/// Leaves a non-empty `workdir` untouched and reports it as already present:
+/// cloning into an app that already has files would either fail halfway or bury
+/// work the agent has already done.
 ///
 /// Runs non-interactively. A private repo the machine has no credential for
 /// must fail with an error the user can read, not park a `git` process on a
 /// password prompt no one can see — hence `GIT_TERMINAL_PROMPT=0` and ssh's
 /// `BatchMode`, and the time limit in [`run_clone`] for the prompts those two
 /// cannot reach.
-pub fn clone_app_repo(url: &str, workdir: &Path) -> anyhow::Result<()> {
+pub fn clone_app_repo(url: &str, workdir: &Path) -> anyhow::Result<CloneOutcome> {
     let url = app_git::validate_remote_url(url)?;
     if !is_empty_dir(workdir) {
-        anyhow::bail!(
-            "refusing to clone into a non-empty directory: {}",
-            workdir.display()
-        );
+        return Ok(CloneOutcome::AlreadyPresent);
     }
     if let Some(parent) = workdir.parent() {
         std::fs::create_dir_all(parent)?;
@@ -63,11 +71,13 @@ pub fn clone_app_repo(url: &str, workdir: &Path) -> anyhow::Result<()> {
     // empty, but leaving it behind on failure would make the next attempt look
     // like a half-finished checkout.
     let _ = std::fs::remove_dir(workdir);
-    run_clone(&url, workdir, None)
+    run_clone(&url, workdir, None)?;
+    Ok(CloneOutcome::Cloned)
 }
 
 /// Clone `url` into `workdir` using a Gitea deploy key (on-demand checkout for
-/// collaborators — §5.4). Same empty-dir rule as [`clone_app_repo`].
+/// collaborators — §5.4). A pre-existing checkout is left untouched, as in
+/// [`clone_app_repo`].
 pub fn clone_app_repo_with_deploy_key(
     url: &str,
     app_id: &str,
@@ -75,13 +85,10 @@ pub fn clone_app_repo_with_deploy_key(
     deploy_key_pem: &str,
     git_user_name: Option<&str>,
     git_user_email: Option<&str>,
-) -> anyhow::Result<()> {
+) -> anyhow::Result<CloneOutcome> {
     let url = app_git::validate_remote_url(url)?;
     if !is_empty_dir(workdir) {
-        anyhow::bail!(
-            "refusing to clone into a non-empty directory: {}",
-            workdir.display()
-        );
+        return Ok(CloneOutcome::AlreadyPresent);
     }
     if let Some(parent) = workdir.parent() {
         std::fs::create_dir_all(parent)?;
@@ -101,7 +108,7 @@ pub fn clone_app_repo_with_deploy_key(
     if let Err(e) = app_git::set_repo_ssh_command(workdir, app_id) {
         tracing::warn!(app_id, error = %e, "could not point the clone at git-ssh");
     }
-    Ok(())
+    Ok(CloneOutcome::Cloned)
 }
 
 /// `git clone <remote> <workdir>`, with the environment that keeps it
@@ -177,15 +184,17 @@ mod tests {
     }
 
     #[test]
-    fn refuses_to_clone_over_existing_work() {
+    fn skips_a_clone_over_existing_work() {
         let tmp = tempfile::tempdir().unwrap();
         let work = tmp.path().join("app");
         std::fs::create_dir_all(&work).unwrap();
         std::fs::write(work.join("index.html"), b"the agent wrote this").unwrap();
 
-        let err = clone_app_repo("https://example.com/repo.git", &work).unwrap_err();
-        assert!(format!("{err}").contains("non-empty"), "got {err}");
-        // and the existing file is still there
+        assert_eq!(
+            clone_app_repo("https://example.com/repo.git", &work).unwrap(),
+            CloneOutcome::AlreadyPresent
+        );
+        // The existing file is still there, and `git` was not run.
         assert!(work.join("index.html").is_file());
     }
 


### PR DESCRIPTION
## Summary
- Fixes #1391: removing a pi provider in Settings (logout) left its models selectable in the chat model picker — the picker for an already-warm/already-attached session kept the pi child's stale in-process catalog.
- `auth_command_refresh_fanout` already broadcasts `auth_refresh` to every other live pi child on login, on a `models.json` write, and on an explicit refresh — but `auth_logout` was explicitly excluded (and pinned by a test asserting it must not fan out), with nothing else propagating the change. A pooled/prewarmed child, or any chat attached before the removal, never learned the provider was gone until its runtime happened to restart.
- Scopes the fan-out to the logged-out provider, matching the existing `auth_refresh` behavior.
- Also includes an unrelated pre-existing commit on this branch (`fix(apps): skip clone when checkout already exists`).

## Known residual gap (not fixed here)
`RuntimeHandle.available_models` — the data actually published as the MQTT retain the chat picker trusts most — is captured once at `attach` time and never refreshed afterward by design (`manager.rs`: "models come only from the live serve catalog captured at attach time"). This fix makes the pi child's own catalog fresh immediately (so a *new* session/attach reusing that child sees the update right away), but a chat window that was **already open** before the provider was removed keeps showing the old list until that session's runtime restarts. Making an already-open chat live-refresh its model list would be a larger, separate change across the pi_rpc → RuntimeManager → MQTT-publish boundary, and raises a product question (should the model list change mid-session?) worth deciding separately.

## Test plan
- [x] `node scripts/daemon-cargo.js check` — compiles clean
- [x] `node scripts/daemon-cargo.js test --bin amuxd -- pi_rpc::tests` — all 20 `pi_rpc` unit tests pass, including the new `a_logout_fans_out_scoped_to_its_provider`
- [ ] Manual repro: log out a pi provider from Settings, open a new chat, confirm its models no longer appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)