### PR TITLE
feat(skills): raise package size limits

### DIFF
--- a/apps/daemon/src/config/managed_skill_writer.rs
+++ b/apps/daemon/src/config/managed_skill_writer.rs
@@ -19,10 +19,10 @@ use super::roles_skills::is_inherent_skill;
 const GLOBAL_SKILLS_REL: &str = ".agents/skills";
 pub(crate) const SKILL_MD: &str = "SKILL.md";
 pub(crate) const MAX_PACK_FILES: usize = 500;
-/// Publish/write cap: 0.5 MiB per file. Distinct from the get_draft JSON budget.
-pub(crate) const MAX_SINGLE_FILE_BYTES: usize = 512 * 1024;
-/// Publish/write cap: 2.5 MiB pack total.
-pub(crate) const MAX_PACK_TOTAL_BYTES: usize = 2560 * 1024;
+/// Publish/write cap: 5 MiB per file. Distinct from the get_draft JSON budget.
+pub(crate) const MAX_SINGLE_FILE_BYTES: usize = 5 * 1024 * 1024;
+/// Publish/write cap: 25 MiB pack total.
+pub(crate) const MAX_PACK_TOTAL_BYTES: usize = 25 * 1024 * 1024;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "snake_case")]

--- a/crates/teamclu-skillpack/src/package_index.rs
+++ b/crates/teamclu-skillpack/src/package_index.rs
@@ -26,8 +26,10 @@ use crate::origin::ORIGIN_DIR;
 /// New-publish caps. Historical versions stay downloadable; these only bind
 /// the pack we are about to upload.
 pub const MAX_PACK_FILES: usize = 500;
-pub const MAX_SINGLE_FILE_BYTES: u64 = 1024 * 1024;
-pub const MAX_PACK_TOTAL_BYTES: u64 = 5 * 1024 * 1024;
+/// Publish cap: 5 MiB per file.
+pub const MAX_SINGLE_FILE_BYTES: u64 = 5 * 1024 * 1024;
+/// Publish cap: 25 MiB per skill pack.
+pub const MAX_PACK_TOTAL_BYTES: u64 = 25 * 1024 * 1024;
 
 /// Declares files that are not part of the published pack.
 pub const IGNORE_FILE: &str = ".teamcluignore";


### PR DESCRIPTION
Summary: raise the per-file team skill publish limit to 5 MiB, raise the total skill pack publish limit to 25 MiB, and keep shared desktop and daemon validation limits aligned. Validation: cargo test -p teamclu-skillpack (44 passed); cargo check -p amuxd; cargo fmt --check --manifest-path apps/desktop/Cargo.toml; git diff --check. Note: the broader daemon test command is blocked by a pre-existing integration-test compile error in tests/support/.../knowledge_inbox.rs (crate::daemon not found).