### PR TITLE
feat(fc): reuse configured auth methods for app login

### DIFF
--- a/deploy/belayo/README.md
+++ b/deploy/belayo/README.md
@@ -45,7 +45,7 @@ add secret values to these manifests.
 
 | Capability | Self-host | Belayo | Status |
 |---|---|---|---|
-| Cloud API | Caddy to fc:9000 | FC production; Traefik shadow to cloud-api:9000 | Migration pending |
+| Cloud API | Caddy to fc:9000 | Dokploy/Traefik to cloud-api:9000 | Migrated; Alibaba FC is pending decommission |
 | AI Gateway internal | ai-gateway:4001 | teamclu-ai-gateway-iiq8f3:4001 | Aligned |
 | AI Gateway public | /ai/* on the Cloud API host | ai-gateway.service.ucar.cc | Intentional |
 | MQTT WebSocket | Caddy to emqx:8083 | Traefik to emqx:8083 | Aligned |

--- a/deploy/self-host/.env.example
+++ b/deploy/self-host/.env.example
@@ -687,6 +687,10 @@ MAILER_URLPATHS_EMAIL_CHANGE=/auth/v1/verify
 #   http://127.0.0.1:*/callback  desktop loopback (random port, see
 #                                apps/desktop/src/commands/oauth_loopback.rs)
 #   teamclu://auth-callback     iOS ASWebAuthenticationSession + Expo
+#   https://<LOGIN_DOMAIN>/oauth/callback  FC app-hosted Google/WeChat login
+# Set LOGIN_DOMAIN first and append its exact callback to the value below when
+# enabling a social login on the FC app login page. Email and phone OTP do not
+# need a redirect allow-list entry.
 # The globs stop at "." and "/", so the port wildcard above matches but does
 # not leak into other paths.
 #

--- a/deploy/self-host/.env.local.example
+++ b/deploy/self-host/.env.local.example
@@ -116,7 +116,8 @@ MAILER_URLPATHS_INVITE=/auth/v1/verify
 MAILER_URLPATHS_RECOVERY=/auth/v1/verify
 MAILER_URLPATHS_EMAIL_CHANGE=/auth/v1/verify
 # The chromiumapp.org entry is the Chrome extension's synthetic OAuth redirect
-# (chrome.identity.launchWebAuthFlow); see .env.example for the full note.
+# (chrome.identity.launchWebAuthFlow). If FC app login enables Google/WeChat,
+# also append https://<LOGIN_DOMAIN>/oauth/callback to this list.
 ADDITIONAL_REDIRECT_URLS=http://127.0.0.1:*/callback,teamclu://auth-callback,https://nlmkpmokfbboonocdnngddbfpdedkfee.chromiumapp.org/
 
 # Google sign-in — off unless both values are filled. The OAuth client must be

--- a/docs/specs/2026-09-08-apps-login-and-custom-domain-design.md
+++ b/docs/specs/2026-09-08-apps-login-and-custom-domain-design.md
@@ -5,6 +5,16 @@
 - 行号基线：`8aae0a060`
 - 前置文档：`docs/specs/2026-08-27-apps-self-serve-gitea-fc-design.md`（§6 `auth_mode`、§7 公开性、§8 路线图把「自定义域名」列在 Phase 2）
 
+> **2026-09-11 增补（FC app 登录）**：中心登录页复用 Tauri 的 `features.auth` 配置，
+> 同步提供邮箱 OTP、手机号 OTP、Google OAuth PKCE，以及配置了 `WEBSSO_LOGIN_URL` 时的 Web SSO。
+> 手机号登录直接复用 FC auth repository；这些登录/注册路径只创建或复用 Supabase 用户，
+> 不调用 team bootstrap。Web SSO 在 Tauri 中仍使用原生 WebView + localStorage；FC 浏览器流
+> 使用回调桥接，因此配置的登录页需要把 PKCE code 回跳到 `redirect_to`，或把 Supabase 会话
+> 放在回调 URL fragment 中。
+
+本增补 supersedes 下文关于「FC app 不支持 Google/社交登录」的非目标描述；动态 OAuth 2.1
+客户端注册、`app` 自己的登录页和独立用户池仍不在范围内。
+
 ## 0. 一句话
 
 给部署出去的 app 两样东西：一道**真正挡得住、且认得出员工**的登录墙（终端用户注册进我们
@@ -150,7 +160,7 @@ GOTRUE_URI_ALLOW_LIST=http://127.0.0.1:*/callback,teamclaw://auth-callback,teamc
 **非目标（本轮不做）**
 
 - `third`（第三方 IdP）仍然拒绝部署，行为不变。
-- Google / Apple 等社交登录进 app（需要 redirect allow list，见 §7 R3）。
+- Apple 等原生登录进 app；FC app 的 Google/WeChat 浏览器登录见本页 2026-09-11 增补。
 - app 独立用户池 / 独立 Supabase project。
 - 按 team、按 per-app 授权名单的更细粒度受众（`app_member_access` 已存在，本轮不接）。
 - 域名级访问策略（IP 白名单、地域限制）。
@@ -179,13 +189,14 @@ GOTRUE_URI_ALLOW_LIST=http://127.0.0.1:*/callback,teamclaw://auth-callback,teamc
 `data_app` 没有影响 —— 它的数据在自己的 Postgres schema（`DATABASE_URL`），本来就不
 经过 Supabase。
 
-### D2 · 用邮箱验证码（OTP），不用 OAuth 2.1，也不用 magic link
+### D2 · 邮箱验证码（OTP）是默认流程；FC 登录主机按配置支持 PKCE
 
-依据 §1.3。附带收益：不需要开 GoTrue 的 `OAUTH_SERVER`、不需要
-`APP_SECRETS_ENCRYPTION_KEY`、不需要自建 GoTrue OAuth 授权页（GoTrue 只提供
-`authorization_path` 配置项，**不提供页面本身**）。
+邮箱 OTP 仍是最兼容任意 app / 自定义域名的默认流程。FC 登录主机同时可以按
+`features.auth` 开启 Google/WeChat 的 GoTrue PKCE，以及 `WEBSSO_LOGIN_URL` 配置的 Web SSO；
+这不使用 OAuth 2.1 动态客户端注册，不需要 `APP_SECRETS_ENCRYPTION_KEY`，也不会创建 team。
 
-§1.2 的两个线上堵点因此**不需要运维介入**。
+Google/WeChat 的登录回调是固定的 `https://<LOGIN_DOMAIN>/oauth/callback`，因此启用时必须将
+它加入 GoTrue 的 `GOTRUE_URI_ALLOW_LIST`；Web SSO 则回到 `https://<LOGIN_DOMAIN>/sso/callback`。
 
 ### D3 · 会话票据由 FC 自签，密钥从 service role key 派生
 
@@ -202,7 +213,8 @@ HKDF-SHA256 派生（`info="teamclu-apps-auth-v1"`）。
 ### D4 · 复用 `auth_mode = platform`，受众用一列新字段表达
 
 不动 `apps_auth_mode_check` 约束、不动 UI 的三个选项、不动 `deployed_auth_mode` 的
-pending 机制。变的是 `platform` 的**实现**（OAuth 2.1 → 代理层 OTP 网关）。
+pending 机制。变的是 `platform` 的**实现**（OAuth 2.1 动态注册 → 代理层 OTP 网关；FC 登录
+主机另外按配置提供 GoTrue PKCE 和 Web SSO）。
 
 两档门槛用新列 `auth_audience`（`any` | `org`）表达，只在 `auth_mode = 'platform'` 时
 有意义。**默认 `org`（收紧）** —— 设计文档 §7「公开性必须显式化」那节的教训是：默认值
@@ -274,7 +286,7 @@ Postgres 和 GoTrue —— `data_app` 至今不通就是这个原因（`APPS_DB_
 ② 中心登录服务
    有中心 cookie？
      是 → 直接签 code
-     否 → 登录页 → 邮箱 → GoTrue /otp → 验证码 → GoTrue /verify → 种中心 cookie → 签 code
+     否 → 登录页 → 邮箱/手机号 OTP，或 Google PKCE / Web SSO → 种中心 cookie → 签 code
    → 302 https://app.example.com/__teamclu/auth/callback?code=<一次性>&next=%2Freport
 
 ③ app 域名网关
@@ -295,7 +307,18 @@ Postgres 和 GoTrue —— `data_app` 至今不通就是这个原因（`APPS_DB_
 | GET | `/` | 登录页；带 `app` / `next` / `r` 参数。有中心会话则直接签 code 并 302 |
 | POST | `/otp` | `{email}` → GoTrue `POST /auth/v1/otp`（`create_user: true`）发验证码 |
 | POST | `/verify` | `{email, code}` → GoTrue `POST /auth/v1/verify`（`type: "email"`）→ 种中心 cookie → 签 code → 302 |
+| POST | `/phone` | `{phone}` → 复用 FC auth repository 发送手机号验证码 |
+| POST | `/phone/verify` / `/phone/select` | 校验手机号验证码，必要时选择关联账号，再种中心 cookie → 签 code → 302 |
+| GET | `/oauth/google` / `/oauth/wechat` | 按 `features.auth` 开启对应的 GoTrue PKCE 授权 |
+| GET | `/oauth/callback` | 校验签名 state cookie，交换 PKCE code，再种中心 cookie |
+| GET | `/sso` / `/sso/callback` | 跳转配置的 Web SSO 登录页并接收 code 或会话 fragment |
+| POST | `/sso/exchange` | 同源桥接页提交 fragment 中的 token，验证后种中心 cookie |
 | POST | `/logout` | 清中心 cookie |
+
+登录方法与 Tauri 的配置保持一致：邮箱 OTP 始终存在，手机号 / Google / WeChat / Web SSO
+由 `features.auth` 和对应环境配置共同决定。浏览器端不能跨 origin 读取 Tauri 所使用的
+`WEBSSO_STORAGE_KEY` localStorage，因此 Web SSO 目标页必须支持 `redirect_to` / `return_to`
+回跳约定；FC 不接受 query string 中的 access/refresh token，避免 token 进入访问日志。
 
 GoTrue 调用走**内网** `SUPABASE_URL`（`http://kong:8000`），不走公网域名。
 
@@ -319,8 +342,8 @@ app** —— 否则 app 里一个同名路由就能伪造回调。
 | 有效期 | 30 天 | 7 天，剩余不足 1 天时滑动续期 |
 | 属性 | `HttpOnly; Secure; SameSite=Lax; Path=/`（都不设 `Domain`） | 同左 |
 
-**三种票据（含下节的 code）共用一把密钥，靠 JWT 的 `aud` 区分**：`teamclu-apps-sso` /
-`teamclu-apps-session` / `teamclu-apps-code`。audience 隔离是承重的，不是装饰：没有它，
+**登录相关票据共用一把密钥，靠 JWT 的 `aud` 区分**：`teamclu-apps-sso` /
+`teamclu-apps-session` / `teamclu-apps-code` / `teamclu-apps-login-state`。audience 隔离是承重的，不是装饰：没有它，
 从中心域偷到的 SSO cookie 会当作 app 会话验过，而下面那条 `aid` 检查根本无从失败
 （SSO 票据没有 `aid`）。
 
@@ -683,7 +706,7 @@ api/supabase/mqtt 共享）。
 |---|---|---|
 | R1 | catch-all Caddy 块吃掉所有未匹配 Host | 必须放文件最末；`ask` 闸门保证未校验域名拿不到证书 |
 | R2 | 身份 header 伪造 | 转发前无条件删除客户端的 `X-Teamclu-*` 再写入 |
-| R3 | 社交登录（Google）在 app 域名上不可用 | 本轮非目标；要做需给 allow list 加 `https://*.apps.<domain>/**`，且**自定义域名做不到**（不可预知） |
+| R3 | 社交登录回调未被 GoTrue 放行 | FC 登录统一回到固定的 `https://<LOGIN_DOMAIN>/oauth/callback`，启用 Google/WeChat 时把这个精确地址加入 `ADDITIONAL_REDIRECT_URLS`；不把任意 app / 自定义域名加入 allow list |
 | R4 | 验证邮件是 TeamClu 的模板和发信域名 | 「不隔离」的必然结果，UI 文案讲清楚 |
 | R5 | OTP 端点被刷 | §4.11 限流；GoTrue 侧本身也有发信限流 |
 | R6 | admin 授权者绑域名 404 | §5.2 必须复用 `updateApp` 的 service-role 绕法 |
@@ -705,9 +728,9 @@ api/supabase/mqtt 共享）。
 
 1. ~~**批次 1 — 会话与 code 原语**~~ ✅ **已完成**（`src/lib/apps-auth-session.ts` +
    `test/apps-auth-session.test.ts`，24 个用例）。验收全部达成，另加了两项设计断言：
-   「失败的兑换不烧 code」（校验顺序）与「三种票据不可互换」（audience 隔离）。
+   「失败的兑换不烧 code」（校验顺序）与「四种票据不可互换」（audience 隔离）。
    两处变异检验确认测试非假绿：去掉 `aid` 绑定 → 红；把 `jti` 标记提到校验之前 → 红。
-2. ~~**批次 2 — 中心登录服务**~~ ✅ **已完成**（`src/lib/apps-login-service.ts`，24 个用例）。
+2. ~~**批次 2 — 中心登录服务**~~ ✅ **已完成**（`src/lib/apps-login-service.ts`，29 个用例，覆盖邮箱/手机号 OTP、Google PKCE 与 Web SSO）。
    顺带把 `LOGIN_DOMAIN` / `APPS_AUTH_SESSION_SECRET` 在 compose、`s.yaml`、`.env.example`
    三处声明齐，并加了 Caddy 的登录站点块 —— env 少加一处会静默失效，留到批次 5 太容易漏。
    两处变异检验：放开返回地址校验 → 红；身份改用用户输入的邮箱而非 GoTrue 的回答 → 红。
@@ -717,7 +740,8 @@ api/supabase/mqtt 共享）。
 
    **实现记的一条**：`services/fc` 是 `strict: false`，**没有 `strictNullChecks` 就没有
    可辨识联合窄化** —— `if (!result.ok)` 之后访问分支独有字段会编译失败。这里改用了「所有
-   字段恒在的扁平结构」。全量测试是绿的而 typecheck 是红的，别只跑测试就下结论。
+   字段恒在的扁平结构」。登录专项测试与 typecheck 必须同时跑；全量测试还会包含需要本机
+   Supabase 的同步用例。
 3. ~~**批次 3 — app 域名网关**~~ ✅ **已完成**（`apps-auth-gate.ts` 21 个用例 +
    `auth_audience` 迁移 + `app-auth-mode.ts` 改造）。四条验收全部达成。三处变异检验：
    未设置受众读作 `any` → 红；不删客户端伪造的身份头 → 红；登录域缺失时放行 → 红。

--- a/services/fc/src/app.ts
+++ b/services/fc/src/app.ts
@@ -101,6 +101,7 @@ export function createApp(deps: AppDeps): Hono {
       if (!isLoginHost(vanityRequestHost(c))) return next();
       const res = await handleLoginRequest(c.req.raw, {
         lookupApp,
+        createAuthRepository: deps.createAuthRepository,
         secureCookies: forwardedProto(c) === "https",
       });
       return res ?? next();

--- a/services/fc/src/lib/apps-auth-page.ts
+++ b/services/fc/src/lib/apps-auth-page.ts
@@ -47,6 +47,12 @@ a.btn:hover{background:var(--accent);color:#fff}
 color:var(--err);border:1px solid currentColor;background:transparent}
 .foot{margin:18px 0 0;font-size:12px;color:var(--muted);text-align:center}
 .code-input{letter-spacing:.4em;font-variant-numeric:tabular-nums}
+.methods{display:flex;flex-wrap:wrap;gap:8px;margin-top:18px;justify-content:center}
+.methods a{font-size:12.5px;color:var(--accent);text-decoration:none}
+.methods a:hover{text-decoration:underline}
+.account-choices{display:grid;gap:8px}
+.account-choices button{height:auto;margin-top:0;padding:10px 12px;text-align:left;display:flex;flex-direction:column;gap:1px}
+.account-choices small{font-size:12px;font-weight:400;opacity:.8}
 `;
 
 export function page(title: string, inner: string, status = 200): Response {

--- a/services/fc/src/lib/apps-auth-session.ts
+++ b/services/fc/src/lib/apps-auth-session.ts
@@ -6,7 +6,7 @@ import { ApiError } from "./http-utils.js";
  * Session primitives for the deployed-apps login wall
  * (`docs/specs/2026-09-08-apps-login-and-custom-domain-design.md` §4.5-§4.6).
  *
- * Three ticket kinds, one signing key, told apart by JWT `aud`:
+ * Four ticket kinds, one signing key, told apart by JWT `aud`:
  *
  *   * **SSO session** — lives on the central login domain. Holding one is what
  *     lets a visitor walk into a second app without seeing the login page.
@@ -14,6 +14,8 @@ import { ApiError } from "./http-utils.js";
  *   * **Auth code** — the one-shot bearer that moves a login from the central
  *     domain to an app's hostname, because a cookie on `login.<domain>` cannot
  *     be read by `app.example.com`.
+ *   * **Login state** — a short-lived HttpOnly cookie that binds a browser
+ *     OAuth / Web SSO callback to its PKCE verifier and app return address.
  *
  * The audience separation is load-bearing, not decoration: without it an SSO
  * cookie lifted from the central domain would verify as an app session, and the
@@ -30,6 +32,7 @@ const ISSUER = "teamclu-fc";
 const AUD_SSO = "teamclu-apps-sso";
 const AUD_APP = "teamclu-apps-session";
 const AUD_CODE = "teamclu-apps-code";
+const AUD_LOGIN_STATE = "teamclu-apps-login-state";
 
 /** A visitor stays signed in to the platform for a month. */
 export const SSO_TTL_SECONDS = 30 * 24 * 60 * 60;
@@ -44,6 +47,9 @@ export const APP_RENEW_WINDOW_SECONDS = 24 * 60 * 60;
 
 export const SSO_COOKIE = "__teamclu_sso";
 export const APP_COOKIE = "__teamclu_app_session";
+/** Short-lived state for browser OAuth / Web SSO callbacks on the login host. */
+export const LOGIN_STATE_COOKIE = "__teamclu_login_state";
+export const LOGIN_STATE_TTL_SECONDS = 10 * 60;
 
 /**
  * Paths the app-domain gateway owns and never forwards to the app itself.
@@ -73,6 +79,20 @@ export type AuthCodeClaims = {
   /** Origin the code may be redeemed on, pinned when the code was minted. */
   redirect: string;
   jti: string;
+};
+
+/**
+ * State kept in an HttpOnly cookie while a browser login provider is open.
+ * The PKCE verifier never goes in the URL; the signed cookie is the only place
+ * the callback can recover it.
+ */
+export type LoginStateClaims = {
+  appId: string;
+  redirect: string;
+  next: string;
+  provider: string;
+  state: string;
+  codeVerifier: string;
 };
 
 // --- signing key ------------------------------------------------------------
@@ -185,6 +205,24 @@ export function mintAuthCode(
   );
 }
 
+export function mintLoginState(
+  claims: LoginStateClaims,
+  ttlSeconds = LOGIN_STATE_TTL_SECONDS,
+): Promise<{ token: string; expiresAt: number }> {
+  return mint(
+    AUD_LOGIN_STATE,
+    {
+      aid: claims.appId,
+      redirect: claims.redirect,
+      next: claims.next,
+      provider: claims.provider,
+      state: claims.state,
+      code_verifier: claims.codeVerifier,
+    },
+    ttlSeconds,
+  );
+}
+
 // --- verification -----------------------------------------------------------
 
 /**
@@ -283,6 +321,28 @@ export async function consumeAuthCode(
   sweepSpentCodes(now);
   if (spentCodes.has(claims.jti)) return null;
   spentCodes.set(claims.jti, now + SPENT_CODE_TTL_MS);
+  return claims;
+}
+
+export async function verifyLoginState(token: string): Promise<LoginStateClaims | null> {
+  const payload = await verify(token, AUD_LOGIN_STATE);
+  if (!payload) return null;
+  const claims: LoginStateClaims = {
+    appId: str(payload.aid),
+    redirect: str(payload.redirect),
+    next: str(payload.next),
+    provider: str(payload.provider),
+    state: str(payload.state),
+    codeVerifier: str(payload.code_verifier),
+  };
+  if (
+    !claims.appId ||
+    !claims.redirect ||
+    !claims.next ||
+    !claims.provider ||
+    !claims.state ||
+    !claims.codeVerifier
+  ) return null;
   return claims;
 }
 

--- a/services/fc/src/lib/apps-login-service.ts
+++ b/services/fc/src/lib/apps-login-service.ts
@@ -1,36 +1,43 @@
+import { createHash, randomBytes } from "node:crypto";
+
 import { appOrigins } from "./apps-public-host.js";
 import { esc, page, redirect, safeNext } from "./apps-auth-page.js";
 import {
   APP_AUTH_CALLBACK_PATH,
+  LOGIN_STATE_COOKIE,
+  LOGIN_STATE_TTL_SECONDS,
   SSO_COOKIE,
   SSO_TTL_SECONDS,
   clearSessionCookie,
+  mintLoginState,
   mintAuthCode,
   mintSsoSession,
   readCookie,
   serializeSessionCookie,
+  verifyLoginState,
   verifySsoSession,
 } from "./apps-auth-session.js";
 import { isRateLimited, resolveClientIp } from "./rate-limit.js";
+import { resolveFeatures } from "./routes/config.js";
 
 /**
  * The central login service for deployed apps
  * (`docs/specs/2026-09-08-apps-login-and-custom-domain-design.md` §4.3-§4.4).
  *
  * It answers on one hostname — `LOGIN_DOMAIN` — and owns the entire login
- * experience: the page, the email round trip, and the SSO cookie. Apps never
- * see any of it. What crosses back to an app's own hostname is a single
- * one-shot code, because a cookie set here cannot be read on
- * `app.example.com`, and once custom domains exist that is the common case
- * rather than the exception.
+ * experience: the page, the email/phone round trips, configured OAuth/Web SSO,
+ * and the SSO cookie. Apps never see any of it. What crosses back to an app's
+ * own hostname is a single one-shot code, because a cookie set here cannot be
+ * read on `app.example.com`, and once custom domains exist that is the common
+ * case rather than the exception.
  *
  * Holding a valid SSO cookie is what makes the second app skip the login page:
  * `GET /` mints a code immediately and bounces, so the visitor sees two
  * redirects and no form.
  *
- * The whole flow is plain `<form>` POSTs with no JavaScript. An app's login
- * wall that depends on a script bundle is a login wall that fails closed on a
- * bad network — and there is nothing here that needs a script.
+ * Email and phone stay plain `<form>` POSTs. Web SSO has one tiny inline bridge
+ * script because only the browser can read a provider session in a URL
+ * fragment; it has no dependency on the app's script bundle.
  */
 
 export type LoginApp = {
@@ -44,6 +51,8 @@ export type LookupLoginApp = (appId: string) => Promise<LoginApp | null>;
 
 export type LoginServiceDeps = {
   lookupApp: LookupLoginApp;
+  /** The same auth repository used by /v1/auth/*, needed for phone login. */
+  createAuthRepository?: () => unknown | Promise<unknown>;
   fetchImpl?: typeof fetch;
   env?: NodeJS.ProcessEnv;
   /** False only on a plain-http local box; every real deploy terminates TLS. */
@@ -54,9 +63,28 @@ export type LoginServiceDeps = {
 
 /** Verification codes per IP+email per minute. GoTrue also limits sending. */
 const OTP_RATE_LIMIT = 5;
+const PHONE_OTP_RATE_LIMIT = 3;
+const OAUTH_CALLBACK_PATH = "/oauth/callback";
+const WEB_SSO_CALLBACK_PATH = "/sso/callback";
+
+type OAuthProvider = "google" | "wechat";
+type LoginMethod = "phone" | "google" | "wechat" | "webSSO";
+
+type PhoneLoginUser = {
+  id: string;
+  org_id?: string | null;
+  org_name?: string | null;
+  nickname?: string | null;
+  email?: string | null;
+};
+
+type PhoneAuthRepository = {
+  phoneSendCode: (args: { phone: string; captchaVerify?: string }) => Promise<unknown>;
+  phoneLogin: (args: { phone: string; code: string; userId?: string }) => Promise<unknown>;
+};
 
 // ---------------------------------------------------------------------------
-// Request context: everything the four handlers need, validated once.
+// Request context: everything the login flow handlers need, validated once.
 // ---------------------------------------------------------------------------
 
 type LoginContext = {
@@ -150,6 +178,69 @@ function anonKey(env: NodeJS.ProcessEnv): string {
   return (env.SUPABASE_PUBLISHABLE_KEY || env.SUPABASE_ANON_KEY || "").trim();
 }
 
+function publicGotrueBase(env: NodeJS.ProcessEnv): string {
+  return (env.SUPABASE_PUBLIC_URL || env.SUPABASE_URL || "").trim().replace(/\/+$/, "");
+}
+
+function loginOrigin(req: Request, secure: boolean, env: NodeJS.ProcessEnv): string {
+  // The request has already passed the LOGIN_DOMAIN host gate. Prefer the
+  // configured value anyway: on FC the adapter URL can contain the trigger's
+  // generated hostname rather than the public custom domain.
+  const configured = env.LOGIN_DOMAIN?.trim();
+  const host = configured || new URL(req.url).host;
+  return `${secure ? "https" : "http"}://${host}`;
+}
+
+function authMethodEnabled(method: LoginMethod, env: NodeJS.ProcessEnv): boolean {
+  const auth = resolveFeatures(env).auth;
+  return auth?.[method] === true;
+}
+
+function webSsoUrl(env: NodeJS.ProcessEnv): string | null {
+  const raw = env.WEBSSO_LOGIN_URL?.trim();
+  if (!raw) return null;
+  try {
+    const url = new URL(raw);
+    if (url.protocol !== "https:" && url.protocol !== "http:") return null;
+    return url.toString();
+  } catch {
+    return null;
+  }
+}
+
+function pkceVerifier(): string {
+  return randomBytes(32).toString("base64url");
+}
+
+function pkceChallenge(verifier: string): string {
+  return createHash("sha256").update(verifier).digest("base64url");
+}
+
+function flowUrl(path: string, ctx: LoginContext, extra: Record<string, string> = {}): string {
+  const params = new URLSearchParams({ app: ctx.app.id, r: ctx.origin, next: ctx.next, ...extra });
+  return `${path}?${params.toString()}`;
+}
+
+function userFromAuthBody(body: any, fallbackEmail = ""): { sub: string; email: string } | null {
+  const user = body?.user;
+  const sub = typeof user?.id === "string" ? user.id : "";
+  const email =
+    typeof user?.email === "string" && user.email.trim()
+      ? user.email.trim().toLowerCase()
+      : typeof user?.user_metadata?.email === "string" && user.user_metadata.email.trim()
+        ? user.user_metadata.email.trim().toLowerCase()
+        : fallbackEmail;
+  return sub && email ? { sub, email } : null;
+}
+
+function authFailure(error: unknown): { status: number; message: string } {
+  const statusCode = Number((error as any)?.statusCode ?? (error as any)?.status);
+  if (statusCode === 429) return { status: 429, message: "尝试过于频繁，请稍后再试。" };
+  if (statusCode >= 500) return { status: 503, message: "登录服务暂时不可用，请稍后再试。" };
+  const message = typeof (error as any)?.message === "string" ? (error as any).message : "登录失败，请稍后再试。";
+  return { status: statusCode >= 400 && statusCode < 500 ? statusCode : 400, message };
+}
+
 /**
  * `rejected` is the visitor's fault (bad code, refused address) and is safe to
  * act on; `unavailable` is ours. They are separated here so no caller has to
@@ -195,6 +286,43 @@ async function callGotrue(
   return { kind: "rejected", body: parsed, message: "" };
 }
 
+/** Validate a refresh/access token harvested by the browser SSO bridge. */
+async function callGotrueUser(
+  accessToken: string,
+  deps: LoginServiceDeps,
+  env: NodeJS.ProcessEnv,
+): Promise<GotrueResult> {
+  const base = gotrueBase(env);
+  const key = anonKey(env);
+  if (!base || !key) {
+    return { kind: "unavailable", body: null, message: "登录服务尚未配置。" };
+  }
+  const fetchImpl = deps.fetchImpl ?? fetch;
+  let res: Response;
+  try {
+    res = await fetchImpl(`${base}/auth/v1/user`, {
+      method: "GET",
+      headers: { apikey: key, Authorization: `Bearer ${accessToken}` },
+    });
+  } catch {
+    return { kind: "unavailable", body: null, message: "登录服务暂时不可用，请稍后再试。" };
+  }
+  const text = await res.text().catch(() => "");
+  let parsed: any = null;
+  if (text) {
+    try {
+      parsed = JSON.parse(text);
+    } catch {
+      parsed = null;
+    }
+  }
+  if (res.ok) return { kind: "ok", body: { user: parsed }, message: "" };
+  if (res.status >= 500) {
+    return { kind: "unavailable", body: null, message: "登录服务暂时不可用，请稍后再试。" };
+  }
+  return { kind: "rejected", body: parsed, message: "" };
+}
+
 // ---------------------------------------------------------------------------
 // Pages
 // ---------------------------------------------------------------------------
@@ -212,7 +340,37 @@ function errorBlock(message: string): string {
   return message ? `<p class="err">${esc(message)}</p>` : "";
 }
 
-function emailPage(ctx: LoginContext, email = "", error = "", status = 200): Response {
+function methodLinks(
+  ctx: LoginContext,
+  env: NodeJS.ProcessEnv,
+  current?: LoginMethod,
+): string {
+  const links: string[] = [];
+  if (current !== "phone" && authMethodEnabled("phone", env)) {
+    links.push(`<a href="${esc(flowUrl("/", ctx, { method: "phone" }))}">手机号登录</a>`);
+  }
+  if (authMethodEnabled("google", env)) {
+    links.push(`<a href="${esc(flowUrl("/oauth/google", ctx))}">Google 登录</a>`);
+  }
+  // Keep this in lock-step with the Tauri auth config. WeChat is not enabled
+  // by the shipped profiles, but a deployment that turns it on gets the same
+  // provider here as well.
+  if (authMethodEnabled("wechat", env)) {
+    links.push(`<a href="${esc(flowUrl("/oauth/wechat", ctx))}">微信登录</a>`);
+  }
+  if (authMethodEnabled("webSSO", env) && webSsoUrl(env)) {
+    links.push(`<a href="${esc(flowUrl("/sso", ctx))}">快捷登录</a>`);
+  }
+  return links.length ? `<nav class="methods">${links.join("")}</nav>` : "";
+}
+
+function emailPage(
+  ctx: LoginContext,
+  email = "",
+  error = "",
+  status = 200,
+  env: NodeJS.ProcessEnv = process.env,
+): Response {
   return page(
     "登录",
     `<h1>登录</h1><p class="sub">继续访问需要先验证你的邮箱。</p>` +
@@ -221,7 +379,8 @@ function emailPage(ctx: LoginContext, email = "", error = "", status = 200): Res
       `<label for="email">邮箱</label>` +
       `<input id="email" name="email" type="email" inputmode="email" autocomplete="email" ` +
       `autofocus required value="${esc(email)}">` +
-      `<button type="submit">发送验证码</button></form>`,
+      `<button type="submit">发送验证码</button></form>` +
+      methodLinks(ctx, env),
     status,
   );
 }
@@ -243,8 +402,466 @@ function codePage(ctx: LoginContext, email: string, error = "", status = 200): R
   );
 }
 
+function phonePage(
+  ctx: LoginContext,
+  phone = "",
+  error = "",
+  status = 200,
+  env: NodeJS.ProcessEnv = process.env,
+): Response {
+  return page(
+    "手机号登录",
+    `<h1>手机号登录</h1><p class="sub">我们会向你的手机发送 6 位验证码。</p>` +
+      errorBlock(error) +
+      `<form method="post" action="/phone">${carried(ctx)}` +
+      `<label for="phone">手机号</label>` +
+      `<input id="phone" name="phone" type="tel" inputmode="tel" autocomplete="tel" ` +
+      `autofocus required value="${esc(phone)}" placeholder="+8613800138000">` +
+      `<button type="submit">发送验证码</button></form>` +
+      `<p class="foot"><a href="${esc(flowUrl("/", ctx))}">使用邮箱登录</a></p>` +
+      methodLinks(ctx, env, "phone"),
+    status,
+  );
+}
+
+function phoneCodePage(ctx: LoginContext, phone: string, error = "", status = 200): Response {
+  return page(
+    "输入验证码",
+    `<h1>输入验证码</h1><p class="sub">验证码已发送到 ${esc(phone)}。</p>` +
+      errorBlock(error) +
+      `<form method="post" action="/phone/verify">${carried(ctx)}` +
+      `<input type="hidden" name="phone" value="${esc(phone)}">` +
+      `<label for="code">验证码</label>` +
+      `<input id="code" name="code" type="text" inputmode="numeric" autocomplete="one-time-code" ` +
+      `class="code-input" autofocus required maxlength="6" pattern="[0-9]{6}">` +
+      `<button type="submit">登录</button></form>` +
+      `<p class="foot"><a href="${esc(flowUrl("/", ctx, { method: "phone" }))}">换一个手机号</a></p>`,
+    status,
+  );
+}
+
+function phoneAccountPage(
+  ctx: LoginContext,
+  phone: string,
+  code: string,
+  users: PhoneLoginUser[],
+  error = "",
+  status = 200,
+): Response {
+  const choices = users
+    .map((user) => {
+      const label = user.nickname?.trim() || user.email?.trim() || "账号";
+      const detail = user.org_name?.trim() || user.email?.trim() || "";
+      return (
+        `<button type="submit" name="userId" value="${esc(user.id)}">` +
+        `<span>${esc(label)}</span>${detail ? `<small>${esc(detail)}</small>` : ""}</button>`
+      );
+    })
+    .join("");
+  return page(
+    "选择账号",
+    `<h1>选择账号</h1><p class="sub">手机号 ${esc(phone)} 关联了多个账号，请选择要登录的账号。</p>` +
+      errorBlock(error) +
+      `<form method="post" action="/phone/select">${carried(ctx)}` +
+      `<input type="hidden" name="phone" value="${esc(phone)}">` +
+      `<input type="hidden" name="code" value="${esc(code)}">` +
+      `<div class="account-choices">${choices}</div></form>` +
+      `<p class="foot"><a href="${esc(flowUrl("/", ctx, { method: "phone" }))}">使用其他手机号</a></p>`,
+    status,
+  );
+}
+
 function noticePage(message: string, status: number): Response {
   return page("登录", `<h1>无法继续</h1><p class="sub">${esc(message)}</p>`, status);
+}
+
+function retryPage(ctx: LoginContext, message: string, status: number): Response {
+  return page(
+    "登录",
+    `<h1>无法继续</h1><p class="sub">${esc(message)}</p>` +
+      `<a class="btn" href="${esc(flowUrl("/", ctx))}">返回登录</a>`,
+    status,
+  );
+}
+
+function clearLoginState(response: Response, secure: boolean): Response {
+  response.headers.append("Set-Cookie", clearSessionCookie(LOGIN_STATE_COOKIE, secure));
+  return response;
+}
+
+async function contextFromLoginState(
+  state: Awaited<ReturnType<typeof verifyLoginState>>,
+  deps: LoginServiceDeps,
+  env: NodeJS.ProcessEnv,
+): Promise<LoginContext | { error: string; status: number }> {
+  if (!state) return { error: "登录状态已失效，请重新开始。", status: 400 };
+  return loadContext(
+    new URLSearchParams({ app: state.appId, r: state.redirect, next: state.next }),
+    deps,
+    env,
+  );
+}
+
+async function authRepository(deps: LoginServiceDeps): Promise<PhoneAuthRepository | null> {
+  if (!deps.createAuthRepository) return null;
+  const repository = (await deps.createAuthRepository()) as Partial<PhoneAuthRepository> | null;
+  if (
+    !repository ||
+    typeof repository.phoneSendCode !== "function" ||
+    typeof repository.phoneLogin !== "function"
+  ) return null;
+  return repository as PhoneAuthRepository;
+}
+
+async function bounceWithSso(
+  ctx: LoginContext,
+  user: { sub: string; email: string },
+  secure: boolean,
+  cookies: string[] = [],
+): Promise<Response> {
+  const sso = await mintSsoSession(user);
+  return bounceWithCode(ctx, user, [
+    ...cookies,
+    serializeSessionCookie(SSO_COOKIE, sso.token, SSO_TTL_SECONDS, secure),
+  ]);
+}
+
+function isOAuthProvider(value: string): value is OAuthProvider {
+  return value === "google" || value === "wechat";
+}
+
+async function handlePhoneStart(
+  form: URLSearchParams,
+  req: Request,
+  deps: LoginServiceDeps,
+  env: NodeJS.ProcessEnv,
+): Promise<Response> {
+  const ctx = await loadContext(form, deps, env);
+  if ("error" in ctx) return noticePage(ctx.error, ctx.status);
+  if (!authMethodEnabled("phone", env)) return noticePage("手机号登录未启用。", 404);
+
+  const phone = (form.get("phone") ?? "").trim();
+  if (phone.length < 6) return phonePage(ctx, phone, "请填写有效的手机号码。", 400, env);
+
+  const limiter = deps.rateLimited ?? isRateLimited;
+  const { ip } = resolveClientIp((n) => req.headers.get(n) ?? undefined);
+  if (limiter(`apps-login:phone:${ip ?? "unknown"}:${phone}`, PHONE_OTP_RATE_LIMIT)) {
+    return phonePage(ctx, phone, "尝试过于频繁，请稍后再试。", 429, env);
+  }
+
+  try {
+    const repository = await authRepository(deps);
+    if (!repository) return phonePage(ctx, phone, "手机号登录尚未配置。", 503, env);
+    // The desktop client uses the same non-empty captcha placeholder until the
+    // partner captcha is wired. The repository remains the single validator.
+    await repository.phoneSendCode({ phone, captchaVerify: "fc-app-login" });
+    return phoneCodePage(ctx, phone);
+  } catch (error) {
+    const failure = authFailure(error);
+    return phonePage(ctx, phone, failure.message, failure.status, env);
+  }
+}
+
+async function phoneLoginResult(
+  ctx: LoginContext,
+  phone: string,
+  code: string,
+  deps: LoginServiceDeps,
+  env: NodeJS.ProcessEnv,
+  secure: boolean,
+  userId?: string,
+): Promise<Response> {
+  try {
+    const repository = await authRepository(deps);
+    if (!repository) return phoneCodePage(ctx, phone, "手机号登录尚未配置。", 503);
+    const result = (await repository.phoneLogin({ phone, code, userId })) as any;
+    if (result?.multiUser && Array.isArray(result.users)) {
+      return phoneAccountPage(ctx, phone, code, result.users as PhoneLoginUser[]);
+    }
+    const user = userFromAuthBody(result?.session);
+    if (!user) return phoneCodePage(ctx, phone, "登录服务暂时不可用，请稍后再试。", 503);
+    return bounceWithSso(ctx, user, secure);
+  } catch (error) {
+    const failure = authFailure(error);
+    return phoneCodePage(ctx, phone, failure.message, failure.status);
+  }
+}
+
+async function handlePhoneVerify(
+  form: URLSearchParams,
+  deps: LoginServiceDeps,
+  env: NodeJS.ProcessEnv,
+  secure: boolean,
+): Promise<Response> {
+  const ctx = await loadContext(form, deps, env);
+  if ("error" in ctx) return noticePage(ctx.error, ctx.status);
+  if (!authMethodEnabled("phone", env)) return noticePage("手机号登录未启用。", 404);
+  const phone = (form.get("phone") ?? "").trim();
+  const code = (form.get("code") ?? "").trim();
+  if (!phone || !/^\d{6}$/.test(code)) {
+    return phoneCodePage(ctx, phone, "请输入 6 位验证码。", 400);
+  }
+  return phoneLoginResult(ctx, phone, code, deps, env, secure);
+}
+
+async function handlePhoneSelect(
+  form: URLSearchParams,
+  deps: LoginServiceDeps,
+  env: NodeJS.ProcessEnv,
+  secure: boolean,
+): Promise<Response> {
+  const ctx = await loadContext(form, deps, env);
+  if ("error" in ctx) return noticePage(ctx.error, ctx.status);
+  if (!authMethodEnabled("phone", env)) return noticePage("手机号登录未启用。", 404);
+  const phone = (form.get("phone") ?? "").trim();
+  const code = (form.get("code") ?? "").trim();
+  const userId = (form.get("userId") ?? "").trim();
+  if (!phone || !/^\d{6}$/.test(code) || !userId) {
+    return phoneCodePage(ctx, phone, "请选择一个账号。", 400);
+  }
+  // Keep the same repository operation as the first verification. The OTP is
+  // not consumed while the picker is displayed, so the selected user can be
+  // passed back to the same operation.
+  return phoneLoginResult(ctx, phone, code, deps, env, secure, userId);
+}
+
+async function handleOAuthStart(
+  provider: OAuthProvider,
+  url: URL,
+  req: Request,
+  deps: LoginServiceDeps,
+  env: NodeJS.ProcessEnv,
+  secure: boolean,
+): Promise<Response> {
+  const ctx = await loadContext(url.searchParams, deps, env);
+  if ("error" in ctx) return noticePage(ctx.error, ctx.status);
+  if (!authMethodEnabled(provider, env)) return noticePage("该登录方式未启用。", 404);
+  const base = publicGotrueBase(env);
+  if (!base) return noticePage("登录服务尚未配置。", 503);
+
+  const verifier = pkceVerifier();
+  const state = randomBytes(24).toString("base64url");
+  const loginState = await mintLoginState({
+    appId: ctx.app.id,
+    redirect: ctx.origin,
+    next: ctx.next,
+    provider,
+    state,
+    codeVerifier: verifier,
+  });
+  const callback = `${loginOrigin(req, secure, env)}${OAUTH_CALLBACK_PATH}`;
+  const target = new URL(`${base}/auth/v1/authorize`);
+  target.searchParams.set("provider", provider);
+  target.searchParams.set("redirect_to", callback);
+  target.searchParams.set("code_challenge", pkceChallenge(verifier));
+  target.searchParams.set("code_challenge_method", "s256");
+  target.searchParams.set("state", state);
+  return redirect(
+    target.toString(),
+    [serializeSessionCookie(LOGIN_STATE_COOKIE, loginState.token, LOGIN_STATE_TTL_SECONDS, secure)],
+  );
+}
+
+async function handleOAuthCallback(
+  url: URL,
+  req: Request,
+  deps: LoginServiceDeps,
+  env: NodeJS.ProcessEnv,
+  secure: boolean,
+): Promise<Response> {
+  const token = readCookie(req.headers.get("cookie"), LOGIN_STATE_COOKIE) ?? "";
+  const state = await verifyLoginState(token);
+  const clear = () => clearSessionCookie(LOGIN_STATE_COOKIE, secure);
+  if (!state || url.searchParams.get("state") !== state.state || !isOAuthProvider(state.provider)) {
+    return clearLoginState(noticePage("登录状态已失效，请重新开始。", 400), secure);
+  }
+  const ctx = await contextFromLoginState(state, deps, env);
+  if ("error" in ctx) return clearLoginState(noticePage(ctx.error, ctx.status), secure);
+  if (!authMethodEnabled(state.provider, env)) {
+    return clearLoginState(retryPage(ctx, "该登录方式已被关闭，请重新选择登录方式。", 400), secure);
+  }
+  if (url.searchParams.get("error") || !url.searchParams.get("code")) {
+    return clearLoginState(retryPage(ctx, "登录未完成，请重新选择登录方式。", 400), secure);
+  }
+
+  const result = await callGotrue(
+    "/auth/v1/token?grant_type=pkce",
+    { auth_code: url.searchParams.get("code"), code_verifier: state.codeVerifier },
+    deps,
+    env,
+  );
+  if (result.kind !== "ok") {
+    return clearLoginState(
+      retryPage(ctx, result.kind === "unavailable" ? result.message : "登录未完成，请重试。", result.kind === "unavailable" ? 503 : 400),
+      secure,
+    );
+  }
+  const user = userFromAuthBody(result.body);
+  if (!user) return clearLoginState(retryPage(ctx, "登录服务没有返回有效账号。", 503), secure);
+  return bounceWithSso(ctx, user, secure, [clear()]);
+}
+
+function webSsoBridgePage(): Response {
+  return page(
+    "快捷登录",
+    `<h1>快捷登录</h1><p class="sub">正在读取登录结果，请稍候……</p>` +
+      `<p id="message" class="foot">如果页面没有继续，请关闭此页后重试。</p>` +
+      `<script>` +
+      `(async()=>{` +
+      `const p=new URLSearchParams(location.hash.slice(1));` +
+      `history.replaceState(null,"",location.pathname+location.search);` +
+      `const f=document.createElement("form");f.method="POST";f.action="/sso/exchange";` +
+      `for(const k of ["access_token","refresh_token"]){const v=p.get(k);if(v){const i=document.createElement("input");i.type="hidden";i.name=k;i.value=v;f.append(i)}}` +
+      `if(!f.elements.length){document.getElementById("message").textContent="没有读取到登录结果，请重试。";return}` +
+      `document.body.append(f);f.submit();` +
+      `})();</script>`,
+  );
+}
+
+async function handleWebSsoStart(
+  url: URL,
+  req: Request,
+  deps: LoginServiceDeps,
+  env: NodeJS.ProcessEnv,
+  secure: boolean,
+): Promise<Response> {
+  const ctx = await loadContext(url.searchParams, deps, env);
+  if ("error" in ctx) return noticePage(ctx.error, ctx.status);
+  const targetRaw = webSsoUrl(env);
+  if (!authMethodEnabled("webSSO", env) || !targetRaw) {
+    return noticePage("快捷登录未启用。", 404);
+  }
+  const verifier = pkceVerifier();
+  const state = randomBytes(24).toString("base64url");
+  const loginState = await mintLoginState({
+    appId: ctx.app.id,
+    redirect: ctx.origin,
+    next: ctx.next,
+    provider: "webSSO",
+    state,
+    codeVerifier: verifier,
+  });
+  const callback = `${loginOrigin(req, secure, env)}${WEB_SSO_CALLBACK_PATH}`;
+  const target = new URL(targetRaw);
+  // The configured admin login page is the same page Tauri opens. These
+  // standard names let a web-capable admin login return either a PKCE code or
+  // the Supabase session fragment to this bridge. Existing admin pages may
+  // ignore the extra query parameters without affecting Tauri's flow.
+  target.searchParams.set("redirect_to", callback);
+  target.searchParams.set("return_to", callback);
+  target.searchParams.set("state", state);
+  target.searchParams.set("code_challenge", pkceChallenge(verifier));
+  target.searchParams.set("code_challenge_method", "s256");
+  return redirect(
+    target.toString(),
+    [serializeSessionCookie(LOGIN_STATE_COOKIE, loginState.token, LOGIN_STATE_TTL_SECONDS, secure)],
+  );
+}
+
+async function finishWebSso(
+  state: Awaited<ReturnType<typeof verifyLoginState>>,
+  request: { accessToken?: string; refreshToken?: string },
+  deps: LoginServiceDeps,
+  env: NodeJS.ProcessEnv,
+  secure: boolean,
+): Promise<Response> {
+  const ctx = await contextFromLoginState(state, deps, env);
+  if ("error" in ctx) return clearLoginState(noticePage(ctx.error, ctx.status), secure);
+  if (!authMethodEnabled("webSSO", env)) {
+    return clearLoginState(retryPage(ctx, "该登录方式已被关闭，请重新选择登录方式。", 400), secure);
+  }
+  let result: GotrueResult;
+  if (request.refreshToken) {
+    result = await callGotrue(
+      "/auth/v1/token?grant_type=refresh_token",
+      { refresh_token: request.refreshToken },
+      deps,
+      env,
+    );
+  } else if (request.accessToken) {
+    result = await callGotrueUser(request.accessToken, deps, env);
+  } else {
+    return clearLoginState(retryPage(ctx, "没有读取到登录结果，请重试。", 400), secure);
+  }
+  if (result.kind !== "ok") {
+    return clearLoginState(
+      retryPage(ctx, result.kind === "unavailable" ? result.message : "登录未完成，请重试。", result.kind === "unavailable" ? 503 : 400),
+      secure,
+    );
+  }
+  const user = userFromAuthBody(result.body);
+  if (!user) return clearLoginState(retryPage(ctx, "登录服务没有返回有效账号。", 503), secure);
+  return bounceWithSso(ctx, user, secure, [clearSessionCookie(LOGIN_STATE_COOKIE, secure)]);
+}
+
+async function handleWebSsoCallback(
+  url: URL,
+  req: Request,
+  deps: LoginServiceDeps,
+  env: NodeJS.ProcessEnv,
+  secure: boolean,
+): Promise<Response> {
+  const state = await verifyLoginState(readCookie(req.headers.get("cookie"), LOGIN_STATE_COOKIE) ?? "");
+  if (!state || state.provider !== "webSSO") {
+    return clearLoginState(noticePage("登录状态已失效，请重新开始。", 400), secure);
+  }
+  const queryState = url.searchParams.get("state");
+  if (queryState && queryState !== state.state) {
+    return clearLoginState(noticePage("登录状态已失效，请重新开始。", 400), secure);
+  }
+  const ctx = await contextFromLoginState(state, deps, env);
+  if ("error" in ctx) return clearLoginState(noticePage(ctx.error, ctx.status), secure);
+  if (!authMethodEnabled("webSSO", env)) {
+    return clearLoginState(retryPage(ctx, "该登录方式已被关闭，请重新选择登录方式。", 400), secure);
+  }
+  if (url.searchParams.get("error")) {
+    return clearLoginState(retryPage(ctx, "登录未完成，请重新选择登录方式。", 400), secure);
+  }
+  const code = url.searchParams.get("code");
+  if (code) {
+    if (queryState !== state.state) {
+      return clearLoginState(noticePage("登录状态已失效，请重新开始。", 400), secure);
+    }
+    const result = await callGotrue(
+      "/auth/v1/token?grant_type=pkce",
+      { auth_code: code, code_verifier: state.codeVerifier },
+      deps,
+      env,
+    );
+    if (result.kind !== "ok") {
+      return clearLoginState(
+        retryPage(ctx, result.kind === "unavailable" ? result.message : "登录未完成，请重试。", result.kind === "unavailable" ? 503 : 400),
+        secure,
+      );
+    }
+    const user = userFromAuthBody(result.body);
+    if (!user) return clearLoginState(noticePage("登录服务没有返回有效账号。", 503), secure);
+    return bounceWithSso(ctx, user, secure, [clearSessionCookie(LOGIN_STATE_COOKIE, secure)]);
+  }
+  // Supabase implicit-flow tokens arrive in the URL fragment, which the
+  // browser-only bridge above reads without sending them to FC access logs.
+  // Never accept access or refresh tokens in the query string.
+  return webSsoBridgePage();
+}
+
+async function handleWebSsoExchange(
+  req: Request,
+  deps: LoginServiceDeps,
+  env: NodeJS.ProcessEnv,
+  secure: boolean,
+): Promise<Response> {
+  const state = await verifyLoginState(readCookie(req.headers.get("cookie"), LOGIN_STATE_COOKIE) ?? "");
+  if (!state || state.provider !== "webSSO") {
+    return clearLoginState(noticePage("登录状态已失效，请重新开始。", 400), secure);
+  }
+  const body = new URLSearchParams(await req.text());
+  return finishWebSso(
+    state,
+    { accessToken: body.get("access_token") ?? undefined, refreshToken: body.get("refresh_token") ?? undefined },
+    deps,
+    env,
+    secure,
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -298,7 +915,10 @@ async function handleRoot(
   const session = await verifySsoSession(readCookie(req.headers.get("cookie"), SSO_COOKIE) ?? "");
   if (session) return bounceWithCode(ctx, session);
 
-  return emailPage(ctx);
+  if (url.searchParams.get("method") === "phone" && authMethodEnabled("phone", env)) {
+    return phonePage(ctx, "", "", 200, env);
+  }
+  return emailPage(ctx, "", "", 200, env);
 }
 
 async function handleOtp(
@@ -312,7 +932,7 @@ async function handleOtp(
 
   const email = (form.get("email") ?? "").trim().toLowerCase();
   if (!looksLikeEmail(email)) {
-    return emailPage(ctx, email, "请填写一个有效的邮箱地址。", 400);
+    return emailPage(ctx, email, "请填写一个有效的邮箱地址。", 400, env);
   }
 
   // Per IP AND per address: keying on one alone lets an attacker either mail
@@ -320,7 +940,7 @@ async function handleOtp(
   const limiter = deps.rateLimited ?? isRateLimited;
   const { ip } = resolveClientIp((n) => req.headers.get(n) ?? undefined);
   if (limiter(`apps-login:otp:${ip ?? "unknown"}:${email}`, OTP_RATE_LIMIT)) {
-    return emailPage(ctx, email, "尝试过于频繁，请等一分钟再试。", 429);
+    return emailPage(ctx, email, "尝试过于频繁，请等一分钟再试。", 429, env);
   }
 
   const result = await callGotrue("/auth/v1/otp", { email, create_user: true }, deps, env);
@@ -331,6 +951,7 @@ async function handleOtp(
       email,
       down ? result.message : "这个邮箱地址无法接收验证码。",
       down ? 503 : 400,
+      env,
     );
   }
   return codePage(ctx, email);
@@ -347,7 +968,7 @@ async function handleVerify(
 
   const email = (form.get("email") ?? "").trim().toLowerCase();
   const code = (form.get("code") ?? "").trim();
-  if (!looksLikeEmail(email)) return emailPage(ctx, email, "请重新输入邮箱地址。", 400);
+  if (!looksLikeEmail(email)) return emailPage(ctx, email, "请重新输入邮箱地址。", 400, env);
   if (!code) return codePage(ctx, email, "请输入验证码。", 400);
 
   const result = await callGotrue(
@@ -366,18 +987,14 @@ async function handleVerify(
     );
   }
 
-  const sub = typeof result.body?.user?.id === "string" ? result.body.user.id : "";
-  const verifiedEmail =
-    typeof result.body?.user?.email === "string" ? result.body.user.email : email;
-  if (!sub) {
+  const user = userFromAuthBody(result.body, email);
+  if (!user) {
     // GoTrue answered 200 without a user. Treat as unavailable rather than
     // minting a session with no subject to bind it to.
     return codePage(ctx, email, "登录服务暂时不可用，请稍后再试。", 503);
   }
 
-  const sso = await mintSsoSession({ sub, email: verifiedEmail });
-  const cookie = serializeSessionCookie(SSO_COOKIE, sso.token, SSO_TTL_SECONDS, secure);
-  return bounceWithCode(ctx, { sub, email: verifiedEmail }, [cookie]);
+  return bounceWithSso(ctx, user, secure);
 }
 
 function handleLogout(secure: boolean): Response {
@@ -403,14 +1020,33 @@ export async function handleLoginRequest(
 
   if (req.method === "GET" && path === "/") return handleRoot(url, req, deps, env);
 
-  if (req.method === "POST" && (path === "/otp" || path === "/verify" || path === "/logout")) {
+  if (req.method === "GET" && (path === "/oauth/google" || path === "/oauth/wechat")) {
+    return handleOAuthStart(path.slice("/oauth/".length) as OAuthProvider, url, req, deps, env, secure);
+  }
+  if (req.method === "GET" && path === "/oauth/callback") {
+    return handleOAuthCallback(url, req, deps, env, secure);
+  }
+  if (req.method === "GET" && path === "/sso") {
+    return handleWebSsoStart(url, req, deps, env, secure);
+  }
+  if (req.method === "GET" && path === WEB_SSO_CALLBACK_PATH) {
+    return handleWebSsoCallback(url, req, deps, env, secure);
+  }
+
+  if (
+    req.method === "POST" &&
+    ["/otp", "/verify", "/logout", "/phone", "/phone/verify", "/phone/select", "/sso/exchange"].includes(path)
+  ) {
     if (path === "/logout") return handleLogout(secure);
+    if (path === "/sso/exchange") return handleWebSsoExchange(req, deps, env, secure);
     // Deliberately not req.formData(): these forms are urlencoded, and
     // URLSearchParams cannot be talked into multipart parsing by a caller.
     const form = new URLSearchParams(await req.text());
-    return path === "/otp"
-      ? handleOtp(form, req, deps, env)
-      : handleVerify(form, deps, env, secure);
+    if (path === "/otp") return handleOtp(form, req, deps, env);
+    if (path === "/verify") return handleVerify(form, deps, env, secure);
+    if (path === "/phone") return handlePhoneStart(form, req, deps, env);
+    if (path === "/phone/verify") return handlePhoneVerify(form, deps, env, secure);
+    return handlePhoneSelect(form, deps, env, secure);
   }
 
   // Logout answers on GET too, and really does clear the cookie.
@@ -431,7 +1067,7 @@ export async function handleLoginRequest(
 
   // A GET to the other POST-only paths is a stale bookmark or a back button,
   // not an error worth a status code — send them to the start of the flow.
-  if (req.method === "GET" && (path === "/otp" || path === "/verify")) {
+  if (req.method === "GET" && (path === "/otp" || path === "/verify" || path.startsWith("/phone"))) {
     return redirect("/");
   }
 

--- a/services/fc/src/lib/feature-profiles.ts
+++ b/services/fc/src/lib/feature-profiles.ts
@@ -143,7 +143,7 @@ export const FEATURE_PROFILES: Record<string, FeatureFlags> = {
   // is now the whole story — the host comes from WEBSSO_LOGIN_URL on that
   // deployment, not from anything baked into the build.
   belayo: {
-    auth: { google: false, wechat: false, phone: true, password: false, webSSO: true },
+    auth: { google: true, wechat: false, phone: true, password: false, webSSO: true },
     channels: { discord: true, feishu: true, email: true, kook: true, wecom: true, wechat: true, seatalk: false },
     // Entry point only, same as self-host. Creating an app needs GITEA_*, which
     // this deployment now has (its own Gitea, reached over the VPC). Deploying

--- a/services/fc/src/lib/routes/config.ts
+++ b/services/fc/src/lib/routes/config.ts
@@ -30,8 +30,8 @@ function parseBool(raw) {
 // s.yaml, `"${X:-}"` in docker-compose — so "not configured" reaches the process
 // as `""`, never as undefined. Any `??` chain over these therefore treats a
 // blank as a real value; this helper is what makes "leave it empty" mean absent.
-function envValue(name: string): string | undefined {
-  const value = process.env[name]?.trim();
+function envValue(name: string, env: NodeJS.ProcessEnv = process.env): string | undefined {
+  const value = env[name]?.trim();
   return value ? value : undefined;
 }
 
@@ -145,9 +145,9 @@ function mergeFeatures(base: FeatureFlags, override: FeatureFlags): FeatureFlags
 // changes, which is what the tests do.
 const featureCache = new Map<string, FeatureFlags>();
 
-export function resolveFeatures(): FeatureFlags {
-  const profileName = envValue("APP_FEATURES_PROFILE");
-  const rawJson = envValue("APP_FEATURES_JSON");
+export function resolveFeatures(env: NodeJS.ProcessEnv = process.env): FeatureFlags {
+  const profileName = envValue("APP_FEATURES_PROFILE", env);
+  const rawJson = envValue("APP_FEATURES_JSON", env);
   // NUL joins the two halves because it is the one byte neither env var can
   // contain, so no (profile, json) pair can collide with another by splitting
   // differently. Written as an escape rather than as a raw byte: a literal NUL

--- a/services/fc/test/apps-login-service.test.ts
+++ b/services/fc/test/apps-login-service.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import {
   APP_AUTH_CALLBACK_PATH,
+  LOGIN_STATE_COOKIE,
   SSO_COOKIE,
   __resetSpentCodes,
   consumeAuthCode,
@@ -59,6 +60,7 @@ function deps(
   return {
     calls,
     lookupApp: overrides.lookupApp ?? (async (id) => (id === APP_ID ? APP : null)),
+    createAuthRepository: overrides.createAuthRepository,
     rateLimited: overrides.rateLimited ?? (() => false),
     secureCookies: overrides.secureCookies ?? true,
     fetchImpl: (async (url: any, init: any) => {
@@ -80,6 +82,13 @@ const post = (path: string, form: Record<string, string>, headers: Record<string
   });
 
 const flow = { app: APP_ID, r: ORIGIN, next: "/report" };
+
+function cookieValue(response: Response, name: string): string {
+  const raw = response.headers.get("set-cookie") ?? "";
+  const match = raw.match(new RegExp(`${name}=([^;]+)`));
+  assert.ok(match, `missing ${name} cookie`);
+  return match[1];
+}
 
 // --- host routing -----------------------------------------------------------
 
@@ -448,4 +457,161 @@ test("an address containing markup cannot break out of the page", async () => {
     assert.doesNotMatch(html, /<script>alert/);
     assert.match(html, /&lt;script&gt;/);
   });
+});
+
+// --- configured login methods ---------------------------------------------
+
+test("the login page mirrors enabled FC auth methods", async () => {
+  await withEnv(
+    {
+      APP_FEATURES_JSON: JSON.stringify({ auth: { phone: true, google: true, webSSO: true } }),
+      WEBSSO_LOGIN_URL: "https://admin.example.com/sign-in",
+    },
+    async () => {
+      const res = await handleLoginRequest(get(`/?app=${APP_ID}`), deps());
+      const html = await res!.text();
+      assert.match(html, /手机号登录/);
+      assert.match(html, /Google 登录/);
+      assert.match(html, /快捷登录/);
+    },
+  );
+});
+
+test("phone login uses the existing auth repository and does not bootstrap a team", async () => {
+  await withEnv(
+    { APP_FEATURES_JSON: JSON.stringify({ auth: { phone: true } }) },
+    async () => {
+      const calls: any[] = [];
+      const d = deps({
+        createAuthRepository: () => ({
+          phoneSendCode: async (args: any) => calls.push(["send", args]),
+          phoneLogin: async (args: any) => {
+            calls.push(["login", args]);
+            return {
+              session: { user: { id: "phone-user", email: "13700000000@phone.example" } },
+            };
+          },
+        }),
+      });
+      const sent = await handleLoginRequest(
+        post("/phone", { ...flow, phone: "+8613700000000" }),
+        d,
+      );
+      assert.equal(sent?.status, 200);
+      assert.match(await sent!.text(), /action="\/phone\/verify"/);
+      assert.deepEqual(calls[0], ["send", { phone: "+8613700000000", captchaVerify: "fc-app-login" }]);
+
+      const verified = await handleLoginRequest(
+        post("/phone/verify", { ...flow, phone: "+8613700000000", code: "123456" }),
+        d,
+      );
+      assert.equal(verified?.status, 302);
+      assert.match(verified!.headers.get("location")!, new RegExp(`^${ORIGIN}${APP_AUTH_CALLBACK_PATH}`));
+      assert.deepEqual(calls[1], ["login", { phone: "+8613700000000", code: "123456", userId: undefined }]);
+      assert.match(verified!.headers.get("set-cookie")!, new RegExp(`^${SSO_COOKIE}=`));
+    },
+  );
+});
+
+test("phone login supports the repository's multi-account picker", async () => {
+  await withEnv(
+    { APP_FEATURES_JSON: JSON.stringify({ auth: { phone: true } }) },
+    async () => {
+      const selected: any[] = [];
+      const d = deps({
+        createAuthRepository: () => ({
+          phoneSendCode: async () => {},
+          phoneLogin: async (args: any) => {
+            selected.push(args);
+            if (!args.userId) {
+              return { multiUser: true, users: [{ id: "u-2", nickname: "小王", org_name: "研发部" }] };
+            }
+            return { session: { user: { id: "u-2", email: "u-2@example.com" } } };
+          },
+        }),
+      });
+      const picker = await handleLoginRequest(
+        post("/phone/verify", { ...flow, phone: "13700000000", code: "123456" }),
+        d,
+      );
+      assert.equal(picker?.status, 200);
+      assert.match(await picker!.text(), /研发部/);
+
+      const completed = await handleLoginRequest(
+        post("/phone/select", { ...flow, phone: "13700000000", code: "123456", userId: "u-2" }),
+        d,
+      );
+      assert.equal(completed?.status, 302);
+      assert.equal(selected[1].userId, "u-2");
+    },
+  );
+});
+
+test("Google login uses the central login host as a PKCE callback", async () => {
+  await withEnv(
+    { APP_FEATURES_JSON: JSON.stringify({ auth: { google: true } }) },
+    async () => {
+      const d = deps();
+      const start = await handleLoginRequest(get(`/oauth/google?app=${APP_ID}&r=${encodeURIComponent(ORIGIN)}`), d);
+      assert.equal(start?.status, 302);
+      const authorize = new URL(start!.headers.get("location")!);
+      assert.equal(authorize.searchParams.get("provider"), "google");
+      assert.equal(authorize.searchParams.get("redirect_to"), "https://login.example.com/oauth/callback");
+      assert.equal(authorize.searchParams.get("code_challenge_method"), "s256");
+      const state = authorize.searchParams.get("state")!;
+      const callback = await handleLoginRequest(
+        get(`/oauth/callback?code=provider-code&state=${encodeURIComponent(state)}`, {
+          cookie: `${LOGIN_STATE_COOKIE}=${cookieValue(start!, LOGIN_STATE_COOKIE)}`,
+        }),
+        d,
+      );
+      assert.equal(callback?.status, 302);
+      assert.match(callback!.headers.get("location")!, new RegExp(`^${ORIGIN}${APP_AUTH_CALLBACK_PATH}`));
+      assert.match(callback!.headers.get("set-cookie")!, new RegExp(`${SSO_COOKIE}=`));
+      assert.match(callback!.headers.get("set-cookie")!, new RegExp(`${LOGIN_STATE_COOKIE}=;`));
+    },
+  );
+});
+
+test("Web SSO redirects through the configured target and supports a token bridge", async () => {
+  await withEnv(
+    {
+      APP_FEATURES_JSON: JSON.stringify({ auth: { webSSO: true } }),
+      WEBSSO_LOGIN_URL: "https://admin.example.com/sign-in?tenant=teamclu",
+    },
+    async () => {
+      const d = deps({
+        gotrue: (call) => {
+          if (call.url.endsWith("/auth/v1/token?grant_type=refresh_token")) {
+            return new Response(JSON.stringify({ user: { id: "sso-user", email: "sso@example.com" } }), { status: 200 });
+          }
+          return new Response(JSON.stringify({ user: { id: "u-1", email: "a@example.com" } }), { status: 200 });
+        },
+      });
+      const start = await handleLoginRequest(get(`/sso?app=${APP_ID}&r=${encodeURIComponent(ORIGIN)}`), d);
+      assert.equal(start?.status, 302);
+      const target = new URL(start!.headers.get("location")!);
+      assert.equal(target.origin, "https://admin.example.com");
+      assert.equal(target.searchParams.get("redirect_to"), "https://login.example.com/sso/callback");
+      assert.ok(target.searchParams.get("code_challenge"));
+
+      const stateCookie = `${LOGIN_STATE_COOKIE}=${cookieValue(start!, LOGIN_STATE_COOKIE)}`;
+      const bridge = await handleLoginRequest(
+        get(`/sso/callback?state=${encodeURIComponent(target.searchParams.get("state")!)}&refresh_token=must-not-be-accepted`, {
+          cookie: stateCookie,
+        }),
+        d,
+      );
+      assert.equal(bridge?.status, 200);
+      assert.match(await bridge!.text(), /f\.action="\/sso\/exchange"/);
+      assert.equal(d.calls.length, 0, "tokens in the callback query must not reach GoTrue");
+
+      const completed = await handleLoginRequest(
+        post("/sso/exchange", { refresh_token: "external-refresh" }, { cookie: stateCookie }),
+        d,
+      );
+      assert.equal(completed?.status, 302);
+      assert.match(completed!.headers.get("location")!, new RegExp(`^${ORIGIN}${APP_AUTH_CALLBACK_PATH}`));
+    },
+  );
 });

--- a/services/fc/test/deploy-env-parity.test.ts
+++ b/services/fc/test/deploy-env-parity.test.ts
@@ -202,7 +202,7 @@ function envVarsReadBySource(): Set<string> {
         for (const m of src.matchAll(/process\.env\[["']([A-Z_0-9]+)["']\]/g)) found.add(m[1]);
         for (const m of src.matchAll(/\benv\.([A-Z_0-9]+)/g)) found.add(m[1]);
         for (const m of src.matchAll(/\benv\[["']([A-Z_0-9]+)["']\]/g)) found.add(m[1]);
-        for (const m of src.matchAll(/\benvValue\(["']([A-Z_0-9]+)["']\)/g)) found.add(m[1]);
+        for (const m of src.matchAll(/\benvValue\(["']([A-Z_0-9]+)["'](?:\s*,[^)]*)?\)/g)) found.add(m[1]);
       }
     }
   };


### PR DESCRIPTION
## Summary

- reuse FC/Tauri auth feature configuration for deployed-app login
- support email OTP, phone OTP, Google PKCE, and configured Web SSO without team bootstrap
- add signed callback state and deployment callback allow-list guidance
- enable Google in the Belayo profile and record Dokploy as the Cloud API target

## Verification

- `npm run typecheck`
- `node --import tsx --test test/apps-login-service.test.ts test/deploy-env-parity.test.ts` (35 passed)
- `npm run build`
- self-host Auth/FC health checks and Google authorize preflight passed

## Deployment note

Belayo Cloud API is deployed through Dokploy; Alibaba FC is pending decommission. After merge, deploy a new immutable Cloud API image to Dokploy. The running Dokploy service currently points at the existing Belayo GoTrue endpoint, so `https://login.apps.mx5.cn/oauth/callback` must also be allow-listed on that actual GoTrue deployment before Google login is considered end-to-end complete.
