### PR TITLE
fix(deploy): make Belayo releases verifiable

### DIFF
--- a/.github/scripts/belayo-rollout.sh
+++ b/.github/scripts/belayo-rollout.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+service="$1" image="$2" worker="$3" app_id="$4"
+old=$(docker service inspect "$service" --format '{{.Spec.TaskTemplate.ContainerSpec.Image}}')
+rollback() { docker service update --with-registry-auth --update-order start-first --image "$old" --detach=true "$service" >/dev/null || true; }
+trap rollback ERR
+docker service update --with-registry-auth --update-order start-first --update-failure-action rollback --update-monitor 30s --image "$image" --detach=false "$service"
+live=$(docker service ps "$service" --filter desired-state=running --format '{{.Node}} {{.Image}}' | head -1)
+[[ "$live" == "$worker $image"* ]]
+pg=$(docker ps --format '{{.Names}}' | grep dokploy-postgres | head -1)
+docker exec -i "$pg" psql -U dokploy -d dokploy -v ON_ERROR_STOP=1 -c "update application set \"dockerImage\" = '$image' where \"applicationId\" = '$app_id';" >/dev/null
+echo "running=$live"

--- a/.github/workflows/belayo-ai-gateway.yml
+++ b/.github/workflows/belayo-ai-gateway.yml
@@ -21,6 +21,9 @@ on:
     paths:
       - 'services/ai-gateway/**'
       - '.github/workflows/belayo-ai-gateway.yml'
+  # GitHub Actions cron is UTC: 16:00 UTC is 00:00 China Standard Time.
+  schedule:
+    - cron: '0 16 * * *'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/belayo-cloud-api.yml
+++ b/.github/workflows/belayo-cloud-api.yml
@@ -63,11 +63,12 @@ jobs:
           IMG="$IMAGE_REPO:${TAG::9}"
           docker build --platform linux/amd64 -t "$IMG" services/fc
           docker run --rm --entrypoint sh "$IMG" -c 'test -s dist/server.js'
+          # Keep load, inspect and push in one checked remote command.  A
+          # separate best-effort SSH invocation previously let Actions report
+          # success while the worker could not pull the tag.
           docker save "$IMG" | gzip \
-            | ssh "root@$MGR" 'gunzip | docker load'
-          # IMG is intentionally expanded on the runner before ssh executes.
-          # shellcheck disable=SC2029
-          ssh "root@$MGR" docker push "$IMG"
+            | ssh "root@$MGR" \
+                "set -eu; gunzip | docker load; docker image inspect '$IMG'; docker push '$IMG'; echo deployed-image=\"$IMG\" manager=\"\$(hostname)\""
 
       - name: Roll the Cloud API and record the desired image
         env:
@@ -82,6 +83,7 @@ jobs:
             TAG=$4
             APP_ID=$5
             IMG="$IMAGE_REPO:${TAG::9}"
+            echo "deploy-manager=$(hostname) service=$SERVICE image=$IMG"
             OLD_IMAGE=$(docker service inspect "$SERVICE" --format '{{.Spec.TaskTemplate.ContainerSpec.Image}}')
             PG=$(docker ps --format '{{.Names}}' | grep dokploy-postgres | head -1)
             OLD_DESIRED=$(docker exec -i "$PG" psql -U dokploy -d dokploy -Atc \

--- a/.github/workflows/belayo-cloud-api.yml
+++ b/.github/workflows/belayo-cloud-api.yml
@@ -60,7 +60,7 @@ jobs:
           MGR: ${{ secrets.BELAYO_DOKPLOY_HOST }}
           TAG: ${{ github.sha }}
         run: |
-          IMG="$IMAGE_REPO:${TAG::9}"
+          IMG="$IMAGE_REPO:shadow-${TAG::9}"
           docker build --platform linux/amd64 -t "$IMG" services/fc
           docker run --rm --entrypoint sh "$IMG" -c 'test -s dist/server.js'
           # Keep load, inspect and push in one checked remote command.  A
@@ -82,7 +82,7 @@ jobs:
             IMAGE_REPO=$3
             TAG=$4
             APP_ID=$5
-            IMG="$IMAGE_REPO:${TAG::9}"
+            IMG="$IMAGE_REPO:shadow-${TAG::9}"
             echo "deploy-manager=$(hostname) service=$SERVICE image=$IMG"
             OLD_IMAGE=$(docker service inspect "$SERVICE" --format '{{.Spec.TaskTemplate.ContainerSpec.Image}}')
             PG=$(docker ps --format '{{.Names}}' | grep dokploy-postgres | head -1)

--- a/.github/workflows/belayo-cloud-api.yml
+++ b/.github/workflows/belayo-cloud-api.yml
@@ -31,7 +31,10 @@ jobs:
       APP_ID: AyIydhRyN4pMT0_Y0TXvq
       SERVICE: teamclu-cloud-api-shadow-qjau6z
       WORKER: dokploy-worker-2
-      IMAGE_REPO: registry-vpc.cn-shenzhen.aliyuncs.com/betlysaas/teamclu-cloud-api
+      # The service is pinned to a worker outside the manager's VPC.  It must
+      # pull from the public ACR endpoint; `registry-vpc` is reachable only
+      # from the manager and makes Swarm reject the task before it starts.
+      IMAGE_REPO: registry.cn-shenzhen.aliyuncs.com/betlysaas/teamclu-cloud-api
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/belayo-cloud-api.yml
+++ b/.github/workflows/belayo-cloud-api.yml
@@ -31,10 +31,9 @@ jobs:
       APP_ID: AyIydhRyN4pMT0_Y0TXvq
       SERVICE: teamclu-cloud-api-shadow-qjau6z
       WORKER: dokploy-worker-2
-      # The service is pinned to a worker outside the manager's VPC.  It must
-      # pull from the public ACR endpoint; `registry-vpc` is reachable only
-      # from the manager and makes Swarm reject the task before it starts.
-      IMAGE_REPO: registry.cn-shenzhen.aliyuncs.com/betlysaas/teamclu-cloud-api
+      # Belayo manager, worker and ACR are in one VPC. Keep this internal
+      # endpoint; `shadow-<sha>` below identifies the switched environment.
+      IMAGE_REPO: registry-vpc.cn-shenzhen.aliyuncs.com/betlysaas/teamclu-cloud-api
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/belayo-cloud-api.yml
+++ b/.github/workflows/belayo-cloud-api.yml
@@ -75,7 +75,12 @@ jobs:
           MGR: ${{ secrets.BELAYO_DOKPLOY_HOST }}
           TAG: ${{ github.sha }}
         run: |
-          ssh "root@$MGR" bash -s -- "$SERVICE" "$WORKER" "$IMAGE_REPO" "$TAG" "$APP_ID" <<'EOF'
+          IMG="$IMAGE_REPO:shadow-${TAG::9}"
+          scp .github/scripts/belayo-rollout.sh "root@$MGR:/tmp/belayo-rollout.sh"
+          ssh "root@$MGR" chmod 700 /tmp/belayo-rollout.sh
+          ssh "root@$MGR" /tmp/belayo-rollout.sh "$SERVICE" "$IMG" "$WORKER" "$APP_ID"
+          ssh "root@$MGR" rm -f /tmp/belayo-rollout.sh
+          : <<'EOF'
             set -Eeuo pipefail
             SERVICE=$1
             WORKER=$2


### PR DESCRIPTION
## What changed
- keep Cloud API on the Belayo VPC ACR and its `shadow-<sha>` environment tag
- make image transfer and rollout explicit, with actual Swarm image verification and desired-image sync
- add a nightly AI Gateway deploy at 00:00 China Standard Time

## Validation
- Cloud API verification deploy completed with `registry-vpc.cn-shenzhen.aliyuncs.com/betlysaas/teamclu-cloud-api:shadow-afc2c763e` running on `dokploy-worker-2`
- AI Gateway workflow YAML parsed successfully
- `git diff --check` passed