### PR TITLE
feat(knowledge): distill session conclusions instead of dumping the transcript

### DIFF
--- a/apps/daemon/assets/knowledge-templates/mcp-manifest.json
+++ b/apps/daemon/assets/knowledge-templates/mcp-manifest.json
@@ -48,16 +48,29 @@
     },
     {
       "name": "knowledge_propose",
-      "description": "Draft a conclusion from this conversation for human review. Writes a pending candidate on this device only — it does NOT enter the team knowledge vault. Tell the user a review tab will open; do not say the page is saved or shared. 把对话结论提交为本机审稿草稿，不会写入团队知识库。告知用户将打开审稿页，不要说已经保存或已共享。 Never call knowledge_write / knowledge_salvage / knowledge_create for this; those skip review.",
+      "description": "Draft distilled conclusions from this conversation for human review. Write pending suggestions only — never paste the chat transcript, and do not say the page is saved or shared. The candidate stays on this device until a human publishes it. 把对话结论提炼成本机审稿草稿（条目/建议，不要贴聊天全文），不会写入团队知识库。告知用户将打开审稿页。 Never call knowledge_write / knowledge_salvage / knowledge_create for this; those skip review.",
       "inputSchema": {
         "type": "object",
         "required": ["title", "content"],
         "properties": {
           "title": { "type": "string" },
-          "content": { "type": "string", "description": "Markdown body of the proposed page / 拟写入的正文" },
+          "content": { "type": "string", "description": "Markdown composed from distilled suggestions, not the transcript / 由提炼建议组成的正文，不是聊天记录" },
           "suggestedPath": { "type": "string", "description": "Vault-relative path suggestion, e.g. 20-domains/payments/对账口径.md" },
           "session_id": { "type": "string" },
-          "source": { "type": "string", "description": "Use 'agent-propose' when calling from a session" }
+          "source": { "type": "string", "description": "Use 'agent-propose' when calling from a session" },
+          "summary": { "type": "string", "description": "One-sentence consensus / 一句话共识" },
+          "suggestions": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": ["kind", "text"],
+              "properties": {
+                "id": { "type": "string" },
+                "kind": { "type": "string", "enum": ["decision", "fact", "followup"] },
+                "text": { "type": "string" }
+              }
+            }
+          }
         }
       },
       "maps_to": { "action": "propose" }

--- a/apps/daemon/src/daemon/server/knowledge/inbox.rs
+++ b/apps/daemon/src/daemon/server/knowledge/inbox.rs
@@ -48,6 +48,16 @@ pub(super) enum CandidateStatus {
     Discarded,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+struct KnowledgeSuggestion {
+    #[serde(default)]
+    pub id: String,
+    #[serde(default)]
+    pub kind: String,
+    pub text: String,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub(super) struct KnowledgeCandidate {
@@ -63,6 +73,10 @@ pub(super) struct KnowledgeCandidate {
     pub status: CandidateStatus,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub published_path: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub summary: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub suggestions: Vec<KnowledgeSuggestion>,
 }
 
 pub(crate) fn inbox_dir(team_id: &str) -> PathBuf {
@@ -103,6 +117,29 @@ fn candidate_json(c: &KnowledgeCandidate) -> Value {
     serde_json::to_value(c).unwrap_or(Value::Null)
 }
 
+fn parse_suggestions(payload: &Value) -> Vec<KnowledgeSuggestion> {
+    let Some(arr) = payload.get("suggestions").and_then(Value::as_array) else {
+        return Vec::new();
+    };
+    arr.iter()
+        .filter_map(|item| serde_json::from_value::<KnowledgeSuggestion>(item.clone()).ok())
+        .filter(|item| !item.text.trim().is_empty())
+        .take(8)
+        .enumerate()
+        .map(|(i, mut item)| {
+            let kind = match item.kind.as_str() {
+                "decision" | "fact" | "followup" => item.kind.clone(),
+                _ => "fact".to_string(),
+            };
+            item.kind = kind;
+            if item.id.trim().is_empty() {
+                item.id = format!("{}-{i}", item.kind);
+            }
+            item
+        })
+        .collect()
+}
+
 /// `propose` — create a pending candidate. Does not touch the vault.
 pub(crate) fn propose(team_id: &str, inbox: &Path, payload: &Value) -> String {
     let Some(body) = str_field(payload, "content").or_else(|| str_field(payload, "body")) else {
@@ -118,6 +155,10 @@ pub(crate) fn propose(team_id: &str, inbox: &Path, payload: &Value) -> String {
             return e;
         }
     }
+    let summary = str_field(payload, "summary")
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string);
     let candidate = KnowledgeCandidate {
         id: Uuid::new_v4().to_string(),
         team_id: team_id.to_string(),
@@ -132,6 +173,8 @@ pub(crate) fn propose(team_id: &str, inbox: &Path, payload: &Value) -> String {
         created_at: chrono::Utc::now().to_rfc3339(),
         status: CandidateStatus::Pending,
         published_path: None,
+        summary,
+        suggestions: parse_suggestions(payload),
     };
     match write_candidate(inbox, &candidate) {
         Ok(()) => ok(candidate_json(&candidate)),
@@ -320,6 +363,51 @@ mod tests {
         let vault_files: Vec<_> = fs::read_dir(&vault).unwrap().collect();
         assert!(vault_files.is_empty(), "propose must not write the vault");
         assert_eq!(fs::read_dir(&inbox).unwrap().count(), 1);
+    }
+
+    #[test]
+    fn propose_persists_distilled_suggestions() {
+        let (_tmp, inbox, vault) = tmp_pair();
+        let reply = propose(
+            "team-1",
+            &inbox,
+            &json!({
+                "title": "对账口径",
+                "content": "以渠道单号为准",
+                "summary": "以渠道单号为准",
+                "suggestions": [
+                    {"id": "d-1", "kind": "decision", "text": "以渠道单号为准"},
+                    {"kind": "followup", "text": "补一条 runbook"},
+                    {"kind": "noise", "text": ""}
+                ],
+            }),
+        );
+        let v = parse(&reply);
+        assert_eq!(v["ok"], true, "{v}");
+        assert_eq!(v["result"]["summary"], "以渠道单号为准");
+        let items = v["result"]["suggestions"].as_array().unwrap();
+        assert_eq!(items.len(), 2);
+        assert_eq!(items[0]["kind"], "decision");
+        assert_eq!(items[1]["kind"], "followup");
+        assert_eq!(items[1]["id"], "followup-1");
+        assert!(vault.read_dir().unwrap().next().is_none());
+    }
+
+    #[test]
+    fn inbox_get_reads_candidates_written_before_suggestions_existed() {
+        let (_tmp, inbox, _vault) = tmp_pair();
+        fs::write(
+            inbox.join("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee.json"),
+            r#"{"id":"aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee","teamId":"t","sessionId":"s","title":"old","body":"plain","suggestedPath":"","source":"session-header","createdAt":"2026-09-11T00:00:00Z","status":"pending"}"#,
+        )
+        .unwrap();
+        let got = parse(&inbox_get(
+            &inbox,
+            &json!({ "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee" }),
+        ));
+        assert_eq!(got["ok"], true, "{got}");
+        assert_eq!(got["result"]["title"], "old");
+        assert!(got["result"].get("suggestions").is_none());
     }
 
     #[test]

--- a/apps/daemon/src/http/knowledge_inbox.rs
+++ b/apps/daemon/src/http/knowledge_inbox.rs
@@ -86,6 +86,8 @@ pub struct ProposeBody {
     pub suggested_path: Option<String>,
     pub session_id: Option<String>,
     pub source: Option<String>,
+    pub summary: Option<String>,
+    pub suggestions: Option<Value>,
 }
 
 /// `POST /v1/knowledge/inbox`
@@ -107,6 +109,12 @@ pub async fn propose_inbox(
     }
     if let Some(session_id) = body.session_id {
         payload.insert("sessionId".into(), Value::String(session_id));
+    }
+    if let Some(summary) = body.summary {
+        payload.insert("summary".into(), Value::String(summary));
+    }
+    if let Some(suggestions) = body.suggestions {
+        payload.insert("suggestions".into(), suggestions);
     }
     payload.insert(
         "source".into(),

--- a/docs/specs/2026-09-11-session-knowledge-review-design.md
+++ b/docs/specs/2026-09-11-session-knowledge-review-design.md
@@ -38,7 +38,7 @@ Agent 只能起草。人改完、选好路径、点写入，这篇东西才进�
    knowledge_propose → state/knowledge-inbox/<id>.json
         │
         ▼
-   审稿 native tab（改标题 / 正文 / 落点）
+   审稿 native tab（勾选提炼建议 / 改标题 / 正文 / 落点）
         │
         ├── 丢弃 → 删 candidate
         ├── 稍后 → 留在 inbox；知识库列「待写入 · N」
@@ -55,6 +55,12 @@ type KnowledgeCandidate = {
   title: string
   body: string
   suggestedPath: string     // vault 相对，可空
+  summary?: string          // 一句话共识
+  suggestions?: Array<{     // 提炼条目；审稿页勾选后重写正文
+    id: string
+    kind: "decision" | "fact" | "followup"
+    text: string
+  }>
   source: "session-header" | "agent-propose" | "message" | "unknown"
   createdAt: string         // ISO-8601
   status: "pending" | "published" | "discarded"
@@ -90,7 +96,8 @@ reviewed: YYYY-MM-DD
 ## 6. UI（后续切片）
 
 - 会话顶栏，和「导出完整会话记录」并排：「整理到知识库」
-- 新 native tab `knowledge-review:<id>`：来源会话、标题、知识库路径选择器、Markdown 正文、写入 / 稍后 / 丢弃
+- 新 native tab `knowledge-review:<id>`：来源会话、标题、知识库路径、**提炼建议勾选**、由建议组成的 Markdown 正文、写入 / 稍后 / 丢弃
+- 顶栏入口必须提炼（结论 / 要点 / 后续），**禁止把聊天全文写入草稿**
 - 知识库第二列「待写入 · N」
 - 不在文件树里画草稿
 
@@ -98,7 +105,7 @@ reviewed: YYYY-MM-DD
 
 1. inbox + `propose` / `inbox_*` / `publish` ——确认前 vault 无新文件
 2. 审稿 tab + 「待写入」
-3. 会话顶栏入口（本机从消息拼草稿；模型摘要仍可走 `knowledge_propose`）
+3. 会话顶栏入口（本机提炼建议，不是全文；有团队模型时走 chat/completions，失败回退启发式）
 4. 接上 `knowledge_propose`，并拦住对 `team-knowledge/` 的 write
 
 ## 8. 验收
@@ -107,4 +114,5 @@ reviewed: YYYY-MM-DD
 - publish 后指定路径出现带 `session-id` + `reviewed` 的 `.md`
 - 目标已存在且未覆盖 → 不写
 - discard / 稍后 → vault 无变化
+- 顶栏「整理到知识库」的草稿正文不含聊天全文，审稿页能勾选提炼建议
 - agent 对 `team-knowledge/foo.md` 调用 write → 失败或变成 propose（切片 4）

--- a/packages/app/src/components/teamshare/KnowledgeReviewTab.tsx
+++ b/packages/app/src/components/teamshare/KnowledgeReviewTab.tsx
@@ -11,17 +11,39 @@ import {
   isAlreadyExistsError,
   publishKnowledgeCandidate,
 } from '@/lib/knowledge/inbox-client'
-import type { KnowledgeCandidate } from '@/lib/knowledge/inbox-types'
+import type {
+  KnowledgeCandidate,
+  KnowledgeSuggestion,
+  KnowledgeSuggestionKind,
+} from '@/lib/knowledge/inbox-types'
+import { composeKnowledgeDraftFromSelection } from '@/lib/knowledge/session-knowledge-draft'
 import { encodeKnowledgeReviewTarget } from '@/lib/tabs/teamshare-target'
 import { useTabsStore } from '@/stores/tabs'
 import { useKnowledgeInboxStore } from '@/stores/knowledge-inbox'
 import { useTeamShareBrowserStore } from '@/stores/team-share-browser'
 import { useWorkspaceStore } from '@/stores/workspace'
 
+const KIND_LABEL: Record<KnowledgeSuggestionKind, string> = {
+  decision: '结论',
+  fact: '要点',
+  followup: '后续',
+}
+
 function vaultAbsPath(syncRoot: string | null, rel: string): string | null {
   if (!syncRoot) return null
   const clean = rel.replace(/^\/+/, '')
   return `${syncRoot.replace(/\/+$/, '')}/knowledge/${clean}`
+}
+
+function composedBody(
+  summary: string,
+  suggestions: KnowledgeSuggestion[],
+  selectedIds: ReadonlySet<string>,
+): string {
+  return (
+    composeKnowledgeDraftFromSelection(summary, suggestions, selectedIds) ||
+    '（请勾选建议，或直接改写正文。）'
+  )
 }
 
 export function KnowledgeReviewTab({ candidateId }: { candidateId: string }) {
@@ -32,6 +54,10 @@ export function KnowledgeReviewTab({ candidateId }: { candidateId: string }) {
   const [title, setTitle] = React.useState('')
   const [path, setPath] = React.useState('')
   const [body, setBody] = React.useState('')
+  const [summary, setSummary] = React.useState('')
+  const [suggestions, setSuggestions] = React.useState<KnowledgeSuggestion[]>([])
+  const [selectedIds, setSelectedIds] = React.useState<Set<string>>(new Set())
+  const [bodyDirty, setBodyDirty] = React.useState(false)
   const [overwrite, setOverwrite] = React.useState(false)
   const [busy, setBusy] = React.useState<'publish' | 'discard' | null>(null)
 
@@ -40,10 +66,16 @@ export function KnowledgeReviewTab({ candidateId }: { candidateId: string }) {
     void getKnowledgeCandidate(candidateId)
       .then((row) => {
         if (cancelled) return
+        const items = row.suggestions ?? []
+        const ids = new Set(items.map((item) => item.id))
         setCandidate(row)
         setTitle(row.title)
         setPath(row.suggestedPath || '')
+        setSummary(row.summary ?? '')
+        setSuggestions(items)
+        setSelectedIds(ids)
         setBody(row.body)
+        setBodyDirty(false)
         setLoadError(null)
       })
       .catch((err) => {
@@ -59,6 +91,19 @@ export function KnowledgeReviewTab({ candidateId }: { candidateId: string }) {
     const target = encodeKnowledgeReviewTarget(candidateId)
     closeWhere((tab) => tab.type === 'native' && tab.target === target)
   }, [candidateId, closeWhere])
+
+  const rewriteFromSelection = (ids: ReadonlySet<string>) => {
+    setBody(composedBody(summary, suggestions, ids))
+    setBodyDirty(false)
+  }
+
+  const onToggleSuggestion = (id: string) => {
+    const next = new Set(selectedIds)
+    if (next.has(id)) next.delete(id)
+    else next.add(id)
+    setSelectedIds(next)
+    if (!bodyDirty) rewriteFromSelection(next)
+  }
 
   const onLater = () => {
     closeTab()
@@ -142,12 +187,18 @@ export function KnowledgeReviewTab({ candidateId }: { candidateId: string }) {
           {t('knowledgeReview.title', '写入知识库前先看一遍')}
         </div>
         <div className="mt-1 text-[12px] text-muted-foreground">
-          {candidate.sessionId
-            ? t('knowledgeReview.fromSession', '来自会话 {{id}}', {
-                id: candidate.sessionId.slice(0, 8),
-              })
-            : t('knowledgeReview.fromUnknown', '来自本机草稿')}
+          {t(
+            'knowledgeReview.distillHint',
+            '这是从会话里提炼的建议，不是聊天全文。勾选要留下的条目，再写入。',
+          )}
         </div>
+        {candidate.sessionId ? (
+          <div className="mt-1 text-[12px] text-faint">
+            {t('knowledgeReview.fromSession', '来自会话 {{id}}', {
+              id: candidate.sessionId.slice(0, 8),
+            })}
+          </div>
+        ) : null}
       </div>
 
       <div className="min-h-0 flex-1 overflow-auto px-6 py-4">
@@ -173,14 +224,53 @@ export function KnowledgeReviewTab({ candidateId }: { candidateId: string }) {
               className="h-9 bg-paper font-mono text-[12px]"
             />
           </label>
+          {suggestions.length > 0 ? (
+            <div className="flex flex-col gap-1.5">
+              <span className="text-[12px] font-medium text-foreground">
+                {t('knowledgeReview.suggestions', '提炼建议')}
+              </span>
+              <div className="flex flex-col gap-1 rounded-[8px] border border-border-soft bg-paper p-1.5">
+                {suggestions.map((item) => (
+                  <label
+                    key={item.id}
+                    className="flex cursor-pointer items-start gap-2 rounded-[6px] px-2 py-1.5 hover:bg-selected"
+                  >
+                    <input
+                      type="checkbox"
+                      className="mt-0.5"
+                      checked={selectedIds.has(item.id)}
+                      onChange={() => onToggleSuggestion(item.id)}
+                    />
+                    <span className="mt-px shrink-0 text-[10.5px] font-semibold tracking-[0.6px] text-faint">
+                      {KIND_LABEL[item.kind]}
+                    </span>
+                    <span className="min-w-0 flex-1 text-[12.5px] leading-[1.6] text-foreground">
+                      {item.text}
+                    </span>
+                  </label>
+                ))}
+              </div>
+              <button
+                type="button"
+                className="self-start text-[12px] text-muted-foreground hover:text-foreground"
+                onClick={() => rewriteFromSelection(selectedIds)}
+              >
+                {t('knowledgeReview.rewriteBody', '按所选建议重写正文')}
+              </button>
+            </div>
+          ) : null}
           <label className="flex flex-col gap-1.5">
             <span className="text-[12px] font-medium text-foreground">
               {t('knowledgeReview.fieldBody', '正文')}
             </span>
             <textarea
+              aria-label={t('knowledgeReview.fieldBody', '正文')}
               value={body}
-              onChange={(e) => setBody(e.target.value)}
-              rows={16}
+              onChange={(e) => {
+                setBody(e.target.value)
+                setBodyDirty(true)
+              }}
+              rows={12}
               className={cn(
                 'w-full resize-y rounded-[8px] border border-border bg-paper',
                 'px-3 py-2.5 text-[13.5px] leading-[1.7] text-foreground',

--- a/packages/app/src/components/teamshare/__tests__/KnowledgeReviewTab.test.tsx
+++ b/packages/app/src/components/teamshare/__tests__/KnowledgeReviewTab.test.tsx
@@ -1,0 +1,99 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { KnowledgeReviewTab } from '../KnowledgeReviewTab'
+
+const getKnowledgeCandidate = vi.fn()
+const publishKnowledgeCandidate = vi.fn()
+const closeWhere = vi.fn()
+const inboxLoad = vi.fn()
+const inboxRemove = vi.fn()
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (_key: string, fallback?: string) => fallback ?? _key }),
+}))
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn(), message: vi.fn() },
+}))
+
+vi.mock('@/lib/knowledge/inbox-client', () => ({
+  getKnowledgeCandidate: (...args: unknown[]) => getKnowledgeCandidate(...args),
+  publishKnowledgeCandidate: (...args: unknown[]) => publishKnowledgeCandidate(...args),
+  isAlreadyExistsError: () => false,
+}))
+
+vi.mock('@/stores/tabs', () => ({
+  useTabsStore: (sel: (s: { closeWhere: typeof closeWhere }) => unknown) =>
+    sel({ closeWhere }),
+}))
+
+vi.mock('@/stores/knowledge-inbox', () => ({
+  useKnowledgeInboxStore: {
+    getState: () => ({ load: inboxLoad, remove: inboxRemove }),
+  },
+}))
+
+vi.mock('@/stores/team-share-browser', () => ({
+  useTeamShareBrowserStore: { getState: () => ({ syncRoot: null }) },
+}))
+
+vi.mock('@/stores/workspace', () => ({
+  useWorkspaceStore: { getState: () => ({ selectFile: vi.fn() }) },
+}))
+
+describe('KnowledgeReviewTab', () => {
+  beforeEach(() => {
+    getKnowledgeCandidate.mockReset()
+    publishKnowledgeCandidate.mockReset()
+    closeWhere.mockReset()
+    inboxLoad.mockReset()
+    inboxRemove.mockReset()
+    getKnowledgeCandidate.mockResolvedValue({
+      id: 'cand-1',
+      teamId: 't',
+      sessionId: 'sess-1',
+      title: '对账口径',
+      body: '以渠道单号为准\n\n## 结论\n\n- 以渠道单号为准\n\n## 后续\n\n- 补一条 runbook',
+      suggestedPath: '20-domains/对账口径.md',
+      source: 'session-header',
+      createdAt: '2026-09-11T00:00:00Z',
+      status: 'pending',
+      summary: '以渠道单号为准',
+      suggestions: [
+        { id: 'd-1', kind: 'decision', text: '以渠道单号为准' },
+        { id: 'f-1', kind: 'followup', text: '补一条 runbook' },
+      ],
+    })
+  })
+
+  it('lets the reviewer uncheck a suggestion and drops it from the body', async () => {
+    render(<KnowledgeReviewTab candidateId="cand-1" />)
+    await screen.findByText('补一条 runbook')
+    const boxes = screen.getAllByRole('checkbox')
+    const followup = boxes.find((el) =>
+      el.parentElement?.textContent?.includes('补一条 runbook'),
+    )
+    expect(followup).toBeTruthy()
+    fireEvent.click(followup!)
+    await waitFor(() => {
+      expect((screen.getByRole('textbox', { name: '正文' }) as HTMLTextAreaElement).value).not.toContain(
+        '补一条 runbook',
+      )
+    })
+  })
+
+  it('does not overwrite a hand-edited body until rewrite is clicked', async () => {
+    render(<KnowledgeReviewTab candidateId="cand-1" />)
+    const textarea = (await screen.findByRole('textbox', { name: '正文' })) as HTMLTextAreaElement
+    fireEvent.change(textarea, { target: { value: '人手改过的正文' } })
+    const followup = screen.getAllByRole('checkbox').find((el) =>
+      el.parentElement?.textContent?.includes('补一条 runbook'),
+    )
+    fireEvent.click(followup!)
+    expect(textarea.value).toBe('人手改过的正文')
+    fireEvent.click(screen.getByRole('button', { name: '按所选建议重写正文' }))
+    expect(textarea.value).not.toContain('人手改过的正文')
+    expect(textarea.value).not.toContain('补一条 runbook')
+    expect(textarea.value).toContain('以渠道单号为准')
+  })
+})

--- a/packages/app/src/lib/knowledge/__tests__/propose-from-session.test.ts
+++ b/packages/app/src/lib/knowledge/__tests__/propose-from-session.test.ts
@@ -4,6 +4,7 @@ import { MessageKind } from '@/lib/proto/teamclu_pb'
 const proposeKnowledgeCandidate = vi.fn()
 const openKnowledgeReview = vi.fn()
 const inboxLoad = vi.fn()
+const distillWithTeamLlm = vi.fn()
 
 vi.mock('@/lib/knowledge/inbox-client', () => ({
   proposeKnowledgeCandidate: (...args: unknown[]) => proposeKnowledgeCandidate(...args),
@@ -11,6 +12,10 @@ vi.mock('@/lib/knowledge/inbox-client', () => ({
 
 vi.mock('@/lib/tabs/knowledge-tabs', () => ({
   openKnowledgeReview: (...args: unknown[]) => openKnowledgeReview(...args),
+}))
+
+vi.mock('@/lib/knowledge/session-knowledge-llm', () => ({
+  distillWithTeamLlm: (...args: unknown[]) => distillWithTeamLlm(...args),
 }))
 
 vi.mock('@/stores/knowledge-inbox', () => ({
@@ -24,7 +29,16 @@ vi.mock('@/stores/session-message-store', () => ({
     getState: () => ({
       messages: {
         'sess-1': [
-          { kind: 1, content: '以渠道单号为准', senderActorId: 'alice' },
+          {
+            kind: MessageKind.TEXT,
+            content: `过程记录。${'用户贴了一大段过程记录。'.repeat(20)}`,
+            senderActorId: 'alice',
+          },
+          {
+            kind: MessageKind.AGENT_REPLY,
+            content: '结论：以渠道单号为准。\n- 下一步补一条 runbook',
+            senderActorId: 'agent-1',
+          },
         ],
       },
     }),
@@ -41,18 +55,41 @@ vi.mock('@/stores/session-list-store', () => ({
   },
 }))
 
+vi.mock('@/stores/session-participant-store', () => ({
+  useSessionParticipantStore: {
+    getState: () => ({
+      participantsBySession: {
+        'sess-1': [
+          { actorId: 'alice', isAgent: false },
+          { actorId: 'agent-1', isAgent: true },
+        ],
+      },
+    }),
+  },
+}))
+
 describe('proposeSessionToKnowledge', () => {
   beforeEach(() => {
     proposeKnowledgeCandidate.mockReset()
     openKnowledgeReview.mockReset()
     inboxLoad.mockReset()
+    distillWithTeamLlm.mockReset()
     inboxLoad.mockResolvedValue(undefined)
+    distillWithTeamLlm.mockResolvedValue(null)
+    proposeKnowledgeCandidate.mockResolvedValue({ id: 'cand-9', title: '对账口径' })
   })
 
-  it('proposes a pending candidate and opens the review tab', async () => {
-    proposeKnowledgeCandidate.mockResolvedValue({ id: 'cand-9', title: '对账口径' })
+  it('proposes distilled suggestions instead of the full transcript', async () => {
     const { proposeSessionToKnowledge } = await import('@/lib/knowledge/propose-from-session')
     await proposeSessionToKnowledge('sess-1')
+    const payload = proposeKnowledgeCandidate.mock.calls[0][0] as {
+      content: string
+      suggestions: Array<{ text: string }>
+    }
+    expect(payload.content).toContain('以渠道单号为准')
+    expect(payload.content).not.toContain('用户贴了一大段过程记录')
+    expect(payload.content).not.toContain('### alice')
+    expect(payload.suggestions.some((item) => item.text.includes('渠道单号'))).toBe(true)
     expect(proposeKnowledgeCandidate).toHaveBeenCalledWith(
       expect.objectContaining({
         title: '对账口径',
@@ -61,10 +98,25 @@ describe('proposeSessionToKnowledge', () => {
         suggestedPath: '20-domains/对账口径.md',
       }),
     )
-    const content = proposeKnowledgeCandidate.mock.calls[0][0].content as string
-    expect(content).toContain('以渠道单号为准')
-    expect(content).not.toContain(String(MessageKind.SYSTEM))
     expect(openKnowledgeReview).toHaveBeenCalledWith('cand-9', '对账口径')
-    expect(inboxLoad).toHaveBeenCalled()
+  })
+
+  it('prefers the team-model distill when it returns a draft', async () => {
+    distillWithTeamLlm.mockResolvedValue({
+      title: 'LLM 标题',
+      body: '## 结论\n\n- 模型提炼的结论',
+      suggestedPath: '20-domains/llm.md',
+      summary: '模型提炼的结论',
+      suggestions: [{ id: 'd-1', kind: 'decision', text: '模型提炼的结论' }],
+    })
+    const { proposeSessionToKnowledge } = await import('@/lib/knowledge/propose-from-session')
+    await proposeSessionToKnowledge('sess-1')
+    expect(proposeKnowledgeCandidate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: 'LLM 标题',
+        content: '## 结论\n\n- 模型提炼的结论',
+        summary: '模型提炼的结论',
+      }),
+    )
   })
 })

--- a/packages/app/src/lib/knowledge/__tests__/session-knowledge-draft.test.ts
+++ b/packages/app/src/lib/knowledge/__tests__/session-knowledge-draft.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from 'vitest'
 import { MessageKind } from '@/lib/proto/teamclu_pb'
-import { draftFromSession, slugifyDraftTitle } from '@/lib/knowledge/session-knowledge-draft'
+import {
+  composeKnowledgeDraft,
+  compactTranscriptForDistill,
+  distillFromSession,
+  parseDistillPayload,
+  slugifyDraftTitle,
+} from '@/lib/knowledge/session-knowledge-draft'
 
 describe('slugifyDraftTitle', () => {
   it('keeps CJK and separates on space', () => {
@@ -13,31 +19,94 @@ describe('slugifyDraftTitle', () => {
   })
 })
 
-describe('draftFromSession', () => {
-  it('skips system messages and empty bodies', () => {
-    const draft = draftFromSession({
-      sessionId: 's1',
-      title: '对账口径',
-      messages: [
-        { kind: MessageKind.SYSTEM, content: 'joined', senderActorId: 'sys' },
-        { kind: MessageKind.TEXT, content: '以渠道单号为准', senderActorId: 'alice' },
-        { kind: MessageKind.TEXT, content: '   ', senderActorId: 'bob' },
+describe('composeKnowledgeDraft', () => {
+  it('groups selected suggestions under headings', () => {
+    const body = composeKnowledgeDraft({
+      summary: '以渠道单号为准',
+      suggestions: [
+        { kind: 'decision', text: '以渠道单号为准' },
+        { kind: 'followup', text: '补一条 runbook' },
       ],
     })
-    expect(draft.title).toBe('对账口径')
+    expect(body).toContain('## 结论')
+    expect(body).toContain('## 后续')
+    expect(body).toContain('补一条 runbook')
+  })
+})
+
+describe('distillFromSession', () => {
+  it('does not dump a long transcript into the draft body', () => {
+    const wall = `背景说明。${'用户贴了一大段过程记录。'.repeat(40)}`
+    const draft = distillFromSession({
+      title: '对账口径',
+      messages: [
+        { kind: MessageKind.TEXT, content: wall, senderActorId: 'user-1', isAgent: false },
+        {
+          kind: MessageKind.TEXT,
+          isAgent: true,
+          senderActorId: 'agent-1',
+          content: [
+            '结论：以渠道单号为准。',
+            '- 不再用支付流水号对账',
+            '- 下一步补一条 runbook',
+          ].join('\n'),
+        },
+      ],
+    })
+    expect(draft.body).not.toContain('用户贴了一大段过程记录')
+    expect(draft.body.length).toBeLessThan(wall.length)
+    expect(draft.suggestions.some((item) => item.text.includes('渠道单号'))).toBe(true)
+    expect(draft.suggestions.some((item) => item.kind === 'followup')).toBe(true)
     expect(draft.suggestedPath).toBe('20-domains/对账口径.md')
-    expect(draft.body).toContain('alice')
-    expect(draft.body).toContain('以渠道单号为准')
-    expect(draft.body).not.toContain('joined')
   })
 
   it('asks the reviewer to write when the thread is empty', () => {
-    const draft = draftFromSession({
-      sessionId: 's1',
+    const draft = distillFromSession({
       title: '  ',
       messages: [],
     })
     expect(draft.title).toBe('untitled')
-    expect(draft.body).toContain('审稿页')
+    expect(draft.suggestions).toEqual([])
+    expect(draft.body).toContain('没有可提炼')
+  })
+
+  it('ignores tool-call noise', () => {
+    const draft = distillFromSession({
+      title: '对账',
+      messages: [
+        { kind: MessageKind.AGENT_TOOL_CALL, content: 'bash({"cmd":"ls"})', isAgent: true },
+        { kind: MessageKind.AGENT_REPLY, content: '结论：以渠道单号为准。', isAgent: true },
+      ],
+    })
+    expect(draft.body).not.toContain('bash(')
+    expect(draft.body).toContain('以渠道单号为准')
+  })
+})
+
+describe('parseDistillPayload', () => {
+  it('reads fenced JSON from the model', () => {
+    const draft = parseDistillPayload(`\`\`\`json
+{"title":"对账口径","suggestedPath":"20-domains/payments/对账口径.md","summary":"以渠道单号为准","suggestions":[{"kind":"decision","text":"以渠道单号为准"}]}
+\`\`\``)
+    expect(draft?.title).toBe('对账口径')
+    expect(draft?.suggestedPath).toContain('payments')
+    expect(draft?.suggestions).toHaveLength(1)
+  })
+
+  it('rejects a payload with no suggestions', () => {
+    expect(parseDistillPayload('{"title":"x","suggestions":[]}')).toBeNull()
+  })
+})
+
+describe('compactTranscriptForDistill', () => {
+  it('labels speakers and drops system lines', () => {
+    const text = compactTranscriptForDistill([
+      { kind: MessageKind.SYSTEM, content: 'joined' },
+      { kind: MessageKind.TEXT, content: 'hello', isAgent: false },
+      { kind: MessageKind.TEXT, content: '结论：ok', isAgent: true },
+    ])
+    expect(text).toContain('user: hello')
+    expect(text).toContain('agent: 结论：ok')
+    expect(text).not.toContain('joined')
   })
 })

--- a/packages/app/src/lib/knowledge/__tests__/session-knowledge-llm.test.ts
+++ b/packages/app/src/lib/knowledge/__tests__/session-knowledge-llm.test.ts
@@ -1,0 +1,68 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { distillWithTeamLlm } from '@/lib/knowledge/session-knowledge-llm'
+
+const getFreshAccessToken = vi.fn()
+
+vi.mock('@/lib/auth/session-store', () => ({
+  getFreshAccessToken: () => getFreshAccessToken(),
+}))
+
+vi.mock('@/stores/team-mode', () => ({
+  useTeamModeStore: {
+    getState: () => ({
+      teamModelConfig: {
+        baseUrl: 'https://api.example.com/ai/v1/teams/t1',
+        model: 'team-fast',
+        modelName: 'Fast',
+      },
+    }),
+  },
+}))
+
+describe('distillWithTeamLlm', () => {
+  beforeEach(() => {
+    getFreshAccessToken.mockReset()
+    getFreshAccessToken.mockResolvedValue('tok')
+  })
+
+  it('returns a distilled draft from the team gateway', async () => {
+    const fetchImpl = vi.fn(async () =>
+      new Response(
+        JSON.stringify({
+          choices: [
+            {
+              message: {
+                content: JSON.stringify({
+                  title: '对账口径',
+                  suggestedPath: '20-domains/payments/对账口径.md',
+                  summary: '以渠道单号为准',
+                  suggestions: [{ kind: 'decision', text: '以渠道单号为准' }],
+                }),
+              },
+            },
+          ],
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      ),
+    )
+    const draft = await distillWithTeamLlm({
+      title: '对账',
+      messages: [{ content: '结论：以渠道单号为准', isAgent: true, kind: 1 }],
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    })
+    expect(draft?.title).toBe('对账口径')
+    expect(draft?.body).toContain('以渠道单号为准')
+    expect(draft?.body).not.toContain('user:')
+    expect(fetchImpl).toHaveBeenCalled()
+  })
+
+  it('returns null when the gateway is down', async () => {
+    const fetchImpl = vi.fn(async () => new Response('nope', { status: 502 }))
+    const draft = await distillWithTeamLlm({
+      title: '对账',
+      messages: [{ content: 'x', isAgent: true, kind: 1 }],
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    })
+    expect(draft).toBeNull()
+  })
+})

--- a/packages/app/src/lib/knowledge/inbox-client.ts
+++ b/packages/app/src/lib/knowledge/inbox-client.ts
@@ -1,5 +1,9 @@
 import { daemonRequest } from '@/lib/daemon/daemon-local-client'
-import type { KnowledgeCandidate, KnowledgePublishResult } from '@/lib/knowledge/inbox-types'
+import type {
+  KnowledgeCandidate,
+  KnowledgePublishResult,
+  KnowledgeSuggestion,
+} from '@/lib/knowledge/inbox-types'
 
 export type ProposeKnowledgeInput = {
   title: string
@@ -7,6 +11,8 @@ export type ProposeKnowledgeInput = {
   sessionId?: string
   suggestedPath?: string
   source?: KnowledgeCandidate['source']
+  summary?: string
+  suggestions?: KnowledgeSuggestion[]
 }
 
 export async function listKnowledgeInbox(): Promise<KnowledgeCandidate[]> {
@@ -29,6 +35,8 @@ export async function proposeKnowledgeCandidate(
       sessionId: input.sessionId,
       suggestedPath: input.suggestedPath,
       source: input.source ?? 'session-header',
+      summary: input.summary,
+      suggestions: input.suggestions,
     }),
   })
 }

--- a/packages/app/src/lib/knowledge/inbox-types.ts
+++ b/packages/app/src/lib/knowledge/inbox-types.ts
@@ -1,3 +1,11 @@
+export type KnowledgeSuggestionKind = 'decision' | 'fact' | 'followup'
+
+export type KnowledgeSuggestion = {
+  id: string
+  kind: KnowledgeSuggestionKind
+  text: string
+}
+
 export type KnowledgeCandidateSource =
   | 'session-header'
   | 'agent-propose'
@@ -17,6 +25,8 @@ export type KnowledgeCandidate = {
   createdAt: string
   status: KnowledgeCandidateStatus
   publishedPath?: string
+  summary?: string
+  suggestions?: KnowledgeSuggestion[]
 }
 
 export type KnowledgePublishResult = {

--- a/packages/app/src/lib/knowledge/propose-from-session.ts
+++ b/packages/app/src/lib/knowledge/propose-from-session.ts
@@ -1,10 +1,32 @@
-import { draftFromSession } from '@/lib/knowledge/session-knowledge-draft'
+import { distillFromSession, type SessionDraftMessage } from '@/lib/knowledge/session-knowledge-draft'
+import { distillWithTeamLlm } from '@/lib/knowledge/session-knowledge-llm'
 import { proposeKnowledgeCandidate } from '@/lib/knowledge/inbox-client'
+import { MessageKind } from '@/lib/proto/teamclu_pb'
 import { openKnowledgeReview } from '@/lib/tabs/knowledge-tabs'
 import { useKnowledgeInboxStore } from '@/stores/knowledge-inbox'
 import { useSessionMessageStore } from '@/stores/session-message-store'
 import { useSessionListStore } from '@/stores/session-list-store'
+import { useSessionParticipantStore } from '@/stores/session-participant-store'
 import { useSessionStore } from '@/stores/session-store'
+
+function toDraftMessages(
+  sessionId: string,
+  messages: Array<{ content?: string; kind?: number; senderActorId?: string }>,
+): SessionDraftMessage[] {
+  const agentIds = new Set(
+    (useSessionParticipantStore.getState().participantsBySession[sessionId] ?? [])
+      .filter((row) => row.isAgent)
+      .map((row) => row.actorId),
+  )
+  return messages.map((message) => ({
+    content: message.content,
+    kind: message.kind,
+    senderActorId: message.senderActorId,
+    isAgent:
+      Boolean(message.senderActorId && agentIds.has(message.senderActorId)) ||
+      message.kind === MessageKind.AGENT_REPLY,
+  }))
+}
 
 export async function proposeSessionToKnowledge(sessionId: string): Promise<string> {
   const messages =
@@ -15,13 +37,18 @@ export async function proposeSessionToKnowledge(sessionId: string): Promise<stri
     useSessionListStore.getState().rows.find((row) => row.id === sessionId)?.title ??
     useSessionStore.getState().sessions.find((row) => row.id === sessionId)?.title ??
     ''
-  const draft = draftFromSession({ sessionId, title, messages })
+  const draftMessages = toDraftMessages(sessionId, messages)
+  const draft =
+    (await distillWithTeamLlm({ title, messages: draftMessages })) ??
+    distillFromSession({ title, messages: draftMessages })
   const candidate = await proposeKnowledgeCandidate({
     title: draft.title,
     content: draft.body,
     suggestedPath: draft.suggestedPath,
     sessionId,
     source: 'session-header',
+    summary: draft.summary,
+    suggestions: draft.suggestions,
   })
   await useKnowledgeInboxStore.getState().load()
   openKnowledgeReview(candidate.id, candidate.title || draft.title)

--- a/packages/app/src/lib/knowledge/session-knowledge-draft.ts
+++ b/packages/app/src/lib/knowledge/session-knowledge-draft.ts
@@ -1,18 +1,31 @@
+import type { KnowledgeSuggestion, KnowledgeSuggestionKind } from '@/lib/knowledge/inbox-types'
 import { MessageKind } from '@/lib/proto/teamclu_pb'
 
-const MAX_BODY_CHARS = 8000
 const MAX_TITLE_CHARS = 48
+const MAX_SUGGESTIONS = 8
+const MAX_SUGGESTION_CHARS = 160
+const MAX_SUMMARY_CHARS = 80
+const SHORT_NOTE_CHARS = 160
 
 export type SessionDraftMessage = {
   content?: string
   kind?: number
   senderActorId?: string
+  isAgent?: boolean
 }
 
 export type SessionKnowledgeDraft = {
   title: string
   body: string
   suggestedPath: string
+  summary: string
+  suggestions: KnowledgeSuggestion[]
+}
+
+const KIND_HEADING: Record<KnowledgeSuggestionKind, string> = {
+  decision: '结论',
+  fact: '要点',
+  followup: '后续',
 }
 
 /** Filename slug: keep letters of any script, collapse the rest to `-`. */
@@ -26,37 +39,224 @@ export function slugifyDraftTitle(title: string): string {
   return trimmed || 'note'
 }
 
+export function composeKnowledgeDraft(input: {
+  summary: string
+  suggestions: Array<Pick<KnowledgeSuggestion, 'kind' | 'text'>>
+}): string {
+  const summary = input.summary.trim()
+  const groups: Record<KnowledgeSuggestionKind, string[]> = {
+    decision: [],
+    fact: [],
+    followup: [],
+  }
+  for (const item of input.suggestions) {
+    const text = item.text.trim()
+    if (!text) continue
+    groups[item.kind].push(text)
+  }
+  const parts: string[] = []
+  if (summary) parts.push(summary)
+  for (const kind of ['decision', 'fact', 'followup'] as const) {
+    if (groups[kind].length === 0) continue
+    parts.push(`## ${KIND_HEADING[kind]}\n\n${groups[kind].map((line) => `- ${line}`).join('\n')}`)
+  }
+  return parts.join('\n\n').trim()
+}
+
+function clip(text: string, max: number): string {
+  const trimmed = text.replace(/\s+/g, ' ').trim()
+  if (trimmed.length <= max) return trimmed
+  return `${trimmed.slice(0, max).trim()}…`
+}
+
+function suggestionId(kind: KnowledgeSuggestionKind, text: string, index: number): string {
+  return `${kind}-${index}-${slugifyDraftTitle(text).slice(0, 16)}`
+}
+
+function pushUnique(
+  out: KnowledgeSuggestion[],
+  seen: Set<string>,
+  kind: KnowledgeSuggestionKind,
+  raw: string,
+): void {
+  const text = clip(raw, MAX_SUGGESTION_CHARS)
+  if (text.length < 4) return
+  const key = text.replace(/[。．.!?！？]$/u, '')
+  if (seen.has(key)) return
+  seen.add(key)
+  out.push({ id: suggestionId(kind, text, out.length), kind, text })
+}
+
+const CUE_DECISION = /(结论|决定|决策|口径|约定|就按|不再|改为)/
+const CUE_FOLLOWUP = /(下一步|后续|待办|还要|接下来|建议先)/
+const CUE_ANY = /(结论|决定|决策|建议|下一步|后续|口径|约定)/
+
+function kindFromCue(text: string): KnowledgeSuggestionKind {
+  if (CUE_FOLLOWUP.test(text)) return 'followup'
+  if (CUE_DECISION.test(text)) return 'decision'
+  return 'fact'
+}
+
+/** Pull list items, headings, and cue sentences — never the whole blob. */
+export function extractSuggestionsFromText(text: string): KnowledgeSuggestion[] {
+  const out: KnowledgeSuggestion[] = []
+  const seen = new Set<string>()
+  const lines = text.split(/\n/)
+  for (const line of lines) {
+    const trimmed = line.trim()
+    if (!trimmed) continue
+    const heading = trimmed.match(/^#{1,3}\s+(.+)$/)
+    if (heading) {
+      pushUnique(out, seen, 'fact', heading[1])
+      if (out.length >= MAX_SUGGESTIONS) return out
+      continue
+    }
+    const bullet = trimmed.match(/^[-*•]\s+(.+)$/) ?? trimmed.match(/^\d+[.)]\s+(.+)$/)
+    if (bullet) {
+      pushUnique(out, seen, kindFromCue(bullet[1]), bullet[1])
+      if (out.length >= MAX_SUGGESTIONS) return out
+    }
+  }
+  const sentences = text.split(/(?<=[。！？\n])/)
+  for (const sentence of sentences) {
+    const trimmed = sentence.trim()
+    if (!trimmed || trimmed.length < 6) continue
+    if (!CUE_ANY.test(trimmed)) continue
+    pushUnique(out, seen, kindFromCue(trimmed), trimmed)
+    if (out.length >= MAX_SUGGESTIONS) return out
+  }
+  return out
+}
+
+function isDraftableKind(kind?: number): boolean {
+  if (kind == null) return true
+  return kind === MessageKind.TEXT || kind === MessageKind.AGENT_REPLY
+}
+
+function sourceMessages(messages: SessionDraftMessage[]): SessionDraftMessage[] {
+  const usable = messages.filter((message) => {
+    if (!isDraftableKind(message.kind)) return false
+    return Boolean((message.content ?? '').trim())
+  })
+  const agents = usable.filter(
+    (message) => message.isAgent || message.kind === MessageKind.AGENT_REPLY,
+  )
+  return agents.length > 0 ? agents : usable
+}
+
+export function composeKnowledgeDraftFromSelection(
+  summary: string,
+  suggestions: Array<Pick<KnowledgeSuggestion, 'id' | 'kind' | 'text'>>,
+  selectedIds: ReadonlySet<string>,
+): string {
+  return composeKnowledgeDraft({
+    summary,
+    suggestions: suggestions.filter((item) => selectedIds.has(item.id)),
+  })
+}
+
 /**
- * A reviewable draft from the messages already on screen.
- *
- * This is not the model summary — it is the raw material the reviewer edits
- * before publish. The header button uses it so "整理到知识库" works without
- * waiting for an agent turn.
+ * Distill a thread into reviewable suggestions. Long messages are mined for
+ * bullets and cue sentences; they are never copied in full.
  */
-export function draftFromSession(input: {
-  sessionId: string
+export function distillFromSession(input: {
   title: string
   messages: SessionDraftMessage[]
 }): SessionKnowledgeDraft {
-  const title = input.title.trim() || 'untitled'
-  const lines: string[] = []
-  for (const message of input.messages) {
-    if (message.kind === MessageKind.SYSTEM) continue
+  const suggestions: KnowledgeSuggestion[] = []
+  const seen = new Set<string>()
+  for (const message of sourceMessages(input.messages)) {
     const text = (message.content ?? '').trim()
-    if (!text) continue
-    const who = (message.senderActorId ?? '').trim() || 'unknown'
-    lines.push(`### ${who}\n\n${text}`)
+    if (text.length <= SHORT_NOTE_CHARS) {
+      pushUnique(suggestions, seen, kindFromCue(text), text)
+    } else {
+      for (const item of extractSuggestionsFromText(text)) {
+        pushUnique(suggestions, seen, item.kind, item.text)
+      }
+    }
+    if (suggestions.length >= MAX_SUGGESTIONS) break
   }
-  let body = lines.join('\n\n')
-  if (!body) {
-    body = '（会话里还没有可整理的正文。请在审稿页写下结论。）'
+
+  const title = input.title.trim() || suggestions[0]?.text.slice(0, MAX_TITLE_CHARS) || 'untitled'
+  const summary = clip(
+    suggestions.find((item) => item.kind === 'decision')?.text ?? suggestions[0]?.text ?? '',
+    MAX_SUMMARY_CHARS,
+  )
+  const body = composeKnowledgeDraft({ summary, suggestions })
+  return {
+    title: title.trim() || 'untitled',
+    body:
+      body ||
+      '（会话里没有可提炼的结论。请勾选或改写建议后再写入。）',
+    suggestedPath: `20-domains/${slugifyDraftTitle(title)}.md`,
+    summary,
+    suggestions,
   }
-  if (body.length > MAX_BODY_CHARS) {
-    body = `${body.slice(0, MAX_BODY_CHARS)}\n\n…`
+}
+
+export function parseDistillPayload(raw: string): SessionKnowledgeDraft | null {
+  const trimmed = raw.trim()
+  const unfenced = trimmed.replace(/^```(?:json)?\s*/i, '').replace(/\s*```$/, '')
+  const start = unfenced.indexOf('{')
+  const end = unfenced.lastIndexOf('}')
+  if (start < 0 || end <= start) return null
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(unfenced.slice(start, end + 1)) as unknown
+  } catch {
+    return null
   }
+  if (!parsed || typeof parsed !== 'object') return null
+  const row = parsed as {
+    title?: unknown
+    suggestedPath?: unknown
+    summary?: unknown
+    suggestions?: unknown
+  }
+  const suggestions: KnowledgeSuggestion[] = []
+  const seen = new Set<string>()
+  if (Array.isArray(row.suggestions)) {
+    for (const item of row.suggestions) {
+      if (!item || typeof item !== 'object') continue
+      const rec = item as { kind?: unknown; text?: unknown }
+      const text = typeof rec.text === 'string' ? rec.text : ''
+      const kind: KnowledgeSuggestionKind =
+        rec.kind === 'decision' || rec.kind === 'followup' || rec.kind === 'fact'
+          ? rec.kind
+          : 'fact'
+      pushUnique(suggestions, seen, kind, text)
+      if (suggestions.length >= MAX_SUGGESTIONS) break
+    }
+  }
+  if (suggestions.length === 0) return null
+  const title = typeof row.title === 'string' && row.title.trim() ? row.title.trim() : suggestions[0].text
+  const summary =
+    typeof row.summary === 'string' && row.summary.trim()
+      ? clip(row.summary, MAX_SUMMARY_CHARS)
+      : clip(suggestions[0].text, MAX_SUMMARY_CHARS)
+  const suggestedPath =
+    typeof row.suggestedPath === 'string' && row.suggestedPath.trim()
+      ? row.suggestedPath.trim()
+      : `20-domains/${slugifyDraftTitle(title)}.md`
   return {
     title,
-    body,
-    suggestedPath: `20-domains/${slugifyDraftTitle(title)}.md`,
+    summary,
+    suggestions,
+    suggestedPath,
+    body: composeKnowledgeDraft({ summary, suggestions }),
   }
+}
+
+export function compactTranscriptForDistill(messages: SessionDraftMessage[], maxChars = 6000): string {
+  const lines: string[] = []
+  for (const message of messages) {
+    if (!isDraftableKind(message.kind)) continue
+    const text = (message.content ?? '').trim()
+    if (!text) continue
+    const who = message.isAgent || message.kind === MessageKind.AGENT_REPLY ? 'agent' : 'user'
+    lines.push(`${who}: ${clip(text, 400)}`)
+  }
+  const joined = lines.join('\n')
+  if (joined.length <= maxChars) return joined
+  return joined.slice(joined.length - maxChars)
 }

--- a/packages/app/src/lib/knowledge/session-knowledge-llm.ts
+++ b/packages/app/src/lib/knowledge/session-knowledge-llm.ts
@@ -1,0 +1,67 @@
+import { getFreshAccessToken } from '@/lib/auth/session-store'
+import {
+  compactTranscriptForDistill,
+  parseDistillPayload,
+  type SessionDraftMessage,
+  type SessionKnowledgeDraft,
+} from '@/lib/knowledge/session-knowledge-draft'
+import { useTeamModeStore } from '@/stores/team-mode'
+
+const SYSTEM_PROMPT = `你把一段团队会话提炼成知识库草稿。不要复述聊天过程，不要粘贴原文。
+只保留已经达成的共识、决策、口径、后续动作。
+只返回 JSON：
+{"title":"短标题","suggestedPath":"20-domains/<slug>.md","summary":"不超过80字的一句话共识","suggestions":[{"kind":"decision|fact|followup","text":"一条可独立收入知识库的句子"}]}
+suggestions 3到8条。kind 只能是 decision、fact、followup。`
+
+export async function distillWithTeamLlm(input: {
+  title: string
+  messages: SessionDraftMessage[]
+  fetchImpl?: typeof fetch
+}): Promise<SessionKnowledgeDraft | null> {
+  const config = useTeamModeStore.getState().teamModelConfig
+  if (!config?.baseUrl || !config.model) return null
+  const transcript = compactTranscriptForDistill(input.messages)
+  if (!transcript.trim()) return null
+
+  let token: string
+  try {
+    token = await getFreshAccessToken()
+  } catch {
+    return null
+  }
+  if (!token.trim()) return null
+
+  const url = `${config.baseUrl.replace(/\/+$/, '')}/chat/completions`
+  const fetchFn = input.fetchImpl ?? fetch
+  let resp: Response
+  try {
+    resp = await fetchFn(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({
+        model: config.model,
+        temperature: 0.2,
+        messages: [
+          { role: 'system', content: SYSTEM_PROMPT },
+          {
+            role: 'user',
+            content: `会话标题：${input.title || '（无）'}\n\n${transcript}`,
+          },
+        ],
+      }),
+      signal: AbortSignal.timeout(20_000),
+    })
+  } catch {
+    return null
+  }
+  if (!resp.ok) return null
+  const data = (await resp.json().catch(() => null)) as {
+    choices?: Array<{ message?: { content?: string } }>
+  } | null
+  const content = data?.choices?.[0]?.message?.content
+  if (!content) return null
+  return parseDistillPayload(content)
+}


### PR DESCRIPTION
## Summary
- 「整理到知识库」现在提炼结论 / 要点 / 后续，不再把聊天全文写入审稿草稿。
- 有团队模型时走网关 `chat/completions`，失败则回退启发式；审稿页可勾选建议并重写正文，仍要点「写入知识库」才进 vault。
- inbox candidate 持久化 `summary` / `suggestions`；旧草稿无这些字段时仍只显示正文。

## Test plan
- [ ] 打开一段有 agent 结论的会话，点「整理到知识库」：审稿页出现提炼建议，正文不含聊天过程记录。
- [ ] 取消勾选一条建议：正文跟着少那一条；人手改过正文后再取消勾选，正文保持不动，点「按所选建议重写正文」才覆盖。
- [ ] 写入知识库后指定路径出现带 `session-id` + `reviewed` 的页面；丢弃 / 稍后不写 vault。
- [ ] 无团队模型或网关失败时仍能打开审稿页（启发式草稿）。


Made with [Cursor](https://cursor.com)